### PR TITLE
Fix bug regarding missing instance metadata options for bastion ec2

### DIFF
--- a/terraform/modules/bastion_linux/main.tf
+++ b/terraform/modules/bastion_linux/main.tf
@@ -384,7 +384,9 @@ resource "aws_instance" "bastion_linux" {
   user_data = base64encode(data.template_file.user_data.rendered)
 
   metadata_options {
-    http_tokens = "required"
+    http_endpoint               = "enabled" # defaults to enabled but is required if http_tokens is specified
+    http_put_response_hop_limit = 1         # default is 1, value values are 1 through 64
+    http_tokens                 = "required"
   }
 
   tags = merge(


### PR DESCRIPTION
This is related to #947 
Fixes a bug with some missing terraform attributes.
Marked as optional [here](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance#metadata-options) but [aws cli instructions](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-options.html) says that there are dependencies between them.

I've already run the terraform apply locally against this source branch in the mod platform environment repo (for nomis and performance hub) to test it out (and partly to get familiar with running TF locally!) and to get the bastion ec2's created.


