### PR TITLE
AWS Config remediation: add tags to default VPC ACL and SG

### DIFF
--- a/terraform/global-resources/defaults.tf
+++ b/terraform/global-resources/defaults.tf
@@ -23,3 +23,54 @@ resource "aws_default_subnet" "default_azc" {
 resource "aws_default_vpc_dhcp_options" "default" {
   tags = local.global_resources
 }
+
+# Network ACL
+resource "aws_default_network_acl" "default" {
+  default_network_acl_id = aws_default_vpc.default.default_network_acl_id
+  subnet_ids = [
+    aws_default_subnet.default_aza.id,
+    aws_default_subnet.default_azb.id,
+    aws_default_subnet.default_azc.id
+  ]
+
+  ingress {
+    protocol   = -1
+    rule_no    = 100
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 0
+    to_port    = 0
+  }
+
+  egress {
+    protocol   = -1
+    rule_no    = 100
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 0
+    to_port    = 0
+  }
+
+  tags = local.global_resources
+}
+
+# Security Group
+resource "aws_default_security_group" "default" {
+  vpc_id = aws_default_vpc.default.id
+
+  ingress {
+    protocol  = -1
+    self      = true
+    from_port = 0
+    to_port   = 0
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = local.global_resources
+}


### PR DESCRIPTION
This PR brings the AWS default Network ACL and SecurityGroup into Terraform management, and adds tags to them.