### PR TITLE
Remove PutBucketPolicy permission on Athena query bucket

### DIFF
--- a/terraform/environments/core-logging/athena.tf
+++ b/terraform/environments/core-logging/athena.tf
@@ -83,9 +83,7 @@ data "aws_iam_policy_document" "athena_bucket_policy" {
       "s3:ListBucket",
       "s3:GetEncryptionConfiguration",
       "s3:GetBucketAcl",
-      "s3:GetBucketPolicy",
-      "s3:PutBucketPolicy"
-
+      "s3:GetBucketPolicy"
     ]
     resources = ["${module.s3-bucket-athena.bucket.arn}",
     "${module.s3-bucket-athena.bucket.arn}/*"]


### PR DESCRIPTION
Another small change related to security work: https://github.com/ministryofjustice/modernisation-platform/issues/1192

I don't believe this PutBucketPolicy permission is required for this bucket where query results are stored.

Useful links
- https://aws.amazon.com/premiumsupport/knowledge-center/access-denied-athena/
