### PR TITLE
Change DNS role to be assumed by mp account

### DIFF
--- a/terraform/environments/core-vpc/locals.tf
+++ b/terraform/environments/core-vpc/locals.tf
@@ -1,7 +1,10 @@
+data "aws_caller_identity" "modernisation-platform" {
+  provider = aws.modernisation-platform
+}
+
 locals {
   application_name       = "core-vpc"
   environment_management = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
-
   # This takes the name of the Terraform workspace (e.g. core-vpc-production), strips out the application name (e.g. core-vpc), and checks if
   # the string leftover is `-production`, if it isn't (e.g. core-vpc-non-production => -non-production) then it sets the var to false.
   is-production = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-production"

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -91,7 +91,7 @@ module "vpc" {
   transit     = each.value.cidr.transit_gateway
 
 
-  additional_endpoints = each.value.options.additional_endpoints 
+  additional_endpoints = each.value.options.additional_endpoints
   bastion_linux        = each.value.options.bastion_linux
   #bastion_windows = each.value.options.bastion_windows
 
@@ -188,12 +188,13 @@ module "dns-zone" {
   for_each = local.vpcs[terraform.workspace]
   source   = "../../modules/dns-zone"
 
-  dns_zone         = each.key
-  vpc_id           = module.vpc[each.key].vpc_id
-  public_dns_zone  = data.aws_route53_zone.public
-  private_dns_zone = data.aws_route53_zone.private
-  accounts         = { for key, account in each.value.cidr.subnet_sets : key => account.accounts }
-  environments     = local.environment_management
+  dns_zone                       = each.key
+  vpc_id                         = module.vpc[each.key].vpc_id
+  public_dns_zone                = data.aws_route53_zone.public
+  private_dns_zone               = data.aws_route53_zone.private
+  accounts                       = { for key, account in each.value.cidr.subnet_sets : key => account.accounts }
+  modernisation_platform_account = data.aws_caller_identity.modernisation-platform.account_id
+  environments                   = local.environment_management
 
   # Tags
   tags_common = local.tags

--- a/terraform/modules/dns-zone/main.tf
+++ b/terraform/modules/dns-zone/main.tf
@@ -10,10 +10,12 @@ locals {
   account_names  = [for key, account in var.accounts : account]
   environment_id = { for key, env in var.environments : key => env }
 
-  account_numbers = flatten([
+  account_numbers = concat(flatten([
     for value in flatten(local.account_names) :
     local.environment_id.account_ids[value]
-  ])
+    ]),
+    [var.modernisation_platform_account]
+  )
 
 }
 

--- a/terraform/modules/dns-zone/variables.tf
+++ b/terraform/modules/dns-zone/variables.tf
@@ -9,6 +9,10 @@ variable "accounts" {
   type = map(any)
 }
 
+variable "modernisation_platform_account" {
+}
+
+
 variable "environments" {
 }
 


### PR DESCRIPTION
We want to be able to assume the dns role using the new member ci user.
This user and role will be used to make member changes to dns rather
than the main mod platform ci user and the admin role.

Resolves #746