### PR TITLE
Add slack notification for workflow failure

### DIFF
--- a/.github/workflows/core-logging-deployment.yml
+++ b/.github/workflows/core-logging-deployment.yml
@@ -90,3 +90,11 @@ jobs:
           bash scripts/terraform-init.sh terraform/environments/core-logging
           terraform -chdir="terraform/environments/core-logging" workspace select core-logging-production
           bash scripts/terraform-apply.sh terraform/environments/core-logging
+      - uses: 8398a7/action-slack@v3
+        name: Slack failure notification
+        with:
+          status: ${{ job.status }}
+          fields: workflow,job,repo,commit,message
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: ${{ failure() }}

--- a/.github/workflows/core-network-services-deployment.yml
+++ b/.github/workflows/core-network-services-deployment.yml
@@ -90,3 +90,11 @@ jobs:
           bash scripts/terraform-init.sh terraform/environments/core-network-services
           terraform -chdir="terraform/environments/core-network-services" workspace select core-network-services-production
           bash scripts/terraform-apply.sh terraform/environments/core-network-services
+      - uses: 8398a7/action-slack@v3
+        name: Slack failure notification
+        with:
+          status: ${{ job.status }}
+          fields: workflow,job,repo,commit,message
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: ${{ failure() }}

--- a/.github/workflows/core-security-deployment.yml
+++ b/.github/workflows/core-security-deployment.yml
@@ -90,3 +90,11 @@ jobs:
           bash scripts/terraform-init.sh terraform/environments/core-security
           terraform -chdir="terraform/environments/core-security" workspace select core-security-production
           bash scripts/terraform-apply.sh terraform/environments/core-security
+      - uses: 8398a7/action-slack@v3
+        name: Slack failure notification
+        with:
+          status: ${{ job.status }}
+          fields: workflow,job,repo,commit,message
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: ${{ failure() }}

--- a/.github/workflows/core-shared-services-deployment.yml
+++ b/.github/workflows/core-shared-services-deployment.yml
@@ -90,3 +90,11 @@ jobs:
           bash scripts/terraform-init.sh terraform/environments/core-shared-services
           terraform -chdir="terraform/environments/core-shared-services" workspace select core-shared-services-production
           bash scripts/terraform-apply.sh terraform/environments/core-shared-services
+      - uses: 8398a7/action-slack@v3
+        name: Slack failure notification
+        with:
+          status: ${{ job.status }}
+          fields: workflow,job,repo,commit,message
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: ${{ failure() }}

--- a/.github/workflows/core-vpc-development-deployment.yml
+++ b/.github/workflows/core-vpc-development-deployment.yml
@@ -82,6 +82,14 @@ jobs:
           echo "Target apply finished"
           bash scripts/terraform-apply.sh terraform/environments/core-vpc
           echo "Terraform apply finished"
+      - uses: 8398a7/action-slack@v3
+        name: Slack failure notification
+        with:
+          status: ${{ job.status }}
+          fields: workflow,job,repo,commit,message
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: ${{ failure() }}
 
   member-account-ram-associaton:
     runs-on: [ubuntu-latest]
@@ -109,3 +117,11 @@ jobs:
           else
           echo "[+] There were no AWS member accounts to process"
           fi
+      - uses: 8398a7/action-slack@v3
+        name: Slack failure notification
+        with:
+          status: ${{ job.status }}
+          fields: workflow,job,repo,commit,message
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: ${{ failure() }}

--- a/.github/workflows/core-vpc-preproduction-deployment.yml
+++ b/.github/workflows/core-vpc-preproduction-deployment.yml
@@ -82,6 +82,15 @@ jobs:
           echo "Target apply finished"
           bash scripts/terraform-apply.sh terraform/environments/core-vpc
           echo "Terraform apply finished"
+      - uses: 8398a7/action-slack@v3
+        name: Slack failure notification
+        with:
+          status: ${{ job.status }}
+          fields: workflow,job,repo,commit,message
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: ${{ failure() }}
+
 
   member-account-ram-associaton:
     runs-on: [ubuntu-latest]
@@ -109,3 +118,11 @@ jobs:
           else
           echo "[+] There were no AWS member accounts to process"
           fi
+      - uses: 8398a7/action-slack@v3
+        name: Slack failure notification
+        with:
+          status: ${{ job.status }}
+          fields: workflow,job,repo,commit,message
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: ${{ failure() }}

--- a/.github/workflows/core-vpc-production-deployment.yml
+++ b/.github/workflows/core-vpc-production-deployment.yml
@@ -82,6 +82,14 @@ jobs:
           echo "Target apply finished"
           bash scripts/terraform-apply.sh terraform/environments/core-vpc
           echo "Terraform apply finished"
+      - uses: 8398a7/action-slack@v3
+        name: Slack failure notification
+        with:
+          status: ${{ job.status }}
+          fields: workflow,job,repo,commit,message
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: ${{ failure() }}
 
   member-account-ram-associaton:
     runs-on: [ubuntu-latest]
