### PR TITLE
Update tech-docs-github-pages-publisher to 1.2

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -9,7 +9,7 @@ jobs:
   check-links:
     runs-on: ubuntu-latest
     container:
-      image: ministryofjustice/tech-docs-github-pages-publisher:1.1
+      image: ministryofjustice/tech-docs-github-pages-publisher:1.2
     steps:
     - uses: actions/checkout@v2
     - name: htmlproofer

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
   run:
     runs-on: ubuntu-latest
     container:
-      image: ministryofjustice/tech-docs-github-pages-publisher:1.1
+      image: ministryofjustice/tech-docs-github-pages-publisher:1.2
     steps:
     - uses: actions/checkout@v2
     - name: Publish

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-IMAGE := ministryofjustice/tech-docs-github-pages-publisher:1.1
+IMAGE := ministryofjustice/tech-docs-github-pages-publisher:1.2
 
 # Use this to run a local instance of the documentation site, while editing
 .PHONY: preview


### PR DESCRIPTION
This PR updates [tech-docs-github-pages-publisher](https://github.com/ministryofjustice/tech-docs-github-pages-publisher) from 1.1 to 1.2.