### PR TITLE
Ensure use of KMS key for cloudtrail-logging source and target buckets

### DIFF
--- a/terraform/environments/core-logging/s3_logging.tf
+++ b/terraform/environments/core-logging/s3_logging.tf
@@ -297,9 +297,13 @@ module "s3-bucket-cloudtrail-logging" {
     aws.bucket-replication = aws.modernisation-platform-eu-west-1
   }
 
-  acl                                      = "log-delivery-write"
-  bucket_name                              = "modernisation-platform-logs-cloudtrail-logging"
+  acl                        = "log-delivery-write"
+  bucket_name                = "modernisation-platform-logs-cloudtrail-logging"
+  custom_kms_key             = aws_kms_key.s3_logging_cloudtrail.arn
+  custom_replication_kms_key = aws_kms_key.s3_logging_cloudtrail_eu-west-1_replication.arn
+
   replication_enabled                      = true
+  replication_region                       = "eu-west-1"
   versioning_enabled_on_replication_bucket = true
 
   lifecycle_rule = [


### PR DESCRIPTION
To fix this issue: https://github.com/ministryofjustice/modernisation-platform/runs/4044192181?check_suite_focus=true

Cloudtrail logging buckets (like the cloudtrail buckets) needs to use customer-managed CMKs, one for each region in this replication scenario.
