### PR TITLE
Add network-services-cidr-allocation repository

### DIFF
--- a/terraform/github/main.tf
+++ b/terraform/github/main.tf
@@ -106,6 +106,16 @@ module "terraform-module-trusted-advisor" {
   ]
 }
 
+module "terraform-module-network-services-cidr-allocation" {
+  source      = "./modules/repository"
+  name        = "modernisation-platform-terraform-network-services-cidr-allocation"
+  description = "Module for CIDR allocation storage and retrieval"
+  topics = [
+    "aws",
+    "network-services"
+  ]
+}
+
 # Teams and their access to the above repositories
 module "core-team" {
   source      = "./modules/team"
@@ -119,6 +129,7 @@ module "core-team" {
     module.terraform-module-iam-superadmins.repository.id,
     module.terraform-module-s3-bucket-replication-role.repository.id,
     module.terraform-module-s3-bucket.repository.id,
-    module.terraform-module-trusted-advisor.repository.id
+    module.terraform-module-trusted-advisor.repository.id,
+    module.terraform-module-network-services-cidr-allocation.repository.id
   ]
 }


### PR DESCRIPTION
Adds the network-services-cidr-allocation repository to be managed by the Modernisation Platform.