### PR TITLE
Add output for ec2 private IP to bastion module

### DIFF
--- a/terraform/modules/bastion_linux/outputs.tf
+++ b/terraform/modules/bastion_linux/outputs.tf
@@ -1,4 +1,4 @@
 output "bastion_private_ip" {
   description = "Private IP of bastion"
-  value = aws_instance.bastion_linux.private_ip
+  value       = aws_instance.bastion_linux.private_ip
 }

--- a/terraform/modules/bastion_linux/outputs.tf
+++ b/terraform/modules/bastion_linux/outputs.tf
@@ -1,0 +1,4 @@
+output "bastion_private_ip" {
+  description = "Private IP of bastion"
+  value = aws_instance.bastion_linux.private_ip
+}


### PR DESCRIPTION
Bastion instance private IP is used by application instance security group rules so the output was included.