### PR TITLE
Rename Modernisation Platform core to core

### DIFF
--- a/environments/core.json
+++ b/environments/core.json
@@ -1,5 +1,5 @@
 {
-  "name": "modernisation-platform-core",
+  "name": "core",
   "environments": ["logging", "security", "network-services", "shared-services"],
   "tags": {
     "application": "modernisation-platform",


### PR DESCRIPTION
Resolves an issue where the concat of the application name and environment names can't exceed 36 characters.