### PR TITLE
excluding checkov CKV_GIT_1, warning of public repo creation.

### DIFF
--- a/.github/workflows/terraform-static-analysis.yml
+++ b/.github/workflows/terraform-static-analysis.yml
@@ -43,3 +43,4 @@ jobs:
       with:
         scan_type: full 
         tfsec_exclude: AWS095  
+        checkov_exclude: CKV_GIT_1


### PR DESCRIPTION
Repositories are made public intentionally