### PR TITLE
Remove unused time_sleeps

### DIFF
--- a/terraform/environments/core-logging/transit-gateway-attachment.tf
+++ b/terraform/environments/core-logging/transit-gateway-attachment.tf
@@ -23,10 +23,6 @@ resource "aws_ram_principal_association" "transit_gateway_association" {
   resource_share_arn = data.aws_ram_resource_share.transit-gateway-shared.arn
 }
 
-resource "time_sleep" "wait_60_seconds" {
-  create_duration = "60s"
-}
-
 # Attach the VPC to the central Transit Gateway
 module "vpc_attachment" {
   for_each = local.networking

--- a/terraform/environments/core-security/transit-gateway-attachment.tf
+++ b/terraform/environments/core-security/transit-gateway-attachment.tf
@@ -23,10 +23,6 @@ resource "aws_ram_principal_association" "transit_gateway_association" {
   resource_share_arn = data.aws_ram_resource_share.transit-gateway-shared.arn
 }
 
-resource "time_sleep" "wait_60_seconds" {
-  create_duration = "60s"
-}
-
 # Attach the VPC to the central Transit Gateway
 module "vpc_attachment" {
   for_each = local.networking

--- a/terraform/environments/core-shared-services/transit-gateway-attachment.tf
+++ b/terraform/environments/core-shared-services/transit-gateway-attachment.tf
@@ -21,10 +21,6 @@ resource "aws_ram_principal_association" "transit_gateway_association" {
   resource_share_arn = data.aws_ram_resource_share.transit-gateway-shared.arn
 }
 
-resource "time_sleep" "wait_60_seconds" {
-  create_duration = "60s"
-}
-
 # Attach the VPC to the central Transit Gateway
 module "vpc_attachment" {
   for_each = local.networking


### PR DESCRIPTION
These sleeps are not referenced by any other terraform so removing them
should not have any impact.  This will close #304