### PR TITLE
Fix permissions with perf hub ECR repo

### DIFF
--- a/terraform/environments/core-shared-services/ecr_repos.tf
+++ b/terraform/environments/core-shared-services/ecr_repos.tf
@@ -1,12 +1,20 @@
+# Shared Elastic container repositories
 module "performance_hub_ecr_repo" {
   source = "../../modules/app-ecr-repo"
 
   app_name = "performance-hub"
 
-  account_arns = ["arn:aws:iam::${local.environment_management.account_ids["performance-hub-development"]}:user/cicd-member-user",
+  push_principals = [
+    "arn:aws:iam::${local.environment_management.account_ids["performance-hub-development"]}:user/cicd-member-user",
     "arn:aws:iam::${local.environment_management.account_ids["performance-hub-preproduction"]}:user/cicd-member-user",
-    "arn:aws:iam::${local.environment_management.account_ids["performance-hub-production"]}:user/cicd-member-user",
-  data.aws_caller_identity.current.arn]
+    "arn:aws:iam::${local.environment_management.account_ids["performance-hub-production"]}:user/cicd-member-user"
+  ]
+
+  pull_principals = [
+      local.environment_management.account_ids["performance-hub-development"],
+      local.environment_management.account_ids["performance-hub-preproduction"],
+      local.environment_management.account_ids["performance-hub-production"]
+  ]
 
   # Tags
   tags_common = local.tags

--- a/terraform/environments/core-shared-services/ecr_repos.tf
+++ b/terraform/environments/core-shared-services/ecr_repos.tf
@@ -11,9 +11,9 @@ module "performance_hub_ecr_repo" {
   ]
 
   pull_principals = [
-      local.environment_management.account_ids["performance-hub-development"],
-      local.environment_management.account_ids["performance-hub-preproduction"],
-      local.environment_management.account_ids["performance-hub-production"]
+    local.environment_management.account_ids["performance-hub-development"],
+    local.environment_management.account_ids["performance-hub-preproduction"],
+    local.environment_management.account_ids["performance-hub-production"]
   ]
 
   # Tags

--- a/terraform/modules/app-ecr-repo/main.tf
+++ b/terraform/modules/app-ecr-repo/main.tf
@@ -37,7 +37,7 @@ data "aws_iam_policy_document" "ecr_repo_policy" {
     ]
     principals {
       type        = "AWS"
-      identifiers = var.account_arns
+      identifiers = var.push_principals
     }
   }
 
@@ -52,7 +52,7 @@ data "aws_iam_policy_document" "ecr_repo_policy" {
     ]
     principals {
       type        = "AWS"
-      identifiers = var.account_arns
+      identifiers = var.pull_principals
     }
   }
 }

--- a/terraform/modules/app-ecr-repo/variables.tf
+++ b/terraform/modules/app-ecr-repo/variables.tf
@@ -8,8 +8,14 @@ variable "app_name" {
   type        = string
 }
 
-variable "account_arns" {
-  description = "accounts arns"
+variable "push_principals" {
+  description = "AWS principals which require access to push to the repository"
+  type        = list(string)
+  default     = []
+}
+
+variable "pull_principals" {
+  description = "AWS principals which require access to pull from the repository"
   type        = list(string)
   default     = []
 }


### PR DESCRIPTION
The existing permissions would only allow the deployment users and the
main modernisation platform account to push and pull from the repo. But
the actual environment account will be the account pulling the image
when ECS starts the container in that account.  This change splits out
the push and pull permissions in the module to make it possible to have
different permissions for each.