### PR TITLE
Fix/tf baseline schedule

### DIFF
--- a/.github/workflows/scheduled-baseline.yml
+++ b/.github/workflows/scheduled-baseline.yml
@@ -2,7 +2,7 @@ name: "Terraform: scheduled baseline"
 
 on:
   schedule:
-    - cron: "0 23 * * 6"
+    - cron: "30 22 * * 6"
   workflow_dispatch:
 
 env:

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ tmp/
 .vscode/
 .terraform.lock.hcl
 *.tsv
+.idea/


### PR DESCRIPTION
In an attempt to mitigate #1239 , this PR moves the scheduled time back for 30 minutes. According to the github documentation, scheduling runs to begin on the hour often leads to contention which can delay the start of a run.