### PR TITLE
Enabling optimised EBS and use of IMDS v2

### DIFF
--- a/terraform/modules/bastion_linux/main.tf
+++ b/terraform/modules/bastion_linux/main.tf
@@ -371,11 +371,16 @@ resource "aws_instance" "bastion_linux" {
   ami                         = data.aws_ami.linux_2_image.id
   associate_public_ip_address = false
   iam_instance_profile        = aws_iam_instance_profile.bastion_profile.id
+  ebs_optimized               = true
   monitoring                  = false
   vpc_security_group_ids      = [aws_security_group.bastion_linux.id]
   subnet_id                   = data.aws_subnet.private_az_a.id
 
   user_data = base64encode(data.template_file.user_data.rendered)
+
+  metadata_options {
+    http_tokens = "required"
+  }
 
   tags = merge(
     var.tags_common,


### PR DESCRIPTION
**Tweaks to bastion module to fix SCA warnings**
(Addresses part of #947 )

**Move to IMDS v2**
[aws-ec2-enforce-http-token-imds][HIGH] Resource 'module.bastion_linux:aws_instance.bastion_linux' is missing `metadata_options` block - it is required with `http_tokens` set to `required` to make Instance Metadata Service more secure.
  /github/workspace/terraform/modules/bastion_linux/main.tf:368-386

_Comment_
This is regarding the move to force EC2 instances to use IMDS v2
See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html for into about IMDS and blog article from Nov 2019 about release of v3:
https://aws.amazon.com/blogs/security/defense-in-depth-open-firewalls-reverse-proxies-ssrf-vulnerabilities-ec2-instance-metadata-service.

_Impact analysis_
The move to IMDS v2 does not require restarts and the version has been around for some time now. Am assuming the deployed EC2 instances in mod platform environments are fairly recent so should have versions of AWS SDKs or CLIs that support v2. Admittedly, I don’t know about the explicit use of IMDS from mod platform environments.

**Ensure that EC2 is EBS optimised**
Check: CKV_AWS_135: "Ensure that EC2 is EBS optimized"
	FAILED for resource: module.bastion_linux.aws_instance.bastion_linux
	File: /../modules/bastion_linux/main.tf:368-386
	Calling File: /core-sandbox/bastion_linux.tf:12-29
	Guide: https://docs.bridgecrew.io/docs/ensure-that-ec2-is-ebs-optimized

_Comment_
See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-optimized.html and particularly https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-optimized.html#ebs-optimization-support.
This is about using an optimized configuration stack for EBS I/O.

_Impact analysis_
The instance type in question is hard-coded to t3.micro, which is an already supported type. So will be using EBS by default anyway. So enabling this option will not change any configuration on the EC2 instances, merely remove the SCA warning.
