### PR TITLE
Enable dynamic tagging

### DIFF
--- a/scripts/provision-member-directories.sh
+++ b/scripts/provision-member-directories.sh
@@ -104,9 +104,11 @@ copy_templates() {
         if [ `uname` = "Linux" ]
         then
           sed -i "s/environments\//environments\/members\//g" "$1/$filename"
+          sed -i "s/github\.com\/ministryofjustice\/modernisation-platform/github\.com\/ministryofjustice\/modernisation-platform-environments/g" "$1/$filename"
         else
           # This must be a Mac
           sed -i '' "s/environments\//environments\/members\//g" "$1/$filename"
+          sed -i '' "s/github\.com\/ministryofjustice\/modernisation-platform/github\.com\/ministryofjustice\/modernisation-platform-environments/g" "$1/$filename"
         fi
       fi
     fi

--- a/terraform/environments/bench/locals.tf
+++ b/terraform/environments/bench/locals.tf
@@ -2,6 +2,11 @@
 # (when we want to assume a role in the MP, for instance)
 data "aws_organizations_organization" "root_account" {}
 
+# Get the environments file from the main repository
+data "http" "environments_file" {
+  url = "https://raw.githubusercontent.com/ministryofjustice/modernisation-platform/main/environments/${local.application_name}.json"
+}
+
 locals {
 
   application_name = "bench"
@@ -15,12 +20,13 @@ locals {
   is-test          = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-test"
   is-development   = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-development"
 
-  tags = {
-    business-unit = "Platforms"
-    application   = "Modernisation Platform: ${terraform.workspace}"
-    is-production = local.is-production
-    owner         = "Modernisation Platform: modernisation-platform@digital.justice.gov.uk"
-  }
+  # Merge tags from the environment json file with additional ones
+  tags = merge(
+    jsondecode(data.http.environments_file.body).tags,
+    { "is-production" = local.is-production },
+    { "environment-name" = terraform.workspace },
+    { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
+  )
 
   environment = trimprefix(terraform.workspace, "${var.networking[0].application}-")
   vpc_name    = var.networking[0].business-unit

--- a/terraform/environments/bench/outputs.tf
+++ b/terraform/environments/bench/outputs.tf
@@ -1,0 +1,3 @@
+output "tags" {
+  value = local.tags
+}

--- a/terraform/environments/bootstrap/delegate-access/locals.tf
+++ b/terraform/environments/bootstrap/delegate-access/locals.tf
@@ -6,4 +6,13 @@ locals {
   root_account                   = data.aws_organizations_organization.root_account
   modernisation_platform_account = local.root_account.accounts[index(local.root_account.accounts[*].email, "aws+modernisation-platform@digital.justice.gov.uk")]
   environment_management         = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
+
+  environments = {
+    business-unit = "Platforms"
+    application   = "Modernisation Platform: Environments Management"
+    is-production = true
+    owner         = "Modernisation Platform: modernisation-platform@digital.justice.gov.uk"
+    component     = "delegate-access"
+    source-code   = "https://github.com/ministryofjustice/modernisation-platform/tree/main/terraform/environments/bootstrap/delegate-access"
+  }
 }

--- a/terraform/environments/bootstrap/secure-baselines/locals.tf
+++ b/terraform/environments/bootstrap/secure-baselines/locals.tf
@@ -14,6 +14,8 @@ locals {
     application   = "Modernisation Platform: Environments Management"
     is-production = true
     owner         = "Modernisation Platform: modernisation-platform@digital.justice.gov.uk"
+    component     = "secure-baselines"
+    source-code   = "https://github.com/ministryofjustice/modernisation-platform/tree/main/terraform/environments/bootstrap/secure-baselines"
   }
   root_account           = data.aws_organizations_organization.root_account
   environment_management = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)

--- a/terraform/environments/cooker/locals.tf
+++ b/terraform/environments/cooker/locals.tf
@@ -2,6 +2,11 @@
 # (when we want to assume a role in the MP, for instance)
 data "aws_organizations_organization" "root_account" {}
 
+# Get the environments file from the main repository
+data "http" "environments_file" {
+  url = "https://raw.githubusercontent.com/ministryofjustice/modernisation-platform/main/environments/${local.application_name}.json"
+}
+
 locals {
 
   application_name = "cooker"
@@ -15,12 +20,13 @@ locals {
   is-test          = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-test"
   is-development   = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-development"
 
-  tags = {
-    business-unit = "Platforms"
-    application   = "Modernisation Platform: ${terraform.workspace}"
-    is-production = local.is-production
-    owner         = "Modernisation Platform: modernisation-platform@digital.justice.gov.uk"
-  }
+  # Merge tags from the environment json file with additional ones
+  tags = merge(
+    jsondecode(data.http.environments_file.body).tags,
+    { "is-production" = local.is-production },
+    { "environment-name" = terraform.workspace },
+    { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
+  )
 
   environment = trimprefix(terraform.workspace, "${var.networking[0].application}-")
   vpc_name    = var.networking[0].business-unit

--- a/terraform/environments/ops-engineering/locals.tf
+++ b/terraform/environments/ops-engineering/locals.tf
@@ -2,6 +2,11 @@
 # (when we want to assume a role in the MP, for instance)
 data "aws_organizations_organization" "root_account" {}
 
+# Get the environments file from the main repository
+data "http" "environments_file" {
+  url = "https://raw.githubusercontent.com/ministryofjustice/modernisation-platform/main/environments/${local.application_name}.json"
+}
+
 locals {
 
   application_name = "ops-engineering"
@@ -15,12 +20,13 @@ locals {
   is-test          = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-test"
   is-development   = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-development"
 
-  tags = {
-    business-unit = "Platforms"
-    application   = "Modernisation Platform: ${terraform.workspace}"
-    is-production = local.is-production
-    owner         = "Modernisation Platform: modernisation-platform@digital.justice.gov.uk"
-  }
+  # Merge tags from the environment json file with additional ones
+  tags = merge(
+    jsondecode(data.http.environments_file.body).tags,
+    { "is-production" = local.is-production },
+    { "environment-name" = terraform.workspace },
+    { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
+  )
 
   environment = trimprefix(terraform.workspace, "${var.networking[0].application}-")
   vpc_name    = var.networking[0].business-unit

--- a/terraform/environments/performance-hub/locals.tf
+++ b/terraform/environments/performance-hub/locals.tf
@@ -2,6 +2,11 @@
 # (when we want to assume a role in the MP, for instance)
 data "aws_organizations_organization" "root_account" {}
 
+# Get the environments file from the main repository
+data "http" "environments_file" {
+  url = "https://raw.githubusercontent.com/ministryofjustice/modernisation-platform/main/environments/${local.application_name}.json"
+}
+
 locals {
 
   application_name = "performance-hub"
@@ -15,12 +20,13 @@ locals {
   is-test          = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-test"
   is-development   = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-development"
 
-  tags = {
-    business-unit = "Platforms"
-    application   = "Modernisation Platform: ${terraform.workspace}"
-    is-production = local.is-production
-    owner         = "Modernisation Platform: modernisation-platform@digital.justice.gov.uk"
-  }
+  # Merge tags from the environment json file with additional ones
+  tags = merge(
+    jsondecode(data.http.environments_file.body).tags,
+    { "is-production" = local.is-production },
+    { "environment-name" = terraform.workspace },
+    { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
+  )
 
   environment = trimprefix(terraform.workspace, "${var.networking[0].application}-")
   vpc_name    = var.networking[0].business-unit

--- a/terraform/environments/sprinkler/locals.tf
+++ b/terraform/environments/sprinkler/locals.tf
@@ -2,6 +2,11 @@
 # (when we want to assume a role in the MP, for instance)
 data "aws_organizations_organization" "root_account" {}
 
+# Get the environments file from the main repository
+data "http" "environments_file" {
+  url = "https://raw.githubusercontent.com/ministryofjustice/modernisation-platform/main/environments/${local.application_name}.json"
+}
+
 locals {
 
   application_name = "sprinkler"
@@ -15,12 +20,13 @@ locals {
   is-test          = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-test"
   is-development   = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-development"
 
-  tags = {
-    business-unit = "Platforms"
-    application   = "Modernisation Platform: ${terraform.workspace}"
-    is-production = local.is-production
-    owner         = "Modernisation Platform: modernisation-platform@digital.justice.gov.uk"
-  }
+  # Merge tags from the environment json file with additional ones
+  tags = merge(
+    jsondecode(data.http.environments_file.body).tags,
+    { "is-production" = local.is-production },
+    { "environment-name" = terraform.workspace },
+    { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
+  )
 
   environment = trimprefix(terraform.workspace, "${var.networking[0].application}-")
   vpc_name    = var.networking[0].business-unit

--- a/terraform/templates/locals.tf
+++ b/terraform/templates/locals.tf
@@ -2,6 +2,11 @@
 # (when we want to assume a role in the MP, for instance)
 data "aws_organizations_organization" "root_account" {}
 
+# Get the environments file from the main repository
+data "http" "environments_file" {
+  url = "https://raw.githubusercontent.com/ministryofjustice/modernisation-platform/main/environments/${local.application_name}.json"
+}
+
 locals {
 
   application_name = "$application_name"
@@ -15,12 +20,13 @@ locals {
   is-test          = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-test"
   is-development   = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-development"
 
-  tags = {
-    business-unit = "Platforms"
-    application   = "Modernisation Platform: ${terraform.workspace}"
-    is-production = local.is-production
-    owner         = "Modernisation Platform: modernisation-platform@digital.justice.gov.uk"
-  }
+  # Merge tags from the environment json file with additional ones
+  tags = merge(
+    jsondecode(data.http.environments_file.body).tags,
+    { "is-production" = local.is-production },
+    { "environment-name" = terraform.workspace },
+    { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
+  )
 
   environment = trimprefix(terraform.workspace, "${var.networking[0].application}-")
   vpc_name    = var.networking[0].business-unit


### PR DESCRIPTION
Currently tags are all statically defined in the locals file for member
accounts. This change pulls the tags from the environments file, so if
the tags in the environment json file are changed this will be reflected
the next time the infrastructure terraform for that account is run.

I am getting the .json file directly from github over http, rather than
referencing the file in the repository, because the same template is
used in the environments repository, and this will work from both
repositories to pull the file to generate the tags. This keeps it
consistent across the repos.

Also some minor updates to the tags to add things like the source code
repository. This will help going forward to identify if a resource in an
account was generated from the members environments repo or this repo.

Summary of changes:

- Changes to templates to get application environment json file using a http data source and use that for tags
- Changes to provision-member-directories script to modify the above tags to change the source repo to the member environment repo
- Add tags to delegate access bootstrap code
- Add additional tags such as source code where appropriate
- Update tags in member account to match the new template

Todo:
On the member environments repository update existing tags to match the new template.