### PR TITLE
Comment out bastion test

### DIFF
--- a/policies/networking/core-vpc.rego
+++ b/policies/networking/core-vpc.rego
@@ -54,10 +54,10 @@ deny[msg] {
   msg := sprintf("`%v` is missing the `options` key", [input.filename])
 }
 
-deny[msg] {
-  not has_field(input.options, "bastion_linux")
-  msg := sprintf("`%v` is missing the `bastion_linux` key", [input.filename])
-}
+# deny[msg] {
+#   not has_field(input.options, "bastion_linux")
+#   msg := sprintf("`%v` is missing the `bastion_linux` key", [input.filename])
+# }
 
 deny[msg] {
   not has_field(input.options, "additional_endpoints")


### PR DESCRIPTION
The bastion test fails because the check for the key returns false if the key is present but it has a false value:

https://www.openpolicyagent.org/docs/latest/policy-reference/#objects

`# check if key "foo" exists and is not false`
`obj.foo`

I've not found a good fix for this yet and since we are not using the bastion key and will be removing commenting this out for now so that we can see the other tests results more easily.