### PR TITLE
Add cname config

### DIFF
--- a/source/CNAME
+++ b/source/CNAME
@@ -1,0 +1,1 @@
+user-guide.modernisation-platform.service.justice.gov.uk


### PR DESCRIPTION
This is required to prevent the cname config in github pages from being
overwritten