### PR TITLE
Add networking for Azure to NOMIS test

### DIFF
--- a/environments-networks/hmpps-test.json
+++ b/environments-networks/hmpps-test.json
@@ -80,6 +80,28 @@
       "cidr_block": "10.184.0.0/16",
       "from_port": "1024",
       "to_port": "65535"
+    },
+    {
+      "subnet_set": "general",
+      "egress": false,
+      "subnet_type": "data",
+      "protocol": "tcp",
+      "rule_action": "allow",
+      "rule_number": 240,
+      "cidr_block": "10.101.0.0/16",
+      "from_port": "1521",
+      "to_port": "1521"
+    },
+    {
+      "subnet_set": "general",
+      "egress": true,
+      "subnet_type": "private",
+      "protocol": "tcp",
+      "rule_action": "allow",
+      "rule_number": 240,
+      "cidr_block": "10.101.0.0/16",
+      "from_port": "1024",
+      "to_port": "65535"
     }
   ]
 }

--- a/terraform/environments/core-network-services/firewall.tf
+++ b/terraform/environments/core-network-services/firewall.tf
@@ -169,15 +169,15 @@ resource "aws_networkfirewall_firewall_policy" "external_inspection" {
     stateless_fragment_default_actions = ["aws:drop"]
     stateless_rule_group_reference {
       priority     = 101
-      resource_arn = aws_networkfirewall_rule_group.global_protect.arn
+      resource_arn = aws_networkfirewall_rule_group.stateless_rules.arn
     }
   }
 }
 
-resource "aws_networkfirewall_rule_group" "global_protect" {
-  description = "Global_Protect"
+resource "aws_networkfirewall_rule_group" "stateless_rules" {
+  description = "Stateless Rules"
   capacity    = 100
-  name        = "global-protect"
+  name        = "stateless_rules"
   type        = "STATELESS"
   rule_group {
     rules_source {
@@ -228,10 +228,34 @@ resource "aws_networkfirewall_rule_group" "global_protect" {
             }
           }
         }
+        stateless_rule { # Azure NOMIS test to MP Nomis database
+          priority = 200
+          rule_definition {
+            actions = ["aws:pass"]
+            match_attributes {
+              source {
+                address_definition = "10.101.0.0/16" # Azure NOMIS Test
+              }
+              source_port {
+                from_port = 1024
+                to_port   = 65535
+              }
+              destination {
+                address_definition = "10.26.8.0/21" # Nomis-Test
+              }
+              destination_port {
+                from_port = 1521
+                to_port   = 1521
+              }
+              protocols = [6]
+            }
+          }
+        }
       }
     }
   }
 }
+
 
 resource "aws_networkfirewall_firewall" "external_inspection" {
   depends_on = [

--- a/terraform/environments/core-network-services/transit_gateway_connections.tf
+++ b/terraform/environments/core-network-services/transit_gateway_connections.tf
@@ -72,10 +72,12 @@ locals {
 
   # To extend the below two data sections, just add additional lines with name and CIDR address to the relevant sections
   egress_pttp_routing_cidrs_non_live_data = {
-    "global-protect" = "10.184.0.0/16"
+    "global-protect" = "10.184.0.0/16",
+    "azure-nomis"    = "10.101.0.0/16"
   }
   egress_pttp_routing_cidrs_live_data = {
-    "global-protect" = "10.184.0.0/16"
+    "global-protect" = "10.184.0.0/16",
+    "azure-nomis"    = "10.101.0.0/16"
   }
 }
 


### PR DESCRIPTION
This adds the following:
 MP TGW egress route back to NOMIS VNETs
 MP Firewall rule to allow traffic from NOMIS VNETs
 MP NACLs rules updated to allow traffic from NOMIS VNETs

This initial PR is for database connectivity, we will add further
connectivity in later PRs.

Part of issue #1379