@@ -109,3 +117,11 @@ jobs:
           else
           echo "[+] There were no AWS member accounts to process"
           fi
+      - uses: 8398a7/action-slack@v3
+        name: Slack failure notification
+        with:
+          status: ${{ job.status }}
+          fields: workflow,job,repo,commit,message
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: ${{ failure() }}

--- a/.github/workflows/core-vpc-test-deployment.yml
+++ b/.github/workflows/core-vpc-test-deployment.yml
@@ -82,6 +82,14 @@ jobs:
           echo "Target apply finished"
           bash scripts/terraform-apply.sh terraform/environments/core-vpc
           echo "Terraform apply finished"
+      - uses: 8398a7/action-slack@v3
+        name: Slack failure notification
+        with:
+          status: ${{ job.status }}
+          fields: workflow,job,repo,commit,message
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: ${{ failure() }}
 
   member-account-ram-associaton:
     runs-on: [ubuntu-latest]
@@ -109,3 +117,11 @@ jobs:
           else
           echo "[+] There were no AWS member accounts to process"
           fi
+      - uses: 8398a7/action-slack@v3
+        name: Slack failure notification
+        with:
+          status: ${{ job.status }}
+          fields: workflow,job,repo,commit,message
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: ${{ failure() }}

--- a/.github/workflows/new-environment-files.yml
+++ b/.github/workflows/new-environment-files.yml
@@ -26,3 +26,12 @@ jobs:
       - run: bash ./scripts/git-pull-request.sh terraform/environments
         env:
           SECRET: ${{ secrets.GITHUB_TOKEN }}
+      - uses: 8398a7/action-slack@v3
+        name: Slack failure notification
+        with:
+          status: ${{ job.status }}
+          fields: workflow,job,repo,commit,message
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: ${{ failure() }}
+

--- a/.github/workflows/new-member-environment-files.yml
+++ b/.github/workflows/new-member-environment-files.yml
@@ -37,6 +37,15 @@ jobs:
       - run: bash ./core-repo/scripts/git-pull-request.sh terraform/environments ./modernisation-platform-environments
         env:
           TERRAFORM_GITHUB_TOKEN: ${{ secrets.TERRAFORM_GITHUB_TOKEN }}
+      - uses: 8398a7/action-slack@v3
+        name: Slack failure notification
+        with:
+          status: ${{ job.status }}
+          fields: workflow,job,repo,commit,message
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: ${{ failure() }}
+
   create-github-environments:
     runs-on: ubuntu-latest
     steps:
@@ -45,3 +54,12 @@ jobs:
         run: bash ./scripts/git-create-environments.sh
         env:
           TERRAFORM_GITHUB_TOKEN: ${{ secrets.TERRAFORM_GITHUB_TOKEN }}
+      - uses: 8398a7/action-slack@v3
+        name: Slack failure notification
+        with:
+          status: ${{ job.status }}
+          fields: workflow,job,repo,commit,message
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: ${{ failure() }}
+

--- a/.github/workflows/terraform-github.yml
+++ b/.github/workflows/terraform-github.yml
@@ -41,3 +41,11 @@ jobs:
       - name: terraform apply
         if: github.event.ref == 'refs/heads/main'
         run: bash scripts/terraform-apply.sh terraform/github
+      - uses: 8398a7/action-slack@v3
+        name: Slack failure notification
+        with:
+          status: ${{ job.status }}
+          fields: workflow,job,repo,commit,message
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: ${{ failure() && github.event.ref == 'refs/heads/main' }}

--- a/terraform/github/main.tf
+++ b/terraform/github/main.tf
@@ -15,6 +15,8 @@ module "core" {
     PRIVILEGED_AWS_SECRET_ACCESS_KEY = "example"
     # Terraform GitHub token for the CI/CD user
     TERRAFORM_GITHUB_TOKEN = "This needs to be manually set in GitHub."
+    # Slack app webhook url
+    SLACK_WEBHOOK_URL = "This needs to be manually set in GitHub."
   }))
 }
 

--- a/terraform/github/providers.tf
+++ b/terraform/github/providers.tf
@@ -1,6 +1,6 @@
 provider "github" {
   owner = "ministryofjustice"
-  token        = var.github_token
+  token = var.github_token
 }
 
 provider "aws" {


### PR DESCRIPTION
This adds a notification to slack when a workflow fails. Note this is
added only to jobs that run when merged into main.  There is no point in
added alerts to jobs that run when a PR is created - we'll see if it
fails on the PR.  But currently once we merge a PR and a job runs you
either have to manually check that the workflow ran ok, or assume it
runs sucessfully.  As 99% of the time they run sucessfully it has caught
us out in the past where things have failed and we've not seen the
impact of the failure until later.