### PR TITLE
Add template for versions.tf

### DIFF
--- a/terraform/templates/versions.tf
+++ b/terraform/templates/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+  required_version = ">= 0.14.0"
+}


### PR DESCRIPTION
As part of #258 and #262, #263, #264, #265, #266, #267, #268, #269, and #270, I had to manually copy and paste a `versions.tf` file. We can add this to the templates directory to automatically copy across for new environments instead of having to remember 👍🏼 