### PR TITLE
Resolve PCA_ACCESS_DENIED failure

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -50,6 +50,7 @@ data "aws_iam_policy_document" "member-access" {
     effect = "Allow"
     actions = [ #tfsec:ignore:AWS099
       "acm:*",
+      "acm-pca:*",
       "application-autoscaling:*",
       "autoscaling:*",
       "cloudfront:*",


### PR DESCRIPTION
Add permission to IAM policy to resolve the issue: PCA denied access for the private certificate request.