### PR TITLE
Add temporary read only users to core accounts

### DIFF
--- a/terraform/environments/core-logging/locals.tf
+++ b/terraform/environments/core-logging/locals.tf
@@ -1,3 +1,7 @@
+data "aws_caller_identity" "modernisation-platform" {
+  provider = aws.modernisation-platform
+}
+
 locals {
   application_name           = "core-logging"
   environment_management     = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)

--- a/terraform/environments/core-network-services/iam.tf
+++ b/terraform/environments/core-network-services/iam.tf
@@ -105,3 +105,20 @@ resource "aws_iam_role_policy" "read_dns" {
     ]
   })
 }
+
+#read only role for health check
+module "iam_assumable_roles" {
+  source               = "terraform-aws-modules/iam/aws//modules/iam-assumable-roles"
+  version              = "~> 2.0"
+  max_session_duration = 43200
+
+  # Read-only role
+  create_readonly_role       = true
+  readonly_role_name         = "readonly"
+  readonly_role_requires_mfa = true
+
+  # Allow created users to assume these roles
+  trusted_role_arns = [
+    data.aws_caller_identity.modernisation-platform.account_id
+  ]
+}

--- a/terraform/environments/core-security/iam.tf
+++ b/terraform/environments/core-security/iam.tf
@@ -1,3 +1,20 @@
 data "aws_iam_role" "vpc-flow-log" {
   name = "AWSVPCFlowLog"
 }
+
+#read only role for health check
+module "iam_assumable_roles" {
+  source               = "terraform-aws-modules/iam/aws//modules/iam-assumable-roles"
+  version              = "~> 2.0"
+  max_session_duration = 43200
+
+  # Read-only role
+  create_readonly_role       = true
+  readonly_role_name         = "readonly"
+  readonly_role_requires_mfa = true
+
+  # Allow created users to assume these roles
+  trusted_role_arns = [
+    data.aws_caller_identity.modernisation-platform.account_id
+  ]
+}

--- a/terraform/environments/core-security/locals.tf
+++ b/terraform/environments/core-security/locals.tf
@@ -1,3 +1,7 @@
+data "aws_caller_identity" "modernisation-platform" {
+  provider = aws.modernisation-platform
+}
+
 locals {
   application_name           = "core-security"
   environment_management     = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)

--- a/terraform/environments/core-shared-services/iam.tf
+++ b/terraform/environments/core-shared-services/iam.tf
@@ -33,3 +33,20 @@ resource "aws_iam_instance_profile" "image_builder" {
   name = "image-builder"
   role = aws_iam_role.image_builder.name
 }
+
+#read only role for health check
+module "iam_assumable_roles" {
+  source               = "terraform-aws-modules/iam/aws//modules/iam-assumable-roles"
+  version              = "~> 2.0"
+  max_session_duration = 43200
+
+  # Read-only role
+  create_readonly_role       = true
+  readonly_role_name         = "readonly"
+  readonly_role_requires_mfa = true
+
+  # Allow created users to assume these roles
+  trusted_role_arns = [
+    data.aws_caller_identity.modernisation-platform.account_id
+  ]
+}

--- a/terraform/environments/core-shared-services/locals.tf
+++ b/terraform/environments/core-shared-services/locals.tf
@@ -2,6 +2,10 @@ data "aws_organizations_organization" "root_account" {}
 
 data "aws_caller_identity" "current" {}
 
+data "aws_caller_identity" "modernisation-platform" {
+  provider = aws.modernisation-platform
+}
+
 locals {
   application_name           = "core-shared-services"
   environment_management     = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)

--- a/terraform/environments/core-vpc/iam.tf
+++ b/terraform/environments/core-vpc/iam.tf
@@ -1,3 +1,20 @@
 data "aws_iam_role" "vpc-flow-log" {
   name = "AWSVPCFlowLog"
 }
+
+#read only role for health check
+module "iam_assumable_roles" {
+  source               = "terraform-aws-modules/iam/aws//modules/iam-assumable-roles"
+  version              = "~> 2.0"
+  max_session_duration = 43200
+
+  # Read-only role
+  create_readonly_role       = true
+  readonly_role_name         = "readonly"
+  readonly_role_requires_mfa = true
+
+  # Allow created users to assume these roles
+  trusted_role_arns = [
+    data.aws_caller_identity.modernisation-platform.account_id
+  ]
+}

