### PR TITLE
Update tech-docs and workflows to tech-docs 1.1

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,12 +1,8 @@
-name: Publish
+name: Check for broken links
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - "main"
-    paths-ignore:
-      - "docs/**"
+  pull_request:
 
 jobs:
   run:
@@ -15,5 +11,5 @@ jobs:
       image: ministryofjustice/tech-docs-github-pages-publisher:1.1
     steps:
     - uses: actions/checkout@v2
-    - name: Publish
-      run: /publishing-scripts/publish.sh
+    - name: htmlproofer
+      run: /publishing-scripts/publish.sh no-repository-changes

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -3,9 +3,10 @@ name: Check for broken links
 on:
   workflow_dispatch:
   pull_request:
+    paths: 'source/**'
 
 jobs:
-  run:
+  check-links:
     runs-on: ubuntu-latest
     container:
       image: ministryofjustice/tech-docs-github-pages-publisher:1.1

--- a/makefile
+++ b/makefile
@@ -1,8 +1,4 @@
-# Update ROOT_DOCPATH to match your github pages site. By default, this will be
-# /[repository name], e.g. for the repo ministryofjustice/technical-guidance
-# this should be "/technical-guidance"
-
-IMAGE := ministryofjustice/tech-docs-github-pages-publisher:0.8
+IMAGE := ministryofjustice/tech-docs-github-pages-publisher:1.1
 
 # Use this to run a local instance of the documentation site, while editing
 .PHONY: preview


### PR DESCRIPTION
Thanks to @digitalronin for updating tech-docs 👍🏼 

This PR:

- updates `tech-docs-github-pages-publisher` to 1.1, which:
    - fixes a bug where the link checker fails for unpublished pages, as it used the `host` URL rather than a relative link
    - removes the need to set `ROOT_DOCPATH`
- adds a workflow to check links on PRs that change `source` rather than just on push to main