### PR TITLE
Fix secure-baselines not running on scheduled run

### DIFF
--- a/.github/workflows/scheduled-baseline.yml
+++ b/.github/workflows/scheduled-baseline.yml
@@ -3,6 +3,11 @@ name: "Terraform: scheduled baseline"
 on:
   schedule:
     - cron: "30 22 * * 6"
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/scheduled-baseline.yml'
   workflow_dispatch:
 
 env:
@@ -37,7 +42,6 @@ jobs:
         if: ${{ failure() }}
   secure-baselines:
     runs-on: ubuntu-latest
-    if: github.event.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
     needs: [delegate-access]
     env:
       AWS_ACCESS_KEY_ID:  ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
When the schedule baselines runs on a schedule, the last job,
secure-baselines isn't running, this runs when you manually trigger it.
I believe it is because of the if statement, the `refs/heads/main` part
of this statement isn't triggered it is not a merge into main as it is
with a PR.  Removing this if statement as it's not needed in any case.