### PR TITLE
GitHub creating a pull request: set method to POST explicitly

### DIFF
--- a/scripts/git-pull-request.sh
+++ b/scripts/git-pull-request.sh
@@ -10,8 +10,9 @@ This PR commits new files under $1."
 
 payload=$(echo "${pull_request_body}" | jq --arg branch "$pull_request_branch" --arg pr_title "$pull_request_title" -R --slurp '{ body: ., base: "main", head: $branch, title: $pr_title }')
 
-echo "${payload}" | curl  \
-  -s -S \
+echo "${payload}" | curl \
+  -X POST \
   -H "Accept: application/vnd.github.v3+json" \
   -H "Authorization: token ${GITHUB_TOKEN}" \
-  --data @- "${repository_url}" > /dev/null
+  $repository_url \
+  -d @- > /dev/null


### PR DESCRIPTION
Explicitly set the `curl` method to POST and remove double space to create a PR as part of the [`new environments files` workflow](https://github.com/ministryofjustice/modernisation-platform/actions/workflows/new-environment-files.yml).