### PR TITLE
Enable baselines module

### DIFF
--- a/terraform/global-resources/baselines.tf
+++ b/terraform/global-resources/baselines.tf
@@ -1,0 +1,3 @@
+module "baselines" {
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines"
+}


### PR DESCRIPTION
I've moved PR #33, #34, #35 to a separate [Terraform module](https://github.com/ministryofjustice/modernisation-platform-terraform-baselines) and this enables that.