### PR TITLE
Changes tag key from global_resources to tags

### DIFF
--- a/terraform/modernisation-platform-account/dynamodb.tf
+++ b/terraform/modernisation-platform-account/dynamodb.tf
@@ -1,12 +1,16 @@
 resource "aws_dynamodb_table" "state-lock" {
   name         = "modernisation-platform-terraform-state-lock"
-  hash_key     = "LockID"
   billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "LockID"
 
   attribute {
     name = "LockID"
     type = "S"
   }
 
-  tags = local.global_resources
+  server_side_encryption {
+    enabled = true
+  }
+
+  tags = local.tags
 }

--- a/terraform/modernisation-platform-account/locals.tf
+++ b/terraform/modernisation-platform-account/locals.tf
@@ -3,12 +3,11 @@ data "aws_regions" "current" {}
 data "aws_caller_identity" "current" {}
 
 locals {
-  global_resources = {
+  root_account = data.aws_organizations_organization.root_account
+  tags = {
     business-unit = "Platforms"
     application   = "Modernisation Platform"
     is-production = true
     owner         = "Modernisation Platform: modernisation-platform@digital.justice.gov.uk"
   }
-  root_account    = data.aws_organizations_organization.root_account
-  account_regions = data.aws_regions.current.names
 }

--- a/terraform/modernisation-platform-account/providers.tf
+++ b/terraform/modernisation-platform-account/providers.tf
@@ -104,7 +104,7 @@ module "baselines-modernisation-platform" {
     aws.us-west-2      = aws.modernisation-platform-us-west-2
   }
   root_account_id = local.root_account.master_account_id
-  tags            = local.global_resources
+  tags            = local.tags
 }
 
 module "trusted-advisor-modernisation-platform" {

--- a/terraform/modernisation-platform-account/route53.tf
+++ b/terraform/modernisation-platform-account/route53.tf
@@ -1,4 +1,4 @@
 resource "aws_route53_zone" "modernisation-platform" {
   name = "modernisation-platform.service.justice.gov.uk"
-  tags = local.global_resources
+  tags = local.tags
 }

--- a/terraform/modernisation-platform-account/s3.tf
+++ b/terraform/modernisation-platform-account/s3.tf
@@ -6,7 +6,7 @@ module "state-bucket" {
   bucket_policy        = data.aws_iam_policy_document.allow-state-access-from-root-account.json
   bucket_name          = "modernisation-platform-terraform-state"
   replication_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/AWSS3BucketReplication"
-  tags                 = local.global_resources
+  tags                 = local.tags
 }
 
 # Allow access to the bucket from the MoJ root account

--- a/terraform/modernisation-platform-account/vpc.tf
+++ b/terraform/modernisation-platform-account/vpc.tf
@@ -1,15 +1,15 @@
 # Subnets
 resource "aws_default_subnet" "default_aza" {
   availability_zone = "eu-west-2a"
-  tags              = local.global_resources
+  tags              = local.tags
 }
 
 resource "aws_default_subnet" "default_azb" {
   availability_zone = "eu-west-2b"
-  tags              = local.global_resources
+  tags              = local.tags
 }
 
 resource "aws_default_subnet" "default_azc" {
   availability_zone = "eu-west-2c"
-  tags              = local.global_resources
+  tags              = local.tags
 }


### PR DESCRIPTION
As we've moved this out of `global_resources`, I thought it'd be good to tidy up the tag key that's used.