### PR TITLE
Add ci secrets to ami-builds repo

### DIFF
--- a/terraform/github/main.tf
+++ b/terraform/github/main.tf
@@ -135,6 +135,7 @@ module "modernisation-platform-ami-builds" {
     "linux",
     "windows"
   ]
+  secrets = nonsensitive(local.ci_iam_user_keys)
 }
 
 module "modernisation-platform-environments" {


### PR DESCRIPTION
Adding the AWS CI access key and secret to the [AMI build repo](https://github.com/ministryofjustice/modernisation-platform-ami-builds) so workflows can authenticate to AWS.

Related to #1059 
