### PR TITLE
Feature/private acm configuration and member account RAM share config

### DIFF
--- a/terraform/environments/core-network-services/acm-pca.tf
+++ b/terraform/environments/core-network-services/acm-pca.tf
@@ -7,6 +7,7 @@ provider "aws" {
   region = "eu-west-2"
 }
 
+#Create S3 bucket for ACM
 resource "aws_s3_bucket" "acm-pca" {
 
   bucket_prefix ="acm"
@@ -54,6 +55,7 @@ resource "aws_s3_bucket" "acm-pca" {
   )
 }
 
+#S3 bucket access policy
 data "aws_iam_policy_document" "acmpca_bucket_access" {
 
     statement {
@@ -200,7 +202,7 @@ resource "aws_acmpca_certificate_authority_certificate" "non-live_subordinate" {
 resource "aws_acmpca_certificate" "non-live_subordinate" {
 
   depends_on = [aws_acmpca_certificate_authority.root]
-  
+
   certificate_authority_arn   = aws_acmpca_certificate_authority.root.arn
   certificate_signing_request = aws_acmpca_certificate_authority.non-live_subordinate.certificate_signing_request
   signing_algorithm           = "SHA512WITHRSA"
@@ -272,3 +274,7 @@ data "aws_iam_policy_document" "kms-acm" {
     }
   }
 }
+
+#Create RAM share for subordinate certificates
+
+

--- a/terraform/environments/core-network-services/acm-pca.tf
+++ b/terraform/environments/core-network-services/acm-pca.tf
@@ -55,16 +55,6 @@ resource "aws_s3_bucket" "acm-pca" {
 
 }
 
-# # # # # # Block public access policies for this bucket
-resource "aws_s3_bucket_public_access_block" "root_ca" {
-  
-  bucket                  = aws_s3_bucket.acm-pca.id
-  block_public_acls       = false
-  block_public_policy     = false
-  ignore_public_acls      = false
-  restrict_public_buckets = false
-}
-
 
 data "aws_iam_policy_document" "acmpca_bucket_access" {
 
@@ -93,7 +83,7 @@ resource "aws_s3_bucket_policy" "root_ca" {
   policy = data.aws_iam_policy_document.acmpca_bucket_access.json
 
   # Create the Public Access Block before the policy is added
-  depends_on = [aws_s3_bucket_public_access_block.root_ca]
+  #depends_on = [aws_s3_bucket_public_access_block.root_ca]
 
 }
 

--- a/terraform/environments/core-network-services/acm-pca.tf
+++ b/terraform/environments/core-network-services/acm-pca.tf
@@ -3,14 +3,14 @@ data "aws_region" "current" {}
 data "aws_partition" "current" {}
 
 provider "aws" {
-  alias = "eu-west-2"
+  alias  = "eu-west-2"
   region = "eu-west-2"
 }
 
 #Create S3 bucket for ACM
 resource "aws_s3_bucket" "acm-pca" {
 
-  bucket_prefix ="acm"
+  bucket_prefix = "acm"
 
   lifecycle {
     prevent_destroy = false
@@ -58,7 +58,7 @@ resource "aws_s3_bucket" "acm-pca" {
 #S3 bucket access policy
 data "aws_iam_policy_document" "acmpca_bucket_access" {
 
-    statement {
+  statement {
     actions = [
       "s3:GetBucketAcl",
       "s3:GetBucketLocation",
@@ -66,7 +66,7 @@ data "aws_iam_policy_document" "acmpca_bucket_access" {
       "s3:PutObjectAcl"
     ]
 
-     resources = [
+    resources = [
       aws_s3_bucket.acm-pca.arn,
       "${aws_s3_bucket.acm-pca.arn}/*"
     ]
@@ -113,15 +113,15 @@ resource "aws_acmpca_certificate_authority" "root" {
     signing_algorithm = "SHA512WITHRSA"
 
     subject {
-      common_name = "moj-modernisation-platform-root-CA"
-      organization = "ministry-of-justice"
+      common_name         = "moj-modernisation-platform-root-CA"
+      organization        = "ministry-of-justice"
       organizational_unit = "modernisation-platform"
-      country = "UK"
-      state = "UK"
-      locality = "UK"
-     }
+      country             = "UK"
+      state               = "UK"
+      locality            = "UK"
+    }
   }
-   revocation_configuration {
+  revocation_configuration {
 
     crl_configuration {
       custom_cname       = "moj-modernisation-platform-crl-root-CA"
@@ -131,9 +131,9 @@ resource "aws_acmpca_certificate_authority" "root" {
     }
   }
 
-   permanent_deletion_time_in_days = 7
+  permanent_deletion_time_in_days = 7
 
-   tags = merge(
+  tags = merge(
     local.tags,
     {
       Name = "acm-pca-root-ca"
@@ -163,7 +163,7 @@ resource "aws_acmpca_certificate" "live_subordinate" {
 
   template_arn = "arn:${data.aws_partition.current.partition}:acm-pca:::template/SubordinateCACertificate_PathLen0/V1"
 
-   validity {
+  validity {
     type  = "YEARS"
     value = 24
   }
@@ -177,14 +177,14 @@ resource "aws_acmpca_certificate_authority" "live_subordinate" {
     signing_algorithm = "SHA512WITHRSA"
 
     subject {
-      common_name = "moj-modernisation-platform-sub-ca-live-data"
-      organization = "ministry-of-justice"
+      common_name         = "moj-modernisation-platform-sub-ca-live-data"
+      organization        = "ministry-of-justice"
       organizational_unit = "modernisation-platform"
-      country = "UK"
-      state = "UK"
-      locality = "UK"
+      country             = "UK"
+      state               = "UK"
+      locality            = "UK"
     }
-    
+
   }
 }
 
@@ -223,21 +223,21 @@ resource "aws_acmpca_certificate_authority" "non-live_subordinate" {
     signing_algorithm = "SHA512WITHRSA"
 
     subject {
-      common_name = "moj-modernisation-platform-sub-ca-non-live-data"
-      organization = "ministry-of-justice"
+      common_name         = "moj-modernisation-platform-sub-ca-non-live-data"
+      organization        = "ministry-of-justice"
       organizational_unit = "modernisation-platform"
-      country = "UK"
-      state = "UK"
-      locality = "UK"
+      country             = "UK"
+      state               = "UK"
+      locality            = "UK"
     }
   }
 }
 
 # Setup KMS key 
 resource "aws_kms_key" "acm" {
-  description             = "ACM PCA (private certificate authority) encryption key"
-  enable_key_rotation     = true
-  policy                  = data.aws_iam_policy_document.kms-acm.json
+  description         = "ACM PCA (private certificate authority) encryption key"
+  enable_key_rotation = true
+  policy              = data.aws_iam_policy_document.kms-acm.json
 
   tags = merge(
     local.tags,

--- a/terraform/environments/core-network-services/acm-pca.tf
+++ b/terraform/environments/core-network-services/acm-pca.tf
@@ -1,0 +1,133 @@
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+provider "aws" {
+  alias = "eu-west-2"
+  region = "eu-west-2"
+}
+
+# AWS Config: configure an S3 bucket
+module "ca-bucket" {
+  # source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket"
+  source = "../../../../modernisation-platform-terraform-s3-bucket"
+  providers = {
+    aws.bucket-replication = aws.eu-west-2
+  }
+  bucket_policy        = data.aws_iam_policy_document.acmpca_bucket_access.json
+  bucket_prefix        = "acm"
+  custom_kms_key       = aws_kms_key.acm.arn
+  replication_role_arn = module.s3-acm-replication-role.role.arn
+  tags                 = local.tags
+}
+
+module "s3-acm-replication-role" {
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket-replication-role"
+
+  buckets = [
+    module.ca-bucket.bucket.arn
+  ]
+  suffix_name = "-acm-ca"
+  tags = local.tags
+}
+
+data "aws_iam_policy_document" "acmpca_bucket_access" {
+  statement {
+    actions = [
+      "s3:GetBucketAcl",
+      "s3:GetBucketLocation",
+      "s3:PutObject",
+      "s3:PutObjectAcl",
+    ]
+
+    resources = [
+      module.ca-bucket.bucket.arn,
+      "${module.ca-bucket.bucket.arn}/*"
+    ]
+
+    principals {
+      identifiers = ["acm-pca.amazonaws.com"]
+      type        = "Service"
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "root-ca" {
+  bucket = module.ca-bucket.bucket.id
+  policy = data.aws_iam_policy_document.acmpca_bucket_access.json
+}
+
+resource "aws_acmpca_certificate_authority" "root" {
+  type = "ROOT"
+  certificate_authority_configuration {
+    key_algorithm     = "RSA_4096"
+    signing_algorithm = "SHA512WITHRSA"
+
+    subject {
+      common_name = "moj-modernisation-platform-root-CA"
+      organization = "ministry-of-justice"
+      organizational_unit = "modernisation-platform"
+      country = "UK"
+      state = "UK"
+      locality = "UK"
+     }
+  }
+    revocation_configuration {
+    crl_configuration {
+      custom_cname       = "moj-modernisation-platform-crl-root-CA"
+      enabled            = true
+      expiration_in_days = 7
+      s3_bucket_name     = module.ca-bucket.bucket.id
+    }
+  }
+  permanent_deletion_time_in_days = 7
+
+  tags = merge(
+    local.tags,
+    {
+      Name = "acm-pca-root-ca"
+    },
+  )
+}
+
+# KMS
+resource "aws_kms_key" "acm" {
+  description             = "ACM PCA (private certificate authority) encryption key"
+  enable_key_rotation     = true
+  policy                  = data.aws_iam_policy_document.kms-acm.json
+
+  tags = merge(
+    local.tags,
+    {
+      Name = "acm-pca"
+    },
+  )
+}
+
+resource "aws_kms_alias" "acm-alias" {
+  name          = "alias/acm-pca-root"
+  target_key_id = aws_kms_key.acm.arn
+}
+
+data "aws_iam_policy_document" "kms-acm" {
+#   statement {
+#     effect    = "Allow"
+#     actions   = ["kms:*"]
+#     resources = ["*"]
+
+#     principals {
+#       type        = "Service"
+#       identifiers = ["acm-pca.amazonaws.com"]
+#     }
+#   }
+  statement {
+    effect    = "Allow"
+    actions   = ["kms:*"]
+    resources = ["*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+  }
+
+}

--- a/terraform/environments/core-network-services/acm-pca.tf
+++ b/terraform/environments/core-network-services/acm-pca.tf
@@ -52,7 +52,6 @@ resource "aws_s3_bucket" "acm-pca" {
       Name = "acm-pca"
     },
   )
-
 }
 
 
@@ -81,9 +80,6 @@ resource "aws_s3_bucket_policy" "root_ca" {
 
   bucket = aws_s3_bucket.acm-pca.id
   policy = data.aws_iam_policy_document.acmpca_bucket_access.json
-
-  # Create the Public Access Block before the policy is added
-  #depends_on = [aws_s3_bucket_public_access_block.root_ca]
 
 }
 

--- a/terraform/environments/core-network-services/ram.tf
+++ b/terraform/environments/core-network-services/ram.tf
@@ -17,7 +17,7 @@ resource "aws_ram_resource_share" "acm-pca-live" {
   name                      = "acm-pca-live"
   allow_external_principals = false
 
-    tags = merge(
+  tags = merge(
     local.tags,
     {
       Name = "acm-pca-live"
@@ -35,7 +35,7 @@ resource "aws_ram_resource_association" "acm-pca-live" {
 resource "aws_ram_resource_share" "acm-pca-non-live" {
   name                      = "acm-pca-non-live"
   allow_external_principals = false
-  
+
   tags = merge(
     local.tags,
     {

--- a/terraform/environments/core-network-services/ram.tf
+++ b/terraform/environments/core-network-services/ram.tf
@@ -11,3 +11,41 @@ resource "aws_ram_resource_association" "transit-gateway" {
   resource_arn       = aws_ec2_transit_gateway.transit-gateway.arn
   resource_share_arn = aws_ram_resource_share.transit-gateway.id
 }
+
+# Create a resource share for the Certificate Manager
+resource "aws_ram_resource_share" "acm-pca-live" {
+  name                      = "acm-pca-live"
+  allow_external_principals = false
+
+    tags = merge(
+    local.tags,
+    {
+      Name = "acm-pca-live"
+    },
+  )
+}
+
+# Attach the Certificate Manager sub to the resource share
+resource "aws_ram_resource_association" "acm-pca-live" {
+  resource_arn       = aws_acmpca_certificate_authority.live_subordinate.arn
+  resource_share_arn = aws_ram_resource_share.acm-pca-live.id
+}
+
+# Create a resource share for the Certificate Manager
+resource "aws_ram_resource_share" "acm-pca-non-live" {
+  name                      = "acm-pca-non-live"
+  allow_external_principals = false
+  
+  tags = merge(
+    local.tags,
+    {
+      Name = "acm-pca-non-live"
+    },
+  )
+}
+
+# Attach the Certificate Manager sub to the resource share
+resource "aws_ram_resource_association" "acm-pca-non-live" {
+  resource_arn       = aws_acmpca_certificate_authority.non-live_subordinate.arn
+  resource_share_arn = aws_ram_resource_share.acm-pca-non-live.id
+}

--- a/terraform/environments/core-sandbox/base_variables.tf
+++ b/terraform/environments/core-sandbox/base_variables.tf
@@ -15,3 +15,6 @@ variable "account_name" {
   default     = "core-sandbox"
   description = "account name without environment name excluded - can be used to extract environment from workspace name"
 }
+
+
+ 

--- a/terraform/environments/core-sandbox/bastion_linux.tf.bak
+++ b/terraform/environments/core-sandbox/bastion_linux.tf.bak
@@ -1,0 +1,33 @@
+# Sharing
+# provider "aws" {
+#   alias  = "core-vpc-production"
+#   region = "eu-west-2"
+
+#   assume_role {
+#     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-vpc-production"]}:role/ModernisationPlatformAccess"
+#   }
+# }
+
+
+module "bastion_linux" {
+  source = "../../modules/bastion_linux"
+
+  providers = {
+    aws.share-host   = aws.core-vpc-production # Core VPC production holds the share
+    aws.share-tenant = aws                     # The default provider (unaliased, `aws`) is the tenant
+  }
+
+  business_unit         = var.business_unit
+  subnet_set            = var.subnet_set
+  account_name          = var.account_name
+  region                = "eu-west-2"
+  bastion_host_key_pair = "dm_sandbox"
+
+  # Tags
+  tags_common = local.tags
+  tags_prefix = terraform.workspace
+}
+
+# output "test" {
+#   value = module.bastion_linux.test
+# }

--- a/terraform/environments/core-sandbox/locals.tf
+++ b/terraform/environments/core-sandbox/locals.tf
@@ -4,7 +4,7 @@ locals {
 
   # This takes the name of the Terraform workspace (e.g. core-vpc-production), strips out the application name (e.g. core-vpc), and checks if
   # the string leftover is `-production`, if it isn't (e.g. core-vpc-non-production => -non-production) then it sets the var to false.
-  is-production = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-production"
+  is-production    = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-production"
   is-preproduction = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-preproduction"
 
   tags = {
@@ -16,6 +16,6 @@ locals {
 
   json_data = jsondecode(file("networking.auto.tfvars.json"))
 
-  acm_pca = [ substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-production" || substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-preproduction" ? "acm-pca-live" : "acm-pca-non-live" ]
+  acm_pca = [substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-production" || substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-preproduction" ? "acm-pca-live" : "acm-pca-non-live"]
 
 }

--- a/terraform/environments/core-sandbox/locals.tf
+++ b/terraform/environments/core-sandbox/locals.tf
@@ -5,6 +5,7 @@ locals {
   # This takes the name of the Terraform workspace (e.g. core-vpc-production), strips out the application name (e.g. core-vpc), and checks if
   # the string leftover is `-production`, if it isn't (e.g. core-vpc-non-production => -non-production) then it sets the var to false.
   is-production = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-production"
+  is-preproduction = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-preproduction"
 
   tags = {
     business-unit = "Platforms"
@@ -12,4 +13,9 @@ locals {
     is-production = local.is-production
     owner         = "Modernisation Platform: modernisation-platform@digital.justice.gov.uk"
   }
+
+  json_data = jsondecode(file("networking.auto.tfvars.json"))
+
+  acm_pca = [ substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-production" || substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-preproduction" ? "acm-pca-live" : "acm-pca-non-live" ]
+
 }

--- a/terraform/environments/core-sandbox/networking.auto.tfvars.json
+++ b/terraform/environments/core-sandbox/networking.auto.tfvars.json
@@ -1,8 +1,8 @@
 {
   "networking": [
     {
-      "business-unit": "hmpps",
-      "set": "general",
+      "business-unit": "garden-production",
+      "set": "patio",
       "application": "core-sandbox"
     }
   ]

--- a/terraform/environments/core-sandbox/playground.tf
+++ b/terraform/environments/core-sandbox/playground.tf
@@ -1,30 +1,17 @@
 data "aws_caller_identity" "current" {}
 
 module "ram-principal-association" {
+
   source = "../../modules/ram-principal-association"
+ 
   providers = {
+    aws.share-acm    = aws.core-network-services-production
     aws.share-host   = aws.core-vpc-production # Core VPC production holds the share
     aws.share-tenant = aws                     # The default provider (unaliased, `aws`) is the tenant
   }
 
   principal  = data.aws_caller_identity.current.account_id
-  vpc_name   = "hmpps-production"
-  subnet_set = "nomis"
-}
-
-#
-# The below ram-ec2-retagging module needs to be run separately due to Terraform being unable to work out how many IDs there are to tag from a data lookup.
-#
-
-module "ram-ec2-retagging" {
-  source = "../../modules/ram-ec2-retagging"
-  providers = {
-    aws.share-host   = aws.core-vpc-production # Core VPC production holds the share
-    aws.share-tenant = aws                     # The default provider (unaliased, `aws`) is the tenant
-  }
-
-  vpc_name   = "hmpps-production"
-  subnet_set = "nomis"
-
-  depends_on = [module.ram-principal-association]
+  vpc_name   = "garden-production"
+  subnet_set = "patio"
+  acm_pca    = "acm-pca-live"
 }

--- a/terraform/environments/core-sandbox/playground.tf
+++ b/terraform/environments/core-sandbox/playground.tf
@@ -3,7 +3,7 @@ data "aws_caller_identity" "current" {}
 module "ram-principal-association" {
 
   source = "../../modules/ram-principal-association"
- 
+
   providers = {
     aws.share-acm    = aws.core-network-services-production
     aws.share-host   = aws.core-vpc-production # Core VPC production holds the share
@@ -11,7 +11,7 @@ module "ram-principal-association" {
   }
 
   principal  = data.aws_caller_identity.current.account_id
-  vpc_name = local.json_data.networking[0].business-unit
+  vpc_name   = local.json_data.networking[0].business-unit
   subnet_set = local.json_data.networking[0].set
   acm_pca    = local.acm_pca[0]
 

--- a/terraform/environments/core-sandbox/playground.tf
+++ b/terraform/environments/core-sandbox/playground.tf
@@ -11,7 +11,8 @@ module "ram-principal-association" {
   }
 
   principal  = data.aws_caller_identity.current.account_id
-  vpc_name   = "garden-production"
-  subnet_set = "patio"
-  acm_pca    = "acm-pca-live"
+  vpc_name = local.json_data.networking[0].business-unit
+  subnet_set = local.json_data.networking[0].set
+  acm_pca    = local.acm_pca[0]
+
 }

--- a/terraform/environments/core-sandbox/providers.tf
+++ b/terraform/environments/core-sandbox/providers.tf
@@ -21,3 +21,13 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-vpc-production"]}:role/ModernisationPlatformAccess"
   }
 }
+
+# AWS provider for core-vpc-production, to share VPCs into this account
+provider "aws" {
+  alias  = "core-network-services-production"
+  region = "eu-west-2"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
+  }
+}

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -25,6 +25,7 @@ locals {
     }
 
   }
+
 }
 
 module "vpc" {
@@ -97,10 +98,22 @@ locals {
   ])
 }
 
+locals {
+  non-tgw-vpc-subnet = flatten([
+    for key, vpc in module.vpc : [
+      for set in keys(module.vpc[key].non_tgw_subnet_arns_by_subnetset) : {
+        key  = key
+        set  = set
+        arns = module.vpc[key].non_tgw_subnet_arns_by_subnetset[set]
+      }
+    ]
+  ])
+}
+
 module "resource-share" {
   source = "../../modules/ram-resource-share"
   for_each = {
-    for vpc in local.non-tgw-vpc : "${vpc.key}-${vpc.set}" => vpc
+    for vpc in local.non-tgw-vpc-subnet : "${vpc.key}-${vpc.set}" => vpc
   }
 
   # Subnet ARNs to attach to a resource share
@@ -141,3 +154,17 @@ module "dns-zone" {
   tags_prefix = each.key
 
 }
+
+
+# output "name" {
+  
+#   value =  local.non-tgw-vpc-subnet
+# }
+
+
+# output "test" {
+  
+
+#   value = module.vpc["garden-production"].non_tgw_subnet_arns_by_subnetset["patio"]
+# }
+

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -26,7 +26,7 @@ locals {
 
   }
 
-    non-tgw-vpc-subnet = flatten([
+  non-tgw-vpc-subnet = flatten([
     for key, vpc in module.vpc : [
       for set in keys(module.vpc[key].non_tgw_subnet_arns_by_subnetset) : {
         key  = key

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -26,6 +26,16 @@ locals {
 
   }
 
+    non-tgw-vpc-subnet = flatten([
+    for key, vpc in module.vpc : [
+      for set in keys(module.vpc[key].non_tgw_subnet_arns_by_subnetset) : {
+        key  = key
+        set  = set
+        arns = module.vpc[key].non_tgw_subnet_arns_by_subnetset[set]
+      }
+    ]
+  ])
+
 }
 
 module "vpc" {
@@ -98,18 +108,6 @@ locals {
   ])
 }
 
-locals {
-  non-tgw-vpc-subnet = flatten([
-    for key, vpc in module.vpc : [
-      for set in keys(module.vpc[key].non_tgw_subnet_arns_by_subnetset) : {
-        key  = key
-        set  = set
-        arns = module.vpc[key].non_tgw_subnet_arns_by_subnetset[set]
-      }
-    ]
-  ])
-}
-
 module "resource-share" {
   source = "../../modules/ram-resource-share"
   for_each = {
@@ -154,17 +152,4 @@ module "dns-zone" {
   tags_prefix = each.key
 
 }
-
-
-# output "name" {
-  
-#   value =  local.non-tgw-vpc-subnet
-# }
-
-
-# output "test" {
-  
-
-#   value = module.vpc["garden-production"].non_tgw_subnet_arns_by_subnetset["patio"]
-# }
 

--- a/terraform/modules/member-vpc/outputs.tf
+++ b/terraform/modules/member-vpc/outputs.tf
@@ -17,7 +17,7 @@ output "non_tgw_subnet_arns" {
   value = [
     for key, subnet in aws_subnet.subnets :
     subnet.arn
-    
+
     if substr(key, 0, 15) != "transit-gateway"
   ]
 }
@@ -38,7 +38,7 @@ output "non_tgw_subnet_arns_by_subnetset" {
     for set, cidr in var.subnet_sets : set =>
     {
       for key, subnet in local.expanded_worker_subnets_assocation :
-       "${key}-${cidr}"  => aws_subnet.subnets["${subnet.key}-${subnet.type}-${subnet.az}"].arn
+      "${key}-${cidr}" => aws_subnet.subnets["${subnet.key}-${subnet.type}-${subnet.az}"].arn
       if substr(subnet.key, 0, length(set)) == set
 
     }

--- a/terraform/modules/member-vpc/outputs.tf
+++ b/terraform/modules/member-vpc/outputs.tf
@@ -17,6 +17,7 @@ output "non_tgw_subnet_arns" {
   value = [
     for key, subnet in aws_subnet.subnets :
     subnet.arn
+    
     if substr(key, 0, 15) != "transit-gateway"
   ]
 }
@@ -31,6 +32,19 @@ output "non_tgw_subnet_arns_by_set" {
     }
   }
 }
+
+output "non_tgw_subnet_arns_by_subnetset" {
+  value = {
+    for set, cidr in var.subnet_sets : set =>
+    {
+      for key, subnet in local.expanded_worker_subnets_assocation :
+       "${key}-${cidr}"  => aws_subnet.subnets["${subnet.key}-${subnet.type}-${subnet.az}"].arn
+      if substr(subnet.key, 0, length(set)) == set
+
+    }
+  }
+}
+
 
 locals {
   network_acl_refs = { for value in aws_network_acl.default :

--- a/terraform/modules/ram-ec2-retagging/main.tf
+++ b/terraform/modules/ram-ec2-retagging/main.tf
@@ -35,8 +35,8 @@ data "aws_subnet_ids" "host" {
   provider = aws.share-host
 
   vpc_id = data.aws_vpc.host.id
-  
-  
+
+
   tags = {
     Name = "${var.vpc_name}-${var.subnet_set}*"
   }
@@ -45,13 +45,13 @@ data "aws_subnet_ids" "host" {
 
 # List all subnets in the host account
 data "aws_subnet" "host" {
-  
+
   provider = aws.share-host
 
   for_each = data.aws_subnet_ids.host.ids
   id       = each.key
 
-   tags = {
+  tags = {
     Name = "${var.vpc_name}-${var.subnet_set}*"
   }
 }
@@ -60,7 +60,7 @@ data "aws_subnet" "host" {
 
 # Retag subnets in the associated account
 resource "aws_ec2_tag" "subnets" {
-  
+
   for_each = data.aws_subnet.host
 
   resource_id = each.value.id
@@ -71,13 +71,13 @@ resource "aws_ec2_tag" "subnets" {
 
 
 # output "aws_subnet_host" {
-  
+
 #   #garden-production-patio
 #   value = data.aws_subnet.host
 # }
 
 # output "aws_subnet_tennant" {
-  
+
 #   #garden-production-patio
 #   value = data.aws_subnet_ids.associated
 # }

--- a/terraform/modules/ram-ec2-retagging/main.tf
+++ b/terraform/modules/ram-ec2-retagging/main.tf
@@ -24,30 +24,60 @@ resource "aws_ec2_tag" "vpc" {
 
 # Get all subnet IDs in the associated principal account
 data "aws_subnet_ids" "associated" {
-  provider = aws.share-host
+  provider = aws.share-tenant
 
   vpc_id = data.aws_vpc.host.id
 
+}
+
+# Get corresponding subnets, including their tags, from the host account
+data "aws_subnet_ids" "host" {
+  provider = aws.share-host
+
+  vpc_id = data.aws_vpc.host.id
+  
+  
   tags = {
+    Name = "${var.vpc_name}-${var.subnet_set}*"
+  }
+
+}
+
+# List all subnets in the host account
+data "aws_subnet" "host" {
+  
+  provider = aws.share-host
+
+  for_each = data.aws_subnet_ids.host.ids
+  id       = each.key
+
+   tags = {
     Name = "${var.vpc_name}-${var.subnet_set}*"
   }
 }
 
-# Get corresponding subnets, including their tags, from the host account
-data "aws_subnet" "host" {
-  provider = aws.share-host
 
-  for_each = data.aws_subnet_ids.associated.ids
-
-  vpc_id = data.aws_vpc.host.id
-  id     = each.key
-}
 
 # Retag subnets in the associated account
 resource "aws_ec2_tag" "subnets" {
+  
   for_each = data.aws_subnet.host
 
   resource_id = each.value.id
   key         = "Name"
   value       = each.value.tags.Name
 }
+
+
+
+# output "aws_subnet_host" {
+  
+#   #garden-production-patio
+#   value = data.aws_subnet.host
+# }
+
+# output "aws_subnet_tennant" {
+  
+#   #garden-production-patio
+#   value = data.aws_subnet_ids.associated
+# }

--- a/terraform/modules/ram-principal-association/main.tf
+++ b/terraform/modules/ram-principal-association/main.tf
@@ -6,9 +6,14 @@ provider "aws" {
   alias = "share-tenant" # Provider that wants to be shared with
 }
 
+provider "aws" {
+  alias = "share-acm" # Provider that wants to be shared with
+}
+
 data "aws_ram_resource_share" "default" {
   provider       = aws.share-host
   name           = "${var.vpc_name}-${var.subnet_set}-resource-share" # Resource share to lookup
+  
   resource_owner = "SELF"
 
   filter {
@@ -22,4 +27,24 @@ resource "aws_ram_principal_association" "default" {
 
   principal          = var.principal
   resource_share_arn = data.aws_ram_resource_share.default.arn
+}
+
+#configure acm certificate share association
+data "aws_ram_resource_share" "acm" {
+  provider       = aws.share-acm
+  name           = var.acm_pca # Resource share to lookup
+  
+  resource_owner = "SELF"
+
+  filter {
+    name   = "Name"
+    values = [var.acm_pca]
+  }
+}
+
+resource "aws_ram_principal_association" "acm" {
+  provider = aws.share-acm
+
+  principal          = var.principal
+  resource_share_arn = data.aws_ram_resource_share.acm.arn
 }

--- a/terraform/modules/ram-principal-association/main.tf
+++ b/terraform/modules/ram-principal-association/main.tf
@@ -11,9 +11,9 @@ provider "aws" {
 }
 
 data "aws_ram_resource_share" "default" {
-  provider       = aws.share-host
-  name           = "${var.vpc_name}-${var.subnet_set}-resource-share" # Resource share to lookup
-  
+  provider = aws.share-host
+  name     = "${var.vpc_name}-${var.subnet_set}-resource-share" # Resource share to lookup
+
   resource_owner = "SELF"
 
   filter {
@@ -31,9 +31,9 @@ resource "aws_ram_principal_association" "default" {
 
 #configure acm certificate share association
 data "aws_ram_resource_share" "acm" {
-  provider       = aws.share-acm
-  name           = var.acm_pca # Resource share to lookup
-  
+  provider = aws.share-acm
+  name     = var.acm_pca # Resource share to lookup
+
   resource_owner = "SELF"
 
   filter {

--- a/terraform/modules/ram-principal-association/variables.tf
+++ b/terraform/modules/ram-principal-association/variables.tf
@@ -12,3 +12,9 @@ variable "subnet_set" {
   description = "Subnet set to attach to"
   type        = string
 }
+
+variable "acm_pca" {
+  description = "ACM certificate manager"
+  type        = string
+
+}

--- a/terraform/templates/locals.tf
+++ b/terraform/templates/locals.tf
@@ -1,13 +1,13 @@
 locals {
-  application_name       =  "$application_name"
+  application_name       = "$application_name"
   environment_management = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
 
   # This takes the name of the Terraform workspace (e.g. core-vpc-production), strips out the application name (e.g. core-vpc), and checks if
   # the string leftover is `-production`, if it isn't (e.g. core-vpc-non-production => -non-production) then it sets the var to false.
-  is-production = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-production"
+  is-production    = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-production"
   is-preproduction = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-preproduction"
-  is-test = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-test"
-  is-development = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-development"
+  is-test          = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-test"
+  is-development   = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-development"
 
   tags = {
     business-unit = "Platforms"
@@ -18,6 +18,6 @@ locals {
 
   json_data = jsondecode(file("networking.auto.tfvars.json"))
 
-  acm_pca = [ substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-production" || substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-preproduction" ? "acm-pca-live" : "acm-pca-non-live" ]
+  acm_pca = [substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-production" || substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-preproduction" ? "acm-pca-live" : "acm-pca-non-live"]
 
- }
+}

--- a/terraform/templates/locals.tf
+++ b/terraform/templates/locals.tf
@@ -20,4 +20,4 @@ locals {
 
   acm_pca = [ substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-production" || substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-preproduction" ? "acm-pca-live" : "acm-pca-non-live" ]
 
-}
+ }

--- a/terraform/templates/locals.tf
+++ b/terraform/templates/locals.tf
@@ -1,8 +1,23 @@
 locals {
-  application_name       = "$application_name"
+  application_name       =  "$application_name"
   environment_management = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
 
   # This takes the name of the Terraform workspace (e.g. core-vpc-production), strips out the application name (e.g. core-vpc), and checks if
   # the string leftover is `-production`, if it isn't (e.g. core-vpc-non-production => -non-production) then it sets the var to false.
   is-production = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-production"
+  is-preproduction = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-preproduction"
+  is-test = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-test"
+  is-development = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-development"
+
+  tags = {
+    business-unit = "Platforms"
+    application   = "Modernisation Platform: ${terraform.workspace}"
+    is-production = local.is-production
+    owner         = "Modernisation Platform: modernisation-platform@digital.justice.gov.uk"
+  }
+
+  json_data = jsondecode(file("networking.auto.tfvars.json"))
+
+  acm_pca = [ substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-production" || substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-preproduction" ? "acm-pca-live" : "acm-pca-non-live" ]
+
 }

--- a/terraform/templates/main.tf
+++ b/terraform/templates/main.tf
@@ -3,15 +3,15 @@ data "aws_caller_identity" "current" {}
 module "ram-principal-association" {
 
   source = "../../modules/ram-principal-association"
- 
+
   providers = {
     aws.share-acm    = aws.core-network-services-production
-    aws.share-host   = aws.core-vpc-production 
-    aws.share-tenant = aws                    
+    aws.share-host   = aws.core-vpc-production
+    aws.share-tenant = aws
   }
 
   principal  = data.aws_caller_identity.current.account_id
-  vpc_name = terraform.workspace
+  vpc_name   = terraform.workspace
   subnet_set = local.json_data.networking[0].set
   acm_pca    = local.acm_pca[0]
 
@@ -27,7 +27,7 @@ module "ram-ec2-retagging" {
     aws.share-tenant = aws                     # The default provider (unaliased, `aws`) is the tenant
   }
 
-  vpc_name = local.json_data.networking[0].business-unit
+  vpc_name   = local.json_data.networking[0].business-unit
   subnet_set = local.json_data.networking[0].set
 
   depends_on = [module.ram-principal-association]

--- a/terraform/templates/main.tf
+++ b/terraform/templates/main.tf
@@ -11,7 +11,7 @@ module "ram-principal-association" {
   }
 
   principal  = data.aws_caller_identity.current.account_id
-  vpc_name = local.json_data.networking[0].business-unit
+  vpc_name = terraform.workspace
   subnet_set = local.json_data.networking[0].set
   acm_pca    = local.acm_pca[0]
 

--- a/terraform/templates/main.tf
+++ b/terraform/templates/main.tf
@@ -16,3 +16,19 @@ module "ram-principal-association" {
   acm_pca    = local.acm_pca[0]
 
 }
+
+#ram-ec2-retagging module 
+
+
+module "ram-ec2-retagging" {
+  source = "../../modules/ram-ec2-retagging"
+  providers = {
+    aws.share-host   = aws.core-vpc-production # Core VPC production holds the share
+    aws.share-tenant = aws                     # The default provider (unaliased, `aws`) is the tenant
+  }
+
+  vpc_name = local.json_data.networking[0].business-unit
+  subnet_set = local.json_data.networking[0].set
+
+  depends_on = [module.ram-principal-association]
+}

--- a/terraform/templates/main.tf
+++ b/terraform/templates/main.tf
@@ -1,0 +1,18 @@
+data "aws_caller_identity" "current" {}
+
+module "ram-principal-association" {
+
+  source = "../../modules/ram-principal-association"
+ 
+  providers = {
+    aws.share-acm    = aws.core-network-services-production
+    aws.share-host   = aws.core-vpc-production 
+    aws.share-tenant = aws                    
+  }
+
+  principal  = data.aws_caller_identity.current.account_id
+  vpc_name = local.json_data.networking[0].business-unit
+  subnet_set = local.json_data.networking[0].set
+  acm_pca    = local.acm_pca[0]
+
+}


### PR DESCRIPTION
This PR fixes and adds a number of core features:

- Automates ACM Private Root CA and Subordinate certificates. 
- ACM Private CA revocation S3 bucket and list
- ACM PCA subordinate RAM shares for live and non-live CA
- Fixes the core account RAM shares for subnet-sets by association the correct subnets in the resources section
- Fixes the base member account RAM share mapping so that the member accounts map to the correct RAM share hosting the    correct subnet-sets 
- fix the RAM member account tagging for subnets 