### PR TITLE
Revert adding checks

### DIFF
--- a/terraform/github/modules/repository/main.tf
+++ b/terraform/github/modules/repository/main.tf
@@ -45,7 +45,7 @@ resource "github_branch_protection" "default" {
   require_signed_commits = false
 
   required_status_checks {
-    strict = true
+    strict   = true
     contexts = ["format-code"] # format-code is from the template repository
   }
 

--- a/terraform/github/modules/repository/main.tf
+++ b/terraform/github/modules/repository/main.tf
@@ -46,20 +46,7 @@ resource "github_branch_protection" "default" {
 
   required_status_checks {
     strict = true
-    contexts = ["format-code", # format-code is from the template repository
-      "core-vpc-development-deployment-plan",
-      "core-vpc-test-deployment-plan",
-      "core-vpc-preproduction-deployment-plan",
-      "core-vpc-production-deployment-plan",
-      "run-opa-policy-tests",
-      "check-environments-deployment-plan",
-      "check-links",
-      "github-plan-and-apply",
-      "core-logging-deployment-plan",
-      "core-network-services-deployment-plan",
-      "core-security-deployment-plan",
-      "core-shared-services-deployment-plan"
-    ]
+    contexts = ["format-code"] # format-code is from the template repository
   }
 
   required_pull_request_reviews {


### PR DESCRIPTION
2 reasons for reverting this,
1) This means the check must always run, if it doesn't then the merge is
blocked.
2) This is at the module level so it is forcing all of these checks to
run even in repos that don't even have this workflow. Unfortunately it
doesn't work only if they exist, it expects them to exist.