### PR TITLE
Add role to allow dns record modification

### DIFF
--- a/terraform/environments/core-network-services/iam.tf
+++ b/terraform/environments/core-network-services/iam.tf
@@ -1,3 +1,56 @@
 data "aws_iam_role" "vpc-flow-log" {
   name = "AWSVPCFlowLog"
 }
+
+# Role to allow ci/cd to update DNS records for ACM certificate validation
+resource "aws_iam_role" "dns" {
+  name = "modify-dns-records"
+  assume_role_policy = jsonencode(
+    {
+      "Version" : "2012-10-17",
+      "Statement" : [
+        {
+          "Effect" : "Allow",
+          "Principal" : {
+            "AWS" : data.aws_caller_identity.modernisation-platform.account_id
+          },
+          "Action" : "sts:AssumeRole",
+          "Condition" : {}
+        }
+      ]
+  })
+
+  tags = merge(
+    local.tags,
+    {
+      Name = "modify-dns-records"
+    },
+  )
+}
+
+resource "aws_iam_role_policy" "dns" {
+  name = "modify-dns-records"
+  role = aws_iam_role.dns.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        "Effect" : "Allow",
+        "Action" : ["route53:GetChange"],
+        "Resource" : "*"
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "route53:ListResourceRecordSets",
+          "route53:ChangeResourceRecordSets"
+        ],
+        Resource = [
+          "arn:aws:route53:::hostedzone/${aws_route53_zone.modernisation-platform.id}",
+          "arn:aws:route53:::hostedzone/${aws_route53_zone.modernisation-platform-internal.id}"
+        ]
+      }
+    ]
+  })
+}

--- a/terraform/environments/core-network-services/locals.tf
+++ b/terraform/environments/core-network-services/locals.tf
@@ -1,3 +1,7 @@
+data "aws_caller_identity" "modernisation-platform" {
+  provider = aws.modernisation-platform
+}
+
 locals {
   application_name       = "core-network-services"
   environment_management = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)


### PR DESCRIPTION
Because of a 64 charater limit on the domain name on a public
certificate, we've had to change the domain name to be
modernisation-platform.service.gov.uk, and have the SAN as eg
platforms-development.modernisation-platform.service...

https://docs.aws.amazon.com/acm/latest/APIReference/API_RequestCertificate.html#ACM-RequestCertificate-request-DomainName

By doing this it means when a user creates a certificate it needs to be validated from
the modernisation-platform domain level. This is created in the
core-network-services account so we need to give user pipelines a role
to be able to create these records without being able to do anything
else in this account.

Permission set taken from here:
https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/r53-api-permissions-ref.html#required-permissions-resource-record-sets
