### PR TITLE
change-cidr-range-for-protected-subnets

### DIFF
--- a/environments-networks/cica-development.json
+++ b/environments-networks/cica-development.json
@@ -1,7 +1,7 @@
 {
   "cidr": {
     "transit_gateway": "10.233.2.64/26",
-    "protected": "10.232.18.0/23",
+    "protected": "10.238.18.0/23",
     "subnet_sets": {
       "general": {
         "cidr": "10.234.40.0/21",

--- a/environments-networks/garden-development.json
+++ b/environments-networks/garden-development.json
@@ -1,7 +1,7 @@
 {
   "cidr": {
     "transit_gateway": "10.233.0.0/26",
-    "protected": "10.232.0.0/23",
+    "protected": "10.238.0.0/23",
     "subnet_sets": {
       "general": {
         "cidr": "10.234.0.0/21",

--- a/environments-networks/garden-production.json
+++ b/environments-networks/garden-production.json
@@ -1,7 +1,7 @@
 {
   "cidr": {
     "transit_gateway": "10.233.0.128/26",
-    "protected": "10.232.4.0/23",
+    "protected": "10.238.4.0/23",
     "subnet_sets": {
       "general": {
         "cidr": "10.237.0.0/21",

--- a/environments-networks/hmpps-development.json
+++ b/environments-networks/hmpps-development.json
@@ -1,7 +1,7 @@
 {
   "cidr": {
     "transit_gateway": "10.233.1.128/26",
-    "protected": "10.232.12.0/23",
+    "protected": "10.238.12.0/23",
     "subnet_sets": {
       "general": {
         "cidr": "10.234.32.0/21",

--- a/environments-networks/hmpps-preproduction.json
+++ b/environments-networks/hmpps-preproduction.json
@@ -1,7 +1,7 @@
 {
   "cidr": {
     "transit_gateway": "10.233.1.0/26",
-    "protected": "10.232.8.0/23",
+    "protected": "10.238.8.0/23",
     "subnet_sets": {
       "general": {
         "cidr": "10.236.0.0/21",

--- a/environments-networks/hmpps-production.json
+++ b/environments-networks/hmpps-production.json
@@ -1,7 +1,7 @@
 {
   "cidr": {
     "transit_gateway": "10.233.2.128/26",
-    "protected": "10.232.20.0/23",
+    "protected": "10.238.20.0/23",
     "subnet_sets": {
       "general": {
         "cidr": "10.237.24.0/21",

--- a/environments-networks/hmpps-test.json
+++ b/environments-networks/hmpps-test.json
@@ -1,7 +1,7 @@
 {
   "cidr": {
     "transit_gateway": "10.233.2.0/26",
-    "protected": "10.232.16.0/23",
+    "protected": "10.238.16.0/23",
     "subnet_sets": {
       "nomis": {
         "cidr": "10.235.8.0/21",

--- a/environments-networks/house-development.json
+++ b/environments-networks/house-development.json
@@ -1,7 +1,7 @@
 {
   "cidr": {
     "transit_gateway": "10.233.0.64/26",
-    "protected": "10.232.2.0/23",
+    "protected": "10.238.2.0/23",
     "subnet_sets": {
       "general": {
         "cidr": "10.234.16.0/21",

--- a/environments-networks/house-production.json
+++ b/environments-networks/house-production.json
@@ -1,7 +1,7 @@
 {
   "cidr": {
     "transit_gateway": "10.233.0.192/26",
-    "protected": "10.232.6.0/23",
+    "protected": "10.238.6.0/23",
     "subnet_sets": {
       "general": {
         "cidr": "10.237.16.0/21",

--- a/environments-networks/platforms-development.json
+++ b/environments-networks/platforms-development.json
@@ -1,7 +1,7 @@
 {
   "cidr": {
     "transit_gateway": "10.233.1.64/26",
-    "protected": "10.232.10.0/23",
+    "protected": "10.238.10.0/23",
     "subnet_sets": {
       "general": {
         "cidr": "10.234.24.0/21",

--- a/environments-networks/platforms-test.json
+++ b/environments-networks/platforms-test.json
@@ -1,7 +1,7 @@
 {
   "cidr": {
     "transit_gateway": "10.233.1.192/26",
-    "protected": "10.232.14.0/23",
+    "protected": "10.238.14.0/23",
     "subnet_sets": {
       "general": {
         "cidr": "10.235.0.0/21",

--- a/environments-networks/template-only.txt
+++ b/environments-networks/template-only.txt
@@ -1,7 +1,7 @@
 {
     "cidr": {
         "transit_gateway": "10.233.0.64/26",
-        "protected": "10.232.2.0/23",
+        "protected": "10.238.2.0/23",
         "subnet_sets": {
             "general": {
                 "cidr": "10.233.32.0/21",


### PR DESCRIPTION
- update protected cidr ranges to use addresses from 10.238.0.0/16
range rather than 10.232.0.0/16 range.

This change is due to a CIDR overlap identified as part of the work to
join Modernisation Platform TGW with PTTP production TGW. The 10.232
range is being used for Magistrates Courts