### PR TITLE
Add local provider to versions.tf for Terraform 0.13

### DIFF
--- a/terraform/global-resources/versions.tf
+++ b/terraform/global-resources/versions.tf
@@ -4,5 +4,8 @@ terraform {
     aws = {
       source = "hashicorp/aws"
     }
+    local = {
+      source = "hashicorp/local"
+    }
   }
 }


### PR DESCRIPTION
This adds the `local` provider to `versions.tf`, as recommended by Terraform 0.13.