### PR TITLE
Set pipefail option to fail tests

### DIFF
--- a/scripts/tests/validate/opa.sh
+++ b/scripts/tests/validate/opa.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -e
+set -o pipefail
 
 environments() {
   jq -n -c -r '[ inputs | . + { filename: input_filename } ]' environments/*.json | conftest test -p policies/environments -


### PR DESCRIPTION
Currently the tests return an exit code of 0 even if they fail.  This is
because they are being piped. Adding the pipefail fixes this.