### PR TITLE
Skip baseline for all anlytical platform accounts

### DIFF
--- a/scripts/loop-through-terraform-workspaces.sh
+++ b/scripts/loop-through-terraform-workspaces.sh
@@ -33,7 +33,7 @@ run_terraform() {
     # Note - this is temporary until we delete default VPCs for all other accounts
     # AP will fail as they have deleted their default VPC, we want to delete all default vpcs
     # But are waiting for v4 of the aws provider which will allow us to do this via TF
-    if [ "$line" != "analytical-platform-management-production" ]; then
+    if [[ "$line" != *"analytical-platform"* ]]; then
 
       # Select workspace
       terraform -chdir="$1" workspace select "$line"


### PR DESCRIPTION
Widening the criteria for skipping the scheduled baseline to include all
analytical platform accounts.  The are deleting their default VPC which
causes the baseline to fail as we expect to manage them in terraform. We
do want default VPCs to be deleted but we can't currently do this until
v4 of the AWS provider is released.  Keeping this work around for now
rather than forcing AP to have default VPCs or removing the default vpc
restrictions from the baseline which would impact all other accounts.