### PR TITLE
Fix bug where options aren't passed in correctly

### DIFF
--- a/scripts/terraform-apply.sh
+++ b/scripts/terraform-apply.sh
@@ -17,7 +17,7 @@ fi
 
 if [ ! -z "$2" ]; then
   options="$2"
-  terraform -chdir="$1" apply -input=false -no-color -auto-approve "$options" | ./scripts/redact-output.sh
+  terraform -chdir="$1" apply -input=false -no-color -auto-approve $options | ./scripts/redact-output.sh
 else
   terraform -chdir="$1" apply -input=false -no-color -auto-approve | ./scripts/redact-output.sh  
 fi

--- a/scripts/terraform-plan.sh
+++ b/scripts/terraform-plan.sh
@@ -17,7 +17,7 @@ fi
 
 if [ ! -z "$2" ]; then
   options="$2"
-  terraform -chdir="$1" plan -input=false -no-color "$options" | ./scripts/redact-output.sh
+  terraform -chdir="$1" plan -input=false -no-color $options | ./scripts/redact-output.sh
 else
   terraform -chdir="$1" plan -input=false -no-color | ./scripts/redact-output.sh  
 fi


### PR DESCRIPTION
Because the options variable was in quotes it was being passed into the
command as a string