--- a/terraform/environments/sprinkler/iam.tf
+++ b/terraform/environments/sprinkler/iam.tf
@@ -1,7 +1,3 @@
-data "aws_iam_role" "vpc-flow-log" {
-  name = "AWSVPCFlowLog"
-}
-
 #read only role for health check
 module "iam_assumable_roles" {
   source               = "terraform-aws-modules/iam/aws//modules/iam-assumable-roles"

--- a/terraform/environments/sprinkler/locals.tf
+++ b/terraform/environments/sprinkler/locals.tf
@@ -7,6 +7,10 @@ data "http" "environments_file" {
   url = "https://raw.githubusercontent.com/ministryofjustice/modernisation-platform/main/environments/${local.application_name}.json"
 }
 
+data "aws_caller_identity" "modernisation-platform" {
+  provider = aws.modernisation-platform
+}
+
 locals {
 
   application_name = "sprinkler"

--- a/terraform/modernisation-platform-account/iam.tf
+++ b/terraform/modernisation-platform-account/iam.tf
@@ -219,3 +219,9 @@ resource "aws_iam_access_key" "member-ci" {
     create_before_destroy = true
   }
 }
+
+# temporary users for healthcheck
+module "temporary_readonly_users" {
+  source        = "../modules/read-only-users"
+  account_alias = data.aws_caller_identity.current.account_id
+}

--- a/terraform/modules/pagerduty-integration/README.md
+++ b/terraform/modules/pagerduty-integration/README.md
@@ -25,15 +25,13 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_sns_topic_subscription.pagerduty_subscription](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_subscription) | resource |
-| [aws_secretsmanager_secret.pagerduty_integration_keys](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
-| [aws_secretsmanager_secret_version.pagerduty_integration_keys](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |
 | [aws_sns_topic.alarm_topics](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/sns_topic) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_pagerduty_integration_name"></a> [pagerduty\_integration\_name](#input\_pagerduty\_integration\_name) | n/a | `string` | n/a | yes |
+| <a name="input_pagerduty_integration_key"></a> [pagerduty\_integration\_key](#input\_pagerduty\_integration\_key) | n/a | `string` | n/a | yes |
 | <a name="input_sns_topics"></a> [sns\_topics](#input\_sns\_topics) | n/a | `list(any)` | n/a | yes |
 
 ## Outputs

--- a/terraform/modules/read-only-users/README.md
+++ b/terraform/modules/read-only-users/README.md
@@ -1,0 +1,13 @@
+# read-only-users
+
+This repository holds a Terraform module that creates set IAM accounts and associated configuration, such as: account password policies, administrator groups, user accounts.
+
+<!--- BEGIN_TF_DOCS --->
+<!--- END_TF_DOCS --->
+
+## First-sign in and changing a password
+The included force_mfa IAM policy doesn't allow a user to change their password without MFA enabled. When onboarding a new superadmin,
+they will need to configure MFA before logging in for the first time.
+
+## Looking for issues?
+If you're looking to raise an issue with this module, please create a new issue in the [Modernisation Platform repository](https://github.com/ministryofjustice/modernisation-platform/issues).

--- a/terraform/modules/read-only-users/README.md
+++ b/terraform/modules/read-only-users/README.md
@@ -3,6 +3,47 @@
 This repository holds a Terraform module that creates set IAM accounts and associated configuration, such as: account password policies, administrator groups, user accounts.
 
 <!--- BEGIN_TF_DOCS --->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.20.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.20.0 |
+| <a name="provider_time"></a> [time](#provider\_time) | n/a |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_iam_group_readonly_with_policies"></a> [iam\_group\_readonly\_with\_policies](#module\_iam\_group\_readonly\_with\_policies) | terraform-aws-modules/iam/aws//modules/iam-group-with-policies | ~> 2.0 |
+| <a name="module_iam_user"></a> [iam\_user](#module\_iam\_user) | terraform-aws-modules/iam/aws//modules/iam-user | ~> 2.0 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [time_sleep.wait_30_seconds](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
+| [aws_iam_policy.ForceMFA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |
+| [aws_iam_policy_document.assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_account_alias"></a> [account\_alias](#input\_account\_alias) | AWS IAM account alias for this account | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_user_passwords"></a> [user\_passwords](#output\_user\_passwords) | Map of users and PGP-encrypted passwords, e.g. { bob: 'abcdefg123456' } |
+
 <!--- END_TF_DOCS --->
 
 ## First-sign in and changing a password

--- a/terraform/modules/read-only-users/main.tf
+++ b/terraform/modules/read-only-users/main.tf
@@ -1,0 +1,83 @@
+# You can define readonly usernames, and their keybase key if applicable, below, and this will automatically create:
+# - their account
+# - an attachment to the "readonly" group, which has the IAM policy of readonly and can assume readonly roles, and forced MFA
+# - if a keybase key is provided, it will also create their user login profile
+locals {
+  readonly_users = {
+    "mikey.dunwoody" = "",
+    "brett.thomas"   = "",
+    "anton.preece"   = "",
+    "stefan.thomas"  = ""
+  }
+}
+
+# sleep to allow time for user creation
+resource "time_sleep" "wait_30_seconds" {
+  depends_on = [module.iam_user]
+
+  create_duration = "30s"
+
+  triggers = {
+    for user in module.iam_user : user.this_iam_user_name => user.this_iam_user_arn
+  }
+
+}
+
+# Attach created users to a AWS IAM group, with several policies
+module "iam_group_readonly_with_policies" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-group-with-policies"
+  version = "~> 2.0"
+  name    = "readonly"
+
+  group_users = [
+    for user in module.iam_user : user.this_iam_user_name
+  ]
+
+  custom_group_policy_arns = [
+    "arn:aws:iam::aws:policy/ReadOnlyAccess",
+    data.aws_iam_policy.ForceMFA.arn
+  ]
+
+  custom_group_policies = [
+    {
+      name   = "AssumeReadOnlyRole"
+      policy = data.aws_iam_policy_document.assume_role.json
+    }
+  ]
+}
+
+# Create each user
+module "iam_user" {
+  for_each              = local.readonly_users
+  source                = "terraform-aws-modules/iam/aws//modules/iam-user"
+  version               = "~> 2.0"
+  name                  = "${each.key}-readonly"
+  force_destroy         = true
+  pgp_key               = each.value
+  create_iam_access_key = false
+
+  # The following is dependent on whether a PGP key has been set
+  create_iam_user_login_profile = length(each.value) > 0 ? true : false
+  password_reset_required       = length(each.value) < 0 ? true : false
+}
+
+# Allow users to assume roles if MFA enabled
+data "aws_iam_policy_document" "assume_role" {
+  statement {
+    sid    = "AssumeRole"
+    effect = "Allow"
+    actions = [
+      "sts:AssumeRole"
+    ]
+    resources = ["arn:aws:iam::*:role/readonly"]
+    condition {
+      test     = "BoolIfExists"
+      variable = "aws:MultiFactorAuthPresent"
+      values   = ["true"]
+    }
+  }
+}
+
+data "aws_iam_policy" "ForceMFA" {
+  name = "ForceMFA"
+}

--- a/terraform/modules/read-only-users/outputs.tf
+++ b/terraform/modules/read-only-users/outputs.tf
@@ -1,0 +1,8 @@
+output "user_passwords" {
+  value = {
+    for user in module.iam_user :
+    user.this_iam_user_name => user.this_iam_user_login_profile_encrypted_password
+    if length(user.pgp_key) > 0
+  }
+  description = "Map of users and PGP-encrypted passwords, e.g. { bob: 'abcdefg123456' }"
+}

--- a/terraform/modules/read-only-users/variables.tf
+++ b/terraform/modules/read-only-users/variables.tf
@@ -1,0 +1,4 @@
+variable "account_alias" {
+  description = "AWS IAM account alias for this account"
+  type        = string
+}

--- a/terraform/modules/read-only-users/versions.tf
+++ b/terraform/modules/read-only-users/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.20.0"
+    }
+  }
+}

--- a/terraform/modules/vpc-tgw-routing/README.md
+++ b/terraform/modules/vpc-tgw-routing/README.md
@@ -25,12 +25,14 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_ec2_transit_gateway_route.example](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_route) | resource |
+| [aws_ec2_transit_gateway_route.external_inspection_out](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_route) | resource |
 | [aws_route.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_external_inspection_out"></a> [external\_inspection\_out](#input\_external\_inspection\_out) | Transit Gateway route table ID for internal-inspection-out | `string` | n/a | yes |
 | <a name="input_route_table"></a> [route\_table](#input\_route\_table) | Route Table | `any` | n/a | yes |
 | <a name="input_subnet_sets"></a> [subnet\_sets](#input\_subnet\_sets) | Key, value map of subnet sets and their CIDR blocks | `map(any)` | n/a | yes |
 | <a name="input_tgw_id"></a> [tgw\_id](#input\_tgw\_id) | Transit Gateway ID | `string` | n/a | yes |


### PR DESCRIPTION
This is for an IT health check.  This adds the testers to the
modernisation platform core account and gives them read only access to
that account and the ability to assume a readonly role in the other core
accounts.

The readonly role is created in the required accounts.

This PR should be reverted and all users and roles removed after the
health check.

Closes #1318 