### PR TITLE
Fix scheduled baselines not running

### DIFF
--- a/.github/workflows/scheduled-baseline.yml
+++ b/.github/workflows/scheduled-baseline.yml
@@ -15,7 +15,6 @@ defaults:
 jobs:
   delegate-access:
     runs-on: ubuntu-latest
-    if: github.event.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
     env:
       AWS_ACCESS_KEY_ID:  ${{ secrets.PRIVILEGED_AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY:  ${{ secrets.PRIVILEGED_AWS_SECRET_ACCESS_KEY }}
@@ -46,7 +45,6 @@ jobs:
       - run: bash scripts/loop-through-terraform-workspaces.sh terraform/environments/bootstrap/secure-baselines apply
   single-sign-on:
     runs-on: ubuntu-latest
-    if: github.event.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
     env:
       AWS_ACCESS_KEY_ID:  ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY:  ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
Baselines where being skipped when run on a schedule due to the if
statement.  Removing the statement to fix.  By default this should now
run against the latest commit on main.