### PR TITLE
Copy application variables template accross

### DIFF
--- a/scripts/provision-member-directories.sh
+++ b/scripts/provision-member-directories.sh
@@ -124,6 +124,8 @@ copy_templates() {
 
   # Rename member providers file
   mv $1/member-providers.tf $1/providers.tf
+  # copy application variable file
+  cp core-repo/terraform/templates/application_variables.json $1
 
   echo "Finished copying templates."
 }


### PR DESCRIPTION
This file currently gets missed as the templates variable is only
terraform files.  This explicitly copies the required file.  If we end
up needing more non TF files we may want to switch this to exclude files rather
than include them.