### PR TITLE
Integrate existing core alarms with pagerduty

### DIFF
--- a/.github/workflows/core-vpc-development-deployment.yml
+++ b/.github/workflows/core-vpc-development-deployment.yml
@@ -55,7 +55,7 @@ jobs:
           terraform -chdir="terraform/environments/core-vpc" workspace select "core-vpc-${TF_ENV}"
 
           #RUN TERRAFORM PLAN
-          PLAN=`bash scripts/terraform-plan.sh terraform/environments/core-vpc "-target=module.vpc -target=module.vpc_tgw_routing -target=module.core-vpc-tgw-routes -target=module.dns-zone -target=module.dns_zone_extend -target=module.vpc_nacls" | tee /dev/stderr | grep '^Plan: \|^No changes.'`
+          PLAN=`bash scripts/terraform-plan.sh terraform/environments/core-vpc "-target=module.vpc -target=module.vpc_tgw_routing -target=module.core-vpc-tgw-routes -target=module.dns-zone -target=module.dns_zone_extend -target=module.vpc_nacls -target=module.pagerduty_core_alerts" | tee /dev/stderr | grep '^Plan: \|^No changes.'`
           PLAN="> TERRAFORM PLAN RESULT - core-vpc - ${TF_ENV}
           ${PLAN}"
           bash scripts/update-pr-comments.sh "${PLAN}"

--- a/.github/workflows/core-vpc-preproduction-deployment.yml
+++ b/.github/workflows/core-vpc-preproduction-deployment.yml
@@ -55,7 +55,7 @@ jobs:
           terraform -chdir="terraform/environments/core-vpc" workspace select "core-vpc-${TF_ENV}"
 
           #RUN TERRAFORM PLAN
-          PLAN=`bash scripts/terraform-plan.sh terraform/environments/core-vpc "-target=module.vpc -target=module.vpc_tgw_routing -target=module.core-vpc-tgw-routes -target=module.dns-zone -target=module.dns_zone_extend -target=module.vpc_nacls" | tee /dev/stderr | grep '^Plan: \|^No changes.'`
+          PLAN=`bash scripts/terraform-plan.sh terraform/environments/core-vpc "-target=module.vpc -target=module.vpc_tgw_routing -target=module.core-vpc-tgw-routes -target=module.dns-zone -target=module.dns_zone_extend -target=module.vpc_nacls -target=module.pagerduty_core_alerts" | tee /dev/stderr | grep '^Plan: \|^No changes.'`
           PLAN="> TERRAFORM PLAN RESULT - core-vpc - ${TF_ENV}
           ${PLAN}"
           bash scripts/update-pr-comments.sh "${PLAN}"

--- a/.github/workflows/core-vpc-production-deployment.yml
+++ b/.github/workflows/core-vpc-production-deployment.yml
@@ -55,7 +55,7 @@ jobs:
           terraform -chdir="terraform/environments/core-vpc" workspace select "core-vpc-${TF_ENV}"
 
           #RUN TERRAFORM PLAN
-          PLAN=`bash scripts/terraform-plan.sh terraform/environments/core-vpc "-target=module.vpc -target=module.vpc_tgw_routing -target=module.core-vpc-tgw-routes -target=module.dns-zone -target=module.dns_zone_extend -target=module.vpc_nacls" | tee /dev/stderr | grep '^Plan: \|^No changes.'`
+          PLAN=`bash scripts/terraform-plan.sh terraform/environments/core-vpc "-target=module.vpc -target=module.vpc_tgw_routing -target=module.core-vpc-tgw-routes -target=module.dns-zone -target=module.dns_zone_extend -target=module.vpc_nacls -target=module.pagerduty_core_alerts" | tee /dev/stderr | grep '^Plan: \|^No changes.'`
           PLAN="> TERRAFORM PLAN RESULT - core-vpc - ${TF_ENV}
           ${PLAN}"
           bash scripts/update-pr-comments.sh "${PLAN}"

--- a/.github/workflows/core-vpc-test-deployment.yml
+++ b/.github/workflows/core-vpc-test-deployment.yml
@@ -55,7 +55,7 @@ jobs:
           terraform -chdir="terraform/environments/core-vpc" workspace select "core-vpc-${TF_ENV}"
 
           #RUN TERRAFORM PLAN
-          PLAN=`bash scripts/terraform-plan.sh terraform/environments/core-vpc "-target=module.vpc -target=module.vpc_tgw_routing -target=module.core-vpc-tgw-routes -target=module.dns-zone -target=module.dns_zone_extend -target=module.vpc_nacls" | tee /dev/stderr | grep '^Plan: \|^No changes.'`
+          PLAN=`bash scripts/terraform-plan.sh terraform/environments/core-vpc "-target=module.vpc -target=module.vpc_tgw_routing -target=module.core-vpc-tgw-routes -target=module.dns-zone -target=module.dns_zone_extend -target=module.vpc_nacls -target=module.pagerduty_core_alerts" | tee /dev/stderr | grep '^Plan: \|^No changes.'`
           PLAN="> TERRAFORM PLAN RESULT - core-vpc - ${TF_ENV}
           ${PLAN}"
           bash scripts/update-pr-comments.sh "${PLAN}"

--- a/terraform/environments/core-logging/locals.tf
+++ b/terraform/environments/core-logging/locals.tf
@@ -1,6 +1,7 @@
 locals {
   application_name       = "core-logging"
   environment_management = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
+  pagerduty_integration_keys = jsondecode(data.aws_secretsmanager_secret_version.pagerduty_integration_keys.secret_string)
 
   # This takes the name of the Terraform workspace (e.g. core-vpc-production), strips out the application name (e.g. core-vpc), and checks if
   # the string leftover is `-production`, if it isn't (e.g. core-vpc-non-production => -non-production) then it sets the var to false.

--- a/terraform/environments/core-logging/locals.tf
+++ b/terraform/environments/core-logging/locals.tf
@@ -1,6 +1,6 @@
 locals {
-  application_name       = "core-logging"
-  environment_management = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
+  application_name           = "core-logging"
+  environment_management     = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
   pagerduty_integration_keys = jsondecode(data.aws_secretsmanager_secret_version.pagerduty_integration_keys.secret_string)
 
   # This takes the name of the Terraform workspace (e.g. core-vpc-production), strips out the application name (e.g. core-vpc), and checks if

--- a/terraform/environments/core-logging/monitoring.tf
+++ b/terraform/environments/core-logging/monitoring.tf
@@ -1,0 +1,5 @@
+module "pagerduty_core_alerts" {
+  source                     = "../../modules/pagerduty-integration"
+  sns_topics                 = ["config", "securityhub-alarms", "cloudtrail"]
+  pagerduty_integration_name = "core_alerts_cloudwatch"
+}

--- a/terraform/environments/core-logging/monitoring.tf
+++ b/terraform/environments/core-logging/monitoring.tf
@@ -1,5 +1,5 @@
 module "pagerduty_core_alerts" {
-  source                     = "../../modules/pagerduty-integration"
-  sns_topics                 = ["config", "securityhub-alarms", "cloudtrail"]
-  pagerduty_integration_key  = local.pagerduty_integration_keys["core_alerts_cloudwatch"]
+  source                    = "../../modules/pagerduty-integration"
+  sns_topics                = ["config", "securityhub-alarms", "cloudtrail"]
+  pagerduty_integration_key = local.pagerduty_integration_keys["core_alerts_cloudwatch"]
 }

--- a/terraform/environments/core-logging/secrets.tf
+++ b/terraform/environments/core-logging/secrets.tf
@@ -9,3 +9,14 @@ data "aws_secretsmanager_secret_version" "environment_management" {
   provider  = aws.modernisation-platform
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+
+# Get the map of pagerduty integration keys
+data "aws_secretsmanager_secret" "pagerduty_integration_keys" {
+  provider  = aws.modernisation-platform
+  name = "pagerduty_integration_keys"
+}
+
+data "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {
+  provider  = aws.modernisation-platform
+  secret_id = data.aws_secretsmanager_secret.pagerduty_integration_keys.id
+}

--- a/terraform/environments/core-logging/secrets.tf
+++ b/terraform/environments/core-logging/secrets.tf
@@ -12,8 +12,8 @@ data "aws_secretsmanager_secret_version" "environment_management" {
 
 # Get the map of pagerduty integration keys
 data "aws_secretsmanager_secret" "pagerduty_integration_keys" {
-  provider  = aws.modernisation-platform
-  name = "pagerduty_integration_keys"
+  provider = aws.modernisation-platform
+  name     = "pagerduty_integration_keys"
 }
 
 data "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {

--- a/terraform/environments/core-network-services/locals.tf
+++ b/terraform/environments/core-network-services/locals.tf
@@ -7,6 +7,7 @@ data "aws_organizations_organization" "root_account" {}
 locals {
   application_name       = "core-network-services"
   environment_management = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
+  pagerduty_integration_keys = jsondecode(data.aws_secretsmanager_secret_version.pagerduty_integration_keys.secret_string)
 
   # This takes the name of the Terraform workspace (e.g. core-vpc-production), strips out the application name (e.g. core-vpc), and checks if
   # the string leftover is `-production`, if it isn't (e.g. core-vpc-non-production => -non-production) then it sets the var to false.

--- a/terraform/environments/core-network-services/locals.tf
+++ b/terraform/environments/core-network-services/locals.tf
@@ -5,8 +5,8 @@ data "aws_caller_identity" "modernisation-platform" {
 data "aws_organizations_organization" "root_account" {}
 
 locals {
-  application_name       = "core-network-services"
-  environment_management = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
+  application_name           = "core-network-services"
+  environment_management     = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
   pagerduty_integration_keys = jsondecode(data.aws_secretsmanager_secret_version.pagerduty_integration_keys.secret_string)
 
   # This takes the name of the Terraform workspace (e.g. core-vpc-production), strips out the application name (e.g. core-vpc), and checks if

--- a/terraform/environments/core-network-services/monitoring.tf
+++ b/terraform/environments/core-network-services/monitoring.tf
@@ -1,0 +1,5 @@
+module "pagerduty_core_alerts" {
+  source                     = "../../modules/pagerduty-integration"
+  sns_topics                 = ["config", "securityhub-alarms", "cloudtrail"]
+  pagerduty_integration_name = "core_alerts_cloudwatch"
+}

--- a/terraform/environments/core-network-services/monitoring.tf
+++ b/terraform/environments/core-network-services/monitoring.tf
@@ -1,5 +1,5 @@
 module "pagerduty_core_alerts" {
   source                     = "../../modules/pagerduty-integration"
   sns_topics                 = ["config", "securityhub-alarms", "cloudtrail"]
-  pagerduty_integration_name = "core_alerts_cloudwatch"
+  pagerduty_integration_key  = local.pagerduty_integration_keys["core_alerts_cloudwatch"]
 }

--- a/terraform/environments/core-network-services/monitoring.tf
+++ b/terraform/environments/core-network-services/monitoring.tf
@@ -1,5 +1,5 @@
 module "pagerduty_core_alerts" {
-  source                     = "../../modules/pagerduty-integration"
-  sns_topics                 = ["config", "securityhub-alarms", "cloudtrail"]
-  pagerduty_integration_key  = local.pagerduty_integration_keys["core_alerts_cloudwatch"]
+  source                    = "../../modules/pagerduty-integration"
+  sns_topics                = ["config", "securityhub-alarms", "cloudtrail"]
+  pagerduty_integration_key = local.pagerduty_integration_keys["core_alerts_cloudwatch"]
 }

--- a/terraform/environments/core-network-services/secrets.tf
+++ b/terraform/environments/core-network-services/secrets.tf
@@ -9,3 +9,14 @@ data "aws_secretsmanager_secret_version" "environment_management" {
   provider  = aws.modernisation-platform
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+
+# Get the map of pagerduty integration keys
+data "aws_secretsmanager_secret" "pagerduty_integration_keys" {
+  provider  = aws.modernisation-platform
+  name = "pagerduty_integration_keys"
+}
+
+data "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {
+  provider  = aws.modernisation-platform
+  secret_id = data.aws_secretsmanager_secret.pagerduty_integration_keys.id
+}

--- a/terraform/environments/core-network-services/secrets.tf
+++ b/terraform/environments/core-network-services/secrets.tf
@@ -12,8 +12,8 @@ data "aws_secretsmanager_secret_version" "environment_management" {
 
 # Get the map of pagerduty integration keys
 data "aws_secretsmanager_secret" "pagerduty_integration_keys" {
-  provider  = aws.modernisation-platform
-  name = "pagerduty_integration_keys"
+  provider = aws.modernisation-platform
+  name     = "pagerduty_integration_keys"
 }
 
 data "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {

--- a/terraform/environments/core-security/locals.tf
+++ b/terraform/environments/core-security/locals.tf
@@ -1,6 +1,6 @@
 locals {
-  application_name       = "core-security"
-  environment_management = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
+  application_name           = "core-security"
+  environment_management     = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
   pagerduty_integration_keys = jsondecode(data.aws_secretsmanager_secret_version.pagerduty_integration_keys.secret_string)
 
   # This takes the name of the Terraform workspace (e.g. core-vpc-production), strips out the application name (e.g. core-vpc), and checks if

--- a/terraform/environments/core-security/locals.tf
+++ b/terraform/environments/core-security/locals.tf
@@ -1,6 +1,7 @@
 locals {
   application_name       = "core-security"
   environment_management = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
+  pagerduty_integration_keys = jsondecode(data.aws_secretsmanager_secret_version.pagerduty_integration_keys.secret_string)
 
   # This takes the name of the Terraform workspace (e.g. core-vpc-production), strips out the application name (e.g. core-vpc), and checks if
   # the string leftover is `-production`, if it isn't (e.g. core-vpc-non-production => -non-production) then it sets the var to false.

--- a/terraform/environments/core-security/monitoring.tf
+++ b/terraform/environments/core-security/monitoring.tf
@@ -1,0 +1,5 @@
+module "pagerduty_core_alerts" {
+  source                     = "../../modules/pagerduty-integration"
+  sns_topics                 = ["config", "securityhub-alarms", "cloudtrail"]
+  pagerduty_integration_name = "core_alerts_cloudwatch"
+}

--- a/terraform/environments/core-security/monitoring.tf
+++ b/terraform/environments/core-security/monitoring.tf
@@ -1,5 +1,5 @@
 module "pagerduty_core_alerts" {
   source                     = "../../modules/pagerduty-integration"
   sns_topics                 = ["config", "securityhub-alarms", "cloudtrail"]
-  pagerduty_integration_name = "core_alerts_cloudwatch"
+  pagerduty_integration_key  = local.pagerduty_integration_keys["core_alerts_cloudwatch"]
 }

--- a/terraform/environments/core-security/monitoring.tf
+++ b/terraform/environments/core-security/monitoring.tf
@@ -1,5 +1,5 @@
 module "pagerduty_core_alerts" {
-  source                     = "../../modules/pagerduty-integration"
-  sns_topics                 = ["config", "securityhub-alarms", "cloudtrail"]
-  pagerduty_integration_key  = local.pagerduty_integration_keys["core_alerts_cloudwatch"]
+  source                    = "../../modules/pagerduty-integration"
+  sns_topics                = ["config", "securityhub-alarms", "cloudtrail"]
+  pagerduty_integration_key = local.pagerduty_integration_keys["core_alerts_cloudwatch"]
 }

--- a/terraform/environments/core-security/secrets.tf
+++ b/terraform/environments/core-security/secrets.tf
@@ -9,3 +9,14 @@ data "aws_secretsmanager_secret_version" "environment_management" {
   provider  = aws.modernisation-platform
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+
+# Get the map of pagerduty integration keys
+data "aws_secretsmanager_secret" "pagerduty_integration_keys" {
+  provider  = aws.modernisation-platform
+  name = "pagerduty_integration_keys"
+}
+
+data "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {
+  provider  = aws.modernisation-platform
+  secret_id = data.aws_secretsmanager_secret.pagerduty_integration_keys.id
+}

--- a/terraform/environments/core-security/secrets.tf
+++ b/terraform/environments/core-security/secrets.tf
@@ -12,8 +12,8 @@ data "aws_secretsmanager_secret_version" "environment_management" {
 
 # Get the map of pagerduty integration keys
 data "aws_secretsmanager_secret" "pagerduty_integration_keys" {
-  provider  = aws.modernisation-platform
-  name = "pagerduty_integration_keys"
+  provider = aws.modernisation-platform
+  name     = "pagerduty_integration_keys"
 }
 
 data "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {

--- a/terraform/environments/core-shared-services/locals.tf
+++ b/terraform/environments/core-shared-services/locals.tf
@@ -5,6 +5,7 @@ data "aws_caller_identity" "current" {}
 locals {
   application_name       = "core-shared-services"
   environment_management = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
+  pagerduty_integration_keys = jsondecode(data.aws_secretsmanager_secret_version.pagerduty_integration_keys.secret_string)
 
   root_account = data.aws_organizations_organization.root_account
 

--- a/terraform/environments/core-shared-services/locals.tf
+++ b/terraform/environments/core-shared-services/locals.tf
@@ -3,8 +3,8 @@ data "aws_organizations_organization" "root_account" {}
 data "aws_caller_identity" "current" {}
 
 locals {
-  application_name       = "core-shared-services"
-  environment_management = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
+  application_name           = "core-shared-services"
+  environment_management     = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
   pagerduty_integration_keys = jsondecode(data.aws_secretsmanager_secret_version.pagerduty_integration_keys.secret_string)
 
   root_account = data.aws_organizations_organization.root_account

--- a/terraform/environments/core-shared-services/monitoring.tf
+++ b/terraform/environments/core-shared-services/monitoring.tf
@@ -1,0 +1,5 @@
+module "pagerduty_core_alerts" {
+  source                     = "../../modules/pagerduty-integration"
+  sns_topics                 = ["config", "securityhub-alarms", "cloudtrail"]
+  pagerduty_integration_name = "core_alerts_cloudwatch"
+}

--- a/terraform/environments/core-shared-services/monitoring.tf
+++ b/terraform/environments/core-shared-services/monitoring.tf
@@ -1,5 +1,5 @@
 module "pagerduty_core_alerts" {
   source                     = "../../modules/pagerduty-integration"
   sns_topics                 = ["config", "securityhub-alarms", "cloudtrail"]
-  pagerduty_integration_name = "core_alerts_cloudwatch"
+  pagerduty_integration_key  = local.pagerduty_integration_keys["core_alerts_cloudwatch"]
 }

--- a/terraform/environments/core-shared-services/monitoring.tf
+++ b/terraform/environments/core-shared-services/monitoring.tf
@@ -1,5 +1,5 @@
 module "pagerduty_core_alerts" {
-  source                     = "../../modules/pagerduty-integration"
-  sns_topics                 = ["config", "securityhub-alarms", "cloudtrail"]
-  pagerduty_integration_key  = local.pagerduty_integration_keys["core_alerts_cloudwatch"]
+  source                    = "../../modules/pagerduty-integration"
+  sns_topics                = ["config", "securityhub-alarms", "cloudtrail"]
+  pagerduty_integration_key = local.pagerduty_integration_keys["core_alerts_cloudwatch"]
 }

--- a/terraform/environments/core-shared-services/secrets.tf
+++ b/terraform/environments/core-shared-services/secrets.tf
@@ -9,3 +9,14 @@ data "aws_secretsmanager_secret_version" "environment_management" {
   provider  = aws.modernisation-platform
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+
+# Get the map of pagerduty integration keys
+data "aws_secretsmanager_secret" "pagerduty_integration_keys" {
+  provider  = aws.modernisation-platform
+  name = "pagerduty_integration_keys"
+}
+
+data "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {
+  provider  = aws.modernisation-platform
+  secret_id = data.aws_secretsmanager_secret.pagerduty_integration_keys.id
+}

--- a/terraform/environments/core-shared-services/secrets.tf
+++ b/terraform/environments/core-shared-services/secrets.tf
@@ -12,8 +12,8 @@ data "aws_secretsmanager_secret_version" "environment_management" {
 
 # Get the map of pagerduty integration keys
 data "aws_secretsmanager_secret" "pagerduty_integration_keys" {
-  provider  = aws.modernisation-platform
-  name = "pagerduty_integration_keys"
+  provider = aws.modernisation-platform
+  name     = "pagerduty_integration_keys"
 }
 
 data "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {

--- a/terraform/environments/core-vpc/locals.tf
+++ b/terraform/environments/core-vpc/locals.tf
@@ -5,8 +5,8 @@ data "aws_caller_identity" "modernisation-platform" {
 data "aws_organizations_organization" "root_account" {}
 
 locals {
-  application_name       = "core-vpc"
-  environment_management = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
+  application_name           = "core-vpc"
+  environment_management     = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
   pagerduty_integration_keys = jsondecode(data.aws_secretsmanager_secret_version.pagerduty_integration_keys.secret_string)
 
   # This takes the name of the Terraform workspace (e.g. core-vpc-production), strips out the application name (e.g. core-vpc), and checks if

--- a/terraform/environments/core-vpc/locals.tf
+++ b/terraform/environments/core-vpc/locals.tf
@@ -7,6 +7,8 @@ data "aws_organizations_organization" "root_account" {}
 locals {
   application_name       = "core-vpc"
   environment_management = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
+  pagerduty_integration_keys = jsondecode(data.aws_secretsmanager_secret_version.pagerduty_integration_keys.secret_string)
+
   # This takes the name of the Terraform workspace (e.g. core-vpc-production), strips out the application name (e.g. core-vpc), and checks if
   # the string leftover is `-production`, if it isn't (e.g. core-vpc-non-production => -non-production) then it sets the var to false.
   is-production = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-production"

--- a/terraform/environments/core-vpc/monitoring.tf
+++ b/terraform/environments/core-vpc/monitoring.tf
@@ -1,0 +1,5 @@
+module "pagerduty_core_alerts" {
+  source                     = "../../modules/pagerduty-integration"
+  sns_topics                 = ["config", "securityhub-alarms", "cloudtrail"]
+  pagerduty_integration_name = "core_alerts_cloudwatch"
+}

--- a/terraform/environments/core-vpc/monitoring.tf
+++ b/terraform/environments/core-vpc/monitoring.tf
@@ -1,5 +1,5 @@
 module "pagerduty_core_alerts" {
   source                     = "../../modules/pagerduty-integration"
   sns_topics                 = ["config", "securityhub-alarms", "cloudtrail"]
-  pagerduty_integration_name = "core_alerts_cloudwatch"
+  pagerduty_integration_key  = local.pagerduty_integration_keys["core_alerts_cloudwatch"]
 }

--- a/terraform/environments/core-vpc/monitoring.tf
+++ b/terraform/environments/core-vpc/monitoring.tf
@@ -1,5 +1,5 @@
 module "pagerduty_core_alerts" {
-  source                     = "../../modules/pagerduty-integration"
-  sns_topics                 = ["config", "securityhub-alarms", "cloudtrail"]
-  pagerduty_integration_key  = local.pagerduty_integration_keys["core_alerts_cloudwatch"]
+  source                    = "../../modules/pagerduty-integration"
+  sns_topics                = ["config", "securityhub-alarms", "cloudtrail"]
+  pagerduty_integration_key = local.pagerduty_integration_keys["core_alerts_cloudwatch"]
 }

--- a/terraform/environments/core-vpc/secrets.tf
+++ b/terraform/environments/core-vpc/secrets.tf
@@ -9,3 +9,14 @@ data "aws_secretsmanager_secret_version" "environment_management" {
   provider  = aws.modernisation-platform
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+
+# Get the map of pagerduty integration keys
+data "aws_secretsmanager_secret" "pagerduty_integration_keys" {
+  provider  = aws.modernisation-platform
+  name = "pagerduty_integration_keys"
+}
+
+data "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {
+  provider  = aws.modernisation-platform
+  secret_id = data.aws_secretsmanager_secret.pagerduty_integration_keys.id
+}

--- a/terraform/environments/core-vpc/secrets.tf
+++ b/terraform/environments/core-vpc/secrets.tf
@@ -12,8 +12,8 @@ data "aws_secretsmanager_secret_version" "environment_management" {
 
 # Get the map of pagerduty integration keys
 data "aws_secretsmanager_secret" "pagerduty_integration_keys" {
-  provider  = aws.modernisation-platform
-  name = "pagerduty_integration_keys"
+  provider = aws.modernisation-platform
+  name     = "pagerduty_integration_keys"
 }
 
 data "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {

--- a/terraform/modernisation-platform-account/baselines.tf
+++ b/terraform/modernisation-platform-account/baselines.tf
@@ -73,7 +73,7 @@ module "trusted-advisor-modernisation-platform" {
   source = "github.com/ministryofjustice/modernisation-platform-terraform-trusted-advisor?ref=v2.1.0"
 }
 
-module "pagerduty" {
+module "pagerduty_core_alerts" {
   source                     = "../modules/pagerduty-integration"
   sns_topics                 = ["config", "securityhub-alarms", "cloudtrail"]
   pagerduty_integration_name = "core_alerts_cloudwatch"

--- a/terraform/modernisation-platform-account/baselines.tf
+++ b/terraform/modernisation-platform-account/baselines.tf
@@ -72,9 +72,3 @@ module "baselines-modernisation-platform" {
 module "trusted-advisor-modernisation-platform" {
   source = "github.com/ministryofjustice/modernisation-platform-terraform-trusted-advisor?ref=v2.1.0"
 }
-
-module "pagerduty_core_alerts" {
-  source                     = "../modules/pagerduty-integration"
-  sns_topics                 = ["config", "securityhub-alarms", "cloudtrail"]
-  pagerduty_integration_name = "core_alerts_cloudwatch"
-}

--- a/terraform/modernisation-platform-account/locals.tf
+++ b/terraform/modernisation-platform-account/locals.tf
@@ -4,6 +4,8 @@ data "aws_caller_identity" "current" {}
 locals {
   root_account           = data.aws_organizations_organization.root_account
   environment_management = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
+  pagerduty_integration_keys = jsondecode(data.aws_secretsmanager_secret_version.pagerduty_integration_keys.secret_string)
+
   root_users_with_state_access = [
     "arn:aws:iam::${local.root_account.master_account_id}:user/ModernisationPlatformOrganisationManagement",
     "arn:aws:iam::${local.root_account.master_account_id}:user/DavidElliott"

--- a/terraform/modernisation-platform-account/locals.tf
+++ b/terraform/modernisation-platform-account/locals.tf
@@ -2,8 +2,8 @@ data "aws_organizations_organization" "root_account" {}
 data "aws_caller_identity" "current" {}
 
 locals {
-  root_account           = data.aws_organizations_organization.root_account
-  environment_management = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
+  root_account               = data.aws_organizations_organization.root_account
+  environment_management     = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
   pagerduty_integration_keys = jsondecode(data.aws_secretsmanager_secret_version.pagerduty_integration_keys.secret_string)
 
   root_users_with_state_access = [

--- a/terraform/modernisation-platform-account/monitoring.tf
+++ b/terraform/modernisation-platform-account/monitoring.tf
@@ -1,5 +1,5 @@
 module "pagerduty_core_alerts" {
-  source                     = "../modules/pagerduty-integration"
-  sns_topics                 = ["config", "securityhub-alarms", "cloudtrail"]
-  pagerduty_integration_key  = local.pagerduty_integration_keys["core_alerts_cloudwatch"]
+  source                    = "../modules/pagerduty-integration"
+  sns_topics                = ["config", "securityhub-alarms", "cloudtrail"]
+  pagerduty_integration_key = local.pagerduty_integration_keys["core_alerts_cloudwatch"]
 }

--- a/terraform/modernisation-platform-account/monitoring.tf
+++ b/terraform/modernisation-platform-account/monitoring.tf
@@ -1,5 +1,5 @@
 module "pagerduty_core_alerts" {
-  source                     = "../../modules/pagerduty-integration"
+  source                     = "../modules/pagerduty-integration"
   sns_topics                 = ["config", "securityhub-alarms", "cloudtrail"]
   pagerduty_integration_key  = local.pagerduty_integration_keys["core_alerts_cloudwatch"]
 }

--- a/terraform/modernisation-platform-account/secrets.tf
+++ b/terraform/modernisation-platform-account/secrets.tf
@@ -58,3 +58,12 @@ resource "aws_secretsmanager_secret" "slack_webhook_url" {
   description = "Slack channel modernisation-platform-notifications webhook url for sending notifications to slack"
   tags        = local.tags
 }
+
+# Get the map of pagerduty integration keys
+data "aws_secretsmanager_secret" "pagerduty_integration_keys" {
+  name = "pagerduty_integration_keys"
+}
+
+data "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {
+  secret_id = data.aws_secretsmanager_secret.pagerduty_integration_keys.id
+}

--- a/terraform/modules/pagerduty-integration/main.tf
+++ b/terraform/modules/pagerduty-integration/main.tf
@@ -1,25 +1,12 @@
-locals {
-  pagerduty_integration_keys = jsondecode(data.aws_secretsmanager_secret_version.pagerduty_integration_keys.secret_string)
-  pagerduty_integration_key  = local.pagerduty_integration_keys[var.pagerduty_integration_name]
-}
-
 # subscribe to SNS topics for pagerduty
 data "aws_sns_topic" "alarm_topics" {
   for_each = toset(var.sns_topics)
   name     = each.key
 }
 
-data "aws_secretsmanager_secret" "pagerduty_integration_keys" {
-  name = "pagerduty_integration_keys"
-}
-
-data "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {
-  secret_id = data.aws_secretsmanager_secret.pagerduty_integration_keys.id
-}
-
 resource "aws_sns_topic_subscription" "pagerduty_subscription" {
   for_each  = data.aws_sns_topic.alarm_topics
   topic_arn = each.value.arn
   protocol  = "https"
-  endpoint  = "https://events.pagerduty.com/integration/${local.pagerduty_integration_key}/enqueue"
+  endpoint  = "https://events.pagerduty.com/integration/${var.pagerduty_integration_key}/enqueue"
 }

--- a/terraform/modules/pagerduty-integration/variables.tf
+++ b/terraform/modules/pagerduty-integration/variables.tf
@@ -2,6 +2,6 @@ variable "sns_topics" {
   type = list(any)
 }
 
-variable "pagerduty_integration_name" {
+variable "pagerduty_integration_key" {
   type = string
 }


### PR DESCRIPTION
See https://github.com/ministryofjustice/modernisation-platform/issues/1334
We want the GuardDuty, SecurityHub and Config Cloudwatch alarms that are already configured to go to a service on pagerduty and then onto our #modernisation-platform-alarms channel.

Module changes:
Having the data lookups in the module breaks when you move add the
module to an account where the integration key secret data lookups don't
exist.
The change means you pass in the integration key rather than the name of
the integration and makes the module is more flexible.

Closes #1334 