### PR TITLE
Skip tfsec warnings about cloudwatch log group kms encryption

### DIFF
--- a/terraform/modules/member-vpc/main.tf
+++ b/terraform/modules/member-vpc/main.tf
@@ -193,6 +193,9 @@ resource "aws_vpc" "vpc" {
 
 
 # VPC Flow Logs
+# TF sec exclusions
+# - Ignore warnings regarding log groups not encrypted using customer-managed KMS keys - following cost/benefit discussion and longer term plans for logging solution
+#tfsec:ignore:AWS089
 resource "aws_cloudwatch_log_group" "default" {
   #checkov:skip=CKV_AWS_158:Temporarily skip KMS encryption check while logging solution is being updated
   name              = "${var.tags_prefix}-vpc-flow-logs"

--- a/terraform/modules/vpc-hub/main.tf
+++ b/terraform/modules/vpc-hub/main.tf
@@ -103,6 +103,9 @@ resource "aws_vpc" "default" {
 #################
 # VPC Flow Logs #
 #################
+# TF sec exclusions
+# - Ignore warnings regarding log groups not encrypted using customer-managed KMS keys - following cost/benefit discussion and longer term plans for logging solution
+#tfsec:ignore:AWS089
 resource "aws_cloudwatch_log_group" "default" {
   #checkov:skip=CKV_AWS_158:Temporarily skip KMS encryption check while logging solution is being updated
   name              = "${var.tags_prefix}-vpc-flow-logs"


### PR DESCRIPTION
Addresses part of #947 

tfsec static code analysis warning is
```
[aws-cloudwatch-log-group-customer-key][LOW] Resource 'aws_cloudwatch_log_group.default' is only using default encryption
  /github/workspace/terraform/modules/member-vpc/main.tf:196-200
```
For both member-vpc and vpc-hub modules

Following team discussion, these changes are the addition of tfsec exclusions around use of kms key encryption for vpc flow log CloudWatch log group. Wasn't felt this was something that needed to be addressed now. To be reconsidered in the future alongside discussions of our approach to key usage/management across the platform.