### PR TITLE
Simplify OU and account creation

### DIFF
--- a/environments/shared-services.json
+++ b/environments/shared-services.json
@@ -4,7 +4,6 @@
   "tags": {
     "application": "shared-services",
     "business-unit": "Platforms",
-    "is-production": false,
     "owner": "Modernisation Platform: modernisation-platform@digital.justice.gov.uk"
   }
 }

--- a/scripts/check-environment-definitions.js
+++ b/scripts/check-environment-definitions.js
@@ -6,7 +6,7 @@ module.exports = async ({ github, context }) => {
     const configurations = await utilities.getFilesRecursively('./environments').then(configuration => configuration.map(application => {
       // Ensure each configuration has the correct keys and/or tags
       const missingConfiguration = utilities.checkKeys(application, ['name', 'environments', 'tags'])
-      const missingRequiredTags = utilities.checkKeys(application.tags, ['business-unit', 'application', 'is-production', 'owner'])
+      const missingRequiredTags = utilities.checkKeys(application.tags, ['business-unit', 'application', 'owner'])
 
       return {
         ...application,

--- a/terraform/environments/environments.tf
+++ b/terraform/environments/environments.tf
@@ -1,10 +1,6 @@
 module "environments" {
-  providers = {
-    aws = aws
-  }
   source                             = "github.com/ministryofjustice/modernisation-platform-terraform-environments"
   environment_directory              = "../../environments"
-  environment_types                  = ["production", "non-production"]
   environment_parent_organisation_id = local.environment_management.modernisation_platform_organisation_unit_id
   environment_prefix                 = "modernisation-platform"
 }


### PR DESCRIPTION
This PR removes a split between non-production and production organization units, and instead has OUs on an application-by-application basis. It also removes checking for the `is-production` tag as this is now inferred.

It requires ministryofjustice/modernisation-platform-terraform-environments#4.