### PR TITLE
Update baseline module reference from regional-enablement to v2.0.0

### DIFF
--- a/terraform/modernisation-platform-account/providers.tf
+++ b/terraform/modernisation-platform-account/providers.tf
@@ -88,7 +88,7 @@ locals {
 }
 
 module "baselines-modernisation-platform" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=regional-enablement"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=v2.0.0"
   providers = {
     # Default and replication regions
     aws                    = aws.modernisation-platform-eu-west-2


### PR DESCRIPTION
Updates the [modernisation-platform-terraform-baselines](https://github.com/ministryofjustice/modernisation-platform-terraform-baselines) from `regional-enablement` to `v2.0.0` for the Modernisation Platform landing zone.