### PR TITLE
added logging.s3.amazonaws.com to kms principals

### DIFF
--- a/terraform/environments/core-logging/s3_logging.tf
+++ b/terraform/environments/core-logging/s3_logging.tf
@@ -68,6 +68,10 @@ data "aws_iam_policy_document" "kms_logging_cloudtrail" {
     resources = ["*"]
     principals {
       type        = "Service"
+      identifiers = ["logging.s3.amazonaws.com"]
+    }
+    principals {
+      type        = "Service"
       identifiers = ["cloudtrail.amazonaws.com"]
     }
     principals {


### PR DESCRIPTION
This PR solves #1355 - from what I could tell the AWS S3 logging service could not access the KMS key used to encrypt the bucket. I previously investigated switching the bucket encryption to use AWS:SSE instead of AWS:KMS which solved the issue, but in discussion with AWS support found that the principal `logging.s3.amazonaws.com` would also work.
While the documented solution is to switch the bucket to AWS:SSE, I think that allowing the principal access to the logging bucket key is more in line with how we have delivered encryption to logging buckets.