### PR TITLE
Remove duplicate headings that GitHub creates

### DIFF
--- a/docs/alliance.md
+++ b/docs/alliance.md
@@ -1,4 +1,4 @@
-# Modernisation Platform - Our alliance
+# Our alliance
 
 As a team, we regularly discuss and decide on our alliance, and document these openly and publicly.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,5 @@
-# Modernisation Platform
+## Contents
 
-## Team
+### Team
 - [Our alliance](alliance.md)
 - [Our team](team.md)

--- a/docs/team.md
+++ b/docs/team.md
@@ -1,4 +1,4 @@
-# Modernisation Platform - Our team
+# Our team
 
 Our team is currently made up of 3 members:
 


### PR DESCRIPTION
GitHub creates headings based on repository names so our pages appear as follows:
<img width="1028" alt="Screenshot 2020-11-04 at 09 45 10" src="https://user-images.githubusercontent.com/1689995/98095443-815efd80-1e82-11eb-9e33-c50b8f52d246.png">

This removes "Modernisation Platform" from our headings so it will now show like this:
<img width="1098" alt="Screenshot 2020-11-04 at 09 45 21" src="https://user-images.githubusercontent.com/1689995/98095555-a6ec0700-1e82-11eb-8e5d-0ffc6f4668e2.png">
