### PR TITLE
Remove core-vpc-non-live-data

### DIFF
--- a/environments/core-vpc.json
+++ b/environments/core-vpc.json
@@ -3,10 +3,6 @@
     {
       "name": "production",
       "access": []
-    },
-    {
-      "name": "non-live-data",
-      "access": []
     }
   ],
   "tags": {


### PR DESCRIPTION
This PR removes `core-vpc-non-live-data` from the Modernisation Platform as part of the the guide in the #429.

I expect this to return 2 to destroy:

- the AWS secret needs to be replaced, so will be destroyed (to remove the account ID)
- the random string that is set as the email address for the account will also be destroyed as it's a separate Terraform resource