### PR TITLE
GitHub team module: update to 4.40.0 and introduce variables for team members

### DIFF
--- a/terraform/github/.terraform.lock.hcl
+++ b/terraform/github/.terraform.lock.hcl
@@ -1,39 +1,21 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
-provider "registry.terraform.io/hashicorp/github" {
-  version = "4.3.2"
-  hashes = [
-    "h1:dLppR+4G7E8FpSXnzj6yAw5yXCZDzPQi4msbWoP9lp4=",
-    "zh:02ac9fa72f71eb643d6cb7de00b9207617da2f95363e1f025c0bc82b1750e16b",
-    "zh:323d7e77c3fc1a8b9074ce89b5314854bb6e56aa0a13a7a2e1e505bee13b366c",
-    "zh:478e65d21a662522bc792ae471d0e9652ff29f7d122312ff400d265a986f400a",
-    "zh:6ba4a7b9fa2b76ae392d052142b441ac5d12a47ffea03d0f89a588df19ebe709",
-    "zh:8c2f9fa31fbb44893fda9a420332166c9db74573b18c62051bd772877167014f",
-    "zh:9dc13944419cce19f775537d10b798681d9d77d2c8c6110301af0e9bc32422fb",
-    "zh:b3847b64f86c81f66f6d7e2fd0679774c5e9afebe6e9ac6d5f207cb6e3f315b7",
-    "zh:b53e5bf625a2feed803f4f2e70e4af405d6fcfc8481591f6149ecb3c9a3f9e4d",
-    "zh:c24b829412a6ac71b280dcf36c2a4109cca2e8da8e8f510e110834bc6c88b3eb",
-    "zh:ea4639a001235d3903a13923b31dbddbcc6d37973a49a20ede4f9c8888eb38f9",
-    "zh:fd0f2f4d60bb4d78155136045862a77b7aea7fcbe0102c065b20aee954fc8fb8",
-  ]
-}
-
 provider "registry.terraform.io/integrations/github" {
-  version     = "4.3.2"
-  constraints = ">= 4.1.0"
+  version     = "4.4.0"
+  constraints = ">= 4.1.0, >= 4.4.0"
   hashes = [
-    "h1:dLppR+4G7E8FpSXnzj6yAw5yXCZDzPQi4msbWoP9lp4=",
-    "zh:02ac9fa72f71eb643d6cb7de00b9207617da2f95363e1f025c0bc82b1750e16b",
-    "zh:323d7e77c3fc1a8b9074ce89b5314854bb6e56aa0a13a7a2e1e505bee13b366c",
-    "zh:478e65d21a662522bc792ae471d0e9652ff29f7d122312ff400d265a986f400a",
-    "zh:6ba4a7b9fa2b76ae392d052142b441ac5d12a47ffea03d0f89a588df19ebe709",
-    "zh:8c2f9fa31fbb44893fda9a420332166c9db74573b18c62051bd772877167014f",
-    "zh:9dc13944419cce19f775537d10b798681d9d77d2c8c6110301af0e9bc32422fb",
-    "zh:b3847b64f86c81f66f6d7e2fd0679774c5e9afebe6e9ac6d5f207cb6e3f315b7",
-    "zh:b53e5bf625a2feed803f4f2e70e4af405d6fcfc8481591f6149ecb3c9a3f9e4d",
-    "zh:c24b829412a6ac71b280dcf36c2a4109cca2e8da8e8f510e110834bc6c88b3eb",
-    "zh:ea4639a001235d3903a13923b31dbddbcc6d37973a49a20ede4f9c8888eb38f9",
-    "zh:fd0f2f4d60bb4d78155136045862a77b7aea7fcbe0102c065b20aee954fc8fb8",
+    "h1:dgn+oL1cC8kz3ODIuT/PyHqgso00SpItPN089ZuUGt4=",
+    "zh:0ebb07c4971ca7d60fce8614270d056328a121fd4ffbda4b29a06d4a1e90e939",
+    "zh:178b333f2f285c1a59b9335320f584bd01304179c2d6a1919366945b55cfb293",
+    "zh:2c9087e987a5e1af2aad803a79fa5bd847ac060d4c766b5a187b9aabb3f734a4",
+    "zh:419597d8d284616ed93a2c13b3833b129aaba7af7a057d2f48aeb7bc3610cefc",
+    "zh:61686d578880ad76cb8e9c2cc72ad14ef2896fde973cca18b8f7c8848781c71d",
+    "zh:662e125ac42a0c113d811afd2e7a0f81ba061f00cc62ba7435bd685f889290b9",
+    "zh:87fb3d97070cae7f0b623d1a9b59e8cfad0dfece4a27ee964c4c77f228592a80",
+    "zh:e9dcc85ef2f2e09d298f3bbbb9b0d673596d62c1d7d480b2999b4badb2f4aeff",
+    "zh:f052c377a0630a6881c183ac5de0dbef4e5627638a23434a6aa7fce8977b43de",
+    "zh:f7456ec2a6a31caa5d2c85f4da660689f8bac5541c70324803de0c26a14586e1",
+    "zh:fbf6bfddde6f209dc65052ca27e0c83e96bae5fde6940edf029ca42e7e4f1110",
   ]
 }

