### PR TITLE
Fix bug where the app json file is needed

### DIFF
--- a/scripts/provision-environment-directories.sh
+++ b/scripts/provision-environment-directories.sh
@@ -93,6 +93,11 @@ copy_templates() {
       then
         sed -i "s/environments\//environments\/accounts\//g" "$1/$filename"
       fi
+      if [ ${filename} == "locals.tf" ]
+      then
+        # we don't need the application data json in this repo so comment out
+        sed -i "application_data = " "# application_data = "
+      fi
     fi
   done
 

--- a/scripts/provision-environment-directories.sh
+++ b/scripts/provision-environment-directories.sh
@@ -93,11 +93,6 @@ copy_templates() {
       then
         sed -i "s/environments\//environments\/accounts\//g" "$1/$filename"
       fi
-      if [ ${filename} == "locals.tf" ]
-      then
-        # we don't need the application data json in this repo so comment out
-        sed -i "application_data = " "# application_data = "
-      fi
     fi
   done
 

--- a/terraform/environments/tariff/locals.tf
+++ b/terraform/environments/tariff/locals.tf
@@ -38,5 +38,5 @@ locals {
   # environment specfic variables
   # example usage:  
   # example_data = local.application_data.accounts[local.environment].example_var
-  application_data = jsondecode(file("./application_variables.json"))
+  # application_data = jsondecode(file("./application_variables.json"))
 }

--- a/terraform/environments/tariff/locals.tf
+++ b/terraform/environments/tariff/locals.tf
@@ -38,5 +38,6 @@ locals {
   # environment specfic variables
   # example usage:  
   # example_data = local.application_data.accounts[local.environment].example_var
-  # application_data = jsondecode(file("./application_variables.json"))
+  application_data = fileexists("./application_variables.json") ? jsondecode(file("./application_variables.json")) : []
+
 }

--- a/terraform/templates/locals.tf
+++ b/terraform/templates/locals.tf
@@ -38,5 +38,5 @@ locals {
   # environment specfic variables
   # example usage:  
   # example_data = local.application_data.accounts[local.environment].example_var
-  application_data = jsondecode(file("./application_variables.json"))
+  application_data = fileexists("./application_variables.json") ? jsondecode(file("./application_variables.json")) : []
 }


### PR DESCRIPTION
The application json file is part of the templates and needed for the
environments repository, but it isn't needed here.  Commenting rather
than removing as it's less code in the provisioning script to comment
rather than remove. Also leaving as a comment also serves as a reminder
as to how we should handle environment specific variables if it is ever
needed in this repository.