### PR TITLE
Make CI users maintainers

### DIFF
--- a/terraform/github/modules/team/main.tf
+++ b/terraform/github/modules/team/main.tf
@@ -40,6 +40,14 @@ resource "github_team_membership" "maintainers" {
   role     = "maintainer"
 }
 
+# CI users need to be a maintainer to edit team memberships through Terraform
+resource "github_team_membership" "ci" {
+  for_each = local.ci_users
+  team_id  = github_team.default.id
+  username = each.value
+  role     = "maintainer"
+}
+
 # Team memberships (as "members")
 resource "github_team_membership" "members" {
   for_each = toset([
@@ -47,13 +55,6 @@ resource "github_team_membership" "members" {
     user
     if ! contains(local.maintainers, user)
   ])
-  team_id  = github_team.default.id
-  username = each.value
-  role     = "member"
-}
-
-resource "github_team_membership" "ci" {
-  for_each = local.ci_users
   team_id  = github_team.default.id
   username = each.value
   role     = "member"


### PR DESCRIPTION
The CI user needs to be a team maintainer to edit the team members.