### PR TITLE
Move TGW routes into a separate module for explicit depends_on

### DIFF
--- a/terraform/environments/core-shared-services/.terraform.lock.hcl
+++ b/terraform/environments/core-shared-services/.terraform.lock.hcl
@@ -2,19 +2,19 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version = "3.25.0"
+  version = "3.26.0"
   hashes = [
-    "h1:oyaXLqVhtPnHDnwk2yU9qP4dTgfPHyuo27mX/ljeCTQ=",
-    "zh:2d3c65461bc63ec39bce7b5afdbed9a3b4dd5c2c8ee94616ad1866e24cf9b8f0",
-    "zh:2fb2ea6ccac30b909b603e183433737a30c58ec1f9a6a8b5565f0f051490c07a",
-    "zh:31a5f192c8cf29fb677cd639824f9a685578a2564c6b790517db33ea56229045",
-    "zh:437a12cf9a4d7bc92c9bf14ee7e224d5d3545cbd2154ba113ae82c4bb68edc27",
-    "zh:4bbdc3155a5dea90b2d50adfa460b0759c4dd959efaf7f66b2a0385a53b469b2",
-    "zh:63a8cd523ba31358692a34a06e111d88769576ac6d0e5adad8e0b4ae0a2d8882",
-    "zh:c4301ce86e8cb2c464949bb99e729ffe7b0c55eaf34b82ba526bb5039bca36f3",
-    "zh:c97b84861c6c550b8d2feb12d089660fffbf51dc7d660dcc9d54d4a7b3c2c882",
-    "zh:d6a103570e2d5c387b068fac4b88654dfa21d44ca1bdfa4bc8ab94c88effd71a",
-    "zh:f08cf2faf960a8ca374ac860f37c31c88ed2bab460116ac74678e0591babaac5",
+    "h1:b1qNzEzDHZpnHSOW4fRo1PFC0U2Ft25PKKs9NSDGe3U=",
+    "zh:26043eed36d070ca032cf04bc980c654a25821a8abc0c85e1e570e3935bbfcbb",
+    "zh:2fe68f3f78d23830a04d7fac3eda550eef1f627dfc130486f70a65dc5c254300",
+    "zh:3d66484c608c64678e639db25d63872783ce60363a1246e30317f21c9c23b84b",
+    "zh:46ffd755cfd4cf94fe66342797b5afdcef010a24e126c67fee141b357d393535",
+    "zh:5e96f24357e945c9067cf5e032ad1d003609629c956c2f9f642fefe714e74587",
+    "zh:60c27aca36bb63bf3e865c2193be80ca83b376581d00f9c220af4b013e163c4d",
+    "zh:896f0f22d19d41e71b22f9240b261714c3915b165ddefeb771e7734d69dc47ea",
+    "zh:90de9966cb2fd3e2f326df291595e55d2dd2d90e7d6dd085c2c8691dce82bdb4",
+    "zh:ad05a91a88ceb1d6de5a568f7cc0b0e5bc0a79f3da70bc28c1e7f3750e362d58",
+    "zh:e8c63f59c6465329e1f3357498face3dd7ef10a033df3c366a33aa9e94b46c01",
   ]
 }
 

--- a/terraform/environments/core-shared-services/vpc.tf
+++ b/terraform/environments/core-shared-services/vpc.tf
@@ -28,3 +28,13 @@ module "vpc" {
   tags_common = local.tags
   tags_prefix = each.key
 }
+
+module "core-vpc-tgw-routes" {
+  for_each = local.networking
+  source   = "../../modules/core-vpc-tgw-routes"
+
+  transit_gateway_id = data.aws_ec2_transit_gateway.transit-gateway.id
+  route_table_ids    = module.vpc[each.key].private_route_tables
+
+  depends_on = [module.vpc_attachment]
+}

--- a/terraform/modules/core-vpc-tgw-routes/main.tf
+++ b/terraform/modules/core-vpc-tgw-routes/main.tf
@@ -1,0 +1,10 @@
+resource "aws_route" "private_transit_gateway" {
+  for_each = tomap(var.route_table_ids)
+
+  route_table_id         = each.value
+  destination_cidr_block = "0.0.0.0/0"
+  transit_gateway_id     = var.transit_gateway_id
+}
+
+variable "transit_gateway_id" {}
+variable "route_table_ids" {}

--- a/terraform/modules/core-vpc/main.tf
+++ b/terraform/modules/core-vpc/main.tf
@@ -270,15 +270,3 @@ resource "aws_route" "private_nat" {
   destination_cidr_block = "0.0.0.0/0"
   nat_gateway_id         = aws_nat_gateway.default["${each.value.group}-public-${each.value.az}"].id
 }
-
-resource "aws_route" "private_transit_gateway" {
-  for_each = {
-    for key, value in local.expanded_subnets_with_keys :
-    key => value
-    if value.type != "public" && var.gateway == "transit"
-  }
-
-  route_table_id         = aws_route_table.private[each.key].id
-  destination_cidr_block = "0.0.0.0/0"
-  transit_gateway_id     = var.transit_gateway_id
-}

--- a/terraform/modules/core-vpc/outputs.tf
+++ b/terraform/modules/core-vpc/outputs.tf
@@ -20,3 +20,11 @@ output "non_tgw_subnet_ids" {
     if value.type != "transit-gateway"
   ]
 }
+
+output "private_route_tables" {
+  value = {
+    for key, value in local.expanded_subnets_with_keys :
+    key => aws_route_table.private[key].id
+    if value.type != "public"
+  }
+}


### PR DESCRIPTION
This PR moves the TGW routes from the `core-vpc` module into `core-vpc-tgw-routes`, so you can explicitly `depends_on` the VPC attachment before creating Transit Gateway routes for the core VPC.