### PR TITLE
Require OPA tests to be run in environments repo

### DIFF
--- a/terraform/github/main.tf
+++ b/terraform/github/main.tf
@@ -108,6 +108,7 @@ module "modernisation-platform-environments" {
     "aws",
     "environments"
   ]
+  required_checks = ["run-opa-policy-tests"]
   secrets = merge(local.member_ci_iam_user_keys, {
     # Terraform GitHub token for the CI/CD user
     TERRAFORM_GITHUB_TOKEN = "This needs to be manually set in GitHub."

--- a/terraform/github/modules/repository/main.tf
+++ b/terraform/github/modules/repository/main.tf
@@ -46,7 +46,7 @@ resource "github_branch_protection" "default" {
 
   required_status_checks {
     strict   = true
-    contexts = ["format-code"] # format-code is from the template repository
+    contexts = concat(["format-code"], var.required_checks) # format-code is from the template repository
   }
 
   required_pull_request_reviews {

--- a/terraform/github/modules/repository/variables.tf
+++ b/terraform/github/modules/repository/variables.tf
@@ -36,3 +36,9 @@ variable "visibility" {
   description = "Visibility type: `public`, `internal`, `private`"
   default     = "public"
 }
+
+variable "required_checks" {
+  type        = list(string)
+  description = "List of required checks"
+  default     = []
+}

--- a/terraform/github/modules/team/main.tf
+++ b/terraform/github/modules/team/main.tf
@@ -5,13 +5,13 @@ locals {
   maintainers = toset([
     for user in var.maintainers :
     user
-    if contains(var.members, user) && ! contains(var.ci, user)
+    if contains(var.members, user) && !contains(var.ci, user)
   ])
   # Only set someone as a member if they're not already a maintainer or already a CI user
   members = toset([
     for user in var.members :
     user
-    if ! contains(var.maintainers, user) && ! contains(var.ci, user)
+    if !contains(var.maintainers, user) && !contains(var.ci, user)
   ])
 }
 


### PR DESCRIPTION
Checks were done on the module level, changing this so that checks can
also be passed in per repo and passing in the opa check to run.