### PR TITLE
Change shared services prefix names

### DIFF
--- a/terraform/environments/core-shared-services/vpc.tf
+++ b/terraform/environments/core-shared-services/vpc.tf
@@ -1,6 +1,6 @@
 locals {
   vpcs = {
-    live = {
+    live_data = {
       cidr = {
         vpc = "10.231.0.0/19"
         subnets = {
@@ -22,7 +22,7 @@ locals {
         }
       }
     }
-    non_live = {
+    non_live_data = {
       cidr = {
         vpc = "10.231.32.0/19"
         subnets = {


### PR DESCRIPTION
- update shared-services json file to change prefix name to live-data
  and non_live_data. Existing names were live and non_live.

A decision has been made to have two environments in our core
accounts which will align with two Transit Gateway routing tables.