### PR TITLE
Remove format-code required

### DIFF
--- a/terraform/github/modules/repository/main.tf
+++ b/terraform/github/modules/repository/main.tf
@@ -46,7 +46,7 @@ resource "github_branch_protection" "default" {
 
   required_status_checks {
     strict   = true
-    contexts = concat(["format-code"], var.required_checks) # format-code is from the template repository
+    contexts = var.required_checks
   }
 
   required_pull_request_reviews {


### PR DESCRIPTION
The code formatter hangs when it has to make a commit because it uses
the same repo token therefore doesn't trigger the workflow to run after
making a commit. This leaves the PR in a hung state as it can't be
merged until the required check has run.

https://github.community/t/push-from-action-does-not-trigger-subsequent-action/16854/5

Removing the need for the formatter to be required, it is only
formatting code and not critical that it runs.

Closes #926 