### PR TITLE
Bootstrap new AWS accounts with assumable roles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .terraform
 *.tfstate*
 .DS_Store
+*-generated.tf

--- a/terraform/environments/README.md
+++ b/terraform/environments/README.md
@@ -1,0 +1,19 @@
+# Modernisation Platform - Environments
+
+This directory creates and maintains organisational units, their accounts, and their relationships with the Modernisation Platform. It needs to be run at the MoJ root account level, with a user that has access to assume a role in the Modernisation Platform.
+
+## Providers
+There are two types of providers in this configuration.
+
+### Static providers
+In [main.tf](main.tf), the default AWS provider is the MoJ root account. There is a secondary provider, with the alias `modernisation-platform`, that assumes the `OrganizationAccountAccessRole` in the Modernisation Platform account.
+
+### Generated providers
+As of 2020-09-29, there is an open issue regarding dynamic providers (hashicorp/terraform#24476) in Terraform. Therefore, we need to generate a file that defines providers as "static" blocks.
+
+`providers.tf` creates a local variable that runs `templatefile()` on [providers.tmpl](providers.tmpl), which loops through accounts created within the `environments` module and creates an `aws_iam_role` in each account to allow the Modernisation Platform access.
+
+This is then uploaded to the `modernisation-platform-terraform-state` S3 bucket and redownloaded if it changes remotely, creating a local file that is a replica of the S3 object.
+
+## State management
+The Terraform state is stored in the `modernisation-platform-terraform-state` bucket alongside other states creates in this repository. The user that this configuration should be run as needs access.

--- a/terraform/environments/environments.tf
+++ b/terraform/environments/environments.tf
@@ -1,10 +1,10 @@
 module "environments" {
   providers = {
-    aws = aws.environments
+    aws = aws
   }
   source                             = "github.com/ministryofjustice/modernisation-platform-terraform-environments"
   environment_directory              = "../../environments"
   environment_types                  = ["production", "non-production"]
-  environment_parent_organisation_id = local.environments_management.modernisation_platform_organisation_id
+  environment_parent_organisation_id = local.environment_management.modernisation_platform_organisation_unit_id
   environment_prefix                 = "modernisation-platform"
 }

--- a/terraform/environments/iam.tf
+++ b/terraform/environments/iam.tf
@@ -1,0 +1,15 @@
+data "aws_iam_policy_document" "assumable-by-modernisation-platform" {
+  version = "2012-10-17"
+
+  statement {
+    sid    = "AllowModernisationPlatformToAssumeRole"
+    effect = "Allow"
+    actions = [
+      "sts:AssumeRole"
+    ]
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${local.modernisation_platform_account.id}:root"]
+    }
+  }
+}

--- a/terraform/environments/locals.tf
+++ b/terraform/environments/locals.tf
@@ -6,3 +6,10 @@ locals {
     owner         = "Modernisation Platform: modernisation-platform@digital.justice.gov.uk"
   }
 }
+
+# This allows us to get the Modernisation Platform account information for use elsewhere
+# (when we want to assume a role in the MP, for instance)
+data "aws_organizations_organization" "root" {}
+locals {
+  modernisation_platform_account = data.aws_organizations_organization.root.accounts[index(data.aws_organizations_organization.root.accounts[*].email, "aws+modernisation-platform@digital.justice.gov.uk")]
+}

