### PR TITLE
Relax pager duty escalation policy

### DIFF
--- a/terraform/pagerduty/policy-schedules.tf
+++ b/terraform/pagerduty/policy-schedules.tf
@@ -1,7 +1,7 @@
 resource "pagerduty_escalation_policy" "default" {
   name      = "Default Modernisation Platform Policy"
   teams     = [pagerduty_team.modernisation_platform.id]
-  num_loops = 9
+  # num_loops = 9
 
   rule {
     escalation_delay_in_minutes = 10
@@ -10,13 +10,14 @@ resource "pagerduty_escalation_policy" "default" {
       id   = pagerduty_schedule.primary.id
     }
   }
-  rule {
-    escalation_delay_in_minutes = 10
-    target {
-      type = "schedule_reference"
-      id   = pagerduty_schedule.secondary.id
-    }
-  }
+  # Comment out until we have a proper on call rota
+  # rule {
+  #   escalation_delay_in_minutes = 10
+  #   target {
+  #     type = "schedule_reference"
+  #     id   = pagerduty_schedule.secondary.id
+  #   }
+  # }
 }
 
 resource "pagerduty_schedule" "primary" {

--- a/terraform/pagerduty/policy-schedules.tf
+++ b/terraform/pagerduty/policy-schedules.tf
@@ -1,6 +1,6 @@
 resource "pagerduty_escalation_policy" "default" {
-  name      = "Default Modernisation Platform Policy"
-  teams     = [pagerduty_team.modernisation_platform.id]
+  name  = "Default Modernisation Platform Policy"
+  teams = [pagerduty_team.modernisation_platform.id]
   # num_loops = 9
 
   rule {

--- a/terraform/pagerduty/services.tf
+++ b/terraform/pagerduty/services.tf
@@ -4,7 +4,7 @@ resource "pagerduty_service" "core_alerts" {
   name                    = "Modernisation Platform Core Alerts"
   description             = "Modernisation Platform Core Infrastructure Alerts"
   auto_resolve_timeout    = 14400
-  acknowledgement_timeout = 7200
+  acknowledgement_timeout = null
   escalation_policy       = pagerduty_escalation_policy.default.id
   alert_creation          = "create_alerts_and_incidents"
 }


### PR DESCRIPTION
We don't currently have an oncall rota so no one is actively responding
to pagerduty alerts, to make the channel less noisy doing the following:

Only loop to escalate to someone once
No secondary schedule
No auto acknowledge (only auto resolve after 4 hours)

This should reduce the number of slack messages we receive.