### PR TITLE
SCA exclusions for secrets not managed by customer-managed KMS keys

### DIFF
--- a/terraform/environments/secrets.tf
+++ b/terraform/environments/secrets.tf
@@ -1,5 +1,10 @@
 # Environment Management
+# Tfsec ignore
+# - AWS095: No requirement currently to encrypt this secret with customer-managed KMS key
+#tfsec:ignore:AWS095
 resource "aws_secretsmanager_secret" "environment_management" {
+  # checkov:skip=CKV_AWS_149:No requirement currently to encrypt this secret with customer-managed KMS key
+
   provider    = aws.modernisation-platform
   name        = "environment_management"
   description = "IDs for AWS-specific resources for environment management, such as organizational unit IDs"

--- a/terraform/modernisation-platform-account/secrets.tf
+++ b/terraform/modernisation-platform-account/secrets.tf
@@ -9,7 +9,11 @@ data "aws_secretsmanager_secret_version" "environment_management" {
 }
 
 # Core CI User
+# Tfsec ignore
+# - AWS095: No requirement currently to encrypt this secret with customer-managed KMS key
+#tfsec:ignore:AWS095
 resource "aws_secretsmanager_secret" "ci_iam_user_keys" {
+  # checkov:skip=CKV_AWS_149:No requirement currently to encrypt this secret with customer-managed KMS key
   name        = "ci_iam_user_keys"
   description = "Access keys for the CI user, this secret is used by GitHub to set the correct repository secrets."
   tags        = local.tags
@@ -24,7 +28,11 @@ resource "aws_secretsmanager_secret_version" "ci_iam_user_keys" {
 }
 
 # Member CI user
+# Tfsec ignore
+# - AWS095: No requirement currently to encrypt this secret with customer-managed KMS key
+#tfsec:ignore:AWS095
 resource "aws_secretsmanager_secret" "member_ci_iam_user_keys" {
+  # checkov:skip=CKV_AWS_149:No requirement currently to encrypt this secret with customer-managed KMS key
   name        = "member_ci_iam_user_keys"
   description = "Access keys for the CI user, this secret is used by GitHub to set the correct repository secrets."
   tags        = local.tags


### PR DESCRIPTION
Addresses part of #947 

Example SCA warning:
```
Check: CKV_AWS_149: "Ensure that Secrets Manager secret is encrypted using KMS"
	FAILED for resource: aws_secretsmanager_secret.member_ci_iam_user_keys
	File: /secrets.tf:27-31
	Guide: https://docs.bridgecrew.io/docs/ensure-that-secrets-manager-secret-is-encrypted-using-kms
```

After a discussion among the team, cost outweighs the benefits of encrypting these secrets with a customer-managed KMS key. AWS-managed key will suffice. This replaces #1043 which was to create and reference the kms keys.