### PR TITLE
Exclude tfsec warning about public github repos

### DIFF
--- a/.github/workflows/terraform-static-analysis.yml
+++ b/.github/workflows/terraform-static-analysis.yml
@@ -25,7 +25,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         scan_type: changed
-        tfsec_exclude: AWS095
+        tfsec_exclude: AWS095,GIT001
         checkov_exclude: CKV_GIT_1,CKV_AWS_126
 
   terraform-static-analysis-full-scan:
@@ -43,5 +43,5 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         scan_type: full 
-        tfsec_exclude: AWS095  
+        tfsec_exclude: AWS095,GIT001
         checkov_exclude: CKV_GIT_1,CKV_AWS_126


### PR DESCRIPTION
Address part of #947 

Simple addition of exclusion already added for checkov to reduce noise from tfsec.