### PR TITLE
Change create workspace logic to not core

### DIFF
--- a/scripts/provision-terraform-workspaces.sh
+++ b/scripts/provision-terraform-workspaces.sh
@@ -115,7 +115,7 @@ do
     fi
 
     ACCOUNT_TYPE=$(jq -r '."account-type"' ${JSON_FILE})
-    if [[ "${RETURN_CODE_MEMBER_REPO}" -ne 0 && "${ACCOUNT_TYPE}" == "member" ]]
+    if [[ "${RETURN_CODE_MEMBER_REPO}" -ne 0 && "${ACCOUNT_TYPE}" != "core" ]]
     then
       echo -en "MEMBER ACCOUNT IN ENVIRONMENTS REPO - ${APPLICATION}-${ENV} - ${YELLOW}CREATING${NORMAL}\n"
       terraform -chdir="${TERRAFORM_PATH}" init > /dev/null


### PR DESCRIPTION
Both member and member unrestricted account types need the workspaces to
be created.  This changes the logic so an non core account type get the
workspace created.  This is in keeping with the other logic in the
script.

Fixes #1012