### PR TITLE
Enable versioning on destination logging buckets due to replication requirement

### DIFF
--- a/terraform/environments/core-logging/s3_logging.tf
+++ b/terraform/environments/core-logging/s3_logging.tf
@@ -167,8 +167,10 @@ module "s3-bucket-cloudtrail" {
   custom_kms_key             = aws_kms_key.s3_logging_cloudtrail.arn
   custom_replication_kms_key = aws_kms_key.s3_logging_cloudtrail_eu-west-1_replication.arn
 
-  replication_enabled = true
-  replication_region  = "eu-west-1"
+  replication_enabled                      = true
+  replication_region                       = "eu-west-1"
+  versioning_enabled_on_replication_bucket = true
+
   lifecycle_rule = [
     {
       id      = "main"
@@ -295,9 +297,11 @@ module "s3-bucket-cloudtrail-logging" {
     aws.bucket-replication = aws.modernisation-platform-eu-west-1
   }
 
-  acl                 = "log-delivery-write"
-  bucket_name         = "modernisation-platform-logs-cloudtrail-logging"
-  replication_enabled = true
+  acl                                      = "log-delivery-write"
+  bucket_name                              = "modernisation-platform-logs-cloudtrail-logging"
+  replication_enabled                      = true
+  versioning_enabled_on_replication_bucket = true
+
   lifecycle_rule = [
     {
       id      = "main"


### PR DESCRIPTION
A response to an error in a terraform apply: https://github.com/ministryofjustice/modernisation-platform/runs/4020551939?check_suite_focus=true.

Versioning must be enable if replication is: https://docs.aws.amazon.com/AmazonS3/latest/userguide/replication.html#replication-requirements.

The default to enable this in the s3 module is set to false. So over-riding this to true.
(If this fixes the issue, then the s3 module should probably be updated).