### PR TITLE
Update templates and DNS role policy

### DIFF
--- a/scripts/provision-environment-directories.sh
+++ b/scripts/provision-environment-directories.sh
@@ -84,11 +84,15 @@ copy_templates() {
 
   for file in $templates; do
     filename=$(basename "$file")
-    echo "Copying $file to $1, replacing application_name with $application_name"
-    sed "s/\$application_name/${application_name}/g" "$file" > "$1/$filename"
-    if [ ${filename} == "backend.tf" ]
+
+    if [ ${filename} != "member-providers.tf" ]
     then
-      sed -i "s/environments\//environments\/accounts\//g" "$1/$filename"
+      echo "Copying $file to $1, replacing application_name with $application_name"
+      sed "s/\$application_name/${application_name}/g" "$file" > "$1/$filename"
+      if [ ${filename} == "backend.tf" ]
+      then
+        sed -i "s/environments\//environments\/accounts\//g" "$1/$filename"
+      fi
     fi
   done
 

--- a/scripts/provision-member-directories.sh
+++ b/scripts/provision-member-directories.sh
@@ -91,7 +91,7 @@ copy_templates() {
   for file in $templates; do
     filename=$(basename "$file")
 
-    if [ ${filename} != "subnet_share.tf" ]
+    if [ ${filename} != "subnet_share.tf" ] && [ ${filename} != "providers.tf" ]
     then
       echo "Copying $file to $1, replacing application_name with $application_name"
       sed "s/\$application_name/${application_name}/g" "$file" > "$1/$filename"
@@ -107,6 +107,9 @@ copy_templates() {
       fi
     fi
   done
+
+  # Rename member providers file
+  mv $1/member-providers.tf $1/providers.tf
 
   echo "Finished copying templates."
 }

--- a/terraform/modules/dns-zone/main.tf
+++ b/terraform/modules/dns-zone/main.tf
@@ -110,23 +110,20 @@ resource "aws_iam_role_policy" "dns" {
       {
         "Effect" : "Allow",
         "Action" : [
-          "route53:ListReusableDelegationSets",
-          "route53:ListTrafficPolicyInstances",
-          "route53:GetTrafficPolicyInstanceCount",
+          "route53:ChangeResourceRecordSets",
           "route53:CreateTrafficPolicy",
-          "route53:TestDNSAnswer",
-          "route53:ListHostedZones",
-          "route53:ListHostedZonesByName",
-          "route53:GetAccountLimit",
-          "route53:GetCheckerIpRanges",
-          "route53:ListHealthChecks",
+          "route53:DeleteTrafficPolicy",
+          "route53:CreateTrafficPolicyInstance",
+          "route53:CreateTrafficPolicyVersion",
+          "route53:UpdateTrafficPolicyInstance",
+          "route53:UpdateTrafficPolicyComment",
+          "route53:DeleteTrafficPolicyInstance",
           "route53:CreateHealthCheck",
-          "route53:ListTrafficPolicies",
-          "route53:GetGeoLocation",
-          "route53:ListGeoLocations",
-          "route53:GetHostedZoneCount",
-          "route53:GetHealthCheckCount"
-        ],
+          "route53:UpdateHealthCheck",
+          "route53:DeleteHealthCheck",
+          "route53:List*",
+          "route53:Get*"
+      ],
         "Resource" : "*"
       },
       {

--- a/terraform/modules/dns-zone/main.tf
+++ b/terraform/modules/dns-zone/main.tf
@@ -123,7 +123,7 @@ resource "aws_iam_role_policy" "dns" {
           "route53:DeleteHealthCheck",
           "route53:List*",
           "route53:Get*"
-      ],
+        ],
         "Resource" : "*"
       },
       {

--- a/terraform/templates/member-providers.tf
+++ b/terraform/templates/member-providers.tf
@@ -1,0 +1,23 @@
+# AWS provider for the workspace you're working in (every resource will default to using this, unless otherwise specified)
+provider "aws" {
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
+  }
+}
+
+# AWS provider for the Modernisation Platform, to get things from there if required
+provider "aws" {
+  alias  = "modernisation-platform"
+  region = "eu-west-2"
+}
+
+# AWS provider for core-vpc-<environment>, to share VPCs into this account
+provider "aws" {
+  alias  = "core-vpc"
+  region = "eu-west-2"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/dns-${local.vpc_name}-${local.environment}"
+  }
+}


### PR DESCRIPTION
To secure the members terraform, we needed to change the core-vpc role
to use a business unit scoped role rather than an all access role, and
remove the role for shared services. To do this via sed/file
manipulation was becoming messy, so instead we've created a separate
member-providers.tf template file, and depending on whether the
provision member directories script or the provision environment
directories script is running the correct template will be copied. This
also allows us to further modify the repective providers.tf files in
future if we need to and not have to further modify the scripts.

Terraform plan for the member accounts was failing with the error:
`not authorized to perform: route53:GetHostedZone on resource:`
I checked the policy and it is missing this, also it was missing some
other features which would be required to be able to update this zone.
New policy taken from here:

https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/access-control-managing-permissions.html#example-permissions-record-owner