### PR TITLE
added bullet listing to references

### DIFF
--- a/source/team-guide/accessing-aws-accounts.html.md.erb
+++ b/source/team-guide/accessing-aws-accounts.html.md.erb
@@ -46,8 +46,8 @@ This code defines a cross-account access role that can be assumed by an administ
 baseline for application accounts.
 
 ## References
-https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-console.html
-https://github.com/ministryofjustice/modernisation-platform/blob/main/terraform/modernisation-platform-account/iam.tf
-https://github.com/ministryofjustice/modernisation-platform-terraform-iam-superadmins
-https://github.com/ministryofjustice/modernisation-platform/blob/main/terraform/environments/bootstrap/delegate-access/iam.tf
-https://github.com/99designs/aws-vault
+* https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-console.html
+* https://github.com/ministryofjustice/modernisation-platform/blob/main/terraform/modernisation-platform-account/iam.tf
+* https://github.com/ministryofjustice/modernisation-platform-terraform-iam-superadmins
+* https://github.com/ministryofjustice/modernisation-platform/blob/main/terraform/environments/bootstrap/delegate-access/iam.tf
+* https://github.com/99designs/aws-vault


### PR DESCRIPTION
This fixes a formatting error in the references section of the team guidance on accessing AWS accounts