### PR TITLE
Add NACLs for hmpps-test

### DIFF
--- a/environments-networks/hmpps-test.json
+++ b/environments-networks/hmpps-test.json
@@ -16,5 +16,72 @@
     "additional_endpoints": [],
     "dns_zone_extend": []
   },
-  "nacl": []
+  "nacl": [
+    {
+      "subnet_set": "general",
+      "egress": false,
+      "subnet_type": "data",
+      "protocol": "tcp",
+      "rule_action": "allow",
+      "rule_number": 260,
+      "cidr_block": "0.0.0.0/0",
+      "from_port": "1024",
+      "to_port": "65535"
+    },
+    {
+      "subnet_set": "general",
+      "egress": true,
+      "subnet_type": "data",
+      "protocol": "tcp",
+      "rule_action": "allow",
+      "rule_number": 260,
+      "cidr_block": "0.0.0.0/0",
+      "from_port": "80",
+      "to_port": "80"
+    },
+    {
+      "subnet_set": "general",
+      "egress": true,
+      "subnet_type": "data",
+      "protocol": "tcp",
+      "rule_action": "allow",
+      "rule_number": 265,
+      "cidr_block": "0.0.0.0/0",
+      "from_port": "443",
+      "to_port": "443"
+    },
+    {
+      "subnet_set": "general",
+      "egress": false,
+      "subnet_type": "private",
+      "protocol": "tcp",
+      "rule_action": "allow",
+      "rule_number": 230,
+      "cidr_block": "10.180.92.0/22",
+      "from_port": "80",
+      "to_port": "80"
+    },
+    {
+      "subnet_set": "general",
+      "egress": false,
+      "subnet_type": "private",
+      "protocol": "tcp",
+      "rule_action": "allow",
+      "rule_number": 235,
+      "cidr_block": "10.180.92.0/22",
+      "from_port": "443",
+      "to_port": "443"
+    },
+    {
+      "subnet_set": "general",
+      "egress": true,
+      "subnet_type": "private",
+      "protocol": "tcp",
+      "rule_action": "allow",
+      "rule_number": 230,
+      "cidr_block": "10.180.92.0/22",
+      "from_port": "1024",
+      "to_port": "65535"
+    }
+  ]
 }

--- a/terraform/modules/vpc-nacls/main.tf
+++ b/terraform/modules/vpc-nacls/main.tf
@@ -1,7 +1,7 @@
 locals {
   nacl_base = {
     for value in var.nacl_config :
-    "${value.subnet_set}-${value.cidr_block}-${value.egress}-${value.subnet_type}" => {
+    "${value.subnet_set}-${value.cidr_block}-${value.rule_number}-${value.egress}-${value.subnet_type}" => {
       name        = value.subnet_set
       cidr_block  = value.cidr_block
       egress      = value.egress


### PR DESCRIPTION
NACLs added to allow the following:

Internet access via the NAT gateway for the data subnets
Web traffic through to the private subnet from the Global Protect VPN