### PR TITLE
Add base Terraform scripts for workflows

### DIFF
--- a/scripts/redact-output.sh
+++ b/scripts/redact-output.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Based on: https://github.com/ministryofjustice/opg-org-infra/blob/main/scripts/redact_output.sh
+
+sed -e 's/AWS_SECRET_ACCESS_KEY".*/<REDACTED>/g' \
+    -e 's/AWS_ACCESS_KEY_ID".*/<REDACTED>/g' \
+    -e 's/$AWS_SECRET_ACCESS_KEY".*/<REDACTED>/g' \
+    -e 's/$AWS_ACCESS_KEY_ID".*/<REDACTED>/g' \
+    -e 's/\[id=.*\]/\[id=<REDACTED>\]/g'

--- a/scripts/terraform-apply.sh
+++ b/scripts/terraform-apply.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# This script runs terraform apply with input set to false and no color outputs, suitable for running as part of a CI/CD pipeline.
+# You need to pass through a Terraform directory as an argument, e.g.
+# sh terraform-apply.sh terraform/environments
+
+# This script pipes the output of terraform apply to ./scripts/redact-output.sh to redact sensitive things, such as AWS keys if they
+# are exposed via terraform apply.
+
+# Make redact-output.sh executable
+chmod +x ./scripts/redact-output.sh
+
+if [ -z "$1" ]; then
+  echo "Unsure where to run terraform, exiting"
+  exit 1
+else
+  terraform -chdir="$1" apply -input=false -no-color -auto-approve | ./scripts/redact-output.sh
+fi

--- a/scripts/terraform-init.sh
+++ b/scripts/terraform-init.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# This script runs terraform init with input set to false and no color outputs, suitable for running as part of a CI/CD pipeline.
+# You need to pass through a Terraform directory as an argument, e.g.
+# sh terraform-init.sh terraform/environments
+
+if [ -z "$1" ]; then
+  echo "Unsure where to run terraform, exiting"
+  exit 1
+else
+  terraform -chdir="$1" init -input=false -no-color
+fi

--- a/scripts/terraform-plan.sh
+++ b/scripts/terraform-plan.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# This script runs terraform plan with input set to false and no color outputs, suitable for running as part of a CI/CD pipeline.
+# You need to pass through a Terraform directory as an argument, e.g.
+# sh terraform-plan.sh terraform/environments
+
+# This script pipes the output of terraform plan to ./scripts/redact-output.sh to redact sensitive things, such as AWS keys if they
+# are exposed via terraform plan.
+
+# Make redact-output.sh executable
+chmod +x ./scripts/redact-output.sh
+
+if [ -z "$1" ]; then
+  echo "Unsure where to run terraform, exiting"
+  exit 1
+else
+  terraform -chdir="$1" plan -input=false -no-color | ./scripts/redact-output.sh
+fi


### PR DESCRIPTION
This adds some base scripts to run Terraform as part of a CI/CD pipeline.

`plan` and `apply` are piped to `redact-output.sh`, to redact `AWS_SECRET_ACCESS_KEY` and `AWS_ACCESS_KEY_ID` if exposed, alongside IDs that may be sensitive.