### PR TITLE
amend-transit-gateway-variable-name-in-member-vpc-module

### DIFF
--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -88,7 +88,7 @@ module "vpc" {
 
   subnet_sets = { for key, subnet in each.value.cidr.subnet_sets : key => subnet.cidr }
   protected   = each.value.cidr.protected
-  vpc_cidr    = each.value.cidr.transit_gateway
+  transit     = each.value.cidr.transit_gateway
 
   bastion_linux = each.value.options.bastion_linux
   #bastion_windows = each.value.options.bastion_windows

--- a/terraform/modules/member-vpc/main.tf
+++ b/terraform/modules/member-vpc/main.tf
@@ -47,7 +47,7 @@ locals {
 
   # Transit Gateway subnets
   expanded_tgw_subnets = [
-    for index, cidr in cidrsubnets(var.vpc_cidr, 2, 2, 2) : {
+    for index, cidr in cidrsubnets(var.transit, 2, 2, 2) : {
       key  = "transit-gateway"
       cidr = cidr
       az   = local.availability_zones[index]
@@ -196,7 +196,7 @@ locals {
 
 # VPC
 resource "aws_vpc" "vpc" {
-  cidr_block = var.vpc_cidr
+  cidr_block = var.transit
 
   enable_dns_support   = true
   enable_dns_hostnames = true

--- a/terraform/modules/member-vpc/variables.tf
+++ b/terraform/modules/member-vpc/variables.tf
@@ -1,4 +1,4 @@
-variable "vpc_cidr" {
+variable "transit" {
   type = string
 }
 


### PR DESCRIPTION
Change variable name for Transit Gateway CIDR range as the name could cause confusion.