### PR TITLE
Provide right AWS keys for the delegate-access workflow

### DIFF
--- a/.github/workflows/new-environment.yml
+++ b/.github/workflows/new-environment.yml
@@ -60,8 +60,8 @@ jobs:
     if: github.event.ref == 'refs/heads/main'
     needs: [provision-workspaces]
     env:
-      AWS_ACCESS_KEY_ID:  ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY:  ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_ACCESS_KEY_ID:  ${{ secrets.PRIVILEGED_AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY:  ${{ secrets.PRIVILEGED_AWS_SECRET_ACCESS_KEY }}
     steps:
       - uses: actions/checkout@main
       - uses: hashicorp/setup-terraform@v1


### PR DESCRIPTION
The `delegate-access` workflow relies on OrganizationAccountAccessRole that is only usable with the privileged access keys in this repository.