--- a/terraform/github/locals.tf
+++ b/terraform/github/locals.tf
@@ -1,0 +1,30 @@
+locals {
+  # GitHub usernames for the Modernisation Platform team maintainers
+  # NB: Terraform shows a perputal difference in roles if someone is an organisation owner
+  # and will attempt to change them from `maintainer` to `member`, so owners should go in here.
+  maintainers = toset([
+    "ewastempel",
+    "jakemulley",
+    "philhorrocks",
+    "SteveMarshall"
+  ])
+  # GitHub usernames for the full Modernisation Platform team
+  members = toset([
+    "davidkelliott",
+    "donmasters",
+    "ewastempel",
+    "jackstockley89",
+    "jakemulley",
+    "kcbotsh",
+    "nishamoj",
+    "philhorrocks",
+    "seanprivett",
+    "SimonPPledger",
+    "SteveMarshall",
+    "zuriguardiola"
+  ])
+  # GitHub usernames for CI users
+  ci_users = toset([
+    "modernisation-platform-ci"
+  ])
+}

--- a/terraform/github/main.tf
+++ b/terraform/github/main.tf
@@ -120,7 +120,7 @@ module "terraform-module-modernisation-platform-cidr-allocation" {
   ]
 }
 
-# Teams and their access to the above repositories
+# Everyone, with access to the above repositories
 module "core-team" {
   source      = "./modules/team"
   name        = "modernisation-platform"
@@ -138,4 +138,8 @@ module "core-team" {
     module.terraform-module-s3-bucket.repository.id,
     module.terraform-module-trusted-advisor.repository.id
   ]
+
+  maintainers = local.maintainers
+  members     = local.members
+  ci          = local.ci_users
 }

--- a/terraform/github/modules/team/main.tf
+++ b/terraform/github/modules/team/main.tf
@@ -1,43 +1,14 @@
-locals {
-  # GitHub usernames for the Modernisation Platform team maintainers
-  # NB: Terraform shows a perputal difference in roles if someone is an organisation owner
-  # and will attempt to change them from `maintainer` to `member`, so owners should go in here.
-  maintainers = toset([
-    "ewastempel",
-    "jakemulley",
-    "philhorrocks",
-    "SteveMarshall"
-  ])
-  # GitHub usernames for the full Modernisation Platform team
-  members = toset([
-    "davidkelliott",
-    "donmasters",
-    "ewastempel",
-    "jackstockley89",
-    "jakemulley",
-    "kcbotsh",
-    "nishamoj",
-    "philhorrocks",
-    "seanprivett",
-    "SimonPPledger",
-    "SteveMarshall",
-    "zuriguardiola"
-  ])
-  # GitHub usernames for CI users
-  ci_users = toset([
-    "modernisation-platform-ci"
-  ])
-}
-
 resource "github_team" "default" {
-  name        = var.name
-  privacy     = "closed"
-  description = join(" • ", [var.description, "This team is defined and managed in Terraform"])
+  name                      = var.name
+  privacy                   = "closed"
+  description               = join(" • ", [var.description, "This team is defined and managed in Terraform"])
+  parent_team_id            = var.parent_team_id
+  create_default_maintainer = true
 }
 
 # Team memberships (as "maintainers")
 resource "github_team_membership" "maintainers" {
-  for_each = local.maintainers
+  for_each = var.maintainers
   team_id  = github_team.default.id
   username = each.value
   role     = "maintainer"
@@ -45,7 +16,7 @@ resource "github_team_membership" "maintainers" {
 
 # CI users need to be a maintainer to edit team memberships through Terraform
 resource "github_team_membership" "ci" {
-  for_each = local.ci_users
+  for_each = var.ci
   team_id  = github_team.default.id
   username = each.value
   role     = "maintainer"
@@ -54,13 +25,15 @@ resource "github_team_membership" "ci" {
 # Team memberships (as "members")
 resource "github_team_membership" "members" {
   for_each = toset([
-    for user in local.members :
+    for user in var.members :
     user
-    if ! contains(local.maintainers, user)
+    if !contains(var.maintainers, user)
   ])
   team_id  = github_team.default.id
   username = each.value
   role     = "member"
+
+  depends_on = [github_team_membership.ci]
 }
 
 # Repositories to give access to

--- a/terraform/github/modules/team/main.tf
+++ b/terraform/github/modules/team/main.tf
@@ -27,7 +27,7 @@ resource "github_team_membership" "members" {
   for_each = toset([
     for user in var.members :
     user
-    if !contains(var.maintainers, user)
+    if ! contains(var.maintainers, user)
   ])
   team_id  = github_team.default.id
   username = each.value

--- a/terraform/github/modules/team/outputs.tf
+++ b/terraform/github/modules/team/outputs.tf
@@ -1,0 +1,3 @@
+output "team_id" {
+  value = github_team.default.id
+}

--- a/terraform/github/modules/team/variables.tf
+++ b/terraform/github/modules/team/variables.tf
@@ -11,4 +11,29 @@ variable "description" {
 variable "repositories" {
   description = "Repositories to give the team access to"
   type        = set(string)
+  default     = []
+}
+
+variable "maintainers" {
+  description = "GitHub team maintainers"
+  type        = set(string)
+  default     = []
+}
+
+variable "members" {
+  description = "GitHub team members"
+  type        = set(string)
+  default     = []
+}
+
+variable "ci" {
+  description = "GitHub team members who run as CI"
+  type        = set(string)
+  default     = []
+}
+
+variable "parent_team_id" {
+  description = "GitHub team ID for parent teams"
+  type        = string
+  default     = null
 }

--- a/terraform/github/modules/team/versions.tf
+++ b/terraform/github/modules/team/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.14.2"
   required_providers {
     github = {
-      version = ">= 4.1.0"
+      version = ">= 4.4.0"
       source  = "integrations/github"
     }
   }

--- a/terraform/github/versions.tf
+++ b/terraform/github/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.14.2"
   required_providers {
     github = {
-      version = ">= 4.1.0"
+      version = ">= 4.4.0"
       source  = "integrations/github"
     }
   }


### PR DESCRIPTION
This PR:

- pulls the `local` variable from inside the module for `maintainers`, `members`, `ci` to outside it
- introduces module variables to create teams with different structures, e.g. a subset can be members of a child team
- introduces the `parent_team_id` variable to nest GitHub teams
- updates the GitHub provider to v4.40.0 to allow the creation of default maintainers for a team

This PR forms the basis of introducing a subset team of people who need AWS access, for AWS SSO.