### PR TITLE
Add a password policy for IAM users

### DIFF
--- a/terraform/global-resources/iam.tf
+++ b/terraform/global-resources/iam.tf
@@ -1,0 +1,12 @@
+# Set an IAM account password policy to ensure rotation of passwords, with some sensible defaults
+resource "aws_iam_account_password_policy" "strict" {
+  allow_users_to_change_password = true
+  hard_expiry                    = false
+  max_password_age               = 30
+  minimum_password_length        = 12
+  password_reuse_prevention      = 5
+  require_lowercase_characters   = true
+  require_numbers                = true
+  require_symbols                = true
+  require_uppercase_characters   = true
+}


### PR DESCRIPTION
This PR:
- Creates a password policy for IAM users

This forces:
- 30 day rotation periods
- minimum 12-character passwords
- lowercase and uppercase characters, numbers, symbols
- prevents reusing any of the 5 previously used passwords

It also allows a user to change their own password without enforcing an administrator reset.