### PR TITLE
Clean-up EC2 Transit Gateway attachment module

### DIFF
--- a/terraform/modules/ec2-tgw-attachment/main.tf
+++ b/terraform/modules/ec2-tgw-attachment/main.tf
@@ -2,36 +2,45 @@ provider "aws" {
   alias = "core-network-services"
 }
 
-resource "aws_ec2_transit_gateway_vpc_attachment" "live_data" {
+# Attach provided subnet IDs and VPC to the provided Transit Gateway ID
+resource "aws_ec2_transit_gateway_vpc_attachment" "default" {
   subnet_ids         = var.subnet_ids
-  transit_gateway_id = var.tgw_id
+  transit_gateway_id = var.transit_gateway_id
   vpc_id             = var.vpc_id
 
-  # transit_gateway_default_route_table_association = false
-  # transit_gateway_default_route_table_propagation = false
+  appliance_mode_support = "disable"
+  dns_support            = "enable"
+  ipv6_support           = "disable"
 
-  tags = {
-    Name = "terraform-example"
-    Side = "Creator"
-  }
+  # You can't change these with a RAM-shared Transit Gateway, but we'll
+  # leave them here to be explicit.
+  transit_gateway_default_route_table_association = true
+  transit_gateway_default_route_table_propagation = true
+
+  tags = merge(var.tags, {
+    Name = "shared-transit-gateway-attachment"
+  })
 }
 
-resource "aws_ec2_transit_gateway_route_table_association" "live_data" {
+# Look up route tables to associate with
+data "aws_ec2_transit_gateway_route_table" "default" {
   provider = aws.core-network-services
 
-  transit_gateway_attachment_id  = aws_ec2_transit_gateway_vpc_attachment.live_data.id
-  transit_gateway_route_table_id = data.aws_ec2_transit_gateway_route_table.live_data.id
-}
-
-data "aws_ec2_transit_gateway_route_table" "live_data" {
-  provider = aws.core-network-services
   filter {
     name   = "tag:Name"
-    values = ["live_data"]
+    values = [var.type]
   }
 
   filter {
     name   = "transit-gateway-id"
-    values = [var.tgw_id]
+    values = [var.transit_gateway_id]
   }
+}
+
+# Associate the Transit Gateway Route Table with the VPC
+resource "aws_ec2_transit_gateway_route_table_association" "default" {
+  provider = aws.core-network-services
+
+  transit_gateway_attachment_id  = aws_ec2_transit_gateway_vpc_attachment.default.id
+  transit_gateway_route_table_id = data.aws_ec2_transit_gateway_route_table.default.id
 }

--- a/terraform/modules/ec2-tgw-attachment/outputs.tf
+++ b/terraform/modules/ec2-tgw-attachment/outputs.tf
@@ -1,7 +1,7 @@
 output "tgw_vpc_attachment" {
-  value = aws_ec2_transit_gateway_vpc_attachment.live_data.id
+  value = aws_ec2_transit_gateway_vpc_attachment.default.id
 }
 
 output "tgw_route_table" {
-  value = data.aws_ec2_transit_gateway_route_table.live_data.id
+  value = data.aws_ec2_transit_gateway_route_table.default.id
 }

--- a/terraform/modules/ec2-tgw-attachment/variables.tf
+++ b/terraform/modules/ec2-tgw-attachment/variables.tf
@@ -1,15 +1,30 @@
 variable "subnet_ids" {
-  description = ""
+  description = "Subnet IDs to attach to the Transit Gateway"
   type        = list(string)
 }
 
-variable "tgw_id" {
-  description = ""
+variable "transit_gateway_id" {
+  description = "Transit Gateway ID to attach to"
   type        = string
 
 }
 
 variable "vpc_id" {
-  description = ""
+  description = "VPC ID to attach to the Transit Gateway"
   type        = string
+}
+
+variable "tags" {
+  description = "Tags to attach to resources, where applicable"
+  type        = map(any)
+}
+
+variable "type" {
+  description = "Type of Transit Gateway to attach to"
+  type        = string
+
+  validation {
+    condition     = can(regex("^live_data|non_live_data", var.type))
+    error_message = "Accepted values are live_data, non_live_data."
+  }
 }


### PR DESCRIPTION
Marked as draft due to requiring `terraform state mv`.

This PR cleans up the EC2 Transit Gateway attachment module to allow you to attach to different types of VPCs depending on Terraform workspace (live_data, non_live_data).

It also tags taggable resources with passed-through tags and adds the explicit default options for a TGW attachment.