### PR TITLE
Exclude static code analysis open nacl ports warnings

### DIFF
--- a/.github/workflows/terraform-static-analysis.yml
+++ b/.github/workflows/terraform-static-analysis.yml
@@ -25,7 +25,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         scan_type: changed
-        tfsec_exclude: AWS095,GIT001
+        tfsec_exclude: AWS095,GIT001,AWS050
         checkov_exclude: CKV_GIT_1,CKV_AWS_126
 
   terraform-static-analysis-full-scan:
@@ -43,5 +43,5 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         scan_type: full 
-        tfsec_exclude: AWS095,GIT001
+        tfsec_exclude: AWS095,GIT001,AWS050
         checkov_exclude: CKV_GIT_1,CKV_AWS_126


### PR DESCRIPTION
Addresses part of #947 - See Network category of warnings

After a team chat last week, we discussed the value of this rule [https://tfsec.dev/docs/aws/vpc/no-excessive-port-access/](https://tfsec.dev/docs/aws/vpc/no-excessive-port-access/) in the context of mod platform and the costs/benefits of it.
It was deemed to be the case that the cost of this (i.e. the noise it generates within the context of the overall design and approach of the mod platform) outweighs any benefits. We agreed that tfsec shouldn't be considered the optimal way to check for quality in the context of mod platform network security. 
This exclusion would eliminate 36 warnings based on decisions made in terraform/modules/vpc-hub/main.tf

