### PR TITLE
Rename shared-transit-gateway to transit-gateway

### DIFF
--- a/terraform/environments/core-network-services/ram.tf
+++ b/terraform/environments/core-network-services/ram.tf
@@ -1,18 +1,13 @@
-# Create a resource share
-resource "aws_ram_resource_share" "shared-transit-gateway" {
-  name                      = "shared-transit-gateway"
+# Create a resource share for the Transit Gateway
+resource "aws_ram_resource_share" "transit-gateway" {
+  name                      = "transit-gateway"
   allow_external_principals = false
 
-  tags = merge(
-    local.tags,
-    {
-      Name = "shared-transit-gateway"
-    },
-  )
+  tags = local.tags
 }
 
-# Attach the Transit Gateway with the resource share
-resource "aws_ram_resource_association" "ram-association" {
+# Attach the Transit Gateway to the resource share
+resource "aws_ram_resource_association" "transit-gateway" {
   resource_arn       = aws_ec2_transit_gateway.transit-gateway.arn
-  resource_share_arn = aws_ram_resource_share.shared-transit-gateway.id
+  resource_share_arn = aws_ram_resource_share.transit-gateway.id
 }

--- a/terraform/environments/core-shared-services/transit-gateway-attachment.tf
+++ b/terraform/environments/core-shared-services/transit-gateway-attachment.tf
@@ -11,7 +11,7 @@ data "aws_ec2_transit_gateway" "transit-gateway" {
 data "aws_ram_resource_share" "transit-gateway-shared" {
   provider = aws.core-network-services
 
-  name           = "shared-transit-gateway"
+  name           = "transit-gateway"
   resource_owner = "SELF"
 }
 
@@ -36,7 +36,7 @@ module "vpc_attachment" {
     aws.transit-gateway-host   = aws.core-network-services
   }
 
-  resource_share_name = "shared-transit-gateway"
+  resource_share_name = "transit-gateway"
   transit_gateway_id  = data.aws_ec2_transit_gateway.transit-gateway.id
   type                = each.key
 

--- a/terraform/environments/core-vpc/transit-gateway-attachment.tf
+++ b/terraform/environments/core-vpc/transit-gateway-attachment.tf
@@ -15,7 +15,7 @@ module "vpc_attachment" {
     aws.transit-gateway-host   = aws.core-network-services
   }
 
-  resource_share_name = "shared-transit-gateway"
+  resource_share_name = "transit-gateway"
   transit_gateway_id  = data.aws_ec2_transit_gateway.transit-gateway.id
   type                = local.tags.is-production ? "live_data" : "non_live_data"
 


### PR DESCRIPTION
This renames references to `shared-transit-gateway` (which is shared via Resource Access Manager) to `transit-gateway`, as it's inferred that it's shared as it's part of a resource share.