### PR TITLE
Add role to create infrastucture for members

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -63,8 +63,8 @@ data "aws_iam_policy_document" "member-access" {
       "kms:*",
       "lambda:*",
       "logs:*",
-      "organizations:Describe*", 
-      "organizations:List*", 
+      "organizations:Describe*",
+      "organizations:List*",
       "rds:*",
       "rds-db:*",
       "route53:*",
@@ -95,7 +95,7 @@ data "aws_iam_policy_document" "member-access" {
 }
 
 resource "aws_iam_policy" "member-access" {
-  count  = local.account_data.account-type == "member" ? 1 : 0
+  count    = local.account_data.account-type == "member" ? 1 : 0
   provider = aws.workspace
 
   name        = "MemberInfrastructureAccessActions"

--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -30,13 +30,13 @@ module "cicd-member-user" {
 }
 
 module "member-access" {
-  count = local.account_data.account-type == "member" ? 1 : 0
+  count  = local.account_data.account-type == "member" ? 1 : 0
   source = "github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access?ref=v1.0.0"
   providers = {
     aws = aws.workspace
   }
   account_id = local.modernisation_platform_account.id
-  policy_arn = aws_iam_policy.member-access.id
+  policy_arn = aws_iam_policy.member-access[0].id
   role_name  = "MemberInfrastructureAccess"
 }
 
@@ -90,6 +90,9 @@ data "aws_iam_policy_document" "member-access" {
 }
 
 resource "aws_iam_policy" "member-access" {
+  count  = local.account_data.account-type == "member" ? 1 : 0
+  provider = aws.workspace
+
   name        = "MemberInfrastructureAccessActions"
   description = "Restricted admin policy for member CI/CD to use"
   policy      = data.aws_iam_policy_document.member-access.json

--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -44,6 +44,8 @@ data "aws_iam_policy_document" "member-access" {
   statement {
     effect = "Allow"
     actions = [
+      "acm:*",
+      "application-autoscaling:*",
       "autoscaling:*",
       "cloudfront:*",
       "cloudwatch:*",
@@ -51,6 +53,7 @@ data "aws_iam_policy_document" "member-access" {
       "ebs:*",
       "ec2:*",
       "ecr:*",
+      "ecr-public:*",
       "ecs:*",
       "elasticfilesystem:*",
       "elasticloadbalancing:*",
@@ -60,6 +63,8 @@ data "aws_iam_policy_document" "member-access" {
       "kms:*",
       "lambda:*",
       "logs:*",
+      "organizations:Describe*", 
+      "organizations:List*", 
       "rds:*",
       "rds-db:*",
       "route53:*",

--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -28,3 +28,69 @@ module "cicd-member-user" {
     aws = aws.workspace
   }
 }
+
+module "member-access" {
+  count = local.account_data.account-type == "member" ? 1 : 0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access?ref=v1.0.0"
+  providers = {
+    aws = aws.workspace
+  }
+  account_id = local.modernisation_platform_account.id
+  policy_arn = aws_iam_policy.member-access.id
+  role_name  = "MemberInfrastructureAccess"
+}
+
+data "aws_iam_policy_document" "member-access" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "autoscaling:*",
+      "cloudfront:*",
+      "cloudwatch:*",
+      "dynamodb:*",
+      "ebs:*",
+      "ec2:*",
+      "ecr:*",
+      "ecs:*",
+      "elasticfilesystem:*",
+      "elasticloadbalancing:*",
+      "glacier:*",
+      "guardduty:get*",
+      "iam:*",
+      "kms:*",
+      "lambda:*",
+      "logs:*",
+      "rds:*",
+      "rds-db:*",
+      "route53:*",
+      "s3:*",
+      "secretsmanager:*",
+      "ses:*",
+      "sns:*",
+      "sqs:*",
+      "ssm:*"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    effect = "Deny"
+    actions = [
+      "ec2:CreateVpc",
+      "ec2:CreateSubnet",
+      "ec2:CreateVpcPeeringConnection",
+      "iam:CreateUser",
+      "iam:DeleteUser",
+      "iam:CreateGroup",
+      "iam:DeleteGroup",
+      "iam:DeleteGroupPolicy"
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "member-access" {
+  name        = "MemberInfrastructureAccessActions"
+  description = "Restricted admin policy for member CI/CD to use"
+  policy      = data.aws_iam_policy_document.member-access.json
+}

--- a/terraform/modules/iam_baseline/main.tf
+++ b/terraform/modules/iam_baseline/main.tf
@@ -2,10 +2,6 @@ resource "aws_iam_user" "cicd_member_user" {
   name = "cicd-member-user"
 }
 
-resource "aws_iam_access_key" "cicd_member_user_key" {
-  user = aws_iam_user.cicd_member_user.name
-}
-
 resource "aws_iam_group" "cicd_member_group" {
   name = "cicd-member-group"
 }


### PR DESCRIPTION
Resolves #810, currently the member CI/CD user uses a unrestricted admin
role to create infrastructure.  This is a new role which can be assumed
with restricted permissions, so that we can have confidence that users
don't create resources that we don't want them to to.