### PR TITLE
Adding member policy and update guidance around member account deletion

### DIFF
--- a/source/team-guide/deleting-an-environment.html.md.erb
+++ b/source/team-guide/deleting-an-environment.html.md.erb
@@ -227,6 +227,32 @@ If you delete the last environment and there are no more environments for the ap
 
 After following the above steps, you need to delete the actual AWS account that the environment was linked to.
 
+Before the account can be deleted by the root user, a policy needs to be temporarily detached that is designed to _prevent_ access from the root user.
+
+To do this, complete the following steps, comprising AWS CLI commands.
+> Note, all of the following AWS CLI commands can only be run by a user that has access to the AWS Organizations Management account
+1. Identify the policy id 
+```bash
+aws organizations list-policies --filter SERVICE_CONTROL_POLICY --query "Policies[?Name=='Modernisation Platform Member OU SCP - Prevent Root'].[Id,Name]" --output text
+```
+
+2. Identify the target id (an OU) associated with the policy, replacing \<policyId\> (starting "p-"), from the command above
+```bash
+aws organizations list-targets-for-policy --policy-id <policyId> --query "Targets[*].[Name,TargetId]" --output text
+```
+
+3. Detach the policy preventing root access from the Modernisation Platform OU, replacing \<policyId\> with the policy id and \<targetId\> with the target id, both identified above
+```bash
+aws organizations detach-policy --policy-id <policyId> --target-id <targetId>
+```
+
+Now the AWS account can be deleted.
 Follow the [AWS documentation on closing an AWS account](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_accounts_close.html). You will need:
 
 - access to the AWS account's root email address (_not_ the AWS Organizations root account)
+
+Finally, re-instate the policy (detached from the Modernisation Platform OU above), attaching it back to the Modernisation Platform OU.
+Run the following command.
+```bash
+aws organizations attach-policy --policy-id <policyId> --target-id <targetId>
+```

--- a/terraform/environments/scp_mp_member.tf
+++ b/terraform/environments/scp_mp_member.tf
@@ -13,7 +13,35 @@ data "aws_iam_policy_document" "scp_mp_member_ou" {
   }
 }
 
+# Separate policy for preventing root access (so it can be detached separately if need be)
+data "aws_iam_policy_document" "scp_mp_member_ou_prevent_root" {
+  version = "2012-10-17"
+
+  statement {
+    effect    = "Deny"
+    actions   = ["*"]
+    resources = ["*"]
+    condition {
+      test     = "ForAnyValue:StringLike"
+      variable = "aws:PrincipalOrgPaths"
+      values   = ["${data.aws_organizations_organization.root_account.id}/*/${local.modernisation_platform_ou_id}/*"]
+    }
+    # For testing this against a specific account, follow this method
+    # condition {
+    #   test     = "ForAnyValue:StringLike"
+    #   variable = "aws:PrincipalOrgPaths"
+    #   values   = ["${data.aws_organizations_organization.root_account.id}/*/${local.modernisation_platform_ou_id}/*/<member ou id>/*"] 
+    # } 
+    condition {
+      test     = "StringLike"
+      variable = "aws:PrincipalArn"
+      values   = ["arn:aws:iam::*:root"]
+    }
+  }
+}
+
 # This policy will only be applied to accounts within the "Modernisation Platform Member" ou
+# The default policy
 resource "aws_organizations_policy" "scp_mp_member_ou" {
   name        = "Modernisation Platform Member OU SCP"
   description = "Restricts permissions for all OUs and accounts under the Modernisation Platform Member OU"
@@ -27,8 +55,30 @@ resource "aws_organizations_policy" "scp_mp_member_ou" {
   }
 }
 
+# The policy preventing root access
+resource "aws_organizations_policy" "scp_mp_member_ou_prevent_root" {
+  name        = "Modernisation Platform Member OU SCP - Prevent Root"
+  description = "Prevents root user access for all OUs and accounts under the Modernisation Platform Member OU"
+  type        = "SERVICE_CONTROL_POLICY"
+  content     = data.aws_iam_policy_document.scp_mp_member_ou_prevent_root.json
+
+  tags = {
+    business-unit = "Platforms"
+    component     = "SERVICE_CONTROL_POLICY"
+    source-code   = local.github_repository
+  }
+}
+
+
 # Enrol all accounts within the Modernisation Platform Member OU (current and future) to the Modernisation Platform Member OU SCP
+# The default policy
 resource "aws_organizations_policy_attachment" "scp_mp_member_ou" {
   policy_id = aws_organizations_policy.scp_mp_member_ou.id
+  target_id = module.environments.modernisation_platform_member_ou_id
+}
+
+# The policy preventing root access
+resource "aws_organizations_policy_attachment" "scp_mp_member_ou_prevent_root" {
+  policy_id = aws_organizations_policy.scp_mp_member_ou_prevent_root.id
   target_id = module.environments.modernisation_platform_member_ou_id
 }


### PR DESCRIPTION
Addresses #1149.

PR does the following
-  Adds a new SCP (which removes all permissions from the root user) and attaches it to the member account OU (so will be inherited by all member accounts)
- Updates the guidance around account deletion (the above policy will need to be temporarily detached before the account can be closed.
