### PR TITLE
Remote Supervision: NS delegation

### DIFF
--- a/terraform/environments/core-network-services/route53.tf
+++ b/terraform/environments/core-network-services/route53.tf
@@ -1,4 +1,37 @@
+locals {
+  modernisation-platform-domain = "modernisation-platform.service.justice.gov.uk"
+}
+
 resource "aws_route53_zone" "modernisation-platform" {
-  name = "modernisation-platform.service.justice.gov.uk"
+  name = local.modernisation-platform-domain
   tags = local.tags
+}
+
+# Remote Supervision NS delegation
+resource "aws_route53_record" "remote-supervision-production" {
+  allow_overwrite = true
+  name            = "remote-supervision-production.${local.modernisation-platform-domain}"
+  ttl             = 30
+  type            = "NS"
+  zone_id         = aws_route53_zone.modernisation-platform.zone_id
+  records = [
+    "ns-1127.awsdns-12.org.",
+    "ns-123.awsdns-15.com.",
+    "ns-643.awsdns-16.net.",
+    "ns-1848.awsdns-39.co.uk."
+  ]
+}
+
+resource "aws_route53_record" "remote-supervision-non-production" {
+  allow_overwrite = true
+  name            = "remote-supervision-non-production.${local.modernisation-platform-domain}"
+  ttl             = 30
+  type            = "NS"
+  zone_id         = aws_route53_zone.modernisation-platform.zone_id
+  records = [
+    "ns-1127.awsdns-12.org.",
+    "ns-123.awsdns-15.com.",
+    "ns-643.awsdns-16.net.",
+    "ns-1848.awsdns-39.co.uk."
+  ]
 }

--- a/terraform/environments/core-network-services/route53.tf
+++ b/terraform/environments/core-network-services/route53.tf
@@ -15,10 +15,10 @@ resource "aws_route53_record" "remote-supervision-production" {
   type            = "NS"
   zone_id         = aws_route53_zone.modernisation-platform.zone_id
   records = [
-    "ns-1127.awsdns-12.org.",
-    "ns-123.awsdns-15.com.",
-    "ns-643.awsdns-16.net.",
-    "ns-1848.awsdns-39.co.uk."
+    "ns-1009.awsdns-62.net.",
+    "ns-1104.awsdns-10.org.",
+    "ns-316.awsdns-39.com.",
+    "ns-1876.awsdns-42.co.uk"
   ]
 }
 
@@ -29,9 +29,9 @@ resource "aws_route53_record" "remote-supervision-non-production" {
   type            = "NS"
   zone_id         = aws_route53_zone.modernisation-platform.zone_id
   records = [
-    "ns-1127.awsdns-12.org.",
-    "ns-123.awsdns-15.com.",
-    "ns-643.awsdns-16.net.",
-    "ns-1848.awsdns-39.co.uk."
+    "ns-897.awsdns-48.net.",
+    "ns-1217.awsdns-24.org.",
+    "ns-77.awsdns-09.com.",
+    "ns-1636.awsdns-12.co.uk."
   ]
 }

--- a/terraform/environments/core-network-services/route53.tf
+++ b/terraform/environments/core-network-services/route53.tf
@@ -10,7 +10,7 @@ resource "aws_route53_zone" "modernisation-platform" {
 # Remote Supervision NS delegation
 resource "aws_route53_record" "remote-supervision-production" {
   allow_overwrite = true
-  name            = "remote-supervision-production.${local.modernisation-platform-domain}"
+  name            = "rs-production.${local.modernisation-platform-domain}"
   ttl             = 30
   type            = "NS"
   zone_id         = aws_route53_zone.modernisation-platform.zone_id
@@ -24,7 +24,7 @@ resource "aws_route53_record" "remote-supervision-production" {
 
 resource "aws_route53_record" "remote-supervision-non-production" {
   allow_overwrite = true
-  name            = "remote-supervision-non-production.${local.modernisation-platform-domain}"
+  name            = "rs-non-production.${local.modernisation-platform-domain}"
   ttl             = 30
   type            = "NS"
   zone_id         = aws_route53_zone.modernisation-platform.zone_id


### PR DESCRIPTION
Delegates `rs-production.modernisation-platform.service.justice.gov.uk` and `rs-non-production.modernisation-platform.service.justice.gov.uk` to the Remote Supervision accounts.

There is a limit on how long an initial FQDN can be in ACM, so we've shortened these to under 64 characters until the MP platform works on centralising domain and ACM management.