### PR TITLE
Configure Terraform S3 backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .env
+.terraform
+*.tfstate
+.DS_Store

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,7 @@
+# Modernisation Platform Infrastructure
+
+This `terraform` folder contains the infrastructure as code to recreate and administer the Modernisation Platform.
+
+## Contents
+
+- [global-resources](global-resources) contains files for infrastructure that is administered at a global level, such as S3 buckets, that aren't part of a specific platform environment

--- a/terraform/global-resources/README.md
+++ b/terraform/global-resources/README.md
@@ -1,0 +1,3 @@
+# Modernisation Platform - Global Resources
+
+These are resources that are implemented at the root account for the Modernisation Platform. For example, this includes an [backend definition](main.tf) that can be used for other Modernisation Platform-managed implementations.

--- a/terraform/global-resources/locals.tf
+++ b/terraform/global-resources/locals.tf
@@ -1,0 +1,9 @@
+locals {
+  global_resources {
+    application-name    = "Modernisation Platform - Global Resources"
+    business-unit       = "Ministry of Justice - Hosting"
+    tech-contact-email  = "modernisation-platform@digital.justice.gov.uk"
+    budget-holder-email = "steve.marshall@digital.justice.gov.uk"
+    stage               = "production"
+  }
+}

--- a/terraform/global-resources/locals.tf
+++ b/terraform/global-resources/locals.tf
@@ -1,9 +1,8 @@
 locals {
   global_resources {
-    application-name    = "Modernisation Platform - Global Resources"
-    business-unit       = "Ministry of Justice - Hosting"
-    tech-contact-email  = "modernisation-platform@digital.justice.gov.uk"
-    budget-holder-email = "steve.marshall@digital.justice.gov.uk"
-    stage               = "production"
+    business-unit = "Platforms"
+    application   = "Modernisation Platform"
+    is-production = true
+    owner         = "Modernisation Platform: modernisation-platform@digital.justice.gov.uk"
   }
 }

--- a/terraform/global-resources/main.tf
+++ b/terraform/global-resources/main.tf
@@ -1,12 +1,12 @@
 terraform {
-   # `backend` blocks do not support variables, so the bucket name is hard-coded here, although created in the s3.tf file.
+  # `backend` blocks do not support variables, so the bucket name is hard-coded here, although created in the s3.tf file.
   backend "s3" {
-    bucket  = "modernisation-platform-terraform-state"
-    region  = "eu-west-2"
-    key     = "global-resources/terraform.tfstate"
+    bucket = "modernisation-platform-terraform-state"
+    region = "eu-west-2"
+    key    = "global-resources/terraform.tfstate"
   }
 }
 
 provider "aws" {
-  region  = "eu-west-2"
+  region = "eu-west-2"
 }

--- a/terraform/global-resources/main.tf
+++ b/terraform/global-resources/main.tf
@@ -1,0 +1,12 @@
+terraform {
+   # `backend` blocks do not support variables, so the bucket name is hard-coded here, although created in the s3.tf file.
+  backend "s3" {
+    bucket  = "modernisation-platform-terraform-state"
+    region  = "eu-west-2"
+    key     = "global-resources/terraform.tfstate"
+  }
+}
+
+provider "aws" {
+  region  = "eu-west-2"
+}

--- a/terraform/global-resources/s3.tf
+++ b/terraform/global-resources/s3.tf
@@ -1,0 +1,12 @@
+resource "aws_s3_bucket" "modernisation-platform-terraform-state" {
+  bucket = "modernisation-platform-terraform-state"
+  acl    = "private"
+
+  versioning {
+    enabled = true
+  }
+
+  tags {
+    local.global_resources
+  }
+}

--- a/terraform/global-resources/versions.tf
+++ b/terraform/global-resources/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.13"
+}


### PR DESCRIPTION
This PR:

- Defines some local variables for tagging
- Defines an S3 bucket to use for a Terraform backend
- Defines the Terraform backend

This allows remote state sharing in Terraform to ensure that local references are up-to-date and that `terraform apply` doesn't create a conflicting state set if run at the same time by different people.