### PR TITLE
Make perf hub team - AWS admins

### DIFF
--- a/environments/performance-hub.json
+++ b/environments/performance-hub.json
@@ -6,7 +6,7 @@
       "access": [
         {
           "github_slug": "performance-hub-developers",
-          "level": "developer"
+          "level": "administrator"
         }
       ]
     },
@@ -15,7 +15,7 @@
       "access": [
         {
           "github_slug": "performance-hub-developers",
-          "level": "developer"
+          "level": "administrator"
         }
       ]
     }


### PR DESCRIPTION
Elevating the developers access to admin. 'developer' access current does not give access to cloudwatch or secretsmanager