### PR TITLE
AWS Config remediation: tag default VPC and update S3 bucket permissions

### DIFF
--- a/terraform/global-resources/defaults.tf
+++ b/terraform/global-resources/defaults.tf
@@ -1,0 +1,25 @@
+# VPC
+resource "aws_default_vpc" "default" {
+  tags = local.global_resources
+}
+
+# Subnets
+resource "aws_default_subnet" "default_aza" {
+  availability_zone = "eu-west-2a"
+  tags = local.global_resources
+}
+
+resource "aws_default_subnet" "default_azb" {
+  availability_zone = "eu-west-2b"
+  tags = local.global_resources
+}
+
+resource "aws_default_subnet" "default_azc" {
+  availability_zone = "eu-west-2c"
+  tags = local.global_resources
+}
+
+# DHCP options
+resource "aws_default_vpc_dhcp_options" "default" {
+  tags = local.global_resources
+}

--- a/terraform/global-resources/defaults.tf
+++ b/terraform/global-resources/defaults.tf
@@ -6,17 +6,17 @@ resource "aws_default_vpc" "default" {
 # Subnets
 resource "aws_default_subnet" "default_aza" {
   availability_zone = "eu-west-2a"
-  tags = local.global_resources
+  tags              = local.global_resources
 }
 
 resource "aws_default_subnet" "default_azb" {
   availability_zone = "eu-west-2b"
-  tags = local.global_resources
+  tags              = local.global_resources
 }
 
 resource "aws_default_subnet" "default_azc" {
   availability_zone = "eu-west-2c"
-  tags = local.global_resources
+  tags              = local.global_resources
 }
 
 # DHCP options

--- a/terraform/global-resources/s3.tf
+++ b/terraform/global-resources/s3.tf
@@ -19,8 +19,10 @@ resource "aws_s3_bucket" "modernisation-platform-terraform-state" {
 
 resource "aws_s3_bucket_public_access_block" "modernisation-platform-terraform-state" {
   bucket              = aws_s3_bucket.modernisation-platform-terraform-state.id
-  block_public_acls   = true
-  block_public_policy = true
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
 }
 
 # Allow access to the bucket from the MoJ root account

--- a/terraform/global-resources/s3.tf
+++ b/terraform/global-resources/s3.tf
@@ -18,7 +18,7 @@ resource "aws_s3_bucket" "modernisation-platform-terraform-state" {
 }
 
 resource "aws_s3_bucket_public_access_block" "modernisation-platform-terraform-state" {
-  bucket              = aws_s3_bucket.modernisation-platform-terraform-state.id
+  bucket                  = aws_s3_bucket.modernisation-platform-terraform-state.id
   block_public_acls       = true
   block_public_policy     = true
   ignore_public_acls      = true


### PR DESCRIPTION
This resolves the VPC configuration being non-compliant in AWS Config due to not having tags, and tightens up public restrictions on the Terraform state S3 bucket.