--- a/terraform/environments/main.tf
+++ b/terraform/environments/main.tf
@@ -1,5 +1,6 @@
 terraform {
   # `backend` blocks do not support variables, so the bucket name is hard-coded here, although created in the global-resources/s3.tf file.
+  # The user that this Terraform configuration should be run as, has access to this bucket.
   backend "s3" {
     bucket  = "modernisation-platform-terraform-state"
     region  = "eu-west-2"
@@ -8,17 +9,16 @@ terraform {
   }
 }
 
-# Default provider
+# AWS provider (default): the MoJ root account
 provider "aws" {
   region = "eu-west-2"
 }
 
-# Environments provider
+# AWS provider (Modernisation Platform): the Modernisation Platform account
 provider "aws" {
-  alias  = "environments"
+  alias  = "modernisation-platform"
   region = "eu-west-2"
-
   assume_role {
-    role_arn = "arn:aws:iam::${local.environments_management.root_account_id}:role/${local.environments_management.root_account_role}"
+    role_arn = "arn:aws:iam::${local.modernisation_platform_account.id}:role/OrganizationAccountAccessRole"
   }
 }

--- a/terraform/environments/providers.tf
+++ b/terraform/environments/providers.tf
@@ -15,7 +15,7 @@ resource "aws_s3_bucket_object" "modernisation-platform-providers" {
   key          = "providers-generated.tf"
   content      = local.providers_file
   content_type = "text/plain"
-  metadata     = {
+  metadata = {
     md5 = md5(local.providers_file)
   }
   tags = local.environments

--- a/terraform/environments/providers.tf
+++ b/terraform/environments/providers.tf
@@ -1,0 +1,33 @@
+# As of 2020-09-29, there is an open issue regarding dynamic providers (hashicorp/terraform#24476).
+# Therefore, we need to generate a file that defines providers as "static" blocks.
+#
+# This generates a file for additional providers, based on accounts created through the "environments" module
+# in environments.tf.
+#
+# It should not be committed as it holds account IDs.
+locals {
+  providers_file = templatefile("providers.tmpl", { accounts : module.environments.environment_account_ids })
+}
+
+resource "aws_s3_bucket_object" "modernisation-platform-providers" {
+  provider     = aws.modernisation-platform
+  bucket       = "modernisation-platform-terraform-state"
+  key          = "providers-generated.tf"
+  content      = local.providers_file
+  content_type = "text/plain"
+  metadata     = {
+    md5 = md5(local.providers_file)
+  }
+  tags = local.environments
+}
+
+data "aws_s3_bucket_object" "modernisation-platform-providers" {
+  provider = aws.modernisation-platform
+  bucket   = "modernisation-platform-terraform-state"
+  key      = "providers-generated.tf"
+}
+
+resource "local_file" "providers-generated" {
+  filename = "providers-generated.tf"
+  content  = data.aws_s3_bucket_object.modernisation-platform-providers.body
+}

--- a/terraform/environments/providers.tmpl
+++ b/terraform/environments/providers.tmpl
@@ -1,0 +1,15 @@
+%{ for key, value in accounts ~}
+provider "aws" {
+  alias  = "${key}"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${value}:role/OrganizationAccountAccessRole"
+  }
+}
+
+resource "aws_iam_role" "assumable-modernisation-platform-role" {
+  name = "AssumableByModernisationPlatform"
+  assume_role_policy = data.aws_iam_policy_document.assumable-by-modernisation-platform.json
+  provider = aws.${key}
+}
+%{ endfor ~}

--- a/terraform/environments/secrets.tf
+++ b/terraform/environments/secrets.tf
@@ -1,14 +1,16 @@
 # Environments management
-resource "aws_secretsmanager_secret" "environments_management" {
-  name        = "environments_management"
-  description = "IDs for AWS-specific resources for environment management, such as account ID"
+resource "aws_secretsmanager_secret" "environment_management" {
+  provider    = aws.modernisation-platform
+  name        = "environment_management"
+  description = "IDs for AWS-specific resources for environment management, such as organizational unit IDs"
   tags        = local.environments
 }
 
-data "aws_secretsmanager_secret_version" "environments_management" {
-  secret_id = aws_secretsmanager_secret.environments_management.id
+data "aws_secretsmanager_secret_version" "environment_management" {
+  provider  = aws.modernisation-platform
+  secret_id = aws_secretsmanager_secret.environment_management.id
 }
 
 locals {
-  environments_management = jsondecode(data.aws_secretsmanager_secret_version.environments_management.secret_string)
+  environment_management = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
 }


### PR DESCRIPTION
This PR:

- changes how Organisational Units and accounts are created; from the Modernisation Platform assuming a role, to running this directly in the MOJ root account
- creates dynamically generated providers for new OUs and accounts
- creates an assumable role in new accounts for the Modernisation Platform to assume directly rather than through the MOJ root account