### PR TITLE
enable PITR to squash CKV_AWS_28

### DIFF
--- a/terraform/modernisation-platform-account/dynamodb.tf
+++ b/terraform/modernisation-platform-account/dynamodb.tf
@@ -12,5 +12,9 @@ resource "aws_dynamodb_table" "state-lock" {
     enabled = true
   }
 
+  point_in_time_recovery {
+    enabled = true
+  }
+
   tags = local.tags
 }


### PR DESCRIPTION
Enables continuous backups. In this case the cost is negligeable due to low volumes of data being stored in this data base. https://aws.amazon.com/dynamodb/pricing/on-demand/