### PR TITLE
Ignore new SCA warnings

### DIFF
--- a/terraform/environments/core-logging/athena.tf
+++ b/terraform/environments/core-logging/athena.tf
@@ -215,7 +215,7 @@ data "aws_iam_policy_document" "athena_logging" {
 }
 
 resource "aws_lambda_function" "athena_table_update" {
-
+  # tfsec:ignore:aws-lambda-enable-tracing
   # checkov:skip=CKV_AWS_50: "X-ray tracing is not required"
   # checkov:skip=CKV_AWS_117: "Lambda is not environment specific"
   # checkov:skip=CKV_AWS_116: "DLQ not required"

--- a/terraform/modules/app-ecr-repo/main.tf
+++ b/terraform/modules/app-ecr-repo/main.tf
@@ -1,4 +1,4 @@
-#tfsec:ignore:AWS078
+#tfsec:ignore:AWS078 tfsec:ignore:aws-ecr-repository-customer-key
 resource "aws_ecr_repository" "ecr_repo" {
   #checkov:skip=CKV_AWS_51:Skip Tag Mutable requirement we want tags to be overwritten   
   name                 = "${var.app_name}-ecr-repo"


### PR DESCRIPTION
Some new SCA warnings have appeared, looking at them:

```
[aws-lambda-enable-tracing][LOW] Resource 'aws_lambda_function.athena_table_update' uses default value for tracing_config.mode
```
We have already decided that X-Ray tracing is not required and excluded
it from other checks.

```
[aws-ecr-repository-customer-key][LOW] Resource 'module.performance_hub_ecr_repo:aws_ecr_repository.ecr_repo' configures encryption without using CMK
```
We are using the Amazon managed keys, we do not need the flexibility of
customer managed keys for this repo.