### PR TITLE
Write up our team alliance in our docs

### DIFF
--- a/docs/alliance.md
+++ b/docs/alliance.md
@@ -1,0 +1,16 @@
+# Modernisation Platform - Our alliance
+
+As a team, we regularly discuss and decide on our alliance, and document these openly and publicly.
+
+As of 3rd November 2020, our alliance is as follows (in alphabetical order):
+
+- We agree that it is important for us to all develop
+- We agree that it is OK to respectfully challenge and debate each other
+- We agree that no question is a stupid question
+- We will aim to communicate more than necessary in Slack
+- We will be transparent, open and inclusive
+- We will call out each other when we break out principles
+- We will hold a monthly remote social activity
+- We will lead a blameless culture
+- We will regularly introspect and adapt
+- We won't take ourselves too seriously

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,5 @@
+# Modernisation Platform
+
+## Team
+- [Our alliance](alliance.md)
+- [Our team](team.md)

--- a/docs/team.md
+++ b/docs/team.md
@@ -1,0 +1,7 @@
+# Modernisation Platform - Our team
+
+Our team is currently made up of 3 members:
+
+- Jake Mulley, Technical Architect
+- Karen Botsh, Senior Delivery Manager
+- Zuri Guardiola, WebOps Engineer


### PR DESCRIPTION
This resolves #71 where we agreed to document our team alliance openly and publicly.