### PR TITLE
Update JotW tag

### DIFF
--- a/environments/justice-on-the-web.json
+++ b/environments/justice-on-the-web.json
@@ -3,6 +3,6 @@
   "tags": {
     "application": "justice-on-the-web-sandbox",
     "business-unit": "HQ",
-    "owner": "Justice on the Web WordPress team: wordpress@digital.justice.gov.uk"
+    "owner": "Justice on the Web (WordPress): wordpress@digital.justice.gov.uk"
   }
 }

--- a/terraform/environments/bootstrap/.terraform.lock.hcl
+++ b/terraform/environments/bootstrap/.terraform.lock.hcl
@@ -1,0 +1,19 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "3.20.0"
+  hashes = [
+    "h1:Wk7JYiEIslHQorVPWnofRNYUAjyro6IehY/d/Yfmbr8=",
+    "zh:1b53d410c21332750be561092d412d83014fa0656e00f940944d2e7b07b1b9ec",
+    "zh:307bf780790462fe547fe23f8e38a4c178437f3a9dd725f9aa63c6d8c6cbf25d",
+    "zh:5818a978b9766b23a190716b85aad3a4731d33ddb8a81080cf3ef6e4bd68a003",
+    "zh:5f68eb4779208e21d9657b9ff492aa5f6496efea7994bdec1d302f88b0b65f34",
+    "zh:6028208a7b3738801cd9f3376efa40a1e55f4bb8184584f7387b08c054e43c4c",
+    "zh:8130269e2d8c80ea9136dcd26cfeb4e1fac83bda4aab0db70f36651a7b22365d",
+    "zh:9dd4a07beb89606e051b64ab05d75e1c1616389871a55065676b370aebaed8e5",
+    "zh:b7194500db431ba862ea8008db56a5decececda1f904ed8842d2b0f1a04eea9d",
+    "zh:ec214b7341137e6dd47754b843ed16fe3e1d32832537042ee81a64a3ccdbb4bd",
+    "zh:ec2973e04f3cb853895e51f6ec56660574610b860ee3de669ccbb1f04d1089c9",
+  ]
+}


### PR DESCRIPTION
Updates the JotW tag which will: kick-off the create-accounts workflow; after we [upgraded to Terraform 0.14.1 for environment creation](https://github.com/ministryofjustice/modernisation-platform/pull/181).