### PR TITLE
Set aws provider to use eu-west-2

### DIFF
--- a/terraform/global-resources/providers.tf
+++ b/terraform/global-resources/providers.tf
@@ -80,11 +80,10 @@ provider "aws" {
   alias  = "modernisation-platform-us-west-2"
 }
 
-
 module "baselines" {
   source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines"
   providers = {
-    aws                = aws
+    aws                = aws.modernisation-platform-eu-west-2
     aws.ap-northeast-1 = aws.modernisation-platform-ap-northeast-1
     aws.ap-northeast-2 = aws.modernisation-platform-ap-northeast-2
     aws.ap-south-1     = aws.modernisation-platform-ap-south-1


### PR DESCRIPTION
This explicitly sets the `aws` default provider to use the Modernisation Platform `eu-west-2` provider, rather than relying on the caller's `AWS_REGION`.