### PR TITLE
After enabling security hub alarms for the modernisation platform core

### DIFF
--- a/terraform/templates/member-providers.tf
+++ b/terraform/templates/member-providers.tf
@@ -11,13 +11,14 @@ provider "aws" {
 provider "aws" {
   alias  = "modernisation-platform"
   region = "eu-west-2"
+  skip_get_ec2_platforms = true
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
 provider "aws" {
   alias  = "core-vpc"
   region = "eu-west-2"
-
+  skip_get_ec2_platforms = true
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-${local.vpc_name}-${local.environment}"
   }
@@ -27,7 +28,7 @@ provider "aws" {
 provider "aws" {
   alias  = "core-network-services"
   region = "eu-west-2"
-
+  skip_get_ec2_platforms = true
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/modify-dns-records"
   }
@@ -46,6 +47,7 @@ provider "aws" {
 # provider "aws" {
 #   alias  = "core-vpc"
 #   region = "eu-west-2"
+#   skip_get_ec2_platforms = true
 
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-read-only"
@@ -56,6 +58,7 @@ provider "aws" {
 # provider "aws" {
 #   alias  = "core-network-services"
 #   region = "eu-west-2"
+#   skip_get_ec2_platforms = true
 
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/read-dns-records"


### PR DESCRIPTION
account, there were a lot of unauthorized api alarms -

```
Sum unauthorised-api-calls GreaterThanOrEqualToThreshold 1.0
```

Tracking down the alarm reason in cloudtrail shows that the unauthorised
call was to DescribeAccountAttributes from the member-ci user.

This is because calls from the member-ci user assume a role normally,
and the only thing the ci user has direct permissions for is to access
the state. When the Terraform AWS provider first starts it checks the
supported EC2 platforms which uses the above permission.  We don't need
it to do this for the non member accounts that the member-ci has access
to, as it will only ever create EC2 resources in the member account
(which has this permission as it assumes the member admin role)

https://registry.terraform.io/providers/hashicorp/aws/latest/docs#skip_get_ec2_platforms

So this PR is adding the skip option for all the AWS providers that are
not the members account, eg the modernisation-platform core, network-services
and core-vpc accounts to the template for member accounts.