### PR TITLE
Store the slack url as a secret

### DIFF
--- a/terraform/github/aws.tf
+++ b/terraform/github/aws.tf
@@ -19,3 +19,12 @@ locals {
   ci_iam_user_keys        = jsondecode(data.aws_secretsmanager_secret_version.ci_iam_user_keys.secret_string)
   member_ci_iam_user_keys = jsondecode(data.aws_secretsmanager_secret_version.member_ci_iam_user_keys.secret_string)
 }
+
+# Get the slack webhook url
+data "aws_secretsmanager_secret" "slack_webhook_url" {
+  name = "slack_webhook_url"
+}
+
+data "aws_secretsmanager_secret_version" "slack_webhook_url" {
+  secret_id = data.aws_secretsmanager_secret.slack_webhook_url.id
+}

--- a/terraform/github/main.tf
+++ b/terraform/github/main.tf
@@ -16,7 +16,7 @@ module "core" {
     # Terraform GitHub token for the CI/CD user
     TERRAFORM_GITHUB_TOKEN = "This needs to be manually set in GitHub."
     # Slack app webhook url
-    SLACK_WEBHOOK_URL = "This needs to be manually set in GitHub."
+    SLACK_WEBHOOK_URL = data.aws_secretsmanager_secret_version.slack_webhook_url.secret_string
   }))
 }
 

--- a/terraform/modernisation-platform-account/secrets.tf
+++ b/terraform/modernisation-platform-account/secrets.tf
@@ -45,3 +45,16 @@ resource "aws_secretsmanager_secret_version" "member_ci_iam_user_keys" {
     AWS_SECRET_ACCESS_KEY = aws_iam_access_key.member-ci.secret
   })
 }
+
+# Slack channel modernisation-platform-notifications webhook url for sending notifications to slack
+# Not adding a secret version as this url is provided by slack and cannot be added programatically
+# Secret should be manually set in the console.
+# Tfsec ignore
+# - AWS095: No requirement currently to encrypt this secret with customer-managed KMS key
+#tfsec:ignore:AWS095
+resource "aws_secretsmanager_secret" "slack_webhook_url" {
+  # checkov:skip=CKV_AWS_149:No requirement currently to encrypt this secret with customer-managed KMS key
+  name        = "slack_webhook_url"
+  description = "Slack channel modernisation-platform-notifications webhook url for sending notifications to slack"
+  tags        = local.tags
+}


### PR DESCRIPTION
The slack url currently gets overwritten every time we deploy the github
terraform, by creating the secret in AWS (and setting it manually via
the console) next time the github code runs it will pull from the secret
when there is a new version and only update it then.  There is then no
need to set this manually in github.