### PR TITLE
Remove us-east-1 endpoint

### DIFF
--- a/environments-networks/platforms-development.json
+++ b/environments-networks/platforms-development.json
@@ -13,9 +13,7 @@
   },
   "options": {
     "bastion_linux": false,
-    "additional_endpoints": [
-      "com.amazonaws.us-east-1.ecr.dkr"
-    ],
+    "additional_endpoints": [],
     "dns_zone_extend": []
   },
   "nacl": []


### PR DESCRIPTION
This wasn't actually applied for some reason (which we need to look into
why the core-vpc workflow didn't pick it up or if it failed)

Since it's not needed for the PoC removing for now until we can re-add
and investigate further. #763 issue for investigation.