### PR TITLE
Adding SCA exclusion for ACM-PCA S3 bucket logging

### DIFF
--- a/terraform/environments/core-network-services/acm-pca.tf
+++ b/terraform/environments/core-network-services/acm-pca.tf
@@ -8,8 +8,10 @@ provider "aws" {
 }
 
 #Create S3 bucket for ACM
-# Ignore TFSEC warnings regarding not blocking all public access - this is required for CRL
-#tfsec:ignore:AWS098
+# TFSec ignores:
+# - AWS098: Ignore warnings regarding not blocking all public access - this is required for CRL
+# - AWS002: Ignore warnings regarding lack of s3 bucket server access logging - considered overkill given bucket purpose and restricted access to bucket
+#tfsec:ignore:AWS098,AWS002
 resource "aws_s3_bucket" "acm-pca" {
   #checkov:skip=CKV2_AWS_6:Public access is required when S3 bucket used for acm pca CRL
   #checkov:skip=CKV_AWS_144:Ignore lack of cross-regional replication - not required here - represents an overkill

--- a/terraform/environments/core-network-services/acm-pca.tf
+++ b/terraform/environments/core-network-services/acm-pca.tf
@@ -11,10 +11,11 @@ provider "aws" {
 # TFSec ignores:
 # - AWS098: Ignore warnings regarding not blocking all public access - this is required for CRL
 # - AWS002: Ignore warnings regarding lack of s3 bucket server access logging - considered overkill given bucket purpose and restricted access to bucket
-#tfsec:ignore:AWS098,AWS002
+#tfsec:ignore:AWS098 tfsec:ignore:AWS002
 resource "aws_s3_bucket" "acm-pca" {
   #checkov:skip=CKV2_AWS_6:Public access is required when S3 bucket used for acm pca CRL
   #checkov:skip=CKV_AWS_144:Ignore lack of cross-regional replication - not required here - represents an overkill
+  #checkov:skip=CKV_AWS_18:Ignore warnings regarding lack of s3 bucket server access logging - considered overkill given bucket purpose and restricted access to bucket
 
   bucket_prefix = "acm"
 


### PR DESCRIPTION
Addresses part of #947 

As per a recent discussion on the valid arguments for excluding server access logging on this bucket.
Reasons around purpose of bucket (just used by the AWS private cert authority for CRL) and the restrictive access policy that exists anyway.