### PR TITLE
Set GitHub repository secrets from AWS Secrets Manager

### DIFF
--- a/.github/workflows/new-environment.yml
+++ b/.github/workflows/new-environment.yml
@@ -9,8 +9,8 @@ on:
   workflow_dispatch:
 
 env:
-  AWS_ACCESS_KEY_ID:  ${{ secrets.AWS_ACCESS_KEY_ID }}
-  AWS_SECRET_ACCESS_KEY:  ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  AWS_ACCESS_KEY_ID:  ${{ secrets.PRIVILEGED_AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY:  ${{ secrets.PRIVILEGED_AWS_SECRET_ACCESS_KEY }}
   TF_IN_AUTOMATION: true
 
 defaults:

--- a/terraform/github/.terraform.lock.hcl
+++ b/terraform/github/.terraform.lock.hcl
@@ -1,6 +1,24 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.27.0"
+  constraints = ">= 3.20.0"
+  hashes = [
+    "h1:lJaA23rrNSgLEumcW7Y0KKvno5isVVNNIEV5pT92O8E=",
+    "zh:2986eb5a1ffbb0336c6390aad533b62efc832aa8aa5460d523e1f2daa4f42f79",
+    "zh:825317cdb80860833125a856c0befc877cba22d41c631c5a7ca22400693d4356",
+    "zh:a47aad668cc74058f508c56c5407cd715dbb9b6389aa68d37543e897895db43f",
+    "zh:c0011502d0eb4637918127c3987a8cc07a015ea00f74f4956fd111c736286a4d",
+    "zh:d5088ab51043bb2239132f4ed3760292b6aa4f7296232e4b8017f8c5c34f051a",
+    "zh:d893658e983eb17a23a8124c79a910cc729cb1d751d5509b8e756101c828ad91",
+    "zh:dcc4384ee79ea9492c87eb01e664f7f6b1f1d156471476f30b28336c9d9a4aec",
+    "zh:e4abfaf013f31791cd029af7b6f989f73e3efca28fe2917057b428d051c4085f",
+    "zh:f2a4d9446d23afe2a42421e7d5f902d34451fb31b7787b5e3aef95c08fec5ced",
+    "zh:f54a6af10b077db9dc11556c27f59ba5c60e1b2ba96fe3aa9cd90d8c67d980f6",
+  ]
+}
+
 provider "registry.terraform.io/integrations/github" {
   version     = "4.4.0"
   constraints = ">= 4.1.0, >= 4.4.0"

--- a/terraform/github/aws.tf
+++ b/terraform/github/aws.tf
@@ -1,0 +1,12 @@
+# This gets the AWS access keys for CI/CD from AWS Secrets Manager to set as repository secrets.
+data "aws_secretsmanager_secret" "ci_iam_user_keys" {
+  name = "ci_iam_user_keys"
+}
+
+data "aws_secretsmanager_secret_version" "ci_iam_user_keys" {
+  secret_id = data.aws_secretsmanager_secret.ci_iam_user_keys.id
+}
+
+locals {
+  ci_iam_user_keys = jsondecode(data.aws_secretsmanager_secret_version.ci_iam_user_keys.secret_string)
+}

--- a/terraform/github/main.tf
+++ b/terraform/github/main.tf
@@ -10,11 +10,12 @@ module "core" {
     "aws",
     "documentation"
   ]
-  secrets = {
-    AWS_ACCESS_KEY_ID      = "example"
-    AWS_SECRET_ACCESS_KEY  = "example"
+  secrets = merge(local.ci_iam_user_keys, {
+    PRIVILEGED_AWS_ACCESS_KEY_ID     = "example"
+    PRIVILEGED_AWS_SECRET_ACCESS_KEY = "example"
+    # Terraform GitHub token for the CI/CD user
     TERRAFORM_GITHUB_TOKEN = "This needs to be manually set in GitHub."
-  }
+  })
 }
 
 module "hello-world" {

--- a/terraform/github/providers.tf
+++ b/terraform/github/providers.tf
@@ -1,3 +1,7 @@
 provider "github" {
   owner = "ministryofjustice"
 }
+
+provider "aws" {
+  region = "eu-west-2"
+}

--- a/terraform/github/versions.tf
+++ b/terraform/github/versions.tf
@@ -1,6 +1,10 @@
 terraform {
   required_version = ">= 0.14.2"
   required_providers {
+    aws = {
+      version = ">= 3.20.0"
+      source  = "hashicorp/aws"
+    }
     github = {
       version = ">= 4.4.0"
       source  = "integrations/github"


### PR DESCRIPTION
This PR allows our GitHub Terraform to get the AWS access keys for the CI user from AWS; and sets them as repository secrets.

It also changes the previous access keys into a new key: `secrets.PRIVILEGED_AWS_ACCESS_KEY_ID`, so people can default on using `secrets.AWS_ACCESS_KEY_ID` for non-privileged actions.

This PR forms part of the work around #88, #142, and #295.