### PR TITLE
Implement a fix for the cyclical dependency on a generated file

### DIFF
--- a/terraform/environments/Makefile
+++ b/terraform/environments/Makefile
@@ -1,0 +1,5 @@
+BUCKET=modernisation-platform-terraform-state
+KEY=providers-generated.tf
+
+download_required_files:
+	aws s3 cp s3://${BUCKET}/${KEY} ./${KEY}.tf

--- a/terraform/environments/README.md
+++ b/terraform/environments/README.md
@@ -1,6 +1,9 @@
 # Modernisation Platform - Environments
 
-This directory creates and maintains organisational units, their accounts, and their relationships with the Modernisation Platform. It needs to be run at the MoJ root account level, with a user that has access to assume a role in the Modernisation Platform.
+This creates and maintains organisational units, their accounts, and their relationships with the Modernisation Platform. It needs to be run at the MoJ root account level, with a user that has access to assume a role within the Modernisation Platform.
+
+## tldr
+- Run `make download_required_files` with the applicable AWS profile set before running Terraform `init`, `plan`, `apply`
 
 ## Providers
 There are two types of providers in this configuration.
@@ -9,11 +12,14 @@ There are two types of providers in this configuration.
 In [main.tf](main.tf), the default AWS provider is the MoJ root account. There is a secondary provider, with the alias `modernisation-platform`, that assumes the `OrganizationAccountAccessRole` in the Modernisation Platform account.
 
 ### Generated providers
-As of 2020-09-29, there is an open issue regarding dynamic providers (hashicorp/terraform#24476) in Terraform. Therefore, we need to generate a file that defines providers as "static" blocks.
+As of 2020-09-29, there is an open issue regarding [dynamic providers in Terraform](https://github.com/hashicorp/terraform/issues/24476). Therefore, we need to generate a file that defines providers as "static" blocks.
 
-`providers.tf` creates a local variable that runs `templatefile()` on [providers.tmpl](providers.tmpl), which loops through accounts created within the `environments` module and creates an `aws_iam_role` in each account to allow the Modernisation Platform access.
+`providers.tf` creates a local variable that runs `templatefile()` on [providers.tmpl](providers.tmpl), which loops through accounts created within the `environments` module and applies configuration on each one.
 
-This is then uploaded to the `modernisation-platform-terraform-state` S3 bucket and redownloaded if it changes remotely, creating a local file that is a replica of the S3 object.
+This is then uploaded to the `modernisation-platform-terraform-state` S3 bucket.
+
+#### Getting around the cyclical dependency on generated providers
+When Terraform runs, it compares your local state to the remote state held in S3. If you don't have the generated provider file, it'll throw an error saying that you need them, because it can't compare the state without them. To get around this, we've included a Makefile that holds a directive to download the required files from an S3 bucket without Terraform. This should be run before `terraform init, plan, apply` to ensure you've got the up to date file.
 
 ## State management
 The Terraform state is stored in the `modernisation-platform-terraform-state` bucket alongside other states creates in this repository. The user that this configuration should be run as needs access.

--- a/terraform/environments/providers.tf
+++ b/terraform/environments/providers.tf
@@ -20,14 +20,3 @@ resource "aws_s3_bucket_object" "modernisation-platform-providers" {
   }
   tags = local.environments
 }
-
-data "aws_s3_bucket_object" "modernisation-platform-providers" {
-  provider = aws.modernisation-platform
-  bucket   = "modernisation-platform-terraform-state"
-  key      = "providers-generated.tf"
-}
-
-resource "local_file" "providers-generated" {
-  filename = "providers-generated.tf"
-  content  = data.aws_s3_bucket_object.modernisation-platform-providers.body
-}


### PR DESCRIPTION
- Add a Makefile to download generated files
- Update README and fix a link
- Stop Terraform from managing the local version of the generated file

As Terraform doesn't support for_each for providers, we generate static blocks via a template file instead. If you're getting started on the MP, it will throw an error because you don't have that file. This fixes it by providing a way to download the file without using Terraform.