### PR TITLE
Use superadmin Terraform module

### DIFF
--- a/terraform/global-resources/iam.tf
+++ b/terraform/global-resources/iam.tf
@@ -1,11 +1,4 @@
-# Set an IAM account password policy to ensure rotation of passwords, with some sensible defaults
-resource "aws_iam_account_password_policy" "strict" {
-  allow_users_to_change_password = true
-  hard_expiry                    = false
-  minimum_password_length        = 8
-  password_reuse_prevention      = 5
-  require_lowercase_characters   = true
-  require_numbers                = true
-  require_symbols                = true
-  require_uppercase_characters   = true
+module "iam" {
+  source        = "github.com/ministryofjustice/modernisation-platform-terraform-iam-superadmins"
+  account_alias = "moj-modernisation-platform"
 }


### PR DESCRIPTION
This PR:
- Moves to using the superadmin Terraform module to allow superadmin access to accounts
- Devolves password policy management to the Terraform module

This allows us to reuse the superadmin and password management policy across accounts.