### PR TITLE
Add a team script for an easier way to see differences between bootstrapped environments

### DIFF
--- a/scripts/internal/loop-through-bootstrap-workspaces-and-plan.sh
+++ b/scripts/internal/loop-through-bootstrap-workspaces-and-plan.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+prepare_terraform () {
+  # We can buffer output (stdout and stderr) unless terraform exits with a non-zero code, so we don't unneccessarily
+  # log the output of these commands in our CI/CD runner
+  echo "Running terraform init for $called_function"
+  output=$(terraform init -input=false 2>&1) || (echo "$output" && false)
+  echo "Running terraform validate for $called_function"
+  output=$(terraform validate -no-color 2>&1) || (echo "$output" && false)
+}
+
+run_terraform_plan () {
+  # We can buffer output (stdout and stderr) unless terraform exits with a non-zero code, so we don't unneccessarily
+  # log the output of these commands in our CI/CD runner
+  echo "Running terraform refresh for $called_function (this may take a while)"
+  output=$(terraform refresh 2>&1) || (echo $$output && false)
+  echo "Running terraform plan for $called_function (this may take a while)"
+  terraform plan -refresh=false -input=false
+}
+
+get_remote_workspaces() {
+  cd terraform/environments/bootstrap || exit &&
+  called_function="prepare_terraform, in the bootstrap directory"
+  prepare_terraform &&
+  terraform workspace select default
+  terraform workspace list > ../../../tmp/bootstrap-workspaces.tmp
+  cat ../../../tmp/bootstrap-workspaces.tmp | grep "\S" | grep -v "default" | tr -d "* " | tee ../../../tmp/bootstrap-workspaces.tmp
+  cd ../../..
+}
+
+loop_through_workspaces_and_plan() {
+  cd terraform/environments/bootstrap || exit &&
+  while read -r line; do
+    called_function="$line"
+    terraform workspace select $line &&
+    run_terraform_plan
+  done < ../../../tmp/bootstrap-workspaces.tmp
+  cd ../../..
+}
+
+main () {
+  mkdir -p tmp/ &&
+  get_remote_workspaces &&
+  loop_through_workspaces_and_plan
+  rm -r tmp/
+}
+
+main

--- a/scripts/internal/loop-through-bootstrap-workspaces-and-plan.sh
+++ b/scripts/internal/loop-through-bootstrap-workspaces-and-plan.sh
@@ -41,7 +41,7 @@ loop_through_workspaces_and_plan() {
 main () {
   mkdir -p tmp/ &&
   get_remote_workspaces &&
-  loop_through_workspaces_and_plan
+  loop_through_workspaces_and_plan &&
   rm -r tmp/
 }
 


### PR DESCRIPTION
This script will `cd` into the `terraform/environments/bootstrap` folder, get a list of workspaces, and run `terraform plan` in all of them synchronously.

Previously you would have had to do this manually for each terraform workspace, whereas this does it for you so you can start running it and leave it until it's finished. It outputs something similar to the below in your shell:

```Running terraform init for prepare_terraform, in the bootstrap directory
Running terraform validate for prepare_terraform, in the bootstrap directory
Switched to workspace "default".
Switched to workspace "bichard7-dev-current".
Running terraform refresh for bichard7-dev-current (this may take a while)
Running terraform plan for bichard7-dev-current (this may take a while)

No changes. Infrastructure is up-to-date.

This means that Terraform did not detect any differences between your
configuration and real physical resources that exist. As a result, no
actions need to be performed.

Switched to workspace "bichard7-dev-next".
Running terraform refresh for bichard7-dev-next (this may take a while)
```
etc.

This doesn't actually apply any changes, and shouldn't be run as part of a CI/CD process as the `terraform plan` may contain secrets that are output to shell.