### PR TITLE
Add tfsec exclusion for blocking public access to CRL ACM-PCA s3 bucket

### DIFF
--- a/terraform/environments/core-network-services/acm-pca.tf
+++ b/terraform/environments/core-network-services/acm-pca.tf
@@ -8,6 +8,8 @@ provider "aws" {
 }
 
 #Create S3 bucket for ACM
+# Ignore TFSEC warnings regarding not blocking all public access - this is required for CRL
+#tfsec:ignore:AWS098
 resource "aws_s3_bucket" "acm-pca" {
 
   bucket_prefix = "acm"

--- a/terraform/environments/core-network-services/acm-pca.tf
+++ b/terraform/environments/core-network-services/acm-pca.tf
@@ -11,6 +11,7 @@ provider "aws" {
 # Ignore TFSEC warnings regarding not blocking all public access - this is required for CRL
 #tfsec:ignore:AWS098
 resource "aws_s3_bucket" "acm-pca" {
+  #checkov:skip=CKV2_AWS_6:Public access is required when S3 bucket used for acm pca CRL
 
   bucket_prefix = "acm"
 


### PR DESCRIPTION
This addresses part of #947 

Propose we add an exclusion for this since we're creating a CRL associated to the private CA, with a specific, restricted access permitted from acm-pca.amazonaws.com. This is based on https://docs.aws.amazon.com/acm-pca/latest/userguide/PcaCreateCa.html#s3-policies and https://aws.amazon.com/premiumsupport/knowledge-center/s3-bucket-error-crl-acm-ca/.

