### PR TITLE
Fix removal of last account from a business unit

### DIFF
--- a/.github/workflows/core-vpc-development-deployment.yml
+++ b/.github/workflows/core-vpc-development-deployment.yml
@@ -105,7 +105,7 @@ jobs:
       - name: get changed files
         id: new_account
         run: |
-          echo "::set-output name=files::$(git diff --no-commit-id --name-only -r @^ | awk '{print $1}' | grep "environments-networks/*" | grep "${TF_ENV}" | uniq | xargs jq  ".cidr.subnet_sets[].accounts[]" | xargs)"
+          echo "::set-output name=files::$(git diff --no-commit-id --name-only -r @^ | awk '{print $1}' | grep "environments-networks//*" | grep "${TF_ENV}" | uniq | xargs jq  ".cidr.subnet_sets[].accounts[]" | xargs)"
       - name: Set RAM assocation for member account
         run: |
           accounts=(${{ steps.new_account.outputs.files }})

--- a/.github/workflows/core-vpc-preproduction-deployment.yml
+++ b/.github/workflows/core-vpc-preproduction-deployment.yml
@@ -106,7 +106,7 @@ jobs:
       - name: get changed files
         id: new_account
         run: |
-          echo "::set-output name=files::$(git diff --no-commit-id --name-only -r @^ | awk '{print $1}' | grep "environments-networks/*" | grep "${TF_ENV}" | uniq | xargs jq  ".cidr.subnet_sets[].accounts[]" | xargs)"
+          echo "::set-output name=files::$(git diff --no-commit-id --name-only -r @^ | awk '{print $1}' | grep "environments-networks//*" | grep "${TF_ENV}" | uniq | xargs jq  ".cidr.subnet_sets[].accounts[]" | xargs)"
       - name: Set RAM assocation for member account
         run: |
           accounts=(${{ steps.new_account.outputs.files }})

--- a/.github/workflows/core-vpc-production-deployment.yml
+++ b/.github/workflows/core-vpc-production-deployment.yml
@@ -105,7 +105,7 @@ jobs:
       - name: get changed files
         id: new_account
         run: |
-          echo "::set-output name=files::$(git diff --no-commit-id --name-only -r @^ | awk '{print $1}' | grep "environments-networks/*" | grep -v preproduction | grep "${TF_ENV}" | uniq | xargs jq  ".cidr.subnet_sets[].accounts[]" | xargs)"
+          echo "::set-output name=files::$(git diff --no-commit-id --name-only -r @^ | awk '{print $1}' | grep "environments-networks//*" | grep -v preproduction | grep "${TF_ENV}" | uniq | xargs jq  ".cidr.subnet_sets[].accounts[]" | xargs)"
       - name: Set RAM assocation for member account
         run: |
           accounts=(${{ steps.new_account.outputs.files }})

--- a/.github/workflows/core-vpc-test-deployment.yml
+++ b/.github/workflows/core-vpc-test-deployment.yml
@@ -105,7 +105,7 @@ jobs:
       - name: get changed files
         id: new_account
         run: |
-          echo "::set-output name=files::$(git diff --no-commit-id --name-only -r @^ | awk '{print $1}' | grep "environments-networks/*" | grep "${TF_ENV}" | uniq | xargs jq  ".cidr.subnet_sets[].accounts[]" | xargs)"
+          echo "::set-output name=files::$(git diff --no-commit-id --name-only -r @^ | awk '{print $1}' | grep "environments-networks//*" | grep "${TF_ENV}" | uniq | xargs jq  ".cidr.subnet_sets[].accounts[]" | xargs)"
       - name: Set RAM assocation for member account
         run: |
           accounts=(${{ steps.new_account.outputs.files }})

--- a/.github/workflows/new-environment.yml
+++ b/.github/workflows/new-environment.yml
@@ -140,7 +140,7 @@ jobs:
       - name: get new account(s)
         id: new_account
         run: |
-          echo "::set-output name=files::$(git diff --no-commit-id --name-only -r @^ | awk '{print $1}' | grep ".json" | grep -a "environments/*"  | uniq | cut -f2-4 -d"/" | sed 's/.\{5\}$//')"
+          echo "::set-output name=files::$(git diff --no-commit-id --name-only --diff-filter=AM -r @^ | awk '{print $1}' | grep ".json" | grep -a "environments//*"  | uniq | cut -f2-4 -d"/" | sed 's/.\{5\}$//')"
       - name: Run delegate access
         run: |
           accounts=(${{ steps.new_account.outputs.files }})
@@ -182,7 +182,7 @@ jobs:
       - name: get new account(s)
         id: new_account
         run: |
-          echo "::set-output name=files::$(git diff --no-commit-id --name-only -r @^ | awk '{print $1}' | grep ".json" | grep -a "environments/*"  | uniq | cut -f2-4 -d"/" | sed 's/.\{5\}$//')"
+          echo "::set-output name=files::$(git diff --no-commit-id --name-only --diff-filter=AM -r @^ | awk '{print $1}' | grep ".json" | grep -a "environments//*"  | uniq | cut -f2-4 -d"/" | sed 's/.\{5\}$//')"
       - name: Run secure baselines
         run: |
           accounts=(${{ steps.new_account.outputs.files }})
@@ -224,7 +224,7 @@ jobs:
       - name: get new account(s)
         id: new_account
         run: |
-          echo "::set-output name=files::$(git diff --no-commit-id --name-only -r @^ | awk '{print $1}' | grep ".json" | grep -a "environments/*"  | uniq | cut -f2-4 -d"/" | sed 's/.\{5\}$//')"
+          echo "::set-output name=files::$(git diff --no-commit-id --name-only --diff-filter=AM -r @^ | awk '{print $1}' | grep ".json" | grep -a "environments//*"  | uniq | cut -f2-4 -d"/" | sed 's/.\{5\}$//')"
       - name: Run single sign on
         run: |
           accounts=(${{ steps.new_account.outputs.files }})

--- a/scripts/git-create-environments.sh
+++ b/scripts/git-create-environments.sh
@@ -36,7 +36,7 @@ check_if_environment_exists() {
 
 check_if_change_to_application_json() {
   echo "Checking if application $1 has changes..."
-  changed_envs=$(git diff --no-commit-id --name-only -r @^ | awk '{print $1}' | grep ".json" | grep -a "environments/*"  | uniq | cut -f2-4 -d"/" | sed 's/.\{5\}$//')
+  changed_envs=$(git diff --no-commit-id --name-only -r @^ | awk '{print $1}' | grep ".json" | grep -a "environments//*"  | uniq | cut -f2-4 -d"/" | sed 's/.\{5\}$//')
   echo "Changed json files=$changed_envs"  
   application_name=$(echo $1 | sed 's/-[^-]*$//')
   echo "Application name: $application_name"


### PR DESCRIPTION
When trying to remove operations engineering account (the last
platforms-development account) there is an error on the delegate access
and single sign on plans as it is pulling in an "account name" of
platforms-development.

```
Run accounts=(platforms-development)
[+] Running single sign on baseline for account platforms-development

Initializing the backend...

Successfully configured the backend "s3"! Terraform will automatically
use this backend unless the backend configuration changes.

Initializing provider plugins...
- Finding hashicorp/aws versions matching ">= 3.47.0"...
- Installing hashicorp/aws v3.63.0...
- Installed hashicorp/aws v3.63.0 (signed by HashiCorp)

Terraform has created a lock file .terraform.lock.hcl to record the provider
selections it made above. Include this file in your version control repository
so that Terraform can guarantee to make the same selections by default when
you run "terraform init" in the future.

Terraform has been successfully initialized!
Running terraform for workspace in terraform/environments/bootstrap/single-sign-on for account: platforms-development
[+] Terraform plan =====>
Error: Process completed with exit code 1.
```

There are a couple of issues which add to this around the existing diff
command:

```
git diff --no-commit-id --name-only --diff-filter=AM -r @^ | awk
'{print $1}' | grep ".json" | grep -a "environments//*"  | uniq | cut
-f2-4 -d"/" | sed 's/.\{5\}$//')
```

Firstly this looks for changes including deletes, we don't need to worry
about deletes for single sign on, secure baselines and delegate access,
as this infrastructure is removed during account removal, and it is
manually deleted from Terraform state as part of the delete process.

So adding `--diff-filter=AM` filters for only Additions and
Modifications.

Secondly, the `grep -a "environments/*"` part of the command, is
running as "environments*" so it is picking up the changes to the
`environment-networks/platforms-development.json` file, which shouldn't
be picked up. Changing this part to `grep -a "environments//*"` resolves
this.

Finally making similar changes with the //* to other scripts which use
it to ensure similar issues don't occur.