### PR TITLE
Add regional replication to S3 state bucket

### DIFF
--- a/terraform/modernisation-platform-account/s3.tf
+++ b/terraform/modernisation-platform-account/s3.tf
@@ -1,14 +1,91 @@
+# State bucket KMS Source
+resource "aws_kms_key" "s3_state_bucket" {
+  description             = "s3-state-bucket"
+  policy                  = data.aws_iam_policy_document.kms_state_bucket.json
+  enable_key_rotation     = true
+  deletion_window_in_days = 30
+}
+
+resource "aws_kms_alias" "s3_state_bucket" {
+  name          = "alias/s3-state-bucket"
+  target_key_id = aws_kms_key.s3_state_bucket.id
+}
+
+data "aws_iam_policy_document" "kms_state_bucket" {
+
+  # checkov:skip=CKV_AWS_111: "policy is directly related to the resource"
+  # checkov:skip=CKV_AWS_109: "role is resticted by limited actions in member account"
+
+  statement {
+    sid    = "Allow management access of the key to the modernisation platform account"
+    effect = "Allow"
+    actions = [
+      "kms:*"
+    ]
+    resources = [
+      "*"
+    ]
+    principals {
+      type = "AWS"
+      identifiers = [
+        data.aws_caller_identity.current.account_id
+      ]
+    }
+  }
+  statement {
+    sid    = "Allow key decryption to STS bucket replication roles"
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt*"
+    ]
+    resources = ["*"]
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:sts::${data.aws_caller_identity.current.account_id}:assumed-role/AWSS3BucketReplication-terraform-state/s3-replication"
+      ]
+    }
+  }
+}
+
+
+# State bucket KMS Destination
+resource "aws_kms_key" "s3_state_bucket_eu-west-1_replication" {
+  provider = aws.modernisation-platform-eu-west-1
+
+  description             = "s3-state_bucket-eu-west-1-replication"
+  policy                  = data.aws_iam_policy_document.kms_state_bucket.json
+  enable_key_rotation     = true
+  deletion_window_in_days = 30
+}
+resource "aws_kms_alias" "s3_state_bucket_eu-west-1_replication" {
+  provider = aws.modernisation-platform-eu-west-1
+
+  name          = "alias/s3-state_bucket-eu-west-1-replication"
+  target_key_id = aws_kms_key.s3_state_bucket_eu-west-1_replication.id
+}
+
+module "state-bucket-s3-replication-role" {
+  source             = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket-replication-role?ref=v3.0.0"
+  buckets            = [module.state-bucket.bucket.arn]
+  replication_bucket = "modernisation-platform-terraform-state-replication"
+  suffix_name        = "-terraform-state"
+  tags               = local.tags
+}
+
 module "state-bucket" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=v3.0.0"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=v4.0.0"
 
   providers = {
     aws.bucket-replication = aws.modernisation-platform-eu-west-1
   }
-  bucket_policy        = data.aws_iam_policy_document.allow-state-access-from-root-account.json
-  bucket_name          = "modernisation-platform-terraform-state"
-  replication_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/AWSS3BucketReplication"
-  replication_enabled  = false
-  tags                 = local.tags
+  bucket_policy              = data.aws_iam_policy_document.allow-state-access-from-root-account.json
+  bucket_name                = "modernisation-platform-terraform-state"
+  replication_role_arn       = module.state-bucket-s3-replication-role.role.arn
+  replication_enabled        = true
+  custom_kms_key             = aws_kms_key.s3_state_bucket.arn
+  custom_replication_kms_key = aws_kms_key.s3_state_bucket_eu-west-1_replication.arn
+  tags                       = local.tags
 }
 
 # Allow access to the bucket from the MoJ root account


### PR DESCRIPTION
Adding regional replication and switching to customer managed KMS keys for the
terraform state bucket. This follows the AWS best practice guidelines,
and if there is ever an issue where we loose access to the London region
we will still be able to see the last known state of the platform.