### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ministryofjustice/modernisation-platform


### PR DESCRIPTION
This adds the [Modernisation Platform](https://github.com/orgs/ministryofjustice/teams/modernisation-platform) team in GitHub as codeowners for this repository.