### PR TITLE
VPC Hub fixes: point NACL rules to the right resource, add missing tags

### DIFF
--- a/terraform/environments/core-network-services/output.tf
+++ b/terraform/environments/core-network-services/output.tf
@@ -24,31 +24,31 @@ output "transit_gateway_ram_share" {
 }
 
 output "non_live_data_private_route_tables" {
-  value = module.vpc["non_live_data"].private_route_tables
+  value = module.vpc_hub["non_live_data"].private_route_tables
 }
 
 output "public_route_tables" {
   value = {
     for key, value in local.networking :
-    key => module.vpc[key].public_route_tables.tags["Name"]
+    key => module.vpc_hub[key].public_route_tables.tags["Name"]
   }
 }
 
 output "live_data_private_route_tables" {
-  value = module.vpc["live_data"].private_route_tables
+  value = module.vpc_hub["live_data"].private_route_tables
 }
 
 output "public_igw_route" {
   value = {
     for key, value in local.networking :
-    key => module.vpc[key].public_igw_route.destination_cidr_block
+    key => module.vpc_hub[key].public_igw_route.destination_cidr_block
   }
 }
 
 output "non_tgw_subnet_ids" {
-  value = length(module.vpc["non_live_data"].non_tgw_subnet_ids)
+  value = length(module.vpc_hub["non_live_data"].non_tgw_subnet_ids)
 }
 
 output "tgw_subnet_ids" {
-  value = length(module.vpc["non_live_data"].tgw_subnet_ids)
+  value = length(module.vpc_hub["non_live_data"].tgw_subnet_ids)
 }

--- a/terraform/environments/core-network-services/vpc.tf
+++ b/terraform/environments/core-network-services/vpc.tf
@@ -9,23 +9,24 @@ locals {
   useful_vpc_ids = {
     for key in keys(local.networking) :
     key => {
-      vpc_id                 = module.vpc[key].vpc_id
-      private_tgw_subnet_ids = module.vpc[key].tgw_subnet_ids
+      vpc_id                 = module.vpc_hub[key].vpc_id
+      private_tgw_subnet_ids = module.vpc_hub[key].tgw_subnet_ids
     }
   }
 }
 
-module "vpc" {
+module "vpc_hub" {
   for_each = local.networking
-  source   = "../../modules/core-vpc"
+
+  source = "../../modules/vpc-hub"
 
   # CIDRs
   vpc_cidr = each.value
 
-  # private gateway type
-  #   nat = Nat Gateway
+  # Private gateway type
+  #   nat = NAT Gateway
   #   transit = Transit Gateway
-  #   none = no gateway for internal traffic
+  #   none = No gateway for internal traffic
   gateway = "nat"
 
   # VPC Flow Logs

--- a/terraform/modules/vpc-hub/outputs.tf
+++ b/terraform/modules/vpc-hub/outputs.tf
@@ -1,0 +1,44 @@
+output "vpc_id" {
+  value = aws_vpc.default.id
+}
+
+output "tgw_subnet_ids" {
+  description = "Transit Gateway subnet IDs"
+  value       = [for subnet in aws_subnet.transit-gateway : subnet.id]
+}
+
+output "non_tgw_subnet_ids" {
+  description = "Non-Transit Gateway subnet IDs (public, private, data)"
+  value = concat([
+    for subnet in aws_subnet.public :
+    subnet.id
+    ], [
+    for subnet in aws_subnet.private :
+    subnet.id
+    ], [
+    for subnet in aws_subnet.data :
+    subnet.id
+  ])
+}
+
+output "private_route_tables" {
+  value = merge({
+    for key, route_table in aws_route_table.private :
+    "${var.tags_prefix}-${key}" => route_table.id
+    }, {
+    for key, route_table in aws_route_table.data :
+    "${var.tags_prefix}-${key}" => route_table.id
+    }, {
+    for key, route_table in aws_route_table.transit-gateway :
+    "${var.tags_prefix}-${key}" => route_table.id
+  })
+}
+
+output "public_route_tables" {
+  value = aws_route_table.public
+}
+
+output "public_igw_route" {
+  value = aws_route.public-internet-gateway
+}
+

--- a/terraform/modules/vpc-hub/outputs.tf
+++ b/terraform/modules/vpc-hub/outputs.tf
@@ -1,6 +1,6 @@
 output "vpc_id" {
   description = "VPC ID"
-  value = aws_vpc.default.id
+  value       = aws_vpc.default.id
 }
 
 output "tgw_subnet_ids" {
@@ -38,11 +38,11 @@ output "private_route_tables" {
 
 output "public_route_tables" {
   description = "Public route tables"
-  value = aws_route_table.public
+  value       = aws_route_table.public
 }
 
 output "public_igw_route" {
   description = "Public Internet Gateway route"
-  value = aws_route.public-internet-gateway
+  value       = aws_route.public-internet-gateway
 }
 

--- a/terraform/modules/vpc-hub/outputs.tf
+++ b/terraform/modules/vpc-hub/outputs.tf
@@ -1,4 +1,5 @@
 output "vpc_id" {
+  description = "VPC ID"
   value = aws_vpc.default.id
 }
 
@@ -22,6 +23,7 @@ output "non_tgw_subnet_ids" {
 }
 
 output "private_route_tables" {
+  description = "Private route table keys and IDs"
   value = merge({
     for key, route_table in aws_route_table.private :
     "${var.tags_prefix}-${key}" => route_table.id
@@ -35,10 +37,12 @@ output "private_route_tables" {
 }
 
 output "public_route_tables" {
+  description = "Public route tables"
   value = aws_route_table.public
 }
 
 output "public_igw_route" {
+  description = "Public Internet Gateway route"
   value = aws_route.public-internet-gateway
 }
 

--- a/terraform/modules/vpc-hub/variables.tf
+++ b/terraform/modules/vpc-hub/variables.tf
@@ -1,24 +1,29 @@
 variable "vpc_cidr" {
-  description = ""
+  description = "CIDR range for the VPC"
   type        = string
 }
 
 variable "gateway" {
-  description = ""
+  description = "Type of gateway to use for environment"
   type        = string
+  default     = "none"
+  validation {
+    condition     = var.gateway == "transit" || var.gateway == "nat" || var.gateway == "none"
+    error_message = "Must provide either `transit`, `nat` or `none`."
+  }
 }
 
 variable "vpc_flow_log_iam_role" {
-  description = ""
+  description = "VPC Flow Log IAM role ARN for VPC Flow Logs to CloudWatch"
   type        = string
 }
 
 variable "tags_common" {
-  description = ""
+  description = "Ministry of Justice required tags"
   type        = map(any)
 }
 
 variable "tags_prefix" {
-  description = ""
+  description = "Prefix for name tags, e.g. \"live_data\""
   type        = string
 }

--- a/terraform/modules/vpc-hub/versions.tf
+++ b/terraform/modules/vpc-hub/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    aws = {
+      version = ">= 3.20.0"
+      source  = "hashicorp/aws"
+    }
+  }
+  required_version = ">= 0.14.2"
+}


### PR DESCRIPTION
This PR:

- Points `core-network-services` to the VPC Hub module, which replaces the `core-vpc` module
- Adds missing tags
- Points `aws_network_acl_rule` to the right NACL, rather than just `public`
- Fixes outputs in VPC Hub to meet the previous implementation
- Fixes an issue with NAT being configured even if `var.gateway` isn't NAT