### PR TITLE
Fix labeller ignoring non-defined sync-labels option and ignoring .lock.hcl glob

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,7 +5,7 @@ documentation:
   - "source/**"
 
 dependencies:
-  - "**/*.lock.hcl"
+  - "terraform/**/*.lock.hcl"
 
 github-workflow:
   - "github/workflows/**"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -11,3 +11,4 @@ jobs:
     - uses: actions/labeler@main
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        sync-labels: ""


### PR DESCRIPTION
This PR _should_ fix the following issues:

- PRs that include `**.lock.hcl` file changes not being appropriately tagged as `dependencies` ([example](https://github.com/ministryofjustice/modernisation-platform/pull/316/files))
- Labeler ignoring sync-labels being unset or explicitly "false" due to the way ECMAScript uses the variable ([more info](https://github.com/actions/labeler/issues/104)), by now explicitly setting an empty variable. This should fix the issue where manually tagged PRs lose their labels when labeler runs ([example](https://github.com/ministryofjustice/modernisation-platform/pull/320#event-4296370480))