### PR TITLE
Add or update versions.tf files in preparation for Terraform 0.14

### DIFF
--- a/terraform/environments/bichard7/versions.tf
+++ b/terraform/environments/bichard7/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/terraform/environments/bootstrap/versions.tf
+++ b/terraform/environments/bootstrap/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/terraform/environments/core-logging/versions.tf
+++ b/terraform/environments/core-logging/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/terraform/environments/core-network-services/versions.tf
+++ b/terraform/environments/core-network-services/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/terraform/environments/core-sandbox/versions.tf
+++ b/terraform/environments/core-sandbox/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/terraform/environments/core-security/versions.tf
+++ b/terraform/environments/core-security/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/terraform/environments/core-shared-services/versions.tf
+++ b/terraform/environments/core-shared-services/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/terraform/environments/remote-supervision/versions.tf
+++ b/terraform/environments/remote-supervision/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/terraform/environments/versions.tf
+++ b/terraform/environments/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.5"
+  required_version = ">= 0.13"
   required_providers {
     aws = {
       version = ">= 3.13.0"

--- a/terraform/modernisation-platform-account/versions.tf
+++ b/terraform/modernisation-platform-account/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.5"
+  required_version = ">= 0.13"
   required_providers {
     aws = {
       version = ">= 3.13.0"


### PR DESCRIPTION
This pins the Terraform version to a minimum of 0.13 in preparation for the release of Terraform 0.14.

Labelled as a bug because if you run any of these configurations using Terraform 0.12, you get a sporadic phantom resource change that doesn't actually do anything.