### PR TITLE
Remove brackets from tags (they're invalid)

### DIFF
--- a/environments/justice-on-the-web.json
+++ b/environments/justice-on-the-web.json
@@ -3,6 +3,6 @@
   "tags": {
     "application": "justice-on-the-web-sandbox",
     "business-unit": "HQ",
-    "owner": "Justice on the Web (WordPress): wordpress@digital.justice.gov.uk"
+    "owner": "Justice on the Web WordPress: wordpress@digital.justice.gov.uk"
   }
 }


### PR DESCRIPTION
Using brackets within a tag value causes AWS to error as they're invalid.