### PR TITLE
Run publish only on source documentation changes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches:
       - "main"
+    paths:
+      - "source/**"
+      - "config/**"
     paths-ignore:
       - "docs/**"
 


### PR DESCRIPTION
Publish.yml workflow was running on nearly every merge. This is not
needed.