### PR TITLE
Reduce required Terraform version for single sign-on

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/versions.tf
+++ b/terraform/environments/bootstrap/single-sign-on/versions.tf
@@ -5,5 +5,5 @@ terraform {
       source  = "hashicorp/aws"
     }
   }
-  required_version = ">= 0.14.7"
+  required_version = ">= 0.14.6"
 }


### PR DESCRIPTION
The GitHub action for [single sign-on failed](https://github.com/ministryofjustice/modernisation-platform/runs/2002715394?check_suite_focus=true) due to the runner using Terraform 0.14.6 and the required version being `0.14.7`. This reduces the Terraform version by one patch version to resolve that issue.