### PR TITLE
Add Trusted Advisor refresh Lambda

### DIFF
--- a/terraform/global-resources/providers.tf
+++ b/terraform/global-resources/providers.tf
@@ -110,3 +110,7 @@ module "baselines-modernisation-platform" {
   root_account_id = local.root_account.master_account_id
   tags            = local.global_resources
 }
+
+module "trusted-advisor-modernisation-platform" {
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-trusted-advisor"
+}

--- a/terraform/templates/providers.tmpl
+++ b/terraform/templates/providers.tmpl
@@ -40,3 +40,7 @@ module "baselines-${provider_key}" {
   root_account_id = ${root_account_id_path}
   tags            = ${tags_path}
 }
+
+module "trusted-advisor-${provider_key}" {
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-trusted-advisor"
+}


### PR DESCRIPTION
This is the first part of #75, which refreshes AWS Trusted Advisor every 60 minutes to get the most up-to-date check results.