### PR TITLE
Change public to core

### DIFF
--- a/terraform/github/main.tf
+++ b/terraform/github/main.tf
@@ -18,7 +18,7 @@ module "core" {
   source       = "./modules/repository"
   type         = "core"
   name         = "modernisation-platform"
-  description  = "A place for the public work of the Modernisation Platform"
+  description  = "A place for the core work of the Modernisation Platform"
   homepage_url = "https://ministryofjustice.github.io/modernisation-platform/index.html"
   topics = [
     "architecture-decisions",


### PR DESCRIPTION
Using the word `public` conveys that we have private repositories, which we don't, so I've switched this out to `core` so it makes more sense.