### PR TITLE
Add automation to generate Github environments

### DIFF
--- a/.github/workflows/new-member-environment-files.yml
+++ b/.github/workflows/new-member-environment-files.yml
@@ -37,3 +37,11 @@ jobs:
       - run: bash ./core-repo/scripts/git-pull-request.sh terraform/environments ./modernisation-platform-environments
         env:
           TERRAFORM_GITHUB_TOKEN: ${{ secrets.TERRAFORM_GITHUB_TOKEN }}
+  create-github-environments:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - name: Create Github member environments
+        run: bash ./scripts/git-create-environments.sh
+        env:
+          TERRAFORM_GITHUB_TOKEN: ${{ secrets.TERRAFORM_GITHUB_TOKEN }}

--- a/.github/workflows/templates/workflow-template.yml
+++ b/.github/workflows/templates/workflow-template.yml
@@ -1,0 +1,204 @@
+---
+name: $application_name
+on:
+  push:
+    branches: 
+      - main
+    paths:
+      - 'terraform/environments/$application_name/**'
+      - '.github/workflows/$application_name.yml'
+  pull_request:
+    branches:
+      - main
+    types: [opened, edited, reopened, synchronize]
+    paths:
+      - 'terraform/environments/$application_name/**'
+      - '.github/workflows/$application_name.yml'
+  workflow_dispatch:
+env:
+  AWS_ACCESS_KEY_ID:  ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY:  ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  TF_IN_AUTOMATION: true
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  
+  # These jobs run when creating a pull request
+  plan-development:
+    name: Plan Development - $application_name
+    runs-on: ubuntu-latest
+    if: github.ref != 'refs/heads/main'
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2.3.4
+      - name: Load and Configure Terraform
+        uses: hashicorp/setup-terraform@v1.3.2
+        with:
+          terraform_version: 0.14.6
+          terraform_wrapper: false
+      - name: Terraform plan - development
+        run: |
+          echo "Terraform plan - ${TF_ENV}"
+          bash scripts/terraform-init.sh terraform/environments/$application_name
+          terraform -chdir="terraform/environments/$application_name" workspace select "$application_name-${TF_ENV}"
+          bash scripts/terraform-plan.sh terraform/environments/$application_name
+        env:
+          TF_ENV: development
+
+  deploy-development:
+    name: Deploy Development - $application_name
+    runs-on: ubuntu-latest
+    if: github.ref != 'refs/heads/main'
+    environment:
+      name: $application_name-development
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2.3.4
+      - name: Load and Configure Terraform
+        uses: hashicorp/setup-terraform@v1.3.2
+        with:
+          terraform_version: 0.14.6
+          terraform_wrapper: false
+      - name: Terraform apply - development
+        run: |
+          echo "Terraform apply - ${TF_ENV}"
+          bash scripts/terraform-init.sh terraform/environments/$application_name
+          terraform -chdir="terraform/environments/$application_name" workspace select "$application_name-${TF_ENV}"
+          bash scripts/terraform-apply.sh terraform/environments/$application_name
+        env:
+          TF_ENV: development
+
+  plan-test:
+    name: Plan Test - $application_name
+    runs-on: ubuntu-latest
+    if: github.ref != 'refs/heads/main'
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2.3.4
+      - name: Load and Configure Terraform
+        uses: hashicorp/setup-terraform@v1.3.2
+        with:
+          terraform_version: 0.14.6
+          terraform_wrapper: false
+      - name: Terraform plan - test
+        run: |
+          echo "Terraform plan - ${TF_ENV}"
+          bash scripts/terraform-init.sh terraform/environments/$application_name
+          terraform -chdir="terraform/environments/$application_name" workspace select "$application_name-${TF_ENV}"
+          bash scripts/terraform-plan.sh terraform/environments/$application_name
+        env:
+          TF_ENV: test
+
+  deploy-test:
+    name: Deploy Test - $application_name
+    runs-on: ubuntu-latest
+    if: github.ref != 'refs/heads/main'
+    environment:
+      name: $application_name-test
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2.3.4
+      - name: Load and Configure Terraform
+        uses: hashicorp/setup-terraform@v1.3.2
+        with:
+          terraform_version: 0.14.6
+          terraform_wrapper: false
+      - name: Terraform apply - test
+        run: |
+          echo "Terraform apply - ${TF_ENV}"
+          bash scripts/terraform-init.sh terraform/environments/$application_name
+          terraform -chdir="terraform/environments/$application_name" workspace select "$application_name-${TF_ENV}"
+          bash scripts/terraform-apply.sh terraform/environments/$application_name
+        env:
+          TF_ENV: test
+
+  # These jobs run after merging to main
+  plan-preproduction:
+    name: Plan Preproduction - $application_name
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2.3.4
+      - name: Load and Configure Terraform
+        uses: hashicorp/setup-terraform@v1.3.2
+        with:
+          terraform_version: 0.14.6
+          terraform_wrapper: false
+      - name: Terraform plan - preproduction
+        run: |
+          echo "Terraform plan - ${TF_ENV}"
+          bash scripts/terraform-init.sh terraform/environments/$application_name
+          terraform -chdir="terraform/environments/$application_name" workspace select "$application_name-${TF_ENV}"
+          bash scripts/terraform-plan.sh terraform/environments/$application_name
+        env:
+          TF_ENV: preproduction
+
+  deploy-preproduction:
+    name: Deploy Preproduction - $application_name
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    environment:
+      name: $application_name-preproduction
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2.3.4
+      - name: Load and Configure Terraform
+        uses: hashicorp/setup-terraform@v1.3.2
+        with:
+          terraform_version: 0.14.6
+          terraform_wrapper: false
+      - name: Terraform apply - preproduction
+        run: |
+          echo "Terraform apply - ${TF_ENV}"
+          bash scripts/terraform-init.sh terraform/environments/$application_name
+          terraform -chdir="terraform/environments/$application_name" workspace select "$application_name-${TF_ENV}"
+          bash scripts/terraform-apply.sh terraform/environments/$application_name
+        env:
+          TF_ENV: preproduction
+  
+  plan-production:
+    name: Plan Production - $application_name
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2.3.4
+      - name: Load and Configure Terraform
+        uses: hashicorp/setup-terraform@v1.3.2
+        with:
+          terraform_version: 0.14.6
+          terraform_wrapper: false
+      - name: Terraform plan - production
+        run: |
+          echo "Terraform plan - ${TF_ENV}"
+          bash scripts/terraform-init.sh terraform/environments/$application_name
+          terraform -chdir="terraform/environments/$application_name" workspace select "$application_name-${TF_ENV}"
+          bash scripts/terraform-plan.sh terraform/environments/$application_name
+        env:
+          TF_ENV: production
+
+  deploy-production:
+    name: Deploy Production - $application_name
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    environment:
+      name: $application_name-production
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2.3.4
+      - name: Load and Configure Terraform
+        uses: hashicorp/setup-terraform@v1.3.2
+        with:
+          terraform_version: 0.14.6
+          terraform_wrapper: false
+      - name: Terraform apply - production
+        run: |
+          echo "Terraform apply - ${TF_ENV}"
+          bash scripts/terraform-init.sh terraform/environments/$application_name
+          terraform -chdir="terraform/environments/$application_name" workspace select "$application_name-${TF_ENV}"
+          bash scripts/terraform-apply.sh terraform/environments/$application_name
+        env:
+          TF_ENV: production

--- a/scripts/git-create-environments.sh
+++ b/scripts/git-create-environments.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+
+set -e
+
+github_org="ministryofjustice"
+repository="${github_org}/modernisation-platform-environments"
+secret=$TERRAFORM_GITHUB_TOKEN
+
+get_existing_environments() {
+  response=$(curl -s \
+    -H "Accept: application/vnd.github.v3+json" \
+    -H "Authorization: token ${secret}" \
+    https://api.github.com/repos/${repository}/environments
+    )
+  github_environments=$(echo $response | jq -r '.environments[].name')
+  echo "Existing github environments: $github_environments"
+}
+
+get_github_team_id() {
+  team_slug=${1}
+  echo "Getting team id for team: ${team_slug}"
+  response=$(curl -s \
+    -H "Accept: application/vnd.github.v3+json" \
+    -H "Authorization: token ${secret}" \
+    https://api.github.com/orgs/${github_org}/teams/${team_slug})
+  team_id=$(echo ${response} | jq -r '.id')
+  # echo "Team ID for ${team_slug}: ${team_id}"
+  team_ids="${team_ids} ${team_id}"
+}
+
+check_if_environment_exists() {
+  echo "Checking if environment $1 exists..."
+  [[ $github_environments =~ (^|[[:space:]])$1($|[[:space:]]) ]] && environment_exists="true" || environment_exists="false"
+  echo "Environment $1 exists = ${environment_exists}"
+}
+
+create_environment() {
+  environment_name=$1
+  github_teams=$2
+  echo "Creating environment ${environment_name}..."
+  # echo "Teams for payload: ${github_teams}"
+  if [ "${env}" == "preproduction" ] || [ "${env}" == "production" ]
+  then
+    payload="{\"deployment_branch_policy\":{\"protected_branches\":true,\"custom_branch_policies\":false},\"reviewers\": [${github_teams}]}"
+  else
+    payload="{\"reviewers\": [${github_teams}]}"
+  fi
+  # echo "Payload: $payload"
+  echo "${payload}" | curl -s \
+  -X PUT \
+  -H "Accept: application/vnd.github.v3+json" \
+  -H "Authorization: token ${secret}" \
+  https://api.github.com/repos/${repository}/environments/${environment_name}\
+  -d @- > /dev/null 2>&1
+}
+
+create_reviewers_json() {
+  ids=$1
+  for id in ${ids}
+  do
+    # echo "Adding Team ID: $id"
+    raw_jq=`jq -cn --arg team_id "$id" '{ "type": "Team", "id": $team_id|tonumber }'`
+    reviewers_json="${raw_jq},${reviewers_json}"
+    # echo "Reviewers json in loop: ${reviewers_json}"
+  done
+  # remove trailing commas
+  reviewers_json=`echo ${reviewers_json} | sed 's/,*$//g'`
+  # echo "Reviewers json: ${reviewers_json}"
+}
+
+main() {
+  #load existing github environments
+  get_existing_environments
+  # Loop through each application json file
+  for json_file in ./environments/*.json
+  do
+    echo
+    echo "***************************************"
+    echo "Processing file: ${json_file}"  
+    application=`basename "${json_file}" .json`
+
+    # Loop through each environment
+    for env in `cat "${json_file}" | jq -r --arg FILENAME "${application}" '.environments[].name'`
+    do
+      echo
+      environment="${application}-${env}"
+      echo "Processing environment: ${environment}"
+      # Check if not core repo
+      account_type=$(jq -r '."account-type"' ${json_file})
+      if [ "${account_type}" != "core" ]
+      then
+        # Get environment github team slugs
+        teams=$(jq -r --arg e "${env}" '.environments[] | select( .name == $e ) | .access[].github_slug' $json_file)
+        echo "Teams for $environment: $teams"
+        # Check if environment exists and that if has a team associated with it
+        environment_exists="false"
+        check_if_environment_exists "${environment}"
+        if [ "${environment_exists}" = "true" ] || [ "${teams}" == "" ]
+        then
+          echo "${environment} already exists or no github team has been assigned, skipping..."
+        else
+          echo "Creating environment ${environment}"
+          # Get github team ids
+          team_ids=""
+          for team in ${teams}
+          do
+            get_github_team_id ${team}
+          done
+          # echo "Team IDs for ${environment}: ${team_ids}"
+          # Create reviewers json
+          reviewers_json=""
+          create_reviewers_json "${team_ids}"
+          create_environment ${environment} ${reviewers_json}
+        fi
+      else
+        echo "${environment} is a core environment, skipping..."
+      fi
+    done
+  done
+}
+
+main

--- a/scripts/provision-member-directories.sh
+++ b/scripts/provision-member-directories.sh
@@ -55,6 +55,10 @@ provision_environment_directories() {
 
       mkdir -p "$directory"
       copy_templates "$directory" "$application_name"
+      
+      # Create workflow file
+      echo "Creating workflow file"
+      sed "s/\$application_name/$application_name/g" "core-repo/.github/workflows/templates/workflow-template.yml" > "modernisation-platform-environments/.github/workflows/$application_name.yml"
     fi
 
     # This filters and reshapes networking_definitions to only include the business units and subnet sets for $APPLICATION_NAME


### PR DESCRIPTION
Github environments will allow users to control when their deployments
happen.  This takes the github teams defined in the environments json,
and creates an environment per mp environment (aws account). For
preprodcution and production environments, along with reviewer protection,
you can only deploy from main.

Also adds a workflow template that generates a workflow file on account file creation.