### PR TITLE
Update required providers to always specify a minimum AWS provider and Terraform version

### DIFF
--- a/terraform/environments/analytical-platform-management/versions.tf
+++ b/terraform/environments/analytical-platform-management/versions.tf
@@ -1,8 +1,9 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      version = ">= 3.20.0"
+      source  = "hashicorp/aws"
     }
   }
-  required_version = ">= 0.14.0"
+  required_version = ">= 0.14.2"
 }

--- a/terraform/environments/bichard7/versions.tf
+++ b/terraform/environments/bichard7/versions.tf
@@ -1,8 +1,9 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      version = ">= 3.20.0"
+      source  = "hashicorp/aws"
     }
   }
-  required_version = ">= 0.14.0"
+  required_version = ">= 0.14.2"
 }

--- a/terraform/environments/core-logging/versions.tf
+++ b/terraform/environments/core-logging/versions.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      version = ">= 3.20.0"
+      source  = "hashicorp/aws"
     }
   }
   required_version = ">= 0.14.2"

--- a/terraform/environments/core-network-services/versions.tf
+++ b/terraform/environments/core-network-services/versions.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      version = ">= 3.20.0"
+      source  = "hashicorp/aws"
     }
   }
   required_version = ">= 0.14.2"

--- a/terraform/environments/core-sandbox/versions.tf
+++ b/terraform/environments/core-sandbox/versions.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      version = ">= 3.20.0"
+      source  = "hashicorp/aws"
     }
   }
   required_version = ">= 0.14.2"

--- a/terraform/environments/core-security/versions.tf
+++ b/terraform/environments/core-security/versions.tf
@@ -1,8 +1,9 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      version = ">= 3.20.0"
+      source  = "hashicorp/aws"
     }
   }
-  required_version = ">= 0.14.0"
+  required_version = ">= 0.14.2"
 }

--- a/terraform/environments/core-shared-services/versions.tf
+++ b/terraform/environments/core-shared-services/versions.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      version = ">= 3.20.0"
+      source  = "hashicorp/aws"
     }
   }
   required_version = ">= 0.14.2"

--- a/terraform/environments/core-vpc/versions.tf
+++ b/terraform/environments/core-vpc/versions.tf
@@ -1,8 +1,9 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      version = ">= 3.20.0"
+      source  = "hashicorp/aws"
     }
   }
-  required_version = ">= 0.14.0"
+  required_version = ">= 0.14.2"
 }

--- a/terraform/environments/justice-on-the-web/versions.tf
+++ b/terraform/environments/justice-on-the-web/versions.tf
@@ -1,8 +1,9 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      version = ">= 3.20.0"
+      source  = "hashicorp/aws"
     }
   }
-  required_version = ">= 0.14.0"
+  required_version = ">= 0.14.2"
 }

--- a/terraform/environments/remote-supervision/versions.tf
+++ b/terraform/environments/remote-supervision/versions.tf
@@ -1,8 +1,9 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      version = ">= 3.20.0"
+      source  = "hashicorp/aws"
     }
   }
-  required_version = ">= 0.14.0"
+  required_version = ">= 0.14.2"
 }

--- a/terraform/environments/versions.tf
+++ b/terraform/environments/versions.tf
@@ -1,13 +1,9 @@
 terraform {
-  required_version = ">= 0.14.2"
   required_providers {
     aws = {
       version = ">= 3.20.0"
       source  = "hashicorp/aws"
     }
-    random = {
-      version = ">= 3.0.0"
-      source  = "hashicorp/random"
-    }
   }
+  required_version = ">= 0.14.2"
 }

--- a/terraform/modernisation-platform-account/versions.tf
+++ b/terraform/modernisation-platform-account/versions.tf
@@ -1,13 +1,9 @@
 terraform {
-  required_version = ">= 0.14.2"
   required_providers {
     aws = {
       version = ">= 3.20.0"
       source  = "hashicorp/aws"
     }
-    archive = {
-      version = ">= 2.0.0"
-      source  = "hashicorp/archive"
-    }
   }
+  required_version = ">= 0.14.2"
 }

--- a/terraform/templates/versions.tf
+++ b/terraform/templates/versions.tf
@@ -1,8 +1,9 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      version = ">= 3.20.0"
+      source  = "hashicorp/aws"
     }
   }
-  required_version = ">= 0.14.0"
+  required_version = ">= 0.14.2"
 }


### PR DESCRIPTION
This PR updates the templates directory to use a minimum version for:

- Terraform itself, with a minimum version of v0.14.2
- the AWS provider, with a minimum version of v3.20.0

This is to ensure older Terraform versions and AWS providers aren't used, which may cause issues with our configuration. For instance, Terraform 0.14.0 [introduced a bug](https://github.com/hashicorp/terraform/blob/v0.14/CHANGELOG.md#0141-december-08-2020) where ignore_changes doesn't appear to work, forcing some resources to be created, which was fixed in Terraform 0.14.1. Terraform 0.14.1 [also introduced a bug](https://github.com/hashicorp/terraform/blob/v0.14/CHANGELOG.md#0142-december-08-2020) where remote backends were checked for compatibility when they were only used for read rather than write.

By providing an explicit AWS provider version, this change also resolves a bug whereby if you're using the [plugin_cache](https://www.terraform.io/docs/cli/config/config-file.html#provider-plugin-cache) for providers, and you hadn't installed a AWS provider from version 3 yet, it'd continue to use your version 2 provider.

Finally, this PR also removes some unneeded required_provider declarations, where the required_provider is actually inferred from the child module using the provider, rather than the root module.