### PR TITLE
Fix provision workspaces to use the new environments JSON structure

### DIFF
--- a/scripts/provision-terraform-workspaces.sh
+++ b/scripts/provision-terraform-workspaces.sh
@@ -34,7 +34,7 @@ refresh_tmp_location() {
 get_local_definitions() {
   for file in environments/*.json; do
     filename=$(basename "$file" .json)
-    cat "$file" | jq -r --arg filename "$filename" '$filename + "-" + .environments[]' >> $TMP_DIR/local/"$filename".txt
+    cat "$file" | jq -r --arg filename "$filename" '$filename + "-" + .environments[].name' >> $TMP_DIR/local/"$filename".txt
   done
 }
 


### PR DESCRIPTION
The `provision-terraform-workspaces.sh` script has been failing since the structure of the environment JSON files changed as part of #400.

Instead of pointing to the array value, this now points to the object's value for the environment's `name`.