### PR TITLE
Ignoring lack of cross-regional replication for acm-cma bucket

### DIFF
--- a/terraform/environments/core-network-services/acm-pca.tf
+++ b/terraform/environments/core-network-services/acm-pca.tf
@@ -12,6 +12,7 @@ provider "aws" {
 #tfsec:ignore:AWS098
 resource "aws_s3_bucket" "acm-pca" {
   #checkov:skip=CKV2_AWS_6:Public access is required when S3 bucket used for acm pca CRL
+  #checkov:skip=CKV_AWS_144:Ignore lack of cross-regional replication - not required here - represents an overkill
 
   bucket_prefix = "acm"
 


### PR DESCRIPTION
Addresses part of #947 

Relates to static code analysis checkov warning:
```
Check: CKV_AWS_144: "Ensure that S3 bucket has cross-region replication enabled"
	FAILED for resource: aws_s3_bucket.acm-pca
	File: /acm-pca.tf:13-59
	Guide: https://docs.bridgecrew.io/docs/ensure-that-s3-bucket-has-cross-region-replication-enabled
```
Consistent with decisions around cross-regional replication for S3 buckets elsewhere, this PR adds an exclusion for a checkov rule suggesting that replication should be set up. Exclusion added for this particular use case to at least encourage some consideration in future cases should they be different or if design principles change.
