### PR TITLE
Add other GitHub team members into Terraform

### DIFF
--- a/terraform/github/modules/team/main.tf
+++ b/terraform/github/modules/team/main.tf
@@ -1,13 +1,50 @@
+locals {
+  # GitHub usernames for the Modernisation Platform team maintainers
+  # NB: Terraform shows a perputal difference in roles if someone is an organisation owner
+  # and will attempt to change them from `maintainer` to `member`, so owners should go in here.
+  maintainers = toset([
+    "jakemulley",
+    "ewastempel",
+    "SteveMarshall"
+  ])
+  # GitHub usernames for the full Modernisation Platform team
+  members = toset([
+    "davidkelliott",
+    "ewastempel",
+    "jakemulley",
+    "kcbotsh",
+    "nishamoj",
+    "seanprivett",
+    "SimonPPledger",
+    "SteveMarshall",
+    "zuriguardiola"
+  ])
+}
+
 resource "github_team" "default" {
   name        = var.name
   privacy     = "closed"
   description = join(" • ", [var.description, "This team is defined and managed in Terraform"])
 }
 
-resource "github_team_membership" "default" {
+# Team memberships (as "maintainers")
+resource "github_team_membership" "maintainers" {
+  for_each = local.maintainers
   team_id  = github_team.default.id
-  username = "jakemulley"
+  username = each.value
   role     = "maintainer"
+}
+
+# Team memberships (as "members")
+resource "github_team_membership" "members" {
+  for_each = toset([
+    for user in local.members :
+    user
+    if ! contains(local.maintainers, user)
+  ])
+  team_id  = github_team.default.id
+  username = each.value
+  role     = "member"
 }
 
 # Repositories to give access to

--- a/terraform/github/versions.tf
+++ b/terraform/github/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.5"
+  required_version = ">= 0.13"
   required_providers {
     github = {
       version = "3.0.0" # Pin to 3.0.0 as 3.1.0 is currently broken (https://github.com/terraform-providers/terraform-provider-github/issues/566#issuecomment-720150093)


### PR DESCRIPTION
This pulls in the other GitHub [team members](https://github.com/orgs/ministryofjustice/teams/modernisation-platform) into Terraform management.