### PR TITLE
Give write access to all-org-members on env repo

### DIFF
--- a/terraform/github/main.tf
+++ b/terraform/github/main.tf
@@ -151,3 +151,10 @@ module "aws-team" {
 
   parent_team_id = module.core-team.team_id
 }
+
+# Give write access to org on the environments repo (access to merge to main is restricted by codeowners file)
+resource "github_team_repository" "modernisation-platform-environments" {
+  team_id    = "all-org-members"
+  repository = module.modernisation-platform-environments.repository.id
+  permission = "push"
+}


### PR DESCRIPTION
Following the same pattern as on the modernisation-platform repo, we
give write (aka push) access to all-org-members. The main branch is
protected by codeowners.  This avoids us having to add teams to the repo
individually and keeps control of who can merge what into main in the
codeowners file.

Resolves #748