### PR TITLE
Use required provider and remove GenerateDataKey

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -142,6 +142,8 @@ resource "aws_iam_policy" "member-access" {
 # access to the environments parameter when running a tf plan locally
 
 resource "aws_ssm_parameter" "environment_management_arn" {
+  provider = aws.workspace
+
   name  = "environment_management_arn"
   type  = "SecureString"
   value = data.aws_secretsmanager_secret.environment_management.arn

--- a/terraform/environments/secrets.tf
+++ b/terraform/environments/secrets.tf
@@ -1,10 +1,5 @@
 # Environment Management
-# Tfsec ignore
-# - AWS095: No requirement currently to encrypt this secret with customer-managed KMS key
-#tfsec:ignore:AWS095
 resource "aws_secretsmanager_secret" "environment_management" {
-  # checkov:skip=CKV_AWS_149:No requirement currently to encrypt this secret with customer-managed KMS key
-
   provider    = aws.modernisation-platform
   name        = "environment_management"
   description = "IDs for AWS-specific resources for environment management, such as organizational unit IDs"
@@ -87,8 +82,7 @@ data "aws_iam_policy_document" "kms_environment_management" {
     sid    = "Allow key decryption for modernisation platform ou members"
     effect = "Allow"
     actions = [
-      "kms:Decrypt*",
-      "kms:GenerateDataKey"
+      "kms:Decrypt*"
     ]
     resources = ["*"]
     principals {
@@ -103,7 +97,6 @@ data "aws_iam_policy_document" "kms_environment_management" {
   }
 }
 
-#data.aws_organizations_organizational_units.root_ous.children["modernistion-platform"].id
 data "aws_secretsmanager_secret_version" "environment_management" {
   provider  = aws.modernisation-platform
   secret_id = aws_secretsmanager_secret.environment_management.id


### PR DESCRIPTION
TF was failing as the parameter was trying to use a provider which
didn't have the required permissions.

Removing GenerateDataKey as not needed for decrypting data.