### PR TITLE
Fix terraform scripts always exit with 0

### DIFF
--- a/scripts/terraform-apply.sh
+++ b/scripts/terraform-apply.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+set -o pipefail
+set -e
+
 # This script runs terraform apply with input set to false and no color outputs, suitable for running as part of a CI/CD pipeline.
 # You need to pass through a Terraform directory as an argument, e.g.
 # sh terraform-apply.sh terraform/environments

--- a/scripts/terraform-init.sh
+++ b/scripts/terraform-init.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # This script runs terraform init with input set to false and no color outputs, suitable for running as part of a CI/CD pipeline.
 # You need to pass through a Terraform directory as an argument, e.g.
 # sh terraform-init.sh terraform/environments

--- a/scripts/terraform-plan.sh
+++ b/scripts/terraform-plan.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+set -o pipefail
+set -e
+
 # This script runs terraform plan with input set to false and no color outputs, suitable for running as part of a CI/CD pipeline.
 # You need to pass through a Terraform directory as an argument, e.g.
 # sh terraform-plan.sh terraform/environments


### PR DESCRIPTION
Because of piping the terraform command through the redaction script,
the success code will always be 0. Adding pipefail to fix this and also
-e in case there are other uncaught errors in the script.

Closes #559