### PR TITLE
Add read/write permissons for S3 buckets for CICD

### DIFF
--- a/terraform/modules/iam_baseline/main.tf
+++ b/terraform/modules/iam_baseline/main.tf
@@ -1,3 +1,4 @@
+# Create the CICD user in the member account which is used for application deployments
 resource "aws_iam_user" "cicd_member_user" {
   name = "cicd-member-user"
 }
@@ -26,8 +27,9 @@ resource "aws_iam_policy" "policy" {
           "ecr:InitiateLayerUpload",
           "ecr:UploadLayerPart",
           "ecr:CompleteLayerUpload",
-          "iam:PassRole"
-
+          "iam:PassRole",
+          "s3:ListBucket",
+          "s3:*Object*"
         ]
         Effect   = "Allow"
         Resource = "*"


### PR DESCRIPTION
There is a need for the application CICD user to read and write to an S3
bucket.  Adding the permissions as documented here -
https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_examples_s3_rw-bucket.html