### PR TITLE
Require Terraform 0.14.2 for account bootstrapping

### DIFF
--- a/.github/workflows/create-accounts.yml
+++ b/.github/workflows/create-accounts.yml
@@ -19,6 +19,6 @@ jobs:
       - uses: actions/checkout@main
       - uses: hashicorp/setup-terraform@v1
         with:
-          terraform_version: 0.14.1
+          terraform_version: 0.14.2
       - name: Run scripts/create-accounts.sh
         run: sh scripts/create-accounts.sh

--- a/terraform/environments/bootstrap/versions.tf
+++ b/terraform/environments/bootstrap/versions.tf
@@ -1,8 +1,9 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      version = ">= 3.20.0"
+      source  = "hashicorp/aws"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 0.14.2"
 }

--- a/terraform/environments/versions.tf
+++ b/terraform/environments/versions.tf
@@ -1,8 +1,8 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14.2"
   required_providers {
     aws = {
-      version = ">= 3.13.0"
+      version = ">= 3.20.0"
       source  = "hashicorp/aws"
     }
     local = {


### PR DESCRIPTION
Enforces the requirement for Terraform 0.14.2 for bootstrapping accounts and the GitHub actions workflow.