### PR TITLE
Cleanup VPC Transit Gateway routing module

### DIFF
--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -71,8 +71,7 @@ module "vpc_tgw_routing" {
   for_each = local.vpcs[terraform.workspace]
 
   providers = {
-    aws                       = aws
-    aws.core-network-services = aws.core-network-services
+    aws = aws.core-network-services
   }
 
   subnet_sets        = { for key, subnet in each.value.cidr.subnet_sets : key => subnet.cidr }

--- a/terraform/modules/vpc-tgw-routing/main.tf
+++ b/terraform/modules/vpc-tgw-routing/main.tf
@@ -1,11 +1,5 @@
-provider "aws" {
-  alias = "core-network-services"
-}
-
 resource "aws_ec2_transit_gateway_route" "example" {
   for_each = tomap(var.subnet_sets)
-
-  provider = aws.core-network-services
 
   destination_cidr_block         = each.value
   transit_gateway_attachment_id  = var.tgw_vpc_attachment
@@ -13,8 +7,6 @@ resource "aws_ec2_transit_gateway_route" "example" {
 }
 
 data "aws_vpc" "selected" {
-  provider = aws.core-network-services
-
   filter {
     name   = "tag:Name"
     values = ["live_data"]
@@ -22,8 +14,6 @@ data "aws_vpc" "selected" {
 }
 
 data "aws_route_table" "live_data-public" {
-  provider = aws.core-network-services
-
   vpc_id = data.aws_vpc.selected.id
 
   filter {
@@ -33,8 +23,6 @@ data "aws_route_table" "live_data-public" {
 }
 
 resource "aws_route" "test" {
-  provider = aws.core-network-services
-
   for_each = tomap(var.subnet_sets)
 
   route_table_id         = data.aws_route_table.live_data-public.id

--- a/terraform/modules/vpc-tgw-routing/variables.tf
+++ b/terraform/modules/vpc-tgw-routing/variables.tf
@@ -1,5 +1,19 @@
-variable "subnet_sets" {}
-variable "tgw_vpc_attachment" {}
-variable "tgw_route_table" {}
-# variable "vpc_id" {}
-variable "tgw_id" {}
+variable "subnet_sets" {
+  description = "Key, value map of subnet sets and their CIDR blocks"
+  type        = map(any)
+}
+
+variable "tgw_vpc_attachment" {
+  description = "Transit Gateway VPC attachment ID"
+  type        = string
+}
+
+variable "tgw_route_table" {
+  description = "Transit Gateway route table ID"
+  type        = string
+}
+
+variable "tgw_id" {
+  description = "Transit Gateway ID"
+  type        = string
+}

--- a/terraform/modules/vpc-tgw-routing/versions.tf
+++ b/terraform/modules/vpc-tgw-routing/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    aws = {
+      version = ">= 3.20.0"
+      source  = "hashicorp/aws"
+    }
+  }
+  required_version = ">= 0.14.2"
+}


### PR DESCRIPTION
This PR cleans up the VPC TGW routing module:

- Removes the need to specify both a default and aliases for the provider as the module only uses one provider (core-network-services), so you can use the module's default provider, mapped to the correct root provider
- adds suitable descriptions and types to variables
- adds a versions.tf with a minimum Terraform and AWS provider version