### PR TITLE
Give DavidElliott user state access

### DIFF
--- a/terraform/modernisation-platform-account/locals.tf
+++ b/terraform/modernisation-platform-account/locals.tf
@@ -4,6 +4,10 @@ data "aws_caller_identity" "current" {}
 locals {
   root_account           = data.aws_organizations_organization.root_account
   environment_management = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
+  root_users_with_state_access = [
+    "arn:aws:iam::${local.root_account.master_account_id}:user/ModernisationPlatformOrganisationManagement",
+    "arn:aws:iam::${local.root_account.master_account_id}:user/DavidElliott"
+  ]
   tags = {
     business-unit = "Platforms"
     application   = "Modernisation Platform"

--- a/terraform/modernisation-platform-account/s3.tf
+++ b/terraform/modernisation-platform-account/s3.tf
@@ -20,10 +20,8 @@ data "aws_iam_policy_document" "allow-state-access-from-root-account" {
     resources = [module.state-bucket.bucket.arn]
 
     principals {
-      type = "AWS"
-      identifiers = [
-        "arn:aws:iam::${local.root_account.master_account_id}:user/ModernisationPlatformOrganisationManagement"
-      ]
+      type        = "AWS"
+      identifiers = local.root_users_with_state_access
     }
   }
 
@@ -36,10 +34,8 @@ data "aws_iam_policy_document" "allow-state-access-from-root-account" {
     resources = ["${module.state-bucket.bucket.arn}/*"]
 
     principals {
-      type = "AWS"
-      identifiers = [
-        "arn:aws:iam::${local.root_account.master_account_id}:user/ModernisationPlatformOrganisationManagement"
-      ]
+      type        = "AWS"
+      identifiers = local.root_users_with_state_access
     }
   }
 
@@ -49,10 +45,8 @@ data "aws_iam_policy_document" "allow-state-access-from-root-account" {
     resources = ["${module.state-bucket.bucket.arn}/*"]
 
     principals {
-      type = "AWS"
-      identifiers = [
-        "arn:aws:iam::${local.root_account.master_account_id}:user/ModernisationPlatformOrganisationManagement"
-      ]
+      type        = "AWS"
+      identifiers = local.root_users_with_state_access
     }
 
     condition {


### PR DESCRIPTION
In order to create SCPs in the root account you need a user with more
permissions than the ModernisationPlatformOrganisationManagement which we use
to create OUs and accounts, this change gives users with the approriate
permissions access to the state file to be able to make these changes.