### PR TITLE
Force Terraform state ownership to be bucket-owner-full-control

### DIFF
--- a/terraform/environments/main.tf
+++ b/terraform/environments/main.tf
@@ -2,8 +2,8 @@ terraform {
   # `backend` blocks do not support variables, so the following are hard-coded here:
   # - S3 bucket name, which is created in s3.tf
   backend "s3" {
-    acl    = "bucket-owner-full-control"
-    bucket = "modernisation-platform-terraform-state"
+    acl     = "bucket-owner-full-control"
+    bucket  = "modernisation-platform-terraform-state"
     encrypt = true
     key     = "environments/terraform.tfstate"
     region  = "eu-west-2"

--- a/terraform/environments/main.tf
+++ b/terraform/environments/main.tf
@@ -1,11 +1,12 @@
 terraform {
-  # `backend` blocks do not support variables, so the bucket name is hard-coded here, although created in the global-resources/s3.tf file.
-  # The user that this Terraform configuration should be run as, has access to this bucket.
+  # `backend` blocks do not support variables, so the following are hard-coded here:
+  # - S3 bucket name, which is created in s3.tf
   backend "s3" {
-    bucket  = "modernisation-platform-terraform-state"
-    region  = "eu-west-2"
-    key     = "environments/terraform.tfstate"
+    acl    = "bucket-owner-full-control"
+    bucket = "modernisation-platform-terraform-state"
     encrypt = true
+    key     = "environments/terraform.tfstate"
+    region  = "eu-west-2"
   }
 }
 

--- a/terraform/global-resources/main.tf
+++ b/terraform/global-resources/main.tf
@@ -3,6 +3,7 @@ terraform {
   # - S3 bucket name, which is created in s3.tf
   # - DynamoDB table name, which is created in dynamodb.tf
   backend "s3" {
+    acl            = "bucket-owner-full-control"
     bucket         = "modernisation-platform-terraform-state"
     dynamodb_table = "modernisation-platform-terraform-state-lock"
     encrypt        = true

--- a/terraform/global-resources/s3.tf
+++ b/terraform/global-resources/s3.tf
@@ -47,8 +47,7 @@ data "aws_iam_policy_document" "allow-access-from-root-account" {
     sid    = "AllowModifyObjectsFromRootAccount"
     effect = "Allow"
     actions = [
-      "s3:GetObject",
-      "s3:PutObject"
+      "s3:GetObject"
     ]
     resources = ["${aws_s3_bucket.modernisation-platform-terraform-state.arn}/*"]
 
@@ -57,6 +56,25 @@ data "aws_iam_policy_document" "allow-access-from-root-account" {
       identifiers = [
         "arn:aws:iam::${local.root_account.master_account_id}:user/ModernisationPlatformOrganisationManagement"
       ]
+    }
+  }
+
+  statement {
+    effect = "Allow"
+    actions = ["s3:PutObject"]
+    resources = ["${aws_s3_bucket.modernisation-platform-terraform-state.arn}/*"]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${local.root_account.master_account_id}:user/ModernisationPlatformOrganisationManagement"
+      ]
+    }
+
+    condition {
+      test = "StringEquals"
+      variable = "s3:x-amz-acl"
+      values = ["bucket-owner-full-control"]
     }
   }
 


### PR DESCRIPTION
This PR enforces Terraform states to be uploaded with the `bucket-owner-full-control` and enforces a policy for the root account to only be able to upload objects with the ACL `bucket-owner-full-control`.