### PR TITLE
Mark AWS SSO ADR as accepted, and reject AWS IAM Federated Access ADR as rejected

### DIFF
--- a/architecture-decision-record/0002-use-iam-federated-access.md
+++ b/architecture-decision-record/0002-use-iam-federated-access.md
@@ -4,7 +4,7 @@ Date: 2020-09-15
 
 ## Status
 
-🤔 Proposed
+❌ Rejected
 
 ## Context
 

--- a/architecture-decision-record/0003-use-aws-sso.md
+++ b/architecture-decision-record/0003-use-aws-sso.md
@@ -4,7 +4,7 @@ Date: 2020-10-21
 
 ## Status
 
-🤔 Proposed, supersedes [0002 - Use IAM Federated Access](0002-use-iam-federated-access.md)
+✅ Accepted
 
 ## Context
 

--- a/architecture-decision-record/0003-use-aws-sso.md
+++ b/architecture-decision-record/0003-use-aws-sso.md
@@ -16,6 +16,10 @@ Rather than managing the administrative burden of the Joiners, Movers and Leaver
 
 We can, if we wish, still utilise a different service (e.g. GitHub) as a IdP through Auth0, whilst SCIM provisioning with a different IdP (e.g. G-Suite).
 
+We decided to use AWS SSO in favour of [IAM Federated Access](0002-use-iam-federated-access.md) to allow us to centrally manage identities across the Ministry of Justice at the organisational level rather than at a team level.
+
+A further benefit of this is that AWS SSO can be used across all AWS accounts, not just ones provisioned within the Modernisation Platform, as long as the AWS account is part of the AWS organisation.
+
 ## Consequences
 
 ### General consequences

--- a/architecture-decision-record/README.md
+++ b/architecture-decision-record/README.md
@@ -4,9 +4,10 @@ This is our architecture decision log, made during the design and build of the M
 
 ## Table of contents
 1. ✅ [Record architecture decisions](0001-record-architecture-decisions.md)
-1. 🤔 [Use IAM Federated Access](0002-use-iam-federated-access.md)
-1. 🤔 [Use AWS SSO](0003-use-aws-sso.md)
+1. ❌ [Use IAM Federated Access](0002-use-iam-federated-access.md)
+1. ✅ [Use AWS SSO](0003-use-aws-sso.md)
 
 ## Statuses
-- 🤔 Proposed
 - ✅ Accepted
+- ❌ Rejected
+- 🤔 Proposed


### PR DESCRIPTION
Resolves #69 

As a team, we discussed advantages and disadvantages for using AWS SSO or IAM Federated Access and we've opted to use AWS SSO, for a centrally managed JML process for access into AWS accounts and shared operational services for the Modernisation Platform.

A further benefit of this is that AWS SSO can be used across _all_ AWS accounts, not just ones provisioned within the Modernisation Platform, as long as the AWS account is part of the AWS organisation.