### PR TITLE
enhancement/add-triggers-for-updating-repo-files

### DIFF
--- a/.github/workflows/new-environment-files.yml
+++ b/.github/workflows/new-environment-files.yml
@@ -4,6 +4,7 @@ on:
   push:
     paths:
       - 'environments/**.json'
+      - 'environments-networks/**.json'
     branches:
       - main
   workflow_dispatch:

--- a/.github/workflows/new-member-environment-files.yml
+++ b/.github/workflows/new-member-environment-files.yml
@@ -4,6 +4,7 @@ on:
   push:
     paths:
       - 'environments/**.json'
+      - 'environments-networks/**.json'
     branches:
       - main
   workflow_dispatch:


### PR DESCRIPTION
Currently new files workflow jobs are triggered when new accounts are created. We need to ensure the workflows also run when network changes/additions are made.

Closes #690 