### PR TITLE
Remove admin permissions on ops-eng account

### DIFF
--- a/environments/ops-engineering.json
+++ b/environments/ops-engineering.json
@@ -5,7 +5,7 @@
       "name": "development",
       "access": [{
 		"github_slug": "operations-engineering",
-		"level": "administrator"
+		"level": "developer"
 		}]
 	  }
 	],


### PR DESCRIPTION
The ops engineering account is marked for deletion, restricting this
again just in case.