### PR TITLE
Add missing tags to Route53 hosted zone

### DIFF
--- a/terraform/global-resources/route53.tf
+++ b/terraform/global-resources/route53.tf
@@ -1,3 +1,4 @@
 resource "aws_route53_zone" "modernisation-platform" {
   name = "modernisation-platform.service.justice.gov.uk"
+  tags = local.global_resources
 }


### PR DESCRIPTION
This adds the missing tags to the Route53 Hosted Zone.