### PR TITLE
Change live and non-live data refs in core-vpc

### DIFF
--- a/terraform/modules/ec2-tgw-attachment/main.tf
+++ b/terraform/modules/ec2-tgw-attachment/main.tf
@@ -2,7 +2,7 @@ provider "aws" {
   alias = "core-network-services"
 }
 
-resource "aws_ec2_transit_gateway_vpc_attachment" "live" {
+resource "aws_ec2_transit_gateway_vpc_attachment" "live_data" {
   subnet_ids         = var.subnet_ids
   transit_gateway_id = var.tgw_id
   vpc_id             = var.vpc_id
@@ -16,18 +16,18 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "live" {
   }
 }
 
-resource "aws_ec2_transit_gateway_route_table_association" "live" {
+resource "aws_ec2_transit_gateway_route_table_association" "live_data" {
   provider = aws.core-network-services
 
-  transit_gateway_attachment_id  = aws_ec2_transit_gateway_vpc_attachment.live.id
-  transit_gateway_route_table_id = data.aws_ec2_transit_gateway_route_table.live.id
+  transit_gateway_attachment_id  = aws_ec2_transit_gateway_vpc_attachment.live_data.id
+  transit_gateway_route_table_id = data.aws_ec2_transit_gateway_route_table.live_data.id
 }
 
-data "aws_ec2_transit_gateway_route_table" "live" {
+data "aws_ec2_transit_gateway_route_table" "live_data" {
   provider = aws.core-network-services
   filter {
     name   = "tag:Name"
-    values = ["live"]
+    values = ["live_data"]
   }
 
   filter {

--- a/terraform/modules/ec2-tgw-attachment/outputs.tf
+++ b/terraform/modules/ec2-tgw-attachment/outputs.tf
@@ -1,7 +1,7 @@
 output "tgw_vpc_attachment" {
-  value = aws_ec2_transit_gateway_vpc_attachment.live.id
+  value = aws_ec2_transit_gateway_vpc_attachment.live_data.id
 }
 
 output "tgw_route_table" {
-  value = data.aws_ec2_transit_gateway_route_table.live.id
+  value = data.aws_ec2_transit_gateway_route_table.live_data.id
 }

--- a/terraform/modules/vpc-tgw-routing/main.tf
+++ b/terraform/modules/vpc-tgw-routing/main.tf
@@ -17,18 +17,18 @@ data "aws_vpc" "selected" {
 
   filter {
     name   = "tag:Name"
-    values = ["live"]
+    values = ["live_data"]
   }
 }
 
-data "aws_route_table" "live-public" {
+data "aws_route_table" "live_data-public" {
   provider = aws.core-network-services
 
   vpc_id = data.aws_vpc.selected.id
 
   filter {
     name   = "tag:Name"
-    values = ["live-public"]
+    values = ["live_data-public"]
   }
 }
 
@@ -37,7 +37,7 @@ resource "aws_route" "test" {
 
   for_each = tomap(var.subnet_sets)
 
-  route_table_id         = data.aws_route_table.live-public.id
+  route_table_id         = data.aws_route_table.live_data-public.id
   destination_cidr_block = each.value
   transit_gateway_id     = var.tgw_id
 }


### PR DESCRIPTION
- update live and non-live refs in core-vpc to match the names used in
  core-network-services

This change is required to allow the use of the new naming convention in
network-services