### PR TITLE
Transit Gateway attachments: correctly set providers and allow tagging of attachments

### DIFF
--- a/terraform/environments/core-vpc/transit-gateway-attachment.tf
+++ b/terraform/environments/core-vpc/transit-gateway-attachment.tf
@@ -21,6 +21,7 @@ module "vpc_attachment" {
 
   subnet_ids = module.vpc[each.key].tgw_subnet_ids
   vpc_id     = module.vpc[each.key].vpc_id
+  vpc_name   = each.key
 
   tags = local.tags
 }

--- a/terraform/modules/ec2-tgw-attachment/variables.tf
+++ b/terraform/modules/ec2-tgw-attachment/variables.tf
@@ -32,3 +32,8 @@ variable "vpc_id" {
   description = "VPC ID to attach to the Transit Gateway"
   type        = string
 }
+
+variable "vpc_name" {
+  description = "VPC name (used for tagging)"
+  type        = string
+}


### PR DESCRIPTION
This PR corrects some provider declarations for data sources to enable you to call it from a different account to what it needs to be run in.

It also introduces a `vpc_name` variable. This allows you to tag Transit Gateway attachments to appear as `${vpc-name}-attachment`, rather than the previously set `shared-transit-gateway-attachment`.

It means our Transit Gateway attachments in `core-vpc-production` list as:
`hmpps-production-attachment`, and
`laa-production-attachment`