### PR TITLE
Specify AWS provider source

### DIFF
--- a/terraform/global-resources/versions.tf
+++ b/terraform/global-resources/versions.tf
@@ -1,3 +1,8 @@
 terraform {
   required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }


### PR DESCRIPTION
This PR:
- Specifies the AWS provider source

This is because of a change in how [Terraform 0.13 handles provider sources](https://www.terraform.io/upgrade-guides/0-13.html#explicit-provider-source-locations). It introduces a namespace to specify community-maintained providers as a dependency and although it is only required for community-maintained modules, it's best to be explicit, and allows us to view all provider dependencies in one place as the Modernisation Platform grows.