### PR TITLE
Move AWS access keys into Secrets Manager

### DIFF
--- a/terraform/modernisation-platform-account/iam.tf
+++ b/terraform/modernisation-platform-account/iam.tf
@@ -79,9 +79,3 @@ resource "aws_iam_access_key" "ci" {
     create_before_destroy = true
   }
 }
-
-# NOTE: These are extremely sensitive keys. Do not output these anywhere publicly accessible.
-output "ci_access_keys" {
-  value     = aws_iam_access_key.ci
-  sensitive = true
-}

--- a/terraform/modernisation-platform-account/secrets.tf
+++ b/terraform/modernisation-platform-account/secrets.tf
@@ -1,0 +1,13 @@
+resource "aws_secretsmanager_secret" "ci_iam_user_keys" {
+  name = "ci_iam_user_keys"
+  description = "Access keys for the CI user, this secret is used by GitHub to set the correct repository secrets."
+  tags = local.tags
+}
+
+resource "aws_secretsmanager_secret_version" "ci_iam_user_keys" {
+  secret_id = aws_secretsmanager_secret.ci_iam_user_keys.id
+  secret_string = jsonencode({
+    AWS_ACCESS_KEY_ID     = aws_iam_access_key.ci.id
+    AWS_SECRET_ACCESS_KEY = aws_iam_access_key.ci.secret
+  })
+}

--- a/terraform/modernisation-platform-account/secrets.tf
+++ b/terraform/modernisation-platform-account/secrets.tf
@@ -1,7 +1,7 @@
 resource "aws_secretsmanager_secret" "ci_iam_user_keys" {
-  name = "ci_iam_user_keys"
+  name        = "ci_iam_user_keys"
   description = "Access keys for the CI user, this secret is used by GitHub to set the correct repository secrets."
-  tags = local.tags
+  tags        = local.tags
 }
 
 resource "aws_secretsmanager_secret_version" "ci_iam_user_keys" {


### PR DESCRIPTION
This PR moves the CI users IAM access keys into AWS Secrets Manager, so we can take advantage of getting the latest version from our GitHub configuration, and Lambda-driven rotation.