### PR TITLE
SSH to bastion by tag key/value pair Name=bastion_linux

### DIFF
--- a/source/user-guide/accessing-ec2s.html.md.erb
+++ b/source/user-guide/accessing-ec2s.html.md.erb
@@ -13,9 +13,7 @@ These steps outline the AWS and SSH configurations required for users to connect
 
 ## Required configurations to connect to the bastion
 
-1) Ensure AWS CLI v2 and Session Manager plugin are installed locally
-
-For example, on macOS, you can install the following brew packages:
+1) Ensure AWS CLI v2 and Session Manager plugin are installed locally. For example, if you're using macOS, you can install the following brew packages:
 
 - awscli - Official Amazon AWS command-line interface
 - session-manager-plugin - Session Manager Plugin for the AWS CLI


### PR DESCRIPTION
- SSH to bastion by tag key/value pair Name=bastion_linux. This way we don't need to hardcode the instance ID into the SSH configuration. The reason this is important is so that we can terminate bastion instances in order to reset their user data. Instance IDs change upon termination/recreation therefore avoiding using them in the SSH configuration will prevent the annoyance of having to reconfigure it upon every termination, which we plan to do on a daily basis.
- Added a note to install Session Manager Plugin for the AWS CLI