### PR TITLE
Add missing sandbox role to member ci

### DIFF
--- a/terraform/modernisation-platform-account/iam.tf
+++ b/terraform/modernisation-platform-account/iam.tf
@@ -93,6 +93,7 @@ data "aws_iam_policy_document" "member-ci-policy" {
       "arn:aws:iam::${local.environment_management.account_ids["core-vpc-test"]}:role/member-delegation-*-test",
       "arn:aws:iam::${local.environment_management.account_ids["core-vpc-preproduction"]}:role/member-delegation-*-preproduction",
       "arn:aws:iam::${local.environment_management.account_ids["core-vpc-production"]}:role/member-delegation-*-production",
+      "arn:aws:iam::${local.environment_management.account_ids["core-vpc-sandbox"]}:role/member-delegation-*-sandbox",
       "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/modify-dns-records"
     ]
   }


### PR DESCRIPTION
The sprinker workflow was failing with:

```
Error: error configuring Terraform AWS Provider: IAM Role (arn:aws:iam::xxxxxxx:role/member-delegation-garden-sandbox) cannot be assumed.
```

This adds the missing resource to the allow statement