### PR TITLE
Update vision.html.md.erb

### DIFF
--- a/source/team/vision.html.md.erb
+++ b/source/team/vision.html.md.erb
@@ -1,9 +1,9 @@
 ---
 title: Our vision
-last_reviewed_on: 2021-01-13
+last_reviewed_on: 2021-01-27
 review_in: 3 months
 ---
 
 # <%= current_page.data.title %>
 
-A single platform to allow us to operate non-cloud-native MoJ services in a unified, scalable way, to allow us to more quickly migrate legacy services to the public cloud.
+A single platform which allows MoJ to modernise services, and run them in a unified, scalable way

--- a/source/team/vision.html.md.erb
+++ b/source/team/vision.html.md.erb
@@ -6,4 +6,4 @@ review_in: 3 months
 
 # <%= current_page.data.title %>
 
-A single platform which allows MoJ to modernise services, and run them in a unified, scalable way
+A single platform which allows the Ministry of Justice to modernise services, and run them in a unified, scalable way.


### PR DESCRIPTION
Drop ‘high tide…’ - useful for talking about the platform socially but not for the headline vision
Drop ‘non-cloud-native’:  aside from the grating double-hyphenation, we don’t want to explicitly exclude cloud-native services which might not fit on Cloud Platform
Be more explicit about the fact we want to modernise as we move, not just lift & shift