### PR TITLE
Remove name key in env definitions and update create_accounts to use filename instead

### DIFF
--- a/environments/bichard7.json
+++ b/environments/bichard7.json
@@ -1,5 +1,4 @@
 {
-  "name": "bichard7",
   "environments": ["dev-current", "dev-next", "test-current", "test-next", "shared", "sandbox-a", "sandbox-b", "sandbox-c"],
   "tags": {
     "application": "bichard7",

--- a/environments/core-logging.json
+++ b/environments/core-logging.json
@@ -1,5 +1,4 @@
 {
-  "name": "core-logging",
   "environments": ["production"],
   "tags": {
     "application": "modernisation-platform",

--- a/environments/core-network-services.json
+++ b/environments/core-network-services.json
@@ -1,5 +1,4 @@
 {
-  "name": "core-network-services",
   "environments": ["production"],
   "tags": {
     "application": "modernisation-platform",

--- a/environments/core-sandbox.json
+++ b/environments/core-sandbox.json
@@ -1,5 +1,4 @@
 {
-  "name": "core-sandbox",
   "environments": ["dev"],
   "tags": {
     "application": "core-sandbox",

--- a/environments/core-security.json
+++ b/environments/core-security.json
@@ -1,5 +1,4 @@
 {
-  "name": "core-security",
   "environments": ["production"],
   "tags": {
     "application": "modernisation-platform",

--- a/environments/core-shared-services.json
+++ b/environments/core-shared-services.json
@@ -1,5 +1,4 @@
 {
-  "name": "core-shared-services",
   "environments": ["production"],
   "tags": {
     "application": "modernisation-platform",

--- a/environments/remote-supervision.json
+++ b/environments/remote-supervision.json
@@ -1,5 +1,4 @@
 {
-  "name": "remote-supervision",
   "environments": ["non-production", "production"],
   "tags": {
     "application": "remote-supervision",

--- a/scripts/check-environment-definitions.js
+++ b/scripts/check-environment-definitions.js
@@ -28,7 +28,7 @@ module.exports = async ({ github, context }) => {
       message.push('### ❗ Required')
 
       missingRequired.forEach(configuration => {
-        message.push(`\`${configuration.name}\` is missing: \`${configuration.missing.required.join('`, `')}\``)
+        message.push(`\`${configuration.source}\` is missing: \`${configuration.missing.required.join('`, `')}\``)
       })
 
       message.push('Please refer to the Ministry of Justice [Tagging Guidelines](https://ministryofjustice.github.io/technical-guidance/documentation/standards/documenting-infrastructure-owners.html) for more information.')

--- a/scripts/check-environment-definitions.js
+++ b/scripts/check-environment-definitions.js
@@ -5,7 +5,7 @@ module.exports = async ({ github, context }) => {
     // Get all configuration files
     const configurations = await utilities.getFilesRecursively('./environments').then(configuration => configuration.map(application => {
       // Ensure each configuration has the correct keys and/or tags
-      const missingConfiguration = utilities.checkKeys(application, ['name', 'environments', 'tags'])
+      const missingConfiguration = utilities.checkKeys(application, ['environments', 'tags'])
       const missingRequiredTags = utilities.checkKeys(application.tags, ['business-unit', 'application', 'owner'])
 
       return {

--- a/scripts/create-accounts.sh
+++ b/scripts/create-accounts.sh
@@ -23,7 +23,7 @@ create_accounts () {
 }
 
 get_all_local_environment_definitions () {
-  cat environments/*.json | jq -r '. | .name + "-" + .environments[]' > tmp/local-environments.tmp
+  jq -r '(input_filename | ltrimstr("environments/") | rtrimstr(".json")) + "-" + .environments[]' environments/*.json > tmp/local-environments.tmp
 }
 
 get_all_remote_workspace_definitions () {


### PR DESCRIPTION
Removes the name key from environment definitions in favour of using the filename, and updates the `create-accounts.sh` script to use the input_filename provided by `jq`.

This is in preparation for #163.