### PR TITLE
bugfix/core-network-services-routing

### DIFF
--- a/terraform/environments/core-vpc/locals.tf
+++ b/terraform/environments/core-vpc/locals.tf
@@ -5,7 +5,7 @@ locals {
   # This takes the name of the Terraform workspace (e.g. core-vpc-production), strips out the application name (e.g. core-vpc), and checks if
   # the string leftover is `-production`, if it isn't (e.g. core-vpc-non-production => -non-production) then it sets the var to false.
   is-production = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-production"
-  is-live_data = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "production"
+  is-live_data  = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "production"
 
   tags = {
     business-unit = "Platforms"

--- a/terraform/environments/core-vpc/locals.tf
+++ b/terraform/environments/core-vpc/locals.tf
@@ -5,6 +5,7 @@ locals {
   # This takes the name of the Terraform workspace (e.g. core-vpc-production), strips out the application name (e.g. core-vpc), and checks if
   # the string leftover is `-production`, if it isn't (e.g. core-vpc-non-production => -non-production) then it sets the var to false.
   is-production = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-production"
+  is-live_data = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "production"
 
   tags = {
     business-unit = "Platforms"

--- a/terraform/environments/core-vpc/transit-gateway-attachment.tf
+++ b/terraform/environments/core-vpc/transit-gateway-attachment.tf
@@ -17,7 +17,7 @@ module "vpc_attachment" {
 
   resource_share_name = "transit-gateway"
   transit_gateway_id  = data.aws_ec2_transit_gateway.transit-gateway.id
-  type                = local.tags.is-production ? "live_data" : "non_live_data"
+  type                = local.is-live_data ? "live_data" : "non_live_data"
 
   subnet_ids = module.vpc[each.key].tgw_subnet_ids
   vpc_id     = module.vpc[each.key].vpc_id

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -80,6 +80,7 @@ module "vpc_tgw_routing" {
     aws = aws.core-network-services
   }
 
+  type                = local.is-live_data ? "live_data" : "non_live_data"
   subnet_sets        = { for key, subnet in each.value.cidr.subnet_sets : key => subnet.cidr }
   tgw_vpc_attachment = module.vpc_attachment[each.key].tgw_vpc_attachment
   tgw_route_table    = module.vpc_attachment[each.key].tgw_route_table

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -80,7 +80,7 @@ module "vpc_tgw_routing" {
     aws = aws.core-network-services
   }
 
-  type                = local.is-live_data ? "live_data" : "non_live_data"
+  type               = local.is-live_data ? "live_data" : "non_live_data"
   subnet_sets        = { for key, subnet in each.value.cidr.subnet_sets : key => subnet.cidr }
   tgw_vpc_attachment = module.vpc_attachment[each.key].tgw_vpc_attachment
   tgw_route_table    = module.vpc_attachment[each.key].tgw_route_table

--- a/terraform/modules/vpc-tgw-routing/main.tf
+++ b/terraform/modules/vpc-tgw-routing/main.tf
@@ -9,23 +9,23 @@ resource "aws_ec2_transit_gateway_route" "example" {
 data "aws_vpc" "selected" {
   filter {
     name   = "tag:Name"
-    values = ["live_data"]
+    values = [var.type]
   }
 }
 
-data "aws_route_table" "live_data-public" {
+data "aws_route_table" "main-public" {
   vpc_id = data.aws_vpc.selected.id
 
   filter {
     name   = "tag:Name"
-    values = ["live_data-public"]
+    values = ["${var.type}-public"]
   }
 }
 
-resource "aws_route" "test" {
+resource "aws_route" "main" {
   for_each = tomap(var.subnet_sets)
 
-  route_table_id         = data.aws_route_table.live_data-public.id
+  route_table_id         = data.aws_route_table.main-public.id
   destination_cidr_block = each.value
   transit_gateway_id     = var.tgw_id
 }

--- a/terraform/modules/vpc-tgw-routing/variables.tf
+++ b/terraform/modules/vpc-tgw-routing/variables.tf
@@ -17,3 +17,13 @@ variable "tgw_id" {
   description = "Transit Gateway ID"
   type        = string
 }
+
+variable "type" {
+  description = "Type of Routing table (live_data / non_live_data)" 
+  type        = string
+
+  validation {
+    condition     = var.type == "live_data" || var.type == "non_live_data"
+    error_message = "Accepted values are live_data, non_live_data."
+  }
+}

--- a/terraform/modules/vpc-tgw-routing/variables.tf
+++ b/terraform/modules/vpc-tgw-routing/variables.tf
@@ -19,7 +19,7 @@ variable "tgw_id" {
 }
 
 variable "type" {
-  description = "Type of Routing table (live_data / non_live_data)" 
+  description = "Type of Routing table (live_data / non_live_data)"
   type        = string
 
   validation {


### PR DESCRIPTION
- update core-network-services routing to enable all environments to use
  centralised NAT Gateway
- correct ternary used for Transit Gateway Routing tables, previous
  ternary would only work for production

Changes made are required for Core-network-services routing to function
correctly

Closes #485