### PR TITLE
Update access to KMS key for state bucket

### DIFF
--- a/terraform/modernisation-platform-account/s3.tf
+++ b/terraform/modernisation-platform-account/s3.tf
@@ -27,9 +27,10 @@ data "aws_iam_policy_document" "kms_state_bucket" {
     ]
     principals {
       type = "AWS"
-      identifiers = [
-        data.aws_caller_identity.current.account_id
-      ]
+      identifiers = concat(
+        [data.aws_caller_identity.current.account_id],
+        local.root_users_with_state_access
+      )
     }
   }
   statement {


### PR DESCRIPTION
The root account currently can't access the terraform state after the
changes to the state bucket KMS encryption.  This adds access to the KMS
key for anyone who should have access to the state bucket.