### PR TITLE
Change check-environment-definitions to only run on PRs that change something in environments/**

### DIFF
--- a/.github/workflows/check-environment-definitions.yml
+++ b/.github/workflows/check-environment-definitions.yml
@@ -1,6 +1,7 @@
 on:
   pull_request:
     types: [opened, edited, reopened, synchronize]
+    paths: 'environments/**'
 
 jobs:
   check-environment-definitions:


### PR DESCRIPTION
This restricts the `check-environment-definitions` workflow from running unless a PR changes something in `environments/**`, which should mean less checks for unrelated PRs.