### PR TITLE
Add policy for member ci user

### DIFF
--- a/terraform/modernisation-platform-account/iam.tf
+++ b/terraform/modernisation-platform-account/iam.tf
@@ -91,9 +91,12 @@ data "aws_iam_policy_document" "member-ci-policy" {
   }
 
   statement {
-    effect    = "Allow"
-    actions   = ["s3:GetObject"]
-    resources = ["arn:aws:s3:::modernisation-platform-terraform-state/*"]
+    effect  = "Allow"
+    actions = ["s3:GetObject"]
+    resources = [
+      "arn:aws:s3:::modernisation-platform-terraform-state/environments/*",
+      "arn:aws:s3:::modernisation-platform-terraform-state/terraform.tfstate"
+    ]
   }
 
   statement {


### PR DESCRIPTION
The original ci user has the AdministratorAccess policy attached, so it
could access the buckets and secrets etc. This adds a much more
restricted policy to allow the access the user requires.