### PR TITLE
Comment out data call providers so they are instead called by local accounts.

### DIFF
--- a/terraform/modules/bastion_linux/main.tf
+++ b/terraform/modules/bastion_linux/main.tf
@@ -8,7 +8,7 @@ provider "aws" {
 
 # get shared subnet-set vpc object
 data "aws_vpc" "shared_vpc" {
-  provider = aws.share-host
+  # provider = aws.share-host
   tags = {
     Name = "${var.business_unit}-${var.environment}"
   }
@@ -25,7 +25,7 @@ data "aws_subnet" "local_account" {
 
 # get shared subnet-set private (az (a) subnet)
 data "aws_subnet" "private_az_a" {
-  provider = aws.share-host
+  # provider = aws.share-host
   tags = {
     Name = "${var.business_unit}-${var.environment}-${var.subnet_set}-private-${var.region}a"
   }


### PR DESCRIPTION
This change comments out the shared subnet-set vpc data object and shared subnet-set private (az (a) subnet) data object so that data calls are instead done from the member account.