### PR TITLE
Upgrade GitHub resources to use Terraform 0.14.2

### DIFF
--- a/terraform/github/.terraform.lock.hcl
+++ b/terraform/github/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/github" {
+  version     = "4.1.0"
+  constraints = ">= 4.1.0"
+  hashes = [
+    "h1:nOqwWaZWGnOchhT8DWGrOD1cW6/ylxfhPNwx3QxlERQ=",
+    "zh:12a12ef18103cb942ae185c2faaa51973f9f55adf480254866169de0c1a2f870",
+    "zh:4f90da2eeed0182b68cd47b76f110eb35b5f0ce0ea2bdfde60cbdbad350910c6",
+    "zh:509f584e57e7960cd128e0b77eeefd8968e0e5f3dbc6f86f031f007720e817fc",
+    "zh:63c2b58b66ea7868fba323a4899a82bcdf43a3a4c7b2fdd2e241d94aebda996e",
+    "zh:7e7b72d1378acb21fdf116703ff865ebabe9fc014da89f93dfb3c505d5d0907f",
+    "zh:8b74873ce8eeaed0bd7e37c4bd0a826e25404ffc5b9f7126e923dee3596d8634",
+    "zh:8bf2aeaee8744f0140d5bfb850e958d0484b3657878e7d5f9e798ec2125300bd",
+    "zh:cedb3020864da3ec7d34d170747b682fd7e3b1a9f37518a871e4b6a60d4411e2",
+    "zh:d4b34183739236a22e38ce1e662495c9dbeb4f2065a607b6209e8427a30ca571",
+    "zh:e5a24e07208a0adc37bb54c510224a2dc56aa14adb7bb86da433ef86b4f6d0b3",
+  ]
+}

--- a/terraform/github/versions.tf
+++ b/terraform/github/versions.tf
@@ -1,8 +1,8 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14.2"
   required_providers {
     github = {
-      version = ">= 4.0.0"
+      version = ">= 4.1.0"
       source  = "hashicorp/github"
     }
   }


### PR DESCRIPTION
Requires Terraform 0.14.2 to run the Terraform for GitHub resoures.