### PR TITLE
Remove Don, add David and Scott to team

### DIFF
--- a/source/team/team.html.md.erb
+++ b/source/team/team.html.md.erb
@@ -1,23 +1,24 @@
 ---
 title: Our team
-last_reviewed_on: 2021-08-24
+last_reviewed_on: 2022-01-04
 review_in: 3 months
 ---
 
 # <%= current_page.data.title %>
 
-We are currently made up of 13 members:
+We are currently made up of 14 members:
 
 - Adrian Weetman, Webops Engineer
-- Sebastian Norris, Webops Engineer
-- Piotr Grzeskowiak, Webops Engineer
 - Christine Elliott, Business Analyst
+- Dave Sibley, WebOps Engineer
 - David Elliott, Technical Architect
-- Don Masters, WebOps Engineer
 - Fasih Rehman, WebOps Engineer
 - George Fountopoulos, WebOps Engineer
 - Jack Stockley, WebOps Engineer
 - Jake Mulley, Head of Hosting and Digital Operations
 - Karen Botsh, Senior Delivery Manager
+- Piotr Grzeskowiak, Webops Engineer
+- Scott Seaward, User Researcher
 - Sean Privett, Senior Product Manager
+- Sebastian Norris, Webops Engineer
 - Zuri Guardiola, WebOps Engineer

--- a/source/team/team.html.md.erb
+++ b/source/team/team.html.md.erb
@@ -10,7 +10,7 @@ We are currently made up of 14 members:
 
 - Adrian Weetman, Webops Engineer
 - Christine Elliott, Business Analyst
-- Dave Sibley, WebOps Engineer
+- David Sibley, WebOps Engineer
 - David Elliott, Technical Architect
 - Fasih Rehman, WebOps Engineer
 - George Fountopoulos, WebOps Engineer

--- a/terraform/github/locals.tf
+++ b/terraform/github/locals.tf
@@ -40,7 +40,7 @@ locals {
     "pete-j-g",  # Piotr Grzeskowiak
     "adeweetman-al",
     "gfou-al", # George Fountopoulos,
-    "dms1981" # Dave Sibley
+    "dms1981"  # Dave Sibley
   ]
 
   # All members

--- a/terraform/github/locals.tf
+++ b/terraform/github/locals.tf
@@ -40,7 +40,7 @@ locals {
     "pete-j-g",  # Piotr Grzeskowiak
     "adeweetman-al",
     "gfou-al", # George Fountopoulos,
-    "dms1981"  # Dave Sibley
+    "dms1981"  # David Sibley
   ]
 
   # All members

--- a/terraform/github/locals.tf
+++ b/terraform/github/locals.tf
@@ -31,7 +31,6 @@ locals {
   # GitHub usernames for engineers who need full AWS access
   engineers = [
     "davidkelliott",
-    "donmasters",
     "ezman", # Fasih
     "jackstockley89",
     "jakemulley",
@@ -40,7 +39,8 @@ locals {
     "sobostion", # Seb Norris
     "pete-j-g",  # Piotr Grzeskowiak
     "adeweetman-al",
-    "gfou-al" # George Fountopoulos
+    "gfou-al", # George Fountopoulos,
+    "dms1981" # Dave Sibley
   ]
 
   # All members


### PR DESCRIPTION
This alphabetises the team, removes @donmasters (👋🏼 good luck in your new role!), adds David Sibley and Scott Seaward (👋🏼 welcome!).