### PR TITLE
Add networking for Cloud Platform to NOMIS test

### DIFF
--- a/environments-networks/hmpps-test.json
+++ b/environments-networks/hmpps-test.json
@@ -102,6 +102,28 @@
       "cidr_block": "10.101.0.0/16",
       "from_port": "1024",
       "to_port": "65535"
+    },
+    {
+      "subnet_set": "general",
+      "egress": false,
+      "subnet_type": "data",
+      "protocol": "tcp",
+      "rule_action": "allow",
+      "rule_number": 245,
+      "cidr_block": "172.20.0.0/16",
+      "from_port": "1521",
+      "to_port": "1521"
+    },
+    {
+      "subnet_set": "general",
+      "egress": true,
+      "subnet_type": "data",
+      "protocol": "tcp",
+      "rule_action": "allow",
+      "rule_number": 245,
+      "cidr_block": "172.20.0.0/16",
+      "from_port": "1024",
+      "to_port": "65535"
     }
   ]
 }

--- a/terraform/environments/core-network-services/firewall.tf
+++ b/terraform/environments/core-network-services/firewall.tf
@@ -251,6 +251,29 @@ resource "aws_networkfirewall_rule_group" "stateless_rules" {
             }
           }
         }
+        stateless_rule { # Cloud Platform to MP Nomis database
+          priority = 300
+          rule_definition {
+            actions = ["aws:pass"]
+            match_attributes {
+              source {
+                address_definition = "172.20.0.0/16" # Cloud Platform
+              }
+              source_port {
+                from_port = 1024
+                to_port   = 65535
+              }
+              destination {
+                address_definition = "10.26.8.0/21" # Nomis-Test
+              }
+              destination_port {
+                from_port = 1521
+                to_port   = 1521
+              }
+              protocols = [6]
+            }
+          }
+        }
       }
     }
   }

--- a/terraform/environments/core-network-services/transit_gateway_connections.tf
+++ b/terraform/environments/core-network-services/transit_gateway_connections.tf
@@ -74,12 +74,12 @@ locals {
   egress_pttp_routing_cidrs_non_live_data = {
     "global-protect" = "10.184.0.0/16",
     "azure-nomis"    = "10.101.0.0/16",
-    "cloud-platform"    = "172.20.0.0/16"
+    "cloud-platform" = "172.20.0.0/16"
   }
   egress_pttp_routing_cidrs_live_data = {
     "global-protect" = "10.184.0.0/16",
     "azure-nomis"    = "10.101.0.0/16",
-    "cloud-platform"    = "172.20.0.0/16"
+    "cloud-platform" = "172.20.0.0/16"
   }
 }
 

--- a/terraform/environments/core-network-services/transit_gateway_connections.tf
+++ b/terraform/environments/core-network-services/transit_gateway_connections.tf
@@ -73,11 +73,13 @@ locals {
   # To extend the below two data sections, just add additional lines with name and CIDR address to the relevant sections
   egress_pttp_routing_cidrs_non_live_data = {
     "global-protect" = "10.184.0.0/16",
-    "azure-nomis"    = "10.101.0.0/16"
+    "azure-nomis"    = "10.101.0.0/16",
+    "cloud-platform"    = "172.20.0.0/16"
   }
   egress_pttp_routing_cidrs_live_data = {
     "global-protect" = "10.184.0.0/16",
-    "azure-nomis"    = "10.101.0.0/16"
+    "azure-nomis"    = "10.101.0.0/16",
+    "cloud-platform"    = "172.20.0.0/16"
   }
 }
 


### PR DESCRIPTION
This adds the following:
- MP TGW egress route back to CP
- MP Firewall rule to allow traffic from CP to MP NOMIS
- MP hmpps-test subnet NACLs rules updated to allow traffic from CP

This initial PR is for database connectivity, we will add further
connectivity in later PRs.

Part of Issue #1383