### PR TITLE
Update permissions for dns role

### DIFF
--- a/terraform/environments/core-network-services/iam.tf
+++ b/terraform/environments/core-network-services/iam.tf
@@ -37,15 +37,15 @@ resource "aws_iam_role_policy" "dns" {
     Statement = [
       {
         "Effect" : "Allow",
-        "Action" : ["route53:GetChange"],
+        "Action" : [
+          "route53:Get*",
+          "route53:List*"
+        ],
         "Resource" : "*"
       },
       {
         Effect = "Allow",
-        Action = [
-          "route53:ListResourceRecordSets",
-          "route53:ChangeResourceRecordSets"
-        ],
+        Action = ["route53:ChangeResourceRecordSets"],
         Resource = [
           "arn:aws:route53:::hostedzone/${aws_route53_zone.modernisation-platform.id}",
           "arn:aws:route53:::hostedzone/${aws_route53_zone.modernisation-platform-internal.id}"


### PR DESCRIPTION
The permissions were not open enough and causing errors, adding get and
list permissions so it can retrieve all the zones.