### PR TITLE
Revert "Add Christine to the github team"

### DIFF
--- a/terraform/github/locals.tf
+++ b/terraform/github/locals.tf
@@ -25,7 +25,6 @@ locals {
     "seanprivett",
     "SimonPPledger",
     "SteveMarshall",
-    "christine-elliott",
   ]
 
   # GitHub usernames for engineers who need full AWS access


### PR DESCRIPTION
Reverts ministryofjustice/modernisation-platform#558

Removing temporarily as Christine is not part of the moj organisation yet and this is causing the workflow to fail. (Which we need to fix)