### PR TITLE
Add labels to issues templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-template.md
+++ b/.github/ISSUE_TEMPLATE/bug-template.md
@@ -1,7 +1,7 @@
 ---
 name: Modernisation Platform Bug
 about: Create new Modernisation Platform bug
-
+labels: bug
 ---
 
 ## Expected Behavior

--- a/.github/ISSUE_TEMPLATE/story-template.md
+++ b/.github/ISSUE_TEMPLATE/story-template.md
@@ -1,7 +1,7 @@
 ---
 name: Modernisation Platform Story
 about: Create new Modernisation Platform story
-
+labels: enhancement
 ---
 
 ## User Story


### PR DESCRIPTION
Automatically add bug or enchancement labels for issues depending on
which template is used.