### PR TITLE
Update required Terraform and Terraform providers versions

### DIFF
--- a/terraform/environments/versions.tf
+++ b/terraform/environments/versions.tf
@@ -1,11 +1,13 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.13.5"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      version = ">= 3.13.0"
+      source  = "hashicorp/aws"
     }
     local = {
-      source = "hashicorp/local"
+      version = ">= 2.0.0"
+      source  = "hashicorp/local"
     }
   }
 }

--- a/terraform/github/versions.tf
+++ b/terraform/github/versions.tf
@@ -1,9 +1,9 @@
 terraform {
+  required_version = ">= 0.13.5"
   required_providers {
     github = {
       version = "3.0.0" # Pin to 3.0.0 as 3.1.0 is currently broken (https://github.com/terraform-providers/terraform-provider-github/issues/566#issuecomment-720150093)
       source  = "hashicorp/github"
     }
   }
-  required_version = ">= 0.13"
 }

--- a/terraform/global-resources/versions.tf
+++ b/terraform/global-resources/versions.tf
@@ -1,11 +1,13 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.13.5"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      version = ">= 3.13.0"
+      source  = "hashicorp/aws"
     }
     local = {
-      source = "hashicorp/local"
+      version = ">= 2.0.0"
+      source  = "hashicorp/local"
     }
   }
 }


### PR DESCRIPTION
This specifies that the minimum Terraform version required is `0.13.5` and also specifies to use the following provider versions:

- `aws` to use at least `3.13.0`
- `local` to use at least `2.0.0`