### PR TITLE
Error: error creating CloudWatch Events Rule (trigger-lambda-schedule…

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -63,6 +63,7 @@ data "aws_iam_policy_document" "member-access" {
       "ecs:*",
       "elasticfilesystem:*",
       "elasticloadbalancing:*",
+      "events:*",
       "glacier:*",
       "guardduty:get*",
       "iam:*",


### PR DESCRIPTION
…r-stop_ec2_instance_nights): AccessDeniedException: User: arn:aws:sts::348456244381:assumed-role/MemberInfrastructureAccess/1636552269389411041 is not authorized to perform: events:PutRule on resource: arn:aws:events:eu-west-2:348456244381:rule/trigger-lambda-scheduler-stop_ec2_instance_nights because no identity-based policy allows the events:PutRule action

	status code: 400, request id: 05cc04d4-7052-474a-9c62-f6c5463d06dd

  with module.stop_ec2_instance_nights.aws_cloudwatch_event_rule.this,
  on .terraform/modules/stop_ec2_instance_nights/main.tf line 262, in resource "aws_cloudwatch_event_rule" "this":