### PR TITLE
Add environment tag checking with a sample environment

### DIFF
--- a/.github/workflows/check-environment-definitions.yml
+++ b/.github/workflows/check-environment-definitions.yml
@@ -1,0 +1,18 @@
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+jobs:
+  check-environment-definitions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2-beta
+        with:
+          node-version: "14"
+      - run: npm install
+      - uses: actions/github-script@v2
+        with:
+          script: |
+            const run = require(`${process.env.GITHUB_WORKSPACE}/scripts/check-environment-definitions.js`)
+            await run({ github, context })

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This is the Ministry of Justice [Modernisation Platform team](https://github.com
 This repository currently holds the Modernisation Platform's:
 - [Architecture Decision Record (ADR)](architecture-decision-record)
 - [Infrastructure as code](terraform)
+- [Environment definitions](environments)
 
 ## Other useful repositories
 ### Core repositories
@@ -17,5 +18,6 @@ This repository currently holds the Modernisation Platform's:
 ### Terraform modules
 | Name                                                  | Description                                                      | Link                                                                                       |
 |-------------------------------------------------------|------------------------------------------------------------------|--------------------------------------------------------------------------------------------|
-| modernisation-platform-terraform-iam-superadmins      | Module for creating high-level set superadmins in an AWS account | https://github.com/ministryofjustice/modernisation-platform-terraform-iam-superadmins      |
+| modernisation-platform-terraform-environments         | Module for creating environment OUs and application accounts     | https://github.com/ministryofjustice/modernisation-platform-terraform-environments         |
 | modernisation-platform-terraform-iam-federated-access | Module for configuring IAM Federated Access for AWS              | https://github.com/ministryofjustice/modernisation-platform-terraform-iam-federated-access |
+| modernisation-platform-terraform-iam-superadmins      | Module for creating high-level set superadmins in an AWS account | https://github.com/ministryofjustice/modernisation-platform-terraform-iam-superadmins      |

--- a/environments/non-production/shared-services.json
+++ b/environments/non-production/shared-services.json
@@ -1,6 +1,7 @@
 {
   "name": "shared-services",
   "environments": ["dev"],
+  "owner": "Modernisation Platform: modernisation-platform@digital.justice.gov.uk",
   "tags": {
     "business-unit": "Platforms",
     "application": "shared-services",

--- a/environments/non-production/shared-services.json
+++ b/environments/non-production/shared-services.json
@@ -1,0 +1,9 @@
+{
+  "name": "shared-services",
+  "environments": ["dev"],
+  "tags": {
+    "business-unit": "Platforms",
+    "application": "shared-services",
+    "is-production": false
+  }
+}

--- a/environments/non-production/shared-services.json
+++ b/environments/non-production/shared-services.json
@@ -1,10 +1,10 @@
 {
   "name": "shared-services",
   "environments": ["dev"],
-  "owner": "Modernisation Platform: modernisation-platform@digital.justice.gov.uk",
   "tags": {
-    "business-unit": "Platforms",
     "application": "shared-services",
-    "is-production": false
+    "business-unit": "Platforms",
+    "is-production": false,
+    "owner": "Modernisation Platform: modernisation-platform@digital.justice.gov.uk"
   }
 }

--- a/scripts/check-environment-definitions.js
+++ b/scripts/check-environment-definitions.js
@@ -30,20 +30,18 @@ module.exports = async ({ github, context }) => {
       missingRequired.forEach(configuration => {
         message.push(`\`${configuration.name}\` is missing: \`${configuration.missing.required.join('`, `')}\``)
       })
-    }
 
-    message.push('Please refer to the Ministry of Justice [Tagging Guidelines](https://ministryofjustice.github.io/technical-guidance/documentation/standards/documenting-infrastructure-owners.html) for more information.')
+      message.push('Please refer to the Ministry of Justice [Tagging Guidelines](https://ministryofjustice.github.io/technical-guidance/documentation/standards/documenting-infrastructure-owners.html) for more information.')
 
-    const formattedMessage = message.join('\r\n\r\n')
+      const formattedMessage = message.join('\r\n\r\n')
 
-    await github.issues.createComment({
-      issue_number: context.issue.number,
-      owner: context.repo.owner,
-      repo: context.repo.repo,
-      body: formattedMessage
-    })
+      await github.issues.createComment({
+        issue_number: context.issue.number,
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        body: formattedMessage
+      })
 
-    if (missingRequired.length) {
       throw new Error(formattedMessage)
     }
   } catch (e) {

--- a/scripts/check-environment-definitions.js
+++ b/scripts/check-environment-definitions.js
@@ -1,0 +1,53 @@
+const utilities = require('./utilities.js')
+
+module.exports = async ({ github, context }) => {
+  try {
+    // Get all configuration files
+    const configurations = await utilities.getFilesRecursively('./environments').then(configuration => configuration.map(application => {
+      // Ensure each configuration has the correct keys and/or tags
+      const missingConfiguration = utilities.checkKeys(application, ['name', 'environments', 'tags'])
+      const missingRequiredTags = utilities.checkKeys(application.tags, ['business-unit', 'application', 'is-production', 'owner'])
+
+      return {
+        ...application,
+        ...{
+          missing: {
+            required: missingConfiguration.concat(missingRequiredTags)
+          }
+        }
+      }
+    }))
+
+    const message = []
+
+    // Filter out configurations with missing required keys
+    const missingRequired = configurations.filter(configuration => configuration.missing.required.length)
+
+    // If there are any, throw an error
+    if (missingRequired.length) {
+      message.push('### ❗ Required')
+
+      missingRequired.forEach(configuration => {
+        message.push(`\`${configuration.name}\` is missing: \`${configuration.missing.required.join('`, `')}\``)
+      })
+    }
+
+    message.push('Please refer to the Ministry of Justice [Tagging Guidelines](https://ministryofjustice.github.io/technical-guidance/documentation/standards/documenting-infrastructure-owners.html) for more information.')
+
+    const formattedMessage = message.join('\r\n\r\n')
+
+    await github.issues.createComment({
+      issue_number: context.issue.number,
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      body: formattedMessage
+    })
+
+    if (missingRequired.length) {
+      throw new Error(formattedMessage)
+    }
+  } catch (e) {
+    console.error(e)
+    process.exit(1)
+  }
+}

--- a/scripts/utilities.js
+++ b/scripts/utilities.js
@@ -1,0 +1,26 @@
+const fs = require('fs').promises
+
+const utilities = {
+  async getFilesRecursively (directory) {
+    const ls = await fs.readdir(directory, { withFileTypes: true })
+    const files = ls.filter(file => !file.isDirectory()).map(async file => {
+      const filePath = `${directory}/${file.name}`
+      const contents = await fs.readFile(filePath, 'utf8').then(content => JSON.parse(content))
+      return { ...contents, ...{ source: filePath } }
+    })
+
+    const folders = ls.filter(file => file.isDirectory())
+
+    for (const folder of folders) {
+      files.push(...await utilities.getFilesRecursively(`${directory}/${folder.name}/`))
+    }
+
+    return Promise.all(files)
+  },
+  checkKeys (object, keys, required = true) {
+    const objKeys = Object.keys(object)
+    return keys.filter(key => !objKeys.includes(key))
+  }
+}
+
+module.exports = utilities


### PR DESCRIPTION
This PR:
- Adds some sample data to this repository
- Adds a script that will warn about missing key value pairs that are needed to create an OU and account for an application to sit on the Modernisation Platform, and will throw an error if required tags from the MoJ Technical Guidance are missing
- Creates a GitHub workflow to run the script on new PRs, and comment the outcome

It is a clean PR that has been extrapolated from ministryofjustice/modernisation-platform#24, though the optional tag message has been removed as this script checks every file, not just changed ones, so it would have commented on every successive PR about optional tags. ministryofjustice/modernisation-platform#24 was extrapolated from ministryofjustice/modernisation-platform-terraform-environments#1.