### PR TITLE
Add terraform static code analysis

### DIFF
--- a/.github/workflows/terraform-static-analysis.yml
+++ b/.github/workflows/terraform-static-analysis.yml
@@ -1,0 +1,41 @@
+name: Terraform Static Code Analysis
+
+on:
+  workflow_dispatch:
+  pull_requests:
+    paths: 
+      - 'terraform/**'
+      - '.github/workflows/terraform-static-analysis.yml'
+
+jobs:
+  terraform-static-analysis:
+    name: Terraform Static Analysis
+    runs-on: ubuntu-latest
+    if: github.event_name != 'workflow_dispatch'
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2.3.4
+      with:
+        fetch-depth: 0
+    - name: Run Analysis
+      uses: davidkelliott/terraform-static-analysis@main
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        scan_type: changed
+
+  terraform-static-analysis-full-scan:
+    name: Terraform Static Analysis - scan all directories
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch'
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2.3.4
+      with:
+        fetch-depth: 0
+    - name: Run Analysis
+      uses: davidkelliott/terraform-static-analysis@main
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        scan_type: full   


### PR DESCRIPTION
To improve our code quality we want to run static code analysis on our
terraform code.

This action should run TFSEC and Checkov on changed terraform folders.  There is a workflow dispatch option to run a full scan on all our terraform.

There are currently a lot of alerts so we need to tweak this.  Also it takes a couple of minutes to run as it's 2 tests combined, it might be better to use the official actions and split out into 2 workflows that run concurrently.  The main benefit of this custom action is to only run on folders which have changed, and to be able to run a full scan.  The standard actions you have to pass in the terraform directory name, which means if multiple terraform directories are changed it will scan only one.  So there is also no way to scan everything at once.

Work in progress at the moment so likely to change.  If this works out I'll move the action into the moj actions repo, but at the moment I'm still undecided whether to use this or the existing actions.