### PR TITLE
Split out backend and providers declarations, import orphaned repository resource

### DIFF
--- a/terraform/github/backend.tf
+++ b/terraform/github/backend.tf
@@ -1,0 +1,10 @@
+terraform {
+  # `backend` blocks do not support variables, so the following are hard-coded here:
+  # - S3 bucket name, which is created in modernisation-platform-account/s3.tf
+  backend "s3" {
+    bucket  = "modernisation-platform-terraform-state"
+    encrypt = true
+    key     = "github/terraform.tfstate"
+    region  = "eu-west-2"
+  }
+}

--- a/terraform/github/main.tf
+++ b/terraform/github/main.tf
@@ -132,7 +132,7 @@ module "core-team" {
     module.terraform-module-cross-account-access.repository.id,
     module.terraform-module-environments.repository.id,
     module.terraform-module-iam-superadmins.repository.id,
-    module.terraform-module-modernisation-platform-cidr-allocation.id,
+    module.terraform-module-modernisation-platform-cidr-allocation.repository.id,
     module.terraform-module-network-services-cidr-allocation.repository.id,
     module.terraform-module-s3-bucket-replication-role.repository.id,
     module.terraform-module-s3-bucket.repository.id,

--- a/terraform/github/main.tf
+++ b/terraform/github/main.tf
@@ -1,18 +1,3 @@
-terraform {
-  # `backend` blocks do not support variables, so the following are hard-coded here:
-  # - S3 bucket name, which is created in modernisation-platform-account/s3.tf
-  backend "s3" {
-    bucket  = "modernisation-platform-terraform-state"
-    encrypt = true
-    key     = "github/terraform.tfstate"
-    region  = "eu-west-2"
-  }
-}
-
-provider "github" {
-  owner = "ministryofjustice"
-}
-
 # Repositories
 module "core" {
   source       = "./modules/repository"
@@ -124,6 +109,17 @@ module "terraform-module-network-services-cidr-allocation" {
   ]
 }
 
+module "terraform-module-modernisation-platform-cidr-allocation" {
+  source      = "./modules/repository"
+  name        = "modernisation-platform-cidr-allocation"
+  description = "modernisation platform automated cidr allocation"
+  visibility  = "internal"
+  topics = [
+    "aws",
+    "network-services"
+  ]
+}
+
 # Teams and their access to the above repositories
 module "core-team" {
   source      = "./modules/team"
@@ -136,9 +132,10 @@ module "core-team" {
     module.terraform-module-cross-account-access.repository.id,
     module.terraform-module-environments.repository.id,
     module.terraform-module-iam-superadmins.repository.id,
+    module.terraform-module-modernisation-platform-cidr-allocation.id,
+    module.terraform-module-network-services-cidr-allocation.repository.id,
     module.terraform-module-s3-bucket-replication-role.repository.id,
     module.terraform-module-s3-bucket.repository.id,
-    module.terraform-module-trusted-advisor.repository.id,
-    module.terraform-module-network-services-cidr-allocation.repository.id
+    module.terraform-module-trusted-advisor.repository.id
   ]
 }

--- a/terraform/github/modules/repository/main.tf
+++ b/terraform/github/modules/repository/main.tf
@@ -9,7 +9,7 @@ resource "github_repository" "default" {
   name                   = var.name
   description            = join(" • ", [var.description, "This repository is defined and managed in Terraform"])
   homepage_url           = var.homepage_url
-  visibility             = "public"
+  visibility             = var.visibility
   has_issues             = var.type == "core" ? true : false
   has_projects           = var.type == "core" ? true : false
   has_wiki               = var.type == "core" ? true : false
@@ -21,6 +21,7 @@ resource "github_repository" "default" {
   delete_branch_on_merge = true
   auto_init              = false
   archived               = false
+  archive_on_destroy     = true
   vulnerability_alerts   = true
   topics                 = concat(local.topics, var.topics)
 

--- a/terraform/github/modules/repository/variables.tf
+++ b/terraform/github/modules/repository/variables.tf
@@ -15,7 +15,7 @@ variable "homepage_url" {
 }
 
 variable "secrets" {
-  type        = map
+  type        = map(any)
   description = "key:value map for GitHub actions secrets"
   default     = {}
 }
@@ -29,4 +29,10 @@ variable "type" {
   type        = string
   description = "Type of repository: `core`, `module`. Defaults to `module`"
   default     = "module"
+}
+
+variable "visibility" {
+  type        = string
+  description = "Visibility type: `public`, `internal`, `private`"
+  default     = "public"
 }

--- a/terraform/github/modules/repository/versions.tf
+++ b/terraform/github/modules/repository/versions.tf
@@ -1,8 +1,9 @@
 terraform {
+  required_version = ">= 0.14.2"
   required_providers {
     github = {
-      source = "integrations/github"
+      version = ">= 4.1.0"
+      source  = "integrations/github"
     }
   }
-  required_version = ">= 0.13"
 }

--- a/terraform/github/modules/team/main.tf
+++ b/terraform/github/modules/team/main.tf
@@ -56,7 +56,7 @@ resource "github_team_membership" "members" {
   for_each = toset([
     for user in local.members :
     user
-    if ! contains(local.maintainers, user)
+    if !contains(local.maintainers, user)
   ])
   team_id  = github_team.default.id
   username = each.value

--- a/terraform/github/modules/team/versions.tf
+++ b/terraform/github/modules/team/versions.tf
@@ -1,8 +1,9 @@
 terraform {
+  required_version = ">= 0.14.2"
   required_providers {
     github = {
-      source = "integrations/github"
+      version = ">= 4.1.0"
+      source  = "integrations/github"
     }
   }
-  required_version = ">= 0.13"
 }

--- a/terraform/github/providers.tf
+++ b/terraform/github/providers.tf
@@ -1,0 +1,3 @@
+provider "github" {
+  owner = "ministryofjustice"
+}


### PR DESCRIPTION
This PR:

- splits out the `backend` and `provider` declarations into separate files, to mimic other parts of this repository
- imports the `modernisation-platform-cidr-allocation` repository which was manually created, so we can manage it here
- fixes version declarations to use Terraform 0.14.2 or above, and the correct minimum provider version for GitHub
- adds a `visibility` variable for the `modernisation-platform-cidr-allocation` repository to be internal