### PR TITLE
Add route53 record for github pages user guidance

### DIFF
--- a/terraform/environments/core-network-services/route53.tf
+++ b/terraform/environments/core-network-services/route53.tf
@@ -62,3 +62,13 @@ resource "aws_route53_record" "bichard7" {
     "ns-836.awsdns-40.net."
   ]
 }
+
+# Github pages user guidance CNAME record
+
+resource "aws_route53_record" "github_pages" {
+  zone_id = aws_route53_zone.modernisation-platform.zone_id
+  name    = "user-guide"
+  type    = "CNAME"
+  ttl     = "30"
+  records = ["ministryofjustice.github.io"]
+}


### PR DESCRIPTION
We want our user guidance to have a .service.gov.uk url.

Closes #1097 