### PR TITLE
Remove Probation business unit

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-environment.md
+++ b/.github/ISSUE_TEMPLATE/new-environment.md
@@ -48,7 +48,7 @@ owner |
 
 <!-- 
 Valid business-unit values
-HQ,HMPPS,OPG,LAA,HMCTS,CICA,Platforms,CJSE,Probation
+HQ,HMPPS,OPG,LAA,HMCTS,CICA,Platforms,CJSE
 -->
 
 ## Networking options

--- a/environments/remote-supervision.json
+++ b/environments/remote-supervision.json
@@ -22,7 +22,7 @@
   ],
   "tags": {
     "application": "remote-supervision",
-    "business-unit": "Probation",
+    "business-unit": "HMPPS",
     "owner": "Remote Supervision: remote.supervision+hosting@digital.justice.gov.uk"
   }
 }

--- a/policies/environments/environment-definitions.rego
+++ b/policies/environments/environment-definitions.rego
@@ -8,8 +8,7 @@ allowed_business_units := [
   "HMCTS",
   "CICA",
   "Platforms",
-  "CJSE",
-  "Probation"
+  "CJSE"
 ]
 
 deny[msg] {

--- a/policies/environments/environment-definitions_test.rego
+++ b/policies/environments/environment-definitions_test.rego
@@ -29,7 +29,7 @@ test_empty_values {
 }
 
 test_unexpected_business_units {
-  deny["`example.json` uses an unexpected business-unit: got `incorrect-business-unit`, expected one of: HQ, HMPPS, OPG, LAA, HMCTS, CICA, Platforms, CJSE, Probation"] with input as { "filename": "example.json", "tags": { "business-unit": "incorrect-business-unit" } }
+  deny["`example.json` uses an unexpected business-unit: got `incorrect-business-unit`, expected one of: HQ, HMPPS, OPG, LAA, HMCTS, CICA, Platforms, CJSE"] with input as { "filename": "example.json", "tags": { "business-unit": "incorrect-business-unit" } }
 }
 
 test_business_units_length{

--- a/policies/networking/core-vpc_test.rego
+++ b/policies/networking/core-vpc_test.rego
@@ -18,7 +18,7 @@ test_mismatched_transit_gateway_cidr {
 }
 
 test_mismatched_protected_cidr {
-	deny["Protected CIDR mismatch: `1.1.1.1` should equal `10.232.0.0/23` for `garden-development`"] with input as sample_input
+	deny["Protected CIDR mismatch: `1.1.1.1` should equal `10.238.0.0/23` for `garden-development`"] with input as sample_input
 }
 
 test_mismatched_subnet_sets {

--- a/source/user-guide/creating-environments.html.md.erb
+++ b/source/user-guide/creating-environments.html.md.erb
@@ -75,7 +75,7 @@ business-unit | LAA
 owner | find-a-solicitor@ministryofjustice.gov.uk
 
 Valid business-unit values
-HQ,HMPPS,OPG,LAA,HMCTS,CICA,Platforms,CJSE,Probation
+HQ,HMPPS,OPG,LAA,HMCTS,CICA,Platforms,CJSE
 
 ### Additional features
 


### PR DESCRIPTION
Probation is covered in HMPPS, removing this business unit so that it is
no longer available for use.

The only member which uses it is remote supervision so it has been changed there as well, this will update the tags associated with their account.