### PR TITLE
Use `modernisation-platform-terraform-environments` for environment management

### DIFF
--- a/terraform/global-resources/environments.tf
+++ b/terraform/global-resources/environments.tf
@@ -2,9 +2,9 @@ module "environments" {
   providers = {
     aws = aws.environments
   }
-  source                             = "../../../modernisation-platform-environments"
-  environment_types                  = ["production", "non-production"]
+  source                             = "github.com/ministryofjustice/modernisation-platform-terraform-environments"
   environment_directory              = "../../environments"
+  environment_types                  = ["production", "non-production"]
   environment_parent_organisation_id = local.environments_management.modernisation_platform_organisation_id
   environment_prefix                 = "modernisation-platform"
 }

--- a/terraform/global-resources/environments.tf
+++ b/terraform/global-resources/environments.tf
@@ -1,0 +1,10 @@
+module "environments" {
+  providers = {
+    aws = aws.environments
+  }
+  source                             = "../../../modernisation-platform-environments"
+  environment_types                  = ["production", "non-production"]
+  environment_directory              = "../../environments"
+  environment_parent_organisation_id = local.environments_management.modernisation_platform_organisation_id
+  environment_prefix                 = "modernisation-platform"
+}

--- a/terraform/global-resources/main.tf
+++ b/terraform/global-resources/main.tf
@@ -15,7 +15,7 @@ provider "aws" {
 
 # Environments provider
 provider "aws" {
-  alias = "environments"
+  alias  = "environments"
   region = "eu-west-2"
 
   assume_role {

--- a/terraform/global-resources/main.tf
+++ b/terraform/global-resources/main.tf
@@ -8,6 +8,17 @@ terraform {
   }
 }
 
+# Default provider
 provider "aws" {
   region = "eu-west-2"
+}
+
+# Environments provider
+provider "aws" {
+  alias = "environments"
+  region = "eu-west-2"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environments_management.root_account_id}:role/${local.environments_management.root_account_role}"
+  }
 }

--- a/terraform/global-resources/secrets.tf
+++ b/terraform/global-resources/secrets.tf
@@ -1,3 +1,4 @@
+# SAML: Auth0 credentials
 resource "aws_secretsmanager_secret" "auth0_saml" {
   name        = "auth0_saml"
   description = "Auth0 Machine to Machine credentials for Terraform to setup Auth0 for IAM Federated Access"
@@ -8,6 +9,7 @@ data "aws_secretsmanager_secret_version" "auth0_saml" {
   secret_id = aws_secretsmanager_secret.auth0_saml.id
 }
 
+# SAML: GitHub client ID and secrets
 resource "aws_secretsmanager_secret" "github_saml" {
   name        = "github_saml"
   description = "GitHub client id and secret for the Ministry of Justice owned OAuth app"
@@ -18,7 +20,19 @@ data "aws_secretsmanager_secret_version" "github_saml" {
   secret_id = aws_secretsmanager_secret.github_saml.id
 }
 
+# Environments management
+resource "aws_secretsmanager_secret" "environments_management" {
+  name        = "environments_management"
+  description = "IDs for AWS-specific resources for environment management, such as account ID"
+  tags        = local.global_resources
+}
+
+data "aws_secretsmanager_secret_version" "environments_management" {
+  secret_id = aws_secretsmanager_secret.environments_management.id
+}
+
 locals {
   auth0_saml  = jsondecode(data.aws_secretsmanager_secret_version.auth0_saml.secret_string)
   github_saml = jsondecode(data.aws_secretsmanager_secret_version.github_saml.secret_string)
+  environments_management = jsondecode(data.aws_secretsmanager_secret_version.environments_management.secret_string)
 }

--- a/terraform/global-resources/secrets.tf
+++ b/terraform/global-resources/secrets.tf
@@ -32,7 +32,7 @@ data "aws_secretsmanager_secret_version" "environments_management" {
 }
 
 locals {
-  auth0_saml  = jsondecode(data.aws_secretsmanager_secret_version.auth0_saml.secret_string)
-  github_saml = jsondecode(data.aws_secretsmanager_secret_version.github_saml.secret_string)
+  auth0_saml              = jsondecode(data.aws_secretsmanager_secret_version.auth0_saml.secret_string)
+  github_saml             = jsondecode(data.aws_secretsmanager_secret_version.github_saml.secret_string)
   environments_management = jsondecode(data.aws_secretsmanager_secret_version.environments_management.secret_string)
 }


### PR DESCRIPTION
This PR:
- Includes [ministryofjustice/modernisation-platform-terraform-environments](https://github.com/ministryofjustice/modernisation-platform-terraform-environments) for environment management
- Configures a new provider for environment management
- Retrieves secrets for environment management from AWS Secrets Manager

This PR resolves #11, and requires ministryofjustice/aws-root-account#6.