### PR TITLE
update-member-vpc-module-NACL-config

### DIFF
--- a/terraform/modules/member-vpc/main.tf
+++ b/terraform/modules/member-vpc/main.tf
@@ -91,14 +91,14 @@ locals {
     if subnet.key != "transit-gateway"
   ])
 
-# Distinct subnets by key type - Private
+  # Distinct subnets by key type - Private
   distinct_subnets_by_key_type_private = distinct([
     for subnet in local.all_subnets_with_keys :
     "${subnet.key}-${subnet.type}"
     if subnet.type == "private"
   ])
 
-# Distinct subnets by key type - Public
+  # Distinct subnets by key type - Public
   distinct_subnets_by_key_type_public = distinct([
     for subnet in local.all_subnets_with_keys :
     "${subnet.key}-${subnet.type}"

--- a/terraform/modules/member-vpc/variables.tf
+++ b/terraform/modules/member-vpc/variables.tf
@@ -32,7 +32,7 @@ variable "transit_gateway_id" {
 
 variable "additional_endpoints" {
   description = "additional endpoints required for VPC"
-  type        = list
+  type        = list(any)
 }
 
 variable "bastion_linux" {


### PR DESCRIPTION
- Separate Public and Private NACL rule configuration
- Configure Private NACLs to allow ingress high ports only for
  centralised NAT
- Configure Public NACLs to all ingress for 443 only as default

closes #917 