### PR TITLE
Update template and member-ci user to use new member role

### DIFF
--- a/terraform/modernisation-platform-account/iam.tf
+++ b/terraform/modernisation-platform-account/iam.tf
@@ -88,7 +88,7 @@ data "aws_iam_policy_document" "member-ci-policy" {
     effect  = "Allow"
     actions = ["sts:AssumeRole"]
     resources = [
-      "arn:aws:iam::*:role/ModernisationPlatformAccess",
+      "arn:aws:iam::*:role/MemberInfrastructureAccess",
       "arn:aws:iam::${local.environment_management.account_ids["core-vpc-development"]}:role/member-delegation-*-development",
       "arn:aws:iam::${local.environment_management.account_ids["core-vpc-test"]}:role/member-delegation-*-test",
       "arn:aws:iam::${local.environment_management.account_ids["core-vpc-preproduction"]}:role/member-delegation-*-preproduction",

--- a/terraform/templates/member-providers.tf
+++ b/terraform/templates/member-providers.tf
@@ -2,7 +2,7 @@
 provider "aws" {
   region = "eu-west-2"
   assume_role {
-    role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/MemberInfrastructureAccess"
   }
 }
 


### PR DESCRIPTION
Now that we have a restricted member role for member infrastructure
changes we need to update the template.

Also changing the role that the member-ci user can assume to this one.