### PR TITLE
Remove interpolation warnings

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/main.tf
+++ b/terraform/environments/bootstrap/single-sign-on/main.tf
@@ -76,7 +76,7 @@ resource "aws_ssoadmin_account_assignment" "developer" {
 
     "${sso_assignment.github_slug}-${sso_assignment.level}" => sso_assignment
 
-    if("${sso_assignment.level}" == "developer")
+    if(sso_assignment.level == "developer")
   }
 
   provider = aws.sso-management
@@ -101,7 +101,7 @@ resource "aws_ssoadmin_account_assignment" "administator" {
 
     "${sso_assignment.github_slug}-${sso_assignment.level}" => sso_assignment
 
-    if("${sso_assignment.level}" == "administrator")
+    if(sso_assignment.level == "administrator")
   }
 
   provider = aws.sso-management

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -73,7 +73,7 @@ locals {
       account_nos = flatten([
         for subnet_set in data.cidr.subnet_sets : [
           for account in subnet_set.accounts :
-          local.environment_management.account_ids["${account}"]
+          local.environment_management.account_ids[account]
         ]
       ])
     }
@@ -81,7 +81,7 @@ locals {
 
   expanded_account_numbers_with_keys = {
     for data in local.account_numbers :
-    "${data.key}" => data.account_nos
+    data.key => data.account_nos
   }
 
   non-tgw-vpc-subnet = flatten([


### PR DESCRIPTION
Interpolation-only expressions became depreciated in TFv0.12, fixing to
remove the warnings.