### PR TITLE
Exclude checkov warning regarding default SGs and full traffic restriction

### DIFF
--- a/terraform/modules/member-vpc/main.tf
+++ b/terraform/modules/member-vpc/main.tf
@@ -176,6 +176,7 @@ locals {
 
 # VPC
 resource "aws_vpc" "vpc" {
+  #checkov:skip=CKV2_AWS_12:Skip checking default SGs of every VPC restrict all traffic. Default SGs unused, better approach would be to delete when possible
   cidr_block = var.transit
 
   enable_dns_support   = true

--- a/terraform/modules/vpc-hub/main.tf
+++ b/terraform/modules/vpc-hub/main.tf
@@ -75,6 +75,7 @@ locals {
 # VPC #
 #######
 resource "aws_vpc" "default" {
+  #checkov:skip=CKV2_AWS_12:Skip checking default SGs of every VPC restrict all traffic. Default SGs unused, better approach would be to delete when possible
   cidr_block = var.vpc_cidr
 
   # Instance Tenancy


### PR DESCRIPTION
Addresses part of #947 
Follows a chat with @davidkelliott regarding the action to take regarding these warnings.
e.g. _Check: CKV2_AWS_12: "Ensure the default security group of every VPC restricts all traffic" FAILED for resource: aws_vpc.vpc_
https://docs.bridgecrew.io/docs/networking_4

Outcome of discussion was to exclude these warnings. Default security groups are unused. Better longer-term solution would be to bring these under better terraform management / be able to remove them.