### PR TITLE
Adding required role and instance profile for image builder to shared services

### DIFF
--- a/terraform/environments/core-shared-services/iam.tf
+++ b/terraform/environments/core-shared-services/iam.tf
@@ -1,3 +1,35 @@
 data "aws_iam_role" "vpc-flow-log" {
   name = "AWSVPCFlowLog"
 }
+
+# Create IAM role and instance profile for image builder
+# Instance profile gets associated to the image builder Infrastructure Configuration resource
+data "aws_iam_policy" "image_builder_managed_policies" {
+  for_each = toset([
+    "EC2InstanceProfileForImageBuilder",
+    "AmazonSSMManagedInstanceCore"
+  ])
+  name = each.key
+}
+
+data "aws_iam_policy_document" "image_builder_assume_policy" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    effect  = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "image_builder" {
+  name                = "image-builder"
+  assume_role_policy  = data.aws_iam_policy_document.image_builder_assume_policy.json
+  managed_policy_arns = [for k in data.aws_iam_policy.image_builder_managed_policies : k.arn]
+}
+
+resource "aws_iam_instance_profile" "image_builder" {
+  name = "image-builder"
+  role = aws_iam_role.image_builder.name
+}


### PR DESCRIPTION
A follow-on from #1061 and related to #1059.

Some required required configuration of IAM in core-shared services to be able use image builder as per our designs.

See [this aws doc](https://docs.aws.amazon.com/imagebuilder/latest/userguide/image-builder-setting-up.html) for more info.

