### PR TITLE
Update missed publisher versions

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -9,7 +9,7 @@ jobs:
   check-links:
     runs-on: ubuntu-latest
     container:
-      image: ministryofjustice/tech-docs-github-pages-publisher:1.3
+      image: ministryofjustice/tech-docs-github-pages-publisher:1.4
     steps:
     - uses: actions/checkout@v2.3.4
     - name: htmlproofer

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-IMAGE := ministryofjustice/tech-docs-github-pages-publisher:1.3
+IMAGE := ministryofjustice/tech-docs-github-pages-publisher:1.4
 
 # Use this to run a local instance of the documentation site, while editing
 .PHONY: preview


### PR DESCRIPTION
The main publish workflow was updated previously but we missed these
versions in the check-links.yml and make file.