### PR TITLE
Restrict baselines to certain regions for the Modernisation Platform account

### DIFF
--- a/terraform/modernisation-platform-account/providers.tf
+++ b/terraform/modernisation-platform-account/providers.tf
@@ -78,8 +78,19 @@ provider "aws" {
   alias  = "modernisation-platform-us-west-2"
 }
 
+locals {
+  enabled_baseline_regions = [
+    "eu-central-1", # Europe (Frankfurt)
+    "eu-north-1",   # Europe (Stockholm)
+    "eu-west-1",    # Europe (Ireland)
+    "eu-west-2",    # Europe (London)
+    "eu-west-3",    # Europe (Paris)
+    "us-east-1",    # US East (N. Virginia) (for global services)
+  ]
+}
+
 module "baselines-modernisation-platform" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=regional-enablement"
   providers = {
     # Default and replication regions
     aws                    = aws.modernisation-platform-eu-west-2
@@ -103,6 +114,28 @@ module "baselines-modernisation-platform" {
     aws.us-west-1      = aws.modernisation-platform-us-west-1
     aws.us-west-2      = aws.modernisation-platform-us-west-2
   }
+
+  # Regions to enable IAM Access Analyzer in
+  enabled_access_analyzer_regions = local.enabled_baseline_regions
+
+  # Regions to enable AWS Backup in
+  enabled_backup_regions = local.enabled_baseline_regions
+
+  # Regions to enable AWS Config in
+  enabled_config_regions = local.enabled_baseline_regions
+
+  # Regions to enable EBS encryption in
+  enabled_ebs_encryption_regions = local.enabled_baseline_regions
+
+  # Regions to enable GuardDuty in
+  enabled_guardduty_regions = local.enabled_baseline_regions
+
+  # Regions to enable Security Hub in
+  enabled_securityhub_regions = local.enabled_baseline_regions
+
+  # Regions to enable default VPC configuration and VPC Flow Logs in
+  enabled_vpc_regions = local.enabled_baseline_regions
+
   root_account_id = local.root_account.master_account_id
   tags            = local.tags
 }


### PR DESCRIPTION
This PR updates the `modernisation-platform-account` Terraform configuration to use the `regional-enablement` branch of the `modernisation-platform-terraform-baselines`.

This is to allow us to test the [organisational Service Control Policy](https://github.com/ministryofjustice/aws-root-account/pull/95) that restricts regional services to EU and us-east-1 only, and removes superfluous regional enablement of things like GuardDuty, etc.

Note that this only affects the Modernisation Platform account _and not_ any of the environments configured within.