### PR TITLE
Fix invalid firewall group name

### DIFF
--- a/terraform/environments/core-network-services/firewall.tf
+++ b/terraform/environments/core-network-services/firewall.tf
@@ -177,7 +177,7 @@ resource "aws_networkfirewall_firewall_policy" "external_inspection" {
 resource "aws_networkfirewall_rule_group" "stateless_rules" {
   description = "Stateless Rules"
   capacity    = 100
-  name        = "stateless_rules"
+  name        = "stateless-rules"
   type        = "STATELESS"
   rule_group {
     rules_source {


### PR DESCRIPTION
It seems that _ is not allowed in firewall group names, changing to -