### PR TITLE
Cleanup VPC custom NACLs module

### DIFF
--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -83,14 +83,10 @@ module "vpc_tgw_routing" {
 }
 
 module "vpc_nacls" {
-  source = "../../modules/vpc-nacls"
-
-  for_each = local.vpcs[terraform.workspace]
-
+  source      = "../../modules/vpc-nacls"
+  for_each    = local.vpcs[terraform.workspace]
   nacl_config = each.value.nacl
   nacl_refs   = module.vpc[each.key].nacl_refs
-
-  tags_common = local.tags
   tags_prefix = each.key
 }
 

--- a/terraform/modules/vpc-nacls/main.tf
+++ b/terraform/modules/vpc-nacls/main.tf
@@ -1,9 +1,7 @@
 locals {
-
-  nacl_base = { for value in var.nacl_config :
-
-    "${value.app}-${value.cidr_block}-${value.egress}-${value.subnet_type}" =>
-    {
+  nacl_base = {
+    for value in var.nacl_config :
+    "${value.app}-${value.cidr_block}-${value.egress}-${value.subnet_type}" => {
       name        = value.app
       cidr_block  = value.cidr_block
       egress      = value.egress

--- a/terraform/modules/vpc-nacls/variables.tf
+++ b/terraform/modules/vpc-nacls/variables.tf
@@ -1,17 +1,14 @@
 variable "nacl_config" {
-  type = list(any)
+  description = "List of maps of NACLs configurations"
+  type        = list(any)
 }
 
 variable "nacl_refs" {
-  type = map(any)
-}
-
-variable "tags_common" {
-  description = "MOJ required tags"
-  type        = map(string)
+  description = "Map of internal NACL references including arn, id, and name"
+  type        = map(any)
 }
 
 variable "tags_prefix" {
-  description = "prefix for name tags"
+  description = "Prefix for name tags"
   type        = string
 }

--- a/terraform/modules/vpc-nacls/versions.tf
+++ b/terraform/modules/vpc-nacls/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    aws = {
+      version = ">= 3.20.0"
+      source  = "hashicorp/aws"
+    }
+  }
+  required_version = ">= 0.14.2"
+}


### PR DESCRIPTION
This PR cleans up the VPC custom NACLs module:

- removes the tags_common variable, which is unused as NACL rules are untaggable
- adds variable descriptions
- adds a `versions.tf` file