### PR TITLE
refactor-member-iam-role

### DIFF
--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -67,21 +67,21 @@ locals {
 
   }
 
-  account_numbers  = flatten([
-    for dept, data in local.vpcs[terraform.workspace]: {
+  account_numbers = flatten([
+    for dept, data in local.vpcs[terraform.workspace] : {
       key = dept
       account_nos = flatten([
-        for subnet_set in data.cidr.subnet_sets: [
-          for account in subnet_set.accounts:
-            local.environment_management.account_ids["${account}"]
+        for subnet_set in data.cidr.subnet_sets : [
+          for account in subnet_set.accounts :
+          local.environment_management.account_ids["${account}"]
         ]
       ])
     }
   ])
 
   expanded_account_numbers_with_keys = {
-    for data in local.account_numbers:
-      "${data.key}" => data.account_nos
+    for data in local.account_numbers :
+    "${data.key}" => data.account_nos
   }
 
   non-tgw-vpc-subnet = flatten([
@@ -245,7 +245,7 @@ resource "aws_iam_role" "member-delegation" {
             "AWS" : concat(
               local.expanded_account_numbers_with_keys[each.key],
               tolist([data.aws_caller_identity.modernisation-platform.account_id])
-  )
+            )
           },
           "Action" : "sts:AssumeRole",
           "Condition" : {}

--- a/terraform/modules/dns-zone/main.tf
+++ b/terraform/modules/dns-zone/main.tf
@@ -72,69 +72,9 @@ resource "aws_route53_record" "mod-ns-private" {
   records  = aws_route53_zone.private.name_servers
 }
 
-# IAM Section ----------------
-
-# DNS IAM
-resource "aws_iam_role" "dns" {
-  name = "dns-${var.dns_zone}"
-  assume_role_policy = jsonencode(
-    {
-      "Version" : "2012-10-17",
-      "Statement" : [
-        {
-          "Effect" : "Allow",
-          "Principal" : {
-            "AWS" : local.account_numbers
-          },
-          "Action" : "sts:AssumeRole",
-          "Condition" : {}
-        }
-      ]
-  })
-
-  tags = merge(
-    var.tags_common,
-    {
-      Name = "${var.tags_prefix}-dns-role"
-    },
-  )
+output "zone_public" {
+  value = aws_route53_zone.public.id
 }
-
-resource "aws_iam_role_policy" "dns" {
-  name = "dns-${var.dns_zone}"
-  role = aws_iam_role.dns.id
-
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        "Effect" : "Allow",
-        "Action" : [
-          "route53:List*",
-          "route53:Get*"
-        ],
-        "Resource" : "*"
-      },
-      {
-        Effect = "Allow",
-        Action = [
-          "route53:ChangeResourceRecordSets",
-          "route53:CreateTrafficPolicy",
-          "route53:DeleteTrafficPolicy",
-          "route53:CreateTrafficPolicyInstance",
-          "route53:CreateTrafficPolicyVersion",
-          "route53:UpdateTrafficPolicyInstance",
-          "route53:UpdateTrafficPolicyComment",
-          "route53:DeleteTrafficPolicyInstance",
-          "route53:CreateHealthCheck",
-          "route53:UpdateHealthCheck",
-          "route53:DeleteHealthCheck"
-        ],
-        Resource = [
-          "arn:aws:route53:::hostedzone/${aws_route53_zone.public.id}",
-          "arn:aws:route53:::hostedzone/${aws_route53_zone.private.id}"
-        ]
-      },
-    ]
-  })
+output "zone_private" {
+  value = aws_route53_zone.private.id
 }


### PR DESCRIPTION
closes #779 

- remove dns member role from DNS module
- create generic role in core-vpc top level
- add additional permissions for data lookups

This change is required to make the delegate-member role more generic
rather than focused purely on DNS