### PR TITLE
Allow secrets to be set via Terraform

### DIFF
--- a/terraform/github/main.tf
+++ b/terraform/github/main.tf
@@ -25,6 +25,11 @@ module "core" {
     "aws",
     "documentation"
   ]
+  secrets = {
+    AWS_ACCESS_KEY_ID      = "example"
+    AWS_SECRET_ACCESS_KEY  = "example"
+    TERRAFORM_GITHUB_TOKEN = "example"
+  }
 }
 
 module "terraform-module-baselines" {

--- a/terraform/github/modules/repository/main.tf
+++ b/terraform/github/modules/repository/main.tf
@@ -4,6 +4,7 @@ locals {
   topics        = var.type == "core" ? local.base_topics : concat(local.base_topics, local.module_topics)
 }
 
+# Repository basics
 resource "github_repository" "default" {
   name                   = var.name
   description            = join(" • ", [var.description, "This repository is defined and managed in Terraform"])
@@ -47,4 +48,16 @@ resource "github_branch_protection" "default" {
     dismiss_stale_reviews           = true
     required_approving_review_count = 1
   }
+}
+
+# Secrets
+data "github_actions_public_key" "default" {
+  repository = github_repository.default.id
+}
+
+resource "github_actions_secret" "default" {
+  for_each        = var.secrets
+  repository      = github_repository.default.id
+  secret_name     = each.key
+  plaintext_value = each.value
 }

--- a/terraform/github/modules/repository/variables.tf
+++ b/terraform/github/modules/repository/variables.tf
@@ -14,6 +14,12 @@ variable "homepage_url" {
   default     = ""
 }
 
+variable "secrets" {
+  type        = map
+  description = "key:value map for GitHub actions secrets"
+  default     = {}
+}
+
 variable "topics" {
   type        = list(string)
   description = "Repository topics, in addition to 'modernisation-platform', 'terraform-module', 'civil-service'"


### PR DESCRIPTION
Part of #88.

This allows us to set GitHub repository secrets via Terraform in one place.

Note that when you run `terraform plan` it specifies that the plaintext_value is `(sensitive)`.