### PR TITLE
Add naming validation to OPA tests

### DIFF
--- a/policies/README.md
+++ b/policies/README.md
@@ -9,6 +9,8 @@ We use [Conftest](https://www.conftest.dev/) and [Open Policy Agent (OPA)](https
 
 This runs the OPA tests against each json file in the [environments](../environments) and [environments-networks](../environments-networks) folder against the relevant policy folder.
 
+The policies in the [member](./member) folder are additional policies that will only run against an environments .JSON file if the `account-type` is `member`. This is because some of the early core and unrestricted accounts do not follow are current naming conventions.
+
 [scripts/tests/validate/run-opa-tests.sh](../scripts/tests/validate/run-opa-tests.sh)
 
 ## Run the test unit tests
@@ -18,3 +20,5 @@ These verify that the tests are running as expected.
 `conftest verify -p policies/environments`
 
 `conftest verify -p policies/networking`
+
+`conftest verify -p policies/member`

--- a/policies/environments/environment-definitions.rego
+++ b/policies/environments/environment-definitions.rego
@@ -63,6 +63,11 @@ deny[msg] {
 }
 
 deny[msg] {
+  not regex.match("^[a-zA-Z-]{1,20}$", input.tags["business-unit"])
+  msg := sprintf("`%v` Business unit name does not meet requirements", [input.filename])
+}
+
+deny[msg] {
   not has_field(input.tags, "owner")
   msg := sprintf("`%v` is missing the `owner` tag", [input.filename])
 }

--- a/policies/environments/environment-definitions_test.rego
+++ b/policies/environments/environment-definitions_test.rego
@@ -31,3 +31,11 @@ test_empty_values {
 test_unexpected_business_units {
   deny["`example.json` uses an unexpected business-unit: got `incorrect-business-unit`, expected one of: HQ, HMPPS, OPG, LAA, HMCTS, CICA, Platforms, CJSE, Probation"] with input as { "filename": "example.json", "tags": { "business-unit": "incorrect-business-unit" } }
 }
+
+test_business_units_length{
+  deny["`example.json` Business unit name does not meet requirements"] with input as { "filename": "example.json", "tags": { "business-unit": "example-this-is-too-long-for-a-business-unit" } }
+}
+
+test_business_units_character{
+  deny["`example.json` Business unit name does not meet requirements"] with input as { "filename": "example.json", "tags": { "business-unit": "Platforms4" } }
+}

--- a/policies/member/environment-definitions.rego
+++ b/policies/member/environment-definitions.rego
@@ -1,0 +1,18 @@
+package main
+
+allowed_environments := [
+  "development",
+  "test",
+  "preproduction",
+  "production"
+]
+
+deny[msg] {
+  not array_contains(allowed_environments, input.environments[i].name)
+  msg := sprintf("`%v` uses an unexpected environment: got `%v`, expected one of: %v", [input.filename, input.environments[i].name, concat(", ", allowed_environments) ])
+}
+
+deny[msg] {
+  not regex.match("^environments\\/[a-z-]{1,30}\\.json$",input.filename)
+  msg := sprintf("`%v` filename does not meet requirements", [input.filename])
+}

--- a/policies/member/environment-definitions_test.rego
+++ b/policies/member/environment-definitions_test.rego
@@ -1,0 +1,13 @@
+package main
+
+test_invalid_file_name_character{
+  deny["`exampleA.json` filename does not meet requirements"] with input as { "filename": "exampleA.json" }
+}
+
+test_invalid_file_name_length{
+  deny["`example-this-is-too-long-for-an-application-name.json` filename does not meet requirements"] with input as { "filename": "example-this-is-too-long-for-an-application-name.json" }
+}
+
+test_unexpected_environment {
+  deny["`example.json` uses an unexpected environment: got `sandbox`, expected one of: development, test, preproduction, production"] with input as { "filename": "example.json", "environments": [{ "name": "sandbox" }] }
+}

--- a/policies/member/utilities.rego
+++ b/policies/member/utilities.rego
@@ -1,0 +1,10 @@
+package main
+
+has_field(object, field) {
+  object[field]
+  object[field] != ""
+}
+
+array_contains(array, element) {
+  array[_] = element
+}

--- a/policies/networking/core-vpc_test.rego
+++ b/policies/networking/core-vpc_test.rego
@@ -44,7 +44,7 @@ test_no_options {
 }
 
 test_missing_options_keys {
-  deny["`example.json` is missing the `bastion_linux` key"] with input as { "filename": "example.json", "options": {} }
+  # deny["`example.json` is missing the `bastion_linux` key"] with input as { "filename": "example.json", "options": {} }
   deny["`example.json` is missing the `additional_endpoints` key"] with input as { "filename": "example.json", "options": {} }
   deny["`example.json` is missing the `dns_zone_extend` key"] with input as { "filename": "example.json", "options": {} }
 }

--- a/scripts/tests/validate/README.md
+++ b/scripts/tests/validate/README.md
@@ -1,0 +1,1 @@
+See [OPA readme](../../../policies/README.md)

--- a/scripts/tests/validate/run-opa-tests.sh
+++ b/scripts/tests/validate/run-opa-tests.sh
@@ -47,13 +47,19 @@ networking() {
   jq -n -c -r '[ inputs | . + { filename: input_filename } ]' environments-networks/*.json | conftest test -p policies/networking -
 }
 
+member() {
+  jq -n -c -r '[ inputs | . + { filename: input_filename } | select( .["account-type"] == "member" ) ]' environments/*.json | conftest test -p policies/member -
+}
+
 main() {
   check-environment-files-present
   check-network-files-present
   environments & environments_outcome=$!
   networking & networking_outcome=$!
+  member & member_outcome=$!
   wait $environments_outcome
   wait $networking_outcome
+  wait $member_outcome
 }
 
 main


### PR DESCRIPTION
The follow validation is added:

For all accounts -
 - business unit name max 20 characters, only a-z A-Z and -

For member accounts
 - file (application) name max 30 characters, only a-z and -
 - only development,test,preproduction and production environment names
allowed.

OPA tests and readme updated.

Closes #725 