### PR TITLE
Move the RAM principal association into the EC2 TGW attachment module

### DIFF
--- a/terraform/environments/core-vpc/backend.tf
+++ b/terraform/environments/core-vpc/backend.tf
@@ -26,6 +26,15 @@ provider "aws" {
   region = "eu-west-2"
 }
 
+# AWS provider for core-network-services, which is where our Transit Gateway sits
+provider "aws" {
+  alias  = "core-network-services"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
+  }
+}
+
 # Sample outputs
 ## Using the Modernisation Platform provider
 data "aws_caller_identity" "modernisation-platform" {
@@ -36,13 +45,18 @@ output "modernisation-platform-account-id" {
   value = data.aws_caller_identity.modernisation-platform.account_id
 }
 
+## Using the core-network-services provider
+data "aws_caller_identity" "core-network-services" {
+  provider = aws.core-network-services
+}
+
+output "core-network-services-account-id" {
+  value = data.aws_caller_identity.core-network-services.account_id
+}
+
 ## Using the default provider (specifying nothing)
 data "aws_caller_identity" "current" {}
 
 output "current-account-id" {
   value = data.aws_caller_identity.current.account_id
-}
-
-locals {
-  environment_management = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
 }

--- a/terraform/environments/core-vpc/locals.tf
+++ b/terraform/environments/core-vpc/locals.tf
@@ -1,4 +1,5 @@
 locals {
+  environment_management = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
   tags = {
     business-unit = "Platforms"
     application   = "Modernisation Platform: core-vpc"

--- a/terraform/environments/core-vpc/transit-gateway-attachment.tf
+++ b/terraform/environments/core-vpc/transit-gateway-attachment.tf
@@ -1,27 +1,3 @@
-# Assume a role in the core-network-services account
-provider "aws" {
-  alias  = "core-network-services"
-  region = "eu-west-2"
-  assume_role {
-    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
-  }
-}
-
-# # Create RAM principal assocation for this account
-resource "aws_ram_principal_association" "transit_gateway_association" {
-  provider = aws.core-network-services
-
-  principal          = data.aws_caller_identity.current.account_id
-  resource_share_arn = data.aws_ram_resource_share.transit-gateway-shared.arn
-}
-
-data "aws_ram_resource_share" "transit-gateway-shared" {
-  provider = aws.core-network-services
-
-  name           = "shared-transit-gateway"
-  resource_owner = "SELF"
-}
-
 data "aws_ec2_transit_gateway" "transit-gateway" {
   provider = aws.core-network-services
   filter {
@@ -30,34 +6,21 @@ data "aws_ec2_transit_gateway" "transit-gateway" {
   }
 }
 
-resource "time_sleep" "wait_60_seconds" {
-  create_duration = "60s"
-}
-
-# Create the VPC attachment in the second account...
+# Attach the VPC to the central Transit Gateway
 module "vpc_attachment" {
   for_each = toset(keys(local.vpcs[terraform.workspace]))
   source   = "../../modules/ec2-tgw-attachment"
   providers = {
-    aws                       = aws
-    aws.core-network-services = aws.core-network-services
+    aws.transit-gateway-tenant = aws
+    aws.transit-gateway-host   = aws.core-network-services
   }
 
-  subnet_ids         = module.vpc[each.key].tgw_subnet_ids
-  transit_gateway_id = data.aws_ec2_transit_gateway.transit-gateway.id
-  vpc_id             = module.vpc[each.key].vpc_id
-  type               = local.tags.is-production ? "live_data" : "non_live_data"
-  tags               = local.tags
+  resource_share_name = "shared-transit-gateway"
+  transit_gateway_id  = data.aws_ec2_transit_gateway.transit-gateway.id
+  type                = local.tags.is-production ? "live_data" : "non_live_data"
 
-  depends_on = [
-    aws_ram_principal_association.transit_gateway_association,
-    time_sleep.wait_60_seconds
-  ]
+  subnet_ids = module.vpc[each.key].tgw_subnet_ids
+  vpc_id     = module.vpc[each.key].vpc_id
+
+  tags = local.tags
 }
-
-# This doesn't work on shared TGWs
-# resource "aws_ec2_tag" "retag-transit-gateway" {
-#   resource_id = data.aws_ec2_transit_gateway.transit-gateway.id
-#   key         = "Name"
-#   value       = "Test"
-# }

--- a/terraform/modules/ec2-tgw-attachment/variables.tf
+++ b/terraform/modules/ec2-tgw-attachment/variables.tf
@@ -1,17 +1,11 @@
+variable "resource_share_name" {
+  description = "Resource Access Manager (RAM) resource share name to lookup the Transit Gateway Resource Share"
+  type        = string
+}
+
 variable "subnet_ids" {
   description = "Subnet IDs to attach to the Transit Gateway"
   type        = list(string)
-}
-
-variable "transit_gateway_id" {
-  description = "Transit Gateway ID to attach to"
-  type        = string
-
-}
-
-variable "vpc_id" {
-  description = "VPC ID to attach to the Transit Gateway"
-  type        = string
 }
 
 variable "tags" {
@@ -19,12 +13,22 @@ variable "tags" {
   type        = map(any)
 }
 
+variable "transit_gateway_id" {
+  description = "Transit Gateway ID to attach to"
+  type        = string
+}
+
 variable "type" {
   description = "Type of Transit Gateway to attach to"
   type        = string
 
   validation {
-    condition     = can(regex("^live_data|non_live_data", var.type))
+    condition     = var.type == "live_data" || var.type == "non_live_data"
     error_message = "Accepted values are live_data, non_live_data."
   }
+}
+
+variable "vpc_id" {
+  description = "VPC ID to attach to the Transit Gateway"
+  type        = string
 }


### PR DESCRIPTION
This PR moves the RAM principal association for our shared Transit Gateway into our attachment module.

Marked as draft as it requires a `terraform state mv`.