### PR TITLE
change-cidr-for-core-security-and-shared-services

### DIFF
--- a/policies/networking/expected.rego
+++ b/policies/networking/expected.rego
@@ -16,17 +16,17 @@ expected =
     "hmpps-production": "10.233.2.128/26"
   },
   "protected": {
-    "garden-development": "10.232.0.0/23",
-    "house-development": "10.232.2.0/23",
-    "garden-production": "10.232.4.0/23",
-    "house-production": "10.232.6.0/23",
-    "hmpps-preproduction": "10.232.8.0/23",
-    "platforms-development": "10.232.10.0/23",
-    "hmpps-development": "10.232.12.0/23",
-    "platforms-test": "10.232.14.0/23",
-    "hmpps-test": "10.232.16.0/23",
-    "cica-development": "10.232.18.0/23",
-    "hmpps-production": "10.232.20.0/23"
+    "garden-development": "10.238.0.0/23",
+    "house-development": "10.238.2.0/23",
+    "garden-production": "10.238.4.0/23",
+    "house-production": "10.238.6.0/23",
+    "hmpps-preproduction": "10.238.8.0/23",
+    "platforms-development": "10.238.10.0/23",
+    "hmpps-development": "10.238.12.0/23",
+    "platforms-test": "10.238.14.0/23",
+    "hmpps-test": "10.238.16.0/23",
+    "cica-development": "10.238.18.0/23",
+    "hmpps-production": "10.238.20.0/23"
   },
   "subnet_sets": {
     "garden-development": {

--- a/terraform/environments/core-logging/vpc.tf
+++ b/terraform/environments/core-logging/vpc.tf
@@ -18,12 +18,20 @@ module "vpc" {
   #   none = no gateway for internal traffic
   gateway = "transit"
 
-  transit_gateway_id = data.aws_ec2_transit_gateway.transit-gateway.id
-
   # VPC Flow Logs
   vpc_flow_log_iam_role = data.aws_iam_role.vpc-flow-log.arn
 
   # Tags
   tags_common = local.tags
   tags_prefix = each.key
+}
+
+module "core-vpc-tgw-routes" {
+  for_each = local.networking
+  source   = "../../modules/core-vpc-tgw-routes"
+
+  transit_gateway_id = data.aws_ec2_transit_gateway.transit-gateway.id
+  route_table_ids    = module.vpc[each.key].private_route_tables
+
+  depends_on = [module.vpc_attachment]
 }

--- a/terraform/environments/core-security/test/go_test.go
+++ b/terraform/environments/core-security/test/go_test.go
@@ -56,6 +56,6 @@ func TestTransitGateway(t *testing.T) {
 
 	//Check the correct CIDR address have been added
 	output5 := terraform.Output(t, terraformOptions, "vpc_cidrs")
-	assert.Equal(t, output5, "map[live_data:10.231.128.0/19 non_live_data:10.231.160.0/19]")
+	assert.Equal(t, output5, "map[live_data:10.230.192.0/19 non_live_data:10.230.224.0/19]")
 
 }

--- a/terraform/environments/core-security/vpc.tf
+++ b/terraform/environments/core-security/vpc.tf
@@ -1,7 +1,7 @@
 locals {
   networking = {
-    live_data     = "10.231.128.0/19"
-    non_live_data = "10.231.160.0/19"
+    live_data     = "10.230.192.0/19"
+    non_live_data = "10.230.224.0/19"
   }
 }
 
@@ -18,12 +18,20 @@ module "vpc" {
   #   none = no gateway for internal traffic
   gateway = "transit"
 
-  transit_gateway_id = data.aws_ec2_transit_gateway.transit-gateway.id
-
   # VPC Flow Logs
   vpc_flow_log_iam_role = data.aws_iam_role.vpc-flow-log.arn
 
   # Tags
   tags_common = local.tags
   tags_prefix = each.key
+}
+
+module "core-vpc-tgw-routes" {
+  for_each = local.networking
+  source   = "../../modules/core-vpc-tgw-routes"
+
+  transit_gateway_id = data.aws_ec2_transit_gateway.transit-gateway.id
+  route_table_ids    = module.vpc[each.key].private_route_tables
+
+  depends_on = [module.vpc_attachment]
 }

--- a/terraform/environments/core-shared-services/test/go_test.go
+++ b/terraform/environments/core-shared-services/test/go_test.go
@@ -56,6 +56,6 @@ func TestTransitGateway(t *testing.T) {
 
 	//Check the correct CIDR address have been added
 	output5 := terraform.Output(t, terraformOptions, "vpc_cidrs")
-	assert.Equal(t, output5, "map[live_data:10.231.0.0/19 non_live_data:10.231.32.0/19]")
+	assert.Equal(t, output5, "map[live_data:10.230.64.0/19 non_live_data:10.230.96.0/19]")
 
 }

--- a/terraform/environments/core-shared-services/vpc.tf
+++ b/terraform/environments/core-shared-services/vpc.tf
@@ -1,7 +1,7 @@
 locals {
   networking = {
-    live_data     = "10.231.0.0/19"
-    non_live_data = "10.231.32.0/19"
+    live_data     = "10.230.64.0/19"
+    non_live_data = "10.230.96.0/19"
   }
 
   vpc_interface_endpoint_service_names = toset([
@@ -29,14 +29,22 @@ module "vpc" {
   #   none = no gateway for internal traffic
   gateway = "transit"
 
-  transit_gateway_id = data.aws_ec2_transit_gateway.transit-gateway.id
-
   # VPC Flow Logs
   vpc_flow_log_iam_role = data.aws_iam_role.vpc-flow-log.arn
 
   # Tags
   tags_common = local.tags
   tags_prefix = each.key
+}
+
+module "core-vpc-tgw-routes" {
+  for_each = local.networking
+  source   = "../../modules/core-vpc-tgw-routes"
+
+  transit_gateway_id = data.aws_ec2_transit_gateway.transit-gateway.id
+  route_table_ids    = module.vpc[each.key].private_route_tables
+
+  depends_on = [module.vpc_attachment]
 }
 
 locals {


### PR DESCRIPTION
- change core-security account CIDRs
  - live_data     "10.231.128.0/19"   => "10.230.192.0/19"
  - non-live-data "10.231.160.0/19"   => "10.230.224.0/19"
- change core-shared-services account CIDRs
  - live_data     "10.231.0.0/19"     => "10.230.64.0/19"
  - non-live-data "10.231.32.0/19"    => "10.230.96.0/19"
- update below accounts to use core-vpc-tgw-routes for transit-gateway routing
  - core-security
  - core-shared-services
  - core-logging
- updated OPA test json for protected subnets cidr change
- updated Terratest vpc CIDRs

closes #1142 
closes #1140 
closes #1141 