### PR TITLE
Change NOMIS test account to developer role

### DIFF
--- a/environments/nomis.json
+++ b/environments/nomis.json
@@ -6,7 +6,7 @@
       "access": [
         {
           "github_slug": "studio-webops",
-          "level": "administrator"
+          "level": "developer"
         }
       ]
     }


### PR DESCRIPTION
The Nomis team no longer need administrative privillages so returning
them to the developer role.