### PR TITLE
Add Route53 Hosted Zone for modernisation-platform.service.justice.gov.uk

### DIFF
--- a/terraform/global-resources/route53.tf
+++ b/terraform/global-resources/route53.tf
@@ -1,0 +1,3 @@
+resource "aws_route53_zone" "modernisation-platform" {
+  name = "modernisation-platform.service.justice.gov.uk"
+}


### PR DESCRIPTION
Adds a Route53 Hosted Zone for `modernisation-platform.service.justice.gov.uk`.