### PR TITLE
Add team access to environments repo

### DIFF
--- a/terraform/github/locals.tf
+++ b/terraform/github/locals.tf
@@ -45,4 +45,13 @@ locals {
 
   # Everyone
   everyone = concat(local.all_maintainers, local.all_members)
+
+  # Modernisation platform application teams (need to give access to environments repo as needed for github environments)
+  # Hopefully we can get rid of this if this issue is resolved - https://github.com/ministryofjustice/operations-engineering/issues/139
+  # But if not we will need to automate the updating of this list based on slugs in the environment json files.
+  application_teams = [
+    "all-org-members",
+    "operations-engineering",
+    "performance-hub-developers"
+  ]
 }

--- a/terraform/github/main.tf
+++ b/terraform/github/main.tf
@@ -151,9 +151,10 @@ module "aws-team" {
   parent_team_id = module.core-team.team_id
 }
 
-# Give write access to org on the environments repo (access to merge to main is restricted by codeowners file)
-resource "github_team_repository" "modernisation-platform-environments" {
-  team_id    = "all-org-members"
+# Give write access to teams on the environments repo (access to merge to main is restricted by codeowners file)
+resource "github_team_repository" "modernisation-platform-environments-access" {
+  for_each = { for team in local.application_teams : team => team }
+  team_id    = each.value
   repository = module.modernisation-platform-environments.repository.id
   permission = "push"
 }

--- a/terraform/github/main.tf
+++ b/terraform/github/main.tf
@@ -153,7 +153,7 @@ module "aws-team" {
 
 # Give write access to teams on the environments repo (access to merge to main is restricted by codeowners file)
 resource "github_team_repository" "modernisation-platform-environments-access" {
-  for_each = { for team in local.application_teams : team => team }
+  for_each   = { for team in local.application_teams : team => team }
   team_id    = each.value
   repository = module.modernisation-platform-environments.repository.id
   permission = "push"


### PR DESCRIPTION
Adding teams that need access to the environment repo. We need to
explicitly specify team access in the repo for github environments
approvals to work (as we require a team approval, that team must have
access).  Hopefully
https://github.com/ministryofjustice/operations-engineering/issues/139
will be possible and we can just add the parent team once here.  If not
we will need to automate the updating of this list of application teams
and trigger the github workflow to run when any changes to environment
json files are made.