### PR TITLE
Restrict workflow to environments/ path and hide output for terraform init

### DIFF
--- a/.github/workflows/create-accounts.yml
+++ b/.github/workflows/create-accounts.yml
@@ -2,6 +2,8 @@ name: terraform
 
 on:
   push:
+    paths:
+      - 'environments/**.json'
     branches:
       - main
 

--- a/scripts/create-accounts.sh
+++ b/scripts/create-accounts.sh
@@ -28,7 +28,7 @@ get_all_local_environment_definitions () {
 
 get_all_remote_workspace_definitions () {
   cd terraform/environments/bootstrap || exit
-  terraform init -input=false
+  output=$(terraform init -input=false 2>&1) || (echo "$output" && false)
   terraform workspace list > ../../../tmp/remote-workspaces.tmp
   cat ../../../tmp/remote-workspaces.tmp | grep "\S" | grep -v "default" | tr -d "* " | tee ../../../tmp/remote-workspaces.tmp
   cd ../../.. || exit


### PR DESCRIPTION
This changes the workflow to only run when a new environment definition is added, and hides the output from the `terraform init` command.