### PR TITLE
Hi there, I’m trying to add kms encryption for Session Manager data i…

### DIFF
--- a/terraform/environments/core-shared-services/kms.tf
+++ b/terraform/environments/core-shared-services/kms.tf
@@ -38,10 +38,11 @@ data "aws_iam_policy_document" "ebs_encryption_policy_doc" {
   statement {
     effect = "Allow"
     actions = [
-      "kms:DescribeKey",
-      "kms:ReEncrypt*",
       "kms:CreateGrant",
-      "kms:Decrypt"
+      "kms:Decrypt",
+      "kms:DescribeKey",
+      "kms:GenerateDataKey",
+      "kms:ReEncrypt*"
     ]
 
     resources = ["*"]


### PR DESCRIPTION
Refer to slack conversation: https://mojdt.slack.com/archives/C013RM6MFFW/p1637656898003200


…n the Nomis account, I’ve mostly got it setup accept we need the kms:GenerateDataKey permission adding to the developer IAM role.  Please can that be added?  For reference https://docs.aws.amazon.com/systems-manager/latest/userguide/getting-started-restrict-access-quickstart.html and this is the error message I’m currently getting:

----------ERROR-------
Encountered error while initiating handshake. KMSEncryption failed on client with status 2 error: Failed to process action KMSEncryption: Error calling KMS GenerateDataKey API: AccessDeniedException: User: arn:aws:sts::612659970365:assumed-role/AWSReservedSSO_modernisation-platform-developer_a128c494c6e3fd65/rwhittlemoj@digital.justice.gov.uk is not authorized to perform: kms:GenerateDataKey on resource: arn:aws:kms:eu-west-2:612659970365:key/a466d1fa-5c7f-4b10-8343-08763635d8c4 because no resource-based policy allows the kms:GenerateDataKey action
	status code: 400, request id: 96cd8f10-df00-4bf8-925e-f57c77d90efd