### PR TITLE
Move secure-baselines workspace_key_prefix to mimic folder structure

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/.terraform.lock.hcl
+++ b/terraform/environments/bootstrap/delegate-access/.terraform.lock.hcl
@@ -2,7 +2,8 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version = "3.24.1"
+  version     = "3.24.1"
+  constraints = ">= 3.20.0"
   hashes = [
     "h1:REyi17e2k8dLY8tyKb13Orwmc3s1S5bNTkleXrkfcPc=",
     "zh:0afc5eb8c187dfb1f6bb1b023c81c79fa845ac07df4dd74e6d0be93aab3e4dfd",

--- a/terraform/environments/bootstrap/delegate-access/versions.tf
+++ b/terraform/environments/bootstrap/delegate-access/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    aws = {
+      version = ">= 3.20.0"
+      source  = "hashicorp/aws"
+    }
+  }
+  required_version = ">= 0.14.2"
+}

--- a/terraform/environments/bootstrap/secure-baselines/backend.tf
+++ b/terraform/environments/bootstrap/secure-baselines/backend.tf
@@ -1,0 +1,12 @@
+terraform {
+  # `backend` blocks do not support variables, so the following are hard-coded here:
+  # - S3 bucket name, which is created in terraform/modernisation-platform-account/s3.tf
+  backend "s3" {
+    acl                  = "bucket-owner-full-control"
+    bucket               = "modernisation-platform-terraform-state"
+    encrypt              = true
+    key                  = "terraform.tfstate"
+    region               = "eu-west-2"
+    workspace_key_prefix = "environments/bootstrap/secure-baselines" # This will store the object as environments/bootstrap/secure-baselines/${workspace}/terraform.tfstate
+  }
+}

--- a/terraform/environments/bootstrap/secure-baselines/main.tf
+++ b/terraform/environments/bootstrap/secure-baselines/main.tf
@@ -1,17 +1,3 @@
-# Backend
-terraform {
-  # `backend` blocks do not support variables, so the following are hard-coded here:
-  # - S3 bucket name, which is created in s3.tf
-  backend "s3" {
-    acl                  = "bucket-owner-full-control"
-    bucket               = "modernisation-platform-terraform-state"
-    encrypt              = true
-    key                  = "terraform.tfstate"
-    region               = "eu-west-2"
-    workspace_key_prefix = "environments/bootstrap" # This will store the object as environments/bootstrap/${workspace}/terraform.tfstate
-  }
-}
-
 module "baselines" {
   source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=regional-enablement"
   providers = {


### PR DESCRIPTION
This PR moves the secure-baselines `workspace_key_prefix` from `environments/bootstrap` to `environments/bootstrap/secure-baselines`, to mimic the folder structure in this repository.