### PR TITLE
Add missing aws_caller_identity block

### DIFF
--- a/terraform/modernisation-platform-account/locals.tf
+++ b/terraform/modernisation-platform-account/locals.tf
@@ -1,5 +1,6 @@
 data "aws_organizations_organization" "root_account" {}
 data "aws_regions" "current" {}
+data "aws_caller_identity" "current" {}
 
 locals {
   global_resources = {


### PR DESCRIPTION
Adds a missing aws_caller_identity block that is required by https://github.com/ministryofjustice/modernisation-platform/blob/main/terraform/modernisation-platform-account/s3.tf#L8.