### PR TITLE
Suppress Checkov IAM failure messages

### DIFF
--- a/terraform/environments/scp_mp_core.tf
+++ b/terraform/environments/scp_mp_core.tf
@@ -1,12 +1,12 @@
 #  Modernisation Platform Core ou SCP policy
 data "aws_iam_policy_document" "scp_mp_core_ou" {
-#checkov:skip=CKV_AWS_1:Policy applied to a limited number of accounts
-#checkov:skip=CKV_AWS_49:Policy applied to a limited number of accounts
-#checkov:skip=CKV_AWS_107:Policy applied to a limited number of accounts
-#checkov:skip=CKV_AWS_108:Policy applied to a limited number of accounts
-#checkov:skip=CKV_AWS_109:Policy applied to a limited number of accounts
-#checkov:skip=CKV_AWS_110:Policy applied to a limited number of accounts
-#checkov:skip=CKV_AWS_111:Policy applied to a limited number of accounts
+  #checkov:skip=CKV_AWS_1:Policy applied to a limited number of accounts
+  #checkov:skip=CKV_AWS_49:Policy applied to a limited number of accounts
+  #checkov:skip=CKV_AWS_107:Policy applied to a limited number of accounts
+  #checkov:skip=CKV_AWS_108:Policy applied to a limited number of accounts
+  #checkov:skip=CKV_AWS_109:Policy applied to a limited number of accounts
+  #checkov:skip=CKV_AWS_110:Policy applied to a limited number of accounts
+  #checkov:skip=CKV_AWS_111:Policy applied to a limited number of accounts
   version = "2012-10-17"
 
   statement {

--- a/terraform/environments/scp_mp_core.tf
+++ b/terraform/environments/scp_mp_core.tf
@@ -1,5 +1,12 @@
 #  Modernisation Platform Core ou SCP policy
 data "aws_iam_policy_document" "scp_mp_core_ou" {
+#checkov:skip=CKV_AWS_1:Policy applied to a limited number of accounts
+#checkov:skip=CKV_AWS_49:Policy applied to a limited number of accounts
+#checkov:skip=CKV_AWS_107:Policy applied to a limited number of accounts
+#checkov:skip=CKV_AWS_108:Policy applied to a limited number of accounts
+#checkov:skip=CKV_AWS_109:Policy applied to a limited number of accounts
+#checkov:skip=CKV_AWS_110:Policy applied to a limited number of accounts
+#checkov:skip=CKV_AWS_111:Policy applied to a limited number of accounts
   version = "2012-10-17"
 
   statement {

--- a/terraform/environments/scp_mp_member_unrestricted.tf
+++ b/terraform/environments/scp_mp_member_unrestricted.tf
@@ -1,12 +1,12 @@
 #  Modernisation Platform Member Unrestriced ou SCP policy
 data "aws_iam_policy_document" "scp_mp_member_unrestriced_ou" {
-#checkov:skip=CKV_AWS_1:Policy applied to a limited number of accounts
-#checkov:skip=CKV_AWS_49:Policy applied to a limited number of accounts
-#checkov:skip=CKV_AWS_107:Policy applied to a limited number of accounts
-#checkov:skip=CKV_AWS_108:Policy applied to a limited number of accounts
-#checkov:skip=CKV_AWS_109:Policy applied to a limited number of accounts
-#checkov:skip=CKV_AWS_110:Policy applied to a limited number of accounts
-#checkov:skip=CKV_AWS_111:Policy applied to a limited number of accounts
+  #checkov:skip=CKV_AWS_1:Policy applied to a limited number of accounts
+  #checkov:skip=CKV_AWS_49:Policy applied to a limited number of accounts
+  #checkov:skip=CKV_AWS_107:Policy applied to a limited number of accounts
+  #checkov:skip=CKV_AWS_108:Policy applied to a limited number of accounts
+  #checkov:skip=CKV_AWS_109:Policy applied to a limited number of accounts
+  #checkov:skip=CKV_AWS_110:Policy applied to a limited number of accounts
+  #checkov:skip=CKV_AWS_111:Policy applied to a limited number of accounts
   version = "2012-10-17"
 
   statement {

--- a/terraform/environments/scp_mp_member_unrestricted.tf
+++ b/terraform/environments/scp_mp_member_unrestricted.tf
@@ -1,5 +1,12 @@
 #  Modernisation Platform Member Unrestriced ou SCP policy
 data "aws_iam_policy_document" "scp_mp_member_unrestriced_ou" {
+#checkov:skip=CKV_AWS_1:Policy applied to a limited number of accounts
+#checkov:skip=CKV_AWS_49:Policy applied to a limited number of accounts
+#checkov:skip=CKV_AWS_107:Policy applied to a limited number of accounts
+#checkov:skip=CKV_AWS_108:Policy applied to a limited number of accounts
+#checkov:skip=CKV_AWS_109:Policy applied to a limited number of accounts
+#checkov:skip=CKV_AWS_110:Policy applied to a limited number of accounts
+#checkov:skip=CKV_AWS_111:Policy applied to a limited number of accounts
   version = "2012-10-17"
 
   statement {


### PR DESCRIPTION
Addresses part of #947
Suppress warnings for policies intended for admin users