### PR TITLE
Add an 'engineer' team and clean up pre-existing role determination

### DIFF
--- a/terraform/github/locals.tf
+++ b/terraform/github/locals.tf
@@ -2,29 +2,44 @@ locals {
   # GitHub usernames for the Modernisation Platform team maintainers
   # NB: Terraform shows a perputal difference in roles if someone is an organisation owner
   # and will attempt to change them from `maintainer` to `member`, so owners should go in here.
-  maintainers = toset([
+  maintainers = [
     "ewastempel",
     "jakemulley",
     "philhorrocks",
     "SteveMarshall"
-  ])
-  # GitHub usernames for the full Modernisation Platform team
-  members = toset([
+  ]
+
+  # GitHub usernames for CI users
+  ci_users = [
+    "modernisation-platform-ci"
+  ]
+
+  # All GitHub team maintainers
+  all_maintainers = concat(local.maintainers, local.ci_users)
+
+  # GitHub usernames for team members who don't need full AWS access
+  general_members = [
     "davidkelliott",
-    "donmasters",
     "ewastempel",
-    "jackstockley89",
-    "jakemulley",
     "kcbotsh",
     "nishamoj",
-    "philhorrocks",
     "seanprivett",
     "SimonPPledger",
     "SteveMarshall",
+  ]
+
+  # GitHub usernames for engineers who need full AWS access
+  engineers = [
+    "donmasters",
+    "jackstockley89",
+    "jakemulley",
+    "philhorrocks",
     "zuriguardiola"
-  ])
-  # GitHub usernames for CI users
-  ci_users = toset([
-    "modernisation-platform-ci"
-  ])
+  ]
+
+  # All members
+  all_members = concat(local.general_members, local.engineers)
+
+  # Everyone
+  everyone = concat(local.all_maintainers, local.all_members)
 }

--- a/terraform/github/main.tf
+++ b/terraform/github/main.tf
@@ -140,6 +140,19 @@ module "core-team" {
   ]
 
   maintainers = local.maintainers
-  members     = local.members
+  members     = local.everyone
   ci          = local.ci_users
+}
+
+# People who need full AWS access
+module "aws-team" {
+  source      = "./modules/team"
+  name        = "modernisation-platform-engineers"
+  description = "Modernisation Platform team: people who require AWS access"
+
+  maintainers = local.maintainers
+  members     = local.engineers
+  ci          = local.ci_users
+
+  parent_team_id = module.core-team.team_id
 }

--- a/terraform/github/modules/team/main.tf
+++ b/terraform/github/modules/team/main.tf
@@ -1,17 +1,26 @@
+# Separate everyone into their correct levels
+locals {
+  # Only set someone as a maintainer if they're also a member of the team but not a
+  # CI user (as we configure them separately)
+  maintainers = toset([
+    for user in var.maintainers :
+    user
+    if contains(var.members, user) && ! contains(var.ci, user)
+  ])
+  # Only set someone as a member if they're not already a maintainer or already a CI user
+  members = toset([
+    for user in var.members :
+    user
+    if ! contains(var.maintainers, user) && ! contains(var.ci, user)
+  ])
+}
+
 resource "github_team" "default" {
   name                      = var.name
   privacy                   = "closed"
   description               = join(" • ", [var.description, "This team is defined and managed in Terraform"])
   parent_team_id            = var.parent_team_id
   create_default_maintainer = true
-}
-
-# Team memberships (as "maintainers")
-resource "github_team_membership" "maintainers" {
-  for_each = var.maintainers
-  team_id  = github_team.default.id
-  username = each.value
-  role     = "maintainer"
 }
 
 # CI users need to be a maintainer to edit team memberships through Terraform
@@ -22,13 +31,19 @@ resource "github_team_membership" "ci" {
   role     = "maintainer"
 }
 
+# Team memberships (as "maintainers")
+resource "github_team_membership" "maintainers" {
+  for_each = local.maintainers
+  team_id  = github_team.default.id
+  username = each.value
+  role     = "maintainer"
+
+  depends_on = [github_team_membership.ci]
+}
+
 # Team memberships (as "members")
 resource "github_team_membership" "members" {
-  for_each = toset([
-    for user in var.members :
-    user
-    if ! contains(var.maintainers, user)
-  ])
+  for_each = local.members
   team_id  = github_team.default.id
   username = each.value
   role     = "member"


### PR DESCRIPTION
This PR creates a new GitHub team for `engineers` so we can infer AWS access via AWS SSO.

This PR also cleans up pre-existing role determination, so usernames needn't be duplicated if split across more than one team, by providing a local that concats all lists into one.

The module will also work out which team member gets which role, i.e. if someone is a GitHub organisation _owner_ and in the `maintainers` list, they will become a maintainer even if they're passed through as a `member`, as they will always have that permission by being an organisation owner.