### PR TITLE
Add a public access block and enable S3 encryption

### DIFF
--- a/terraform/global-resources/main.tf
+++ b/terraform/global-resources/main.tf
@@ -1,9 +1,10 @@
 terraform {
   # `backend` blocks do not support variables, so the bucket name is hard-coded here, although created in the s3.tf file.
   backend "s3" {
-    bucket = "modernisation-platform-terraform-state"
-    region = "eu-west-2"
-    key    = "global-resources/terraform.tfstate"
+    bucket  = "modernisation-platform-terraform-state"
+    region  = "eu-west-2"
+    key     = "global-resources/terraform.tfstate"
+    encrypt = true
   }
 }
 

--- a/terraform/global-resources/s3.tf
+++ b/terraform/global-resources/s3.tf
@@ -2,9 +2,23 @@ resource "aws_s3_bucket" "modernisation-platform-terraform-state" {
   bucket = "modernisation-platform-terraform-state"
   acl    = "private"
 
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "aws:kms"
+      }
+    }
+  }
+
   versioning {
     enabled = true
   }
 
   tags = local.global_resources
+}
+
+resource "aws_s3_bucket_public_access_block" "modernisation-platform-terraform-state" {
+  bucket              = aws_s3_bucket.modernisation-platform-terraform-state.id
+  block_public_acls   = true
+  block_public_policy = true
 }


### PR DESCRIPTION
This PR:
- Encrypts the `terraform.tfstate` file stored in S3
- Encrypts new S3 objects in the bucket
- Explicitly blocks public access to the S3 bucket

This is to ensure our S3 bucket is as secure as possible.