### PR TITLE
Adding SCA exclusion for detailed monitoring on EC2 instances

### DIFF
--- a/.github/workflows/terraform-static-analysis.yml
+++ b/.github/workflows/terraform-static-analysis.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         scan_type: changed
         tfsec_exclude: AWS095
-        checkov_exclude: CKV_AWS_126
+        checkov_exclude: CKV_GIT_1,CKV_AWS_126
 
   terraform-static-analysis-full-scan:
     name: Terraform Static Analysis - scan all directories


### PR DESCRIPTION
Note this PR address part of #947 

**Warning from Checkov**
: CKV_AWS_126: "Ensure that detailed monitoring is enabled for EC2 instances"
2021-08-25T15:17:32.4002270Z 	FAILED for resource: module.bastion_linux.aws_instance.bastion_linux
2021-08-25T15:17:32.4003107Z 	File: /../modules/bastion_linux/main.tf:368-386
2021-08-25T15:17:32.4004117Z 	Calling File: /core-sandbox/bastion_linux.tf:12-29
2021-08-25T15:17:32.4005551Z 	Guide: https://docs.bridgecrew.io/docs/ensure-that-detailed-monitoring-is-enabled-for-ec2-instances

_Comments_
See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-cloudwatch-new.html for differences between the monitoring types. 

_Impact analysis_
With this being the module for bastion machines, am not sure the detailed monitoring is required given the costs / extra level of monitoring and it seems to have been intentional to keep the monitoring at basic. This is an assumption so please say if incorrect!
Naturally this change would add this exclusion for any EC2 instance deployed as part of the mod platform leaving it in the hands of the devops engineer to make the right choice given the requirements and trade-offs.