### PR TITLE
Revert "Make perf hub team - AWS admins"

### DIFF
--- a/environments/performance-hub.json
+++ b/environments/performance-hub.json
@@ -6,7 +6,7 @@
       "access": [
         {
           "github_slug": "performance-hub-developers",
-          "level": "administrator"
+          "level": "developer"
         }
       ]
     },
@@ -15,7 +15,7 @@
       "access": [
         {
           "github_slug": "performance-hub-developers",
-          "level": "administrator"
+          "level": "developer"
         }
       ]
     }


### PR DESCRIPTION
Reverts ministryofjustice/modernisation-platform#935

We have changed the developer permission set now to have the required permissions so we can revert performance hub team back to developer access.