### PR TITLE
Allow automated environment creation from a JSON file

### DIFF
--- a/environments/non-production/shared-services.json
+++ b/environments/non-production/shared-services.json
@@ -1,0 +1,10 @@
+{
+  "name": "shared-services",
+  "environments": ["logs", "security"],
+  "tags": {
+    "business-unit": "Platforms",
+    "application": "modernisation-platform-shared-services",
+    "is-production": false,
+    "owner": "<Modernisation Platform>: modernisation-platform@digital.justice.gov.uk"
+  }
+}

--- a/terraform/global-resources/environments.tf
+++ b/terraform/global-resources/environments.tf
@@ -1,0 +1,55 @@
+locals {
+  non_prod_path = "../../environments/non-production"
+  applications = [
+    for application in fileset("${local.non_prod_path}", "**") :
+    jsondecode(file("${local.non_prod_path}/${application}"))
+  ]
+  expanded_applications = flatten([
+    for application in local.applications : [
+      for environment in application.environments : {
+        name    = "${application.name}-${environment}"
+        part_of = application.name
+        tags    = application.tags
+      }
+    ]
+  ])
+}
+
+# Create high-level organisation units
+resource "aws_organizations_organizational_unit" "non-production" {
+  provider  = aws.environments
+  name      = "modernisation-platform-non-production"
+  parent_id = local.environments_management.modernisation_platform_organisation_id
+}
+
+resource "aws_organizations_organizational_unit" "production" {
+  provider  = aws.environments
+  name      = "modernisation-platform-production"
+  parent_id = local.environments_management.modernisation_platform_organisation_id
+}
+
+# Create sub-level organisation units per application
+resource "aws_organizations_organizational_unit" "non-production-unit" {
+  provider  = aws.environments
+  parent_id = aws_organizations_organizational_unit.non-production.id
+  for_each = {
+    for application in local.applications :
+    application.name => application
+  }
+  name = "modernisation-platform-${each.value.name}"
+}
+
+# Create accounts for applications and their environments, within the application organisation unit
+resource "aws_organizations_account" "non-production-account" {
+  provider = aws.environments
+  for_each = {
+    for application in local.expanded_applications :
+    application.name => application
+  }
+
+  name                       = each.value.name
+  email                      = "aws+mp+${each.value.name}@digital.justice.gov.uk"
+  iam_user_access_to_billing = "ALLOW"
+  parent_id                  = aws_organizations_organizational_unit.non-production-unit[each.value.part_of].id
+  tags                       = each.value.tags
+}

--- a/terraform/global-resources/main.tf
+++ b/terraform/global-resources/main.tf
@@ -11,3 +11,12 @@ terraform {
 provider "aws" {
   region = "eu-west-2"
 }
+
+provider "aws" {
+  alias  = "environments"
+  region = "eu-west-2"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environments_management.root_account_id}:role/${local.environments_management.root_account_role}"
+  }
+}

--- a/terraform/global-resources/secrets.tf
+++ b/terraform/global-resources/secrets.tf
@@ -1,3 +1,4 @@
+# SAML: Auth0 credentials
 resource "aws_secretsmanager_secret" "auth0_saml" {
   name        = "auth0_saml"
   description = "Auth0 Machine to Machine credentials for Terraform to setup Auth0 for IAM Federated Access"
@@ -8,6 +9,7 @@ data "aws_secretsmanager_secret_version" "auth0_saml" {
   secret_id = aws_secretsmanager_secret.auth0_saml.id
 }
 
+# SAML: GitHub client ID and secrets
 resource "aws_secretsmanager_secret" "github_saml" {
   name        = "github_saml"
   description = "GitHub client id and secret for the Ministry of Justice owned OAuth app"
@@ -18,7 +20,19 @@ data "aws_secretsmanager_secret_version" "github_saml" {
   secret_id = aws_secretsmanager_secret.github_saml.id
 }
 
+# Environments Management
+resource "aws_secretsmanager_secret" "environments_management" {
+  name        = "environments_management"
+  description = "IDs for AWS-specific resources for environment management, such as account ID"
+  tags        = local.global_resources
+}
+
+data "aws_secretsmanager_secret_version" "environments_management" {
+  secret_id = aws_secretsmanager_secret.environments_management.id
+}
+
 locals {
-  auth0_saml  = jsondecode(data.aws_secretsmanager_secret_version.auth0_saml.secret_string)
-  github_saml = jsondecode(data.aws_secretsmanager_secret_version.github_saml.secret_string)
+  auth0_saml              = jsondecode(data.aws_secretsmanager_secret_version.auth0_saml.secret_string)
+  github_saml             = jsondecode(data.aws_secretsmanager_secret_version.github_saml.secret_string)
+  environments_management = jsondecode(data.aws_secretsmanager_secret_version.environments_management.secret_string)
 }


### PR DESCRIPTION
This PR resolves #11, and is reliant on ministryofjustice/aws-root-account#5.

This PR does the following manually:
- Creates two organisational units for `non-production` and `production` application environments

This PR automates the following:
- The creation of child organisation units in either `non-production` and `production` named after applications defined in the `environments` folder
- The creation of attached OU accounts for applications in their respective child organisation units, with some sensible defaults such as allowing access to billing, a standardised email address, and tags.

It does this by assuming a role as defined in ministryofjustice/aws-root-account#5.