### PR TITLE
Suppress sign-in-without-mfa alarms

### DIFF
--- a/terraform/pagerduty/services.tf
+++ b/terraform/pagerduty/services.tf
@@ -14,3 +14,33 @@ resource "pagerduty_service_integration" "cloudwatch" {
   service = pagerduty_service.core_alerts.id
   vendor  = data.pagerduty_vendor.cloudwatch.id
 }
+
+resource "pagerduty_service_event_rule" "mfa-console-access" {
+  service  = pagerduty_service.core_alerts.id
+  position = 0
+  disabled = "false"
+
+  conditions {
+    operator = "and"
+    subconditions {
+      operator = "contains"
+      parameter {
+        value = "sign-in-without-mfa"
+        path  = "summary"
+      }
+    }
+  }
+
+  actions {
+    severity {
+      value = "info"
+    }
+    annotate {
+      value = "Suppressed as triggered by SSO sign on"
+    }
+
+    suppress {
+      value = true
+    }
+  }
+}


### PR DESCRIPTION
This warning whilst required for security hub, it triggers everytime we
log in using SSO (which does actually use MFA via GitHub). So
suppressing this.

Note, when using the path it needs to be a CEF field, see here - https://support.pagerduty.com/docs/pd-cef
This are case sensitive and should be lower case.

Suppressed alarms can still be seen in pagerduty they just don't create
incidents or get pushed to the slack channel.