### PR TITLE
Add member-ci iam policy permissions

### DIFF
--- a/terraform/modernisation-platform-account/dynamodb.tf
+++ b/terraform/modernisation-platform-account/dynamodb.tf
@@ -10,6 +10,11 @@ resource "aws_kms_key" "dynamo_encryption" {
   )
 }
 
+resource "aws_kms_alias" "dynamo_encryption" {
+  name          = "alias/dynamodb-state-lock"
+  target_key_id = aws_kms_key.dynamo_encryption.id
+}
+
 data "aws_iam_policy_document" "dynamo_encryption" {
 
   # checkov:skip=CKV_AWS_109: "Key policy requires asterisk resource"

--- a/terraform/modernisation-platform-account/iam.tf
+++ b/terraform/modernisation-platform-account/iam.tf
@@ -133,6 +133,30 @@ data "aws_iam_policy_document" "member-ci-policy" {
     resources = ["arn:aws:s3:::modernisation-platform-terraform-state/environments/members/*"]
   }
 
+  # Based on https://www.terraform.io/docs/language/settings/backends/s3.html#dynamodb-table-permissions
+  statement {
+    effect = "Allow"
+    actions = [
+      "dynamodb:GetItem",
+      "dynamodb:PutItem",
+      "dynamodb:DeleteItem"
+    ]
+    resources = ["${aws_dynamodb_table.state-lock.arn}"]
+  }
+
+  # Based on https://docs.amazonaws.cn/en_us/AmazonS3/latest/userguide/UsingKMSEncryption.htm
+  statement {
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey"
+    ]
+    resources = [
+      "${aws_kms_key.dynamo_encryption.arn}",
+      "${aws_kms_key.s3_state_bucket.arn}"
+    ]
+  }
+
   statement {
     effect = "Allow"
     actions = [


### PR DESCRIPTION
This fixes an issue with member account CI, specifically with environment terraform operations failing due to lack of access to the kms key used to encrypt the terraform remote state bucket (introduced in https://github.com/ministryofjustice/modernisation-platform/pull/1081)

In addition to adding permissions to the policy applied to the MemberCIAllowActions policy, it
- Explicitly adds required permissions for dynamodb state locking table
- Adds missing alias for dynamodb kms key
