### PR TITLE
Remove unneeded variable

### DIFF
--- a/terraform/environments/core-logging/transit-gateway-attachment.tf
+++ b/terraform/environments/core-logging/transit-gateway-attachment.tf
@@ -32,7 +32,6 @@ module "vpc_attachment" {
     aws.transit-gateway-host   = aws.core-network-services
   }
 
-  resource_share_name = "transit-gateway"
   transit_gateway_id  = data.aws_ec2_transit_gateway.transit-gateway.id
   type                = each.key
 

--- a/terraform/environments/core-logging/transit-gateway-attachment.tf
+++ b/terraform/environments/core-logging/transit-gateway-attachment.tf
@@ -32,8 +32,8 @@ module "vpc_attachment" {
     aws.transit-gateway-host   = aws.core-network-services
   }
 
-  transit_gateway_id  = data.aws_ec2_transit_gateway.transit-gateway.id
-  type                = each.key
+  transit_gateway_id = data.aws_ec2_transit_gateway.transit-gateway.id
+  type               = each.key
 
   subnet_ids = module.vpc[each.key].tgw_subnet_ids
   vpc_id     = module.vpc[each.key].vpc_id

--- a/terraform/environments/core-security/transit-gateway-attachment.tf
+++ b/terraform/environments/core-security/transit-gateway-attachment.tf
@@ -32,7 +32,6 @@ module "vpc_attachment" {
     aws.transit-gateway-host   = aws.core-network-services
   }
 
-  resource_share_name = "transit-gateway"
   transit_gateway_id  = data.aws_ec2_transit_gateway.transit-gateway.id
   type                = each.key
 

--- a/terraform/environments/core-security/transit-gateway-attachment.tf
+++ b/terraform/environments/core-security/transit-gateway-attachment.tf
@@ -32,8 +32,8 @@ module "vpc_attachment" {
     aws.transit-gateway-host   = aws.core-network-services
   }
 
-  transit_gateway_id  = data.aws_ec2_transit_gateway.transit-gateway.id
-  type                = each.key
+  transit_gateway_id = data.aws_ec2_transit_gateway.transit-gateway.id
+  type               = each.key
 
   subnet_ids = module.vpc[each.key].tgw_subnet_ids
   vpc_id     = module.vpc[each.key].vpc_id

--- a/terraform/environments/core-shared-services/transit-gateway-attachment.tf
+++ b/terraform/environments/core-shared-services/transit-gateway-attachment.tf
@@ -30,7 +30,6 @@ module "vpc_attachment" {
     aws.transit-gateway-host   = aws.core-network-services
   }
 
-  resource_share_name = "transit-gateway"
   transit_gateway_id  = data.aws_ec2_transit_gateway.transit-gateway.id
   type                = each.key
 

--- a/terraform/environments/core-shared-services/transit-gateway-attachment.tf
+++ b/terraform/environments/core-shared-services/transit-gateway-attachment.tf
@@ -30,8 +30,8 @@ module "vpc_attachment" {
     aws.transit-gateway-host   = aws.core-network-services
   }
 
-  transit_gateway_id  = data.aws_ec2_transit_gateway.transit-gateway.id
-  type                = each.key
+  transit_gateway_id = data.aws_ec2_transit_gateway.transit-gateway.id
+  type               = each.key
 
   subnet_ids = module.vpc[each.key].tgw_subnet_ids
   vpc_id     = module.vpc[each.key].vpc_id


### PR DESCRIPTION
The attachment has now been moved outside of the module, this removes
an unneeded variable and we tidied up the terraform state.