### PR TITLE
Update baseline variables/providers

### DIFF
--- a/terraform/environments/providers-shared-services-dev.tf
+++ b/terraform/environments/providers-shared-services-dev.tf
@@ -157,7 +157,11 @@ module "cross-account-access-shared-services-dev" {
 module "baselines-shared-services-dev" {
   source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines"
   providers = {
-    aws                = aws.shared-services-dev-eu-west-2
+    # Default and replication regions
+    aws                    = aws.shared-services-dev-eu-west-2
+    aws.replication-region = aws.shared-services-dev-eu-west-1
+
+    # Other regions
     aws.ap-northeast-1 = aws.shared-services-dev-ap-northeast-1
     aws.ap-northeast-2 = aws.shared-services-dev-ap-northeast-2
     aws.ap-south-1     = aws.shared-services-dev-ap-south-1

--- a/terraform/global-resources/providers.tf
+++ b/terraform/global-resources/providers.tf
@@ -85,7 +85,11 @@ provider "aws" {
 module "baselines-modernisation-platform" {
   source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines"
   providers = {
-    aws                = aws.modernisation-platform-eu-west-2
+    # Default and replication regions
+    aws                    = aws.modernisation-platform-eu-west-2
+    aws.replication-region = aws.modernisation-platform-eu-west-1
+
+    # Other regions
     aws.ap-northeast-1 = aws.modernisation-platform-ap-northeast-1
     aws.ap-northeast-2 = aws.modernisation-platform-ap-northeast-2
     aws.ap-south-1     = aws.modernisation-platform-ap-south-1
@@ -103,7 +107,6 @@ module "baselines-modernisation-platform" {
     aws.us-west-1      = aws.modernisation-platform-us-west-1
     aws.us-west-2      = aws.modernisation-platform-us-west-2
   }
-  replication_region = "eu-west-1"
-  root_account_id    = local.root_account.master_account_id
-  tags               = local.global_resources
+  root_account_id = local.root_account.master_account_id
+  tags            = local.global_resources
 }

--- a/terraform/templates/providers.tmpl
+++ b/terraform/templates/providers.tmpl
@@ -28,12 +28,15 @@ module "cross-account-access-${provider_key}" {
 module "baselines-${provider_key}" {
   source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines"
   providers = {
-    aws                = aws.${provider_key}-eu-west-2
+    # Default and replication regions
+    aws                    = aws.${provider_key}-eu-west-2
+    aws.replication-region = aws.${provider_key}-eu-west-1
+
+    # Other regions
     %{~ for region in account_regions ~}
     aws.${region} ${substr("              ", 0, 14-length(region))}= aws.${provider_key}-${region}
     %{~ endfor ~}
   }
-  replication_region = "eu-west-1"
   root_account_id    = ${root_account_id_path}
   tags               = ${tags_path}
 }

--- a/terraform/templates/providers.tmpl
+++ b/terraform/templates/providers.tmpl
@@ -37,6 +37,6 @@ module "baselines-${provider_key}" {
     aws.${region} ${substr("              ", 0, 14-length(region))}= aws.${provider_key}-${region}
     %{~ endfor ~}
   }
-  root_account_id    = ${root_account_id_path}
-  tags               = ${tags_path}
+  root_account_id = ${root_account_id_path}
+  tags            = ${tags_path}
 }


### PR DESCRIPTION
Requires ministryofjustice/modernisation-platform-terraform-baselines#36.

This removes the `replication_region` variable and introduces the `provider.replication-region` declaration.