### PR TITLE
Expand acronyms and add missing tags

### DIFF
--- a/terraform/modules/core-vpc/outputs.tf
+++ b/terraform/modules/core-vpc/outputs.tf
@@ -8,7 +8,7 @@ output "tgw_subnet_ids" {
   value = [
     for key, value in local.expanded_subnets_with_keys :
     aws_subnet.subnets[key].id
-    if value.type == "tgw"
+    if value.type == "transit-gateway"
   ]
 }
 
@@ -17,6 +17,6 @@ output "non_tgw_subnet_ids" {
   value = [
     for key, value in local.expanded_subnets_with_keys :
     aws_subnet.subnets[key].id
-    if value.type != "tgw"
+    if value.type != "transit-gateway"
   ]
 }


### PR DESCRIPTION
This expands acronyms from:
- IG -> Internet Gateway
- TGW -> Transit Gateway
and  rekeys the Internet Gateway to `default` (rather than `ig`, this module only configures 1).

It adds some missing tags on `aws_cloudwatch_log_group`, and updates the default NACLs to be use `=` rather than `:` as key, value separators to match Terraform and show the correct in-file syntax highlighting for IDEs.