### PR TITLE
Networking for AMI building in shared services

### DIFF
--- a/terraform/environments/core-shared-services/data.tf
+++ b/terraform/environments/core-shared-services/data.tf
@@ -1,0 +1,2 @@
+# Discover current region name - used when setting up vpc endpoints
+data "aws_region" "current_region" {}

--- a/terraform/environments/core-shared-services/vpc.tf
+++ b/terraform/environments/core-shared-services/vpc.tf
@@ -41,30 +41,30 @@ module "vpc" {
 
 locals {
   # Derive non_live_data vpc and private subnets for configuration setting up the vpc endpoints
-  non_live_data_vpc_id    = one([for k in module.vpc : k.vpc_id if k.vpc_cidr_block == local.networking.non_live_data])
-  private_subnet_ids      = flatten([for k in module.vpc : k.non_tgw_subnet_ids_map.private if k.vpc_cidr_block == local.networking.non_live_data])
+  non_live_data_vpc_id = one([for k in module.vpc : k.vpc_id if k.vpc_cidr_block == local.networking.non_live_data])
+  private_subnet_ids   = flatten([for k in module.vpc : k.non_tgw_subnet_ids_map.private if k.vpc_cidr_block == local.networking.non_live_data])
 
   # Get the private route table keys and values, then transform the values (the actual route table ids) into a list
   # i.e. transform 
-#   {
-#   "private" = {
-#     "non_live_data-private-eu-west-2a" = "rtb-aaa"
-#     "non_live_data-private-eu-west-2b" = "rtb-bbb"
-#     "non_live_data-private-eu-west-2c" = "rtb-ccc"
-#   },
-#   "data" = {
-#     "non_live_data-data-eu-west-2a" = "rtb-ddd"
-#     ...
-#   },
-#   {
-#   "transit-gateway" = {
-#     "non_live_data-transit-gateway-eu-west-2a" = "rtb-eee"
-#     ...
-#   }
-# }
-# to ["rtb-aaa", "rtb-bbb", "rtb-ccc"]
-  private_route_tables = { for k in module.vpc : "private" => k.private_route_tables_map.private if k.vpc_cidr_block == local.networking.non_live_data }
-  private_route_table_ids = [ for k,v in local.private_route_tables.private : v ]
+  #   {
+  #   "private" = {
+  #     "non_live_data-private-eu-west-2a" = "rtb-aaa"
+  #     "non_live_data-private-eu-west-2b" = "rtb-bbb"
+  #     "non_live_data-private-eu-west-2c" = "rtb-ccc"
+  #   },
+  #   "data" = {
+  #     "non_live_data-data-eu-west-2a" = "rtb-ddd"
+  #     ...
+  #   },
+  #   {
+  #   "transit-gateway" = {
+  #     "non_live_data-transit-gateway-eu-west-2a" = "rtb-eee"
+  #     ...
+  #   }
+  # }
+  # to ["rtb-aaa", "rtb-bbb", "rtb-ccc"]
+  private_route_tables    = { for k in module.vpc : "private" => k.private_route_tables_map.private if k.vpc_cidr_block == local.networking.non_live_data }
+  private_route_table_ids = [for k, v in local.private_route_tables.private : v]
 }
 
 # Create security group for vpc endpoints

--- a/terraform/environments/core-shared-services/vpc.tf
+++ b/terraform/environments/core-shared-services/vpc.tf
@@ -81,6 +81,7 @@ resource "aws_security_group" "interface_endpoint_security_group" {
 }
 
 resource "aws_security_group_rule" "interface_endpoint-security_group_rule" {
+  description       = "Permit secure traffic to this endpoint within the VPC"
   type              = "ingress"
   from_port         = 443
   to_port           = 443

--- a/terraform/environments/core-shared-services/vpc.tf
+++ b/terraform/environments/core-shared-services/vpc.tf
@@ -3,6 +3,17 @@ locals {
     live_data     = "10.231.0.0/19"
     non_live_data = "10.231.32.0/19"
   }
+
+  vpc_interface_endpoint_service_names = toset([
+    "com.amazonaws.${data.aws_region.current_region.name}.imagebuilder",
+    "com.amazonaws.${data.aws_region.current_region.name}.ec2messages",
+    "com.amazonaws.${data.aws_region.current_region.name}.ssm",
+    "com.amazonaws.${data.aws_region.current_region.name}.ssmmessages"
+  ])
+
+  vpc_gateway_endpoint_service_names = toset([
+    "com.amazonaws.${data.aws_region.current_region.name}.s3"
+  ])
 }
 
 module "vpc" {
@@ -25,3 +36,85 @@ module "vpc" {
   tags_common = local.tags
   tags_prefix = each.key
 }
+
+locals {
+  # Derive non_live_data vpc and private subnets for configuration setting up the vpc endpoints
+  non_live_data_vpc_id    = one([for k in module.vpc : k.vpc_id if k.vpc_cidr_block == local.networking.non_live_data])
+  private_subnet_ids      = flatten([for k in module.vpc : k.non_tgw_subnet_ids_map.private if k.vpc_cidr_block == local.networking.non_live_data])
+
+  # Get the private route table keys and values, then transform the values (the actual route table ids) into a list
+  # i.e. transform 
+#   {
+#   "private" = {
+#     "non_live_data-private-eu-west-2a" = "rtb-aaa"
+#     "non_live_data-private-eu-west-2b" = "rtb-bbb"
+#     "non_live_data-private-eu-west-2c" = "rtb-ccc"
+#   },
+#   "data" = {
+#     "non_live_data-data-eu-west-2a" = "rtb-ddd"
+#     ...
+#   },
+#   {
+#   "transit-gateway" = {
+#     "non_live_data-transit-gateway-eu-west-2a" = "rtb-eee"
+#     ...
+#   }
+# }
+# to ["rtb-aaa", "rtb-bbb", "rtb-ccc"]
+  private_route_tables = { for k in module.vpc : "private" => k.private_route_tables_map.private if k.vpc_cidr_block == local.networking.non_live_data }
+  private_route_table_ids = [ for k,v in local.private_route_tables.private : v ]
+}
+
+# Create security group for vpc endpoints
+resource "aws_security_group" "interface_endpoint_security_group" {
+  name        = "${local.application_name}-int-endpoint"
+  description = "Security group to control traffic through vpc interface endpoints"
+  vpc_id      = local.non_live_data_vpc_id
+  tags = merge(
+    local.tags,
+    {
+      Name = "${local.application_name}-int-endpoint"
+    }
+  )
+}
+
+resource "aws_security_group_rule" "interface_endpoint-security_group_rule" {
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = [local.networking.non_live_data]
+  security_group_id = aws_security_group.interface_endpoint_security_group.id
+}
+
+# Create vpc interface endpoints in private subnets in non_live_data vpc
+resource "aws_vpc_endpoint" "vpc_interface_endpoints" {
+  for_each            = local.vpc_interface_endpoint_service_names
+  vpc_id              = local.non_live_data_vpc_id
+  service_name        = each.value
+  vpc_endpoint_type   = "Interface"
+  private_dns_enabled = true
+  subnet_ids          = local.private_subnet_ids
+  security_group_ids  = [aws_security_group.interface_endpoint_security_group.id]
+  tags = merge(
+    local.tags,
+    {
+      Name = "${local.application_name}-${each.value}"
+    }
+  )
+}
+
+resource "aws_vpc_endpoint" "vpc_gateway_endpoint_s3" {
+  for_each          = local.vpc_gateway_endpoint_service_names
+  vpc_endpoint_type = "Gateway"
+  vpc_id            = local.non_live_data_vpc_id
+  service_name      = each.value
+  route_table_ids   = local.private_route_table_ids
+  tags = merge(
+    local.tags,
+    {
+      Name = "${local.application_name}-${each.value}"
+    }
+  )
+}
+

--- a/terraform/modules/vpc-hub/outputs.tf
+++ b/terraform/modules/vpc-hub/outputs.tf
@@ -3,6 +3,11 @@ output "vpc_id" {
   value       = aws_vpc.default.id
 }
 
+output "vpc_cidr_block" {
+  description = "VPC CIDR block"
+  value       = aws_vpc.default.cidr_block
+}
+
 output "tgw_subnet_ids" {
   description = "Transit Gateway subnet IDs"
   value       = [for subnet in aws_subnet.transit-gateway : subnet.id]
@@ -22,6 +27,15 @@ output "non_tgw_subnet_ids" {
   ])
 }
 
+output "non_tgw_subnet_ids_map" {
+  description = "Map of subnet ids, with keys being the subnet types and values being the list of subnet ids"
+  value = {
+    "public" = [for subnet in aws_subnet.public : subnet.id]
+    "private" = [for subnet in aws_subnet.private : subnet.id]
+    "data" = [for subnet in aws_subnet.data : subnet.id]
+  }
+}
+
 output "private_route_tables" {
   description = "Private route table keys and IDs"
   value = merge({
@@ -34,6 +48,21 @@ output "private_route_tables" {
     for key, route_table in aws_route_table.transit-gateway :
     "${var.tags_prefix}-${key}" => route_table.id
   })
+}
+
+output "private_route_tables_map" {
+  description = "Private route table keys and IDs, as a map organised by type"
+  value = {
+    "private" = {
+      for key, route_table in aws_route_table.private : "${var.tags_prefix}-${key}" => route_table.id
+    },
+    "data" = {
+      for key, route_table in aws_route_table.data : "${var.tags_prefix}-${key}" => route_table.id
+    },
+    "transit_gateway" = {
+      for key, route_table in aws_route_table.transit-gateway : "${var.tags_prefix}-${key}" => route_table.id
+    }
+  }
 }
 
 output "public_route_tables" {

--- a/terraform/modules/vpc-hub/outputs.tf
+++ b/terraform/modules/vpc-hub/outputs.tf
@@ -30,9 +30,9 @@ output "non_tgw_subnet_ids" {
 output "non_tgw_subnet_ids_map" {
   description = "Map of subnet ids, with keys being the subnet types and values being the list of subnet ids"
   value = {
-    "public" = [for subnet in aws_subnet.public : subnet.id]
+    "public"  = [for subnet in aws_subnet.public : subnet.id]
     "private" = [for subnet in aws_subnet.private : subnet.id]
-    "data" = [for subnet in aws_subnet.data : subnet.id]
+    "data"    = [for subnet in aws_subnet.data : subnet.id]
   }
 }
 


### PR DESCRIPTION
Adding VPC endpoints (and dependent resources) to private subnet in non_live_data vpc in shared services account as part of the capability to securely build AMIs using Image Builder.

Related to #1061 .