### PR TITLE
Add description to security group rule

### DIFF
--- a/terraform/modules/member-vpc/main.tf
+++ b/terraform/modules/member-vpc/main.tf
@@ -561,7 +561,7 @@ resource "aws_security_group" "endpoints" {
 resource "aws_security_group_rule" "endpoints_ingress_1" {
   for_each = var.subnet_sets
 
-  description = "Allow inbound HTTPS"
+  description       = "Allow inbound HTTPS"
   type              = "ingress"
   from_port         = 443
   to_port           = 443


### PR DESCRIPTION
We are currently getting the following SCA failure as there is no
description:
Check: CKV_AWS_23: "Ensure every security groups rule has a description"
	FAILED for resource: module.vpc.aws_security_group_rule.endpoints_ingress_1
	File: /../modules/member-vpc/main.tf:561-571
	Calling File: /core-vpc/vpc.tf:101-134
	Guide: https://docs.bridgecrew.io/docs/networking_31

		561 | resource "aws_security_group_rule" "endpoints_ingress_1" {
		562 |   for_each = var.subnet_sets
		563 |
		564 |   type              = "ingress"
		565 |   from_port         = 443
		566 |   to_port           = 443
		567 |   protocol          = "tcp"
		568 |   cidr_blocks       = [each.value]
		569 |   security_group_id = aws_security_group.endpoints.id
		570 |
		571 | }