### PR TITLE
bug core-accounts-missing-default-routes

### DIFF
--- a/terraform/environments/core-logging/vpc.tf
+++ b/terraform/environments/core-logging/vpc.tf
@@ -18,6 +18,8 @@ module "vpc" {
   #   none = no gateway for internal traffic
   gateway = "transit"
 
+  transit_gateway_id = data.aws_ec2_transit_gateway.transit-gateway.id
+
   # VPC Flow Logs
   vpc_flow_log_iam_role = data.aws_iam_role.vpc-flow-log.arn
 

--- a/terraform/environments/core-security/vpc.tf
+++ b/terraform/environments/core-security/vpc.tf
@@ -18,6 +18,8 @@ module "vpc" {
   #   none = no gateway for internal traffic
   gateway = "transit"
 
+  transit_gateway_id = data.aws_ec2_transit_gateway.transit-gateway.id
+
   # VPC Flow Logs
   vpc_flow_log_iam_role = data.aws_iam_role.vpc-flow-log.arn
 

--- a/terraform/environments/core-shared-services/vpc.tf
+++ b/terraform/environments/core-shared-services/vpc.tf
@@ -18,6 +18,8 @@ module "vpc" {
   #   none = no gateway for internal traffic
   gateway = "transit"
 
+  transit_gateway_id = data.aws_ec2_transit_gateway.transit-gateway.id
+
   # VPC Flow Logs
   vpc_flow_log_iam_role = data.aws_iam_role.vpc-flow-log.arn
 

--- a/terraform/modules/app-ecr-repo/README.md
+++ b/terraform/modules/app-ecr-repo/README.md
@@ -1,0 +1,44 @@
+# Usage
+
+<!--- BEGIN_TF_DOCS --->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.47.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.47.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_ecr_repository.ecr_repo](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository) | resource |
+| [aws_ecr_repository_policy.ecr_repository_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository_policy) | resource |
+| [aws_iam_policy_document.ecr_repo_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_account_arns"></a> [account\_arns](#input\_account\_arns) | accounts arns | `list(string)` | `[]` | no |
+| <a name="input_app_name"></a> [app\_name](#input\_app\_name) | base name for ecr repo | `string` | n/a | yes |
+| <a name="input_tags_common"></a> [tags\_common](#input\_tags\_common) | MOJ required tags | `map(string)` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_ecr_repository_name"></a> [ecr\_repository\_name](#output\_ecr\_repository\_name) | ECR Repo Name |
+
+<!--- END_TF_DOCS --->
+

--- a/terraform/modules/vpc-hub/README.md
+++ b/terraform/modules/vpc-hub/README.md
@@ -57,6 +57,9 @@ No modules.
 | [aws_route_table.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table) | resource |
 | [aws_route_table.public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table) | resource |
 | [aws_route_table.transit-gateway](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table) | resource |
+| [aws_route.data-tgw](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
+| [aws_route.private-tgw](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
+| [aws_route.transit-gateway-tgw](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
 | [aws_route_table_association.data](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
 | [aws_route_table_association.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
 | [aws_route_table_association.public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
@@ -73,10 +76,13 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_gateway"></a> [gateway](#input\_gateway) | Type of gateway to use for environment | `string` | `"none"` | no |
+| <a name="input_transit_gateway_id"></a> [transit\_gateway\_id](#input/_transit/_gateway/_id) | id of Transit Gateway to use for vpc routing | `string` | `""` | ** conditional |
 | <a name="input_tags_common"></a> [tags\_common](#input\_tags\_common) | Ministry of Justice required tags | `map(any)` | n/a | yes |
 | <a name="input_tags_prefix"></a> [tags\_prefix](#input\_tags\_prefix) | Prefix for name tags, e.g. "live\_data" | `string` | n/a | yes |
 | <a name="input_vpc_cidr"></a> [vpc\_cidr](#input\_vpc\_cidr) | CIDR range for the VPC | `string` | n/a | yes |
 | <a name="input_vpc_flow_log_iam_role"></a> [vpc\_flow\_log\_iam\_role](#input\_vpc\_flow\_log\_iam\_role) | VPC Flow Log IAM role ARN for VPC Flow Logs to CloudWatch | `string` | n/a | yes |
+
+** if variable 'gateway' equals 'transit' then variable 'transit_gateway_id' must be set
 
 ## Outputs
 

--- a/terraform/modules/vpc-hub/README.md
+++ b/terraform/modules/vpc-hub/README.md
@@ -50,16 +50,16 @@ No modules.
 | [aws_network_acl_rule.transit-gateway-local-egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
 | [aws_network_acl_rule.transit-gateway-local-ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
 | [aws_route.data-nat](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
+| [aws_route.data-tgw](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
 | [aws_route.private-nat](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
+| [aws_route.private-tgw](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
 | [aws_route.public-internet-gateway](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
 | [aws_route.transit-gateway-nat](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
+| [aws_route.transit-gateway-tgw](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
 | [aws_route_table.data](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table) | resource |
 | [aws_route_table.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table) | resource |
 | [aws_route_table.public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table) | resource |
 | [aws_route_table.transit-gateway](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table) | resource |
-| [aws_route.data-tgw](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
-| [aws_route.private-tgw](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
-| [aws_route.transit-gateway-tgw](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
 | [aws_route_table_association.data](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
 | [aws_route_table_association.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
 | [aws_route_table_association.public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
@@ -76,13 +76,11 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_gateway"></a> [gateway](#input\_gateway) | Type of gateway to use for environment | `string` | `"none"` | no |
-| <a name="input_transit_gateway_id"></a> [transit\_gateway\_id](#input/_transit/_gateway/_id) | id of Transit Gateway to use for vpc routing | `string` | `""` | ** conditional |
 | <a name="input_tags_common"></a> [tags\_common](#input\_tags\_common) | Ministry of Justice required tags | `map(any)` | n/a | yes |
 | <a name="input_tags_prefix"></a> [tags\_prefix](#input\_tags\_prefix) | Prefix for name tags, e.g. "live\_data" | `string` | n/a | yes |
+| <a name="input_transit_gateway_id"></a> [transit\_gateway\_id](#input\_transit\_gateway\_id) | tgw ID | `string` | `""` | no |
 | <a name="input_vpc_cidr"></a> [vpc\_cidr](#input\_vpc\_cidr) | CIDR range for the VPC | `string` | n/a | yes |
 | <a name="input_vpc_flow_log_iam_role"></a> [vpc\_flow\_log\_iam\_role](#input\_vpc\_flow\_log\_iam\_role) | VPC Flow Log IAM role ARN for VPC Flow Logs to CloudWatch | `string` | n/a | yes |
-
-** if variable 'gateway' equals 'transit' then variable 'transit_gateway_id' must be set
 
 ## Outputs
 

--- a/terraform/modules/vpc-hub/main.tf
+++ b/terraform/modules/vpc-hub/main.tf
@@ -538,6 +538,13 @@ resource "aws_route" "private-nat" {
   destination_cidr_block = "0.0.0.0/0"
   nat_gateway_id         = aws_nat_gateway.public[replace(each.key, "private", "public")].id
 }
+resource "aws_route" "private-tgw" {
+  for_each = (var.gateway == "transit") ? aws_route_table.private : {}
+
+  route_table_id         = each.value.id
+  destination_cidr_block = "0.0.0.0/0"
+  transit_gateway_id     = var.transit_gateway_id
+}
 
 # Data NAT routes
 resource "aws_route" "data-nat" {
@@ -547,6 +554,13 @@ resource "aws_route" "data-nat" {
   destination_cidr_block = "0.0.0.0/0"
   nat_gateway_id         = aws_nat_gateway.public[replace(each.key, "data", "public")].id
 }
+resource "aws_route" "data-tgw" {
+  for_each = (var.gateway == "transit") ? aws_route_table.data : {}
+
+  route_table_id         = each.value.id
+  destination_cidr_block = "0.0.0.0/0"
+  transit_gateway_id     = var.transit_gateway_id
+}
 
 # Transit Gateway NAT routes
 resource "aws_route" "transit-gateway-nat" {
@@ -555,4 +569,11 @@ resource "aws_route" "transit-gateway-nat" {
   route_table_id         = each.value.id
   destination_cidr_block = "0.0.0.0/0"
   nat_gateway_id         = aws_nat_gateway.public[replace(each.key, "transit-gateway", "public")].id
+}
+resource "aws_route" "transit-gateway-tgw" {
+  for_each = (var.gateway == "transit") ? aws_route_table.transit-gateway : {}
+
+  route_table_id         = each.value.id
+  destination_cidr_block = "0.0.0.0/0"
+  transit_gateway_id     = var.transit_gateway_id
 }

--- a/terraform/modules/vpc-hub/variables.tf
+++ b/terraform/modules/vpc-hub/variables.tf
@@ -13,6 +13,11 @@ variable "gateway" {
   }
 }
 
+variable "transit_gateway_id" {
+  description = "tgw ID"
+  type        = string
+  default     = ""
+}
 variable "vpc_flow_log_iam_role" {
   description = "VPC Flow Log IAM role ARN for VPC Flow Logs to CloudWatch"
   type        = string


### PR DESCRIPTION
- update vpc-hub module to enable the default routes to point to the
  attached Transit Gateway
- update code to supply Transit Gateway ID in
  - core-security
  - core-logging
  - core-shared-services