### PR TITLE
replace / with : to fix invalid principal identifier for KMS policy

### DIFF
--- a/terraform/modules/kms/main.tf
+++ b/terraform/modules/kms/main.tf
@@ -52,7 +52,7 @@ data "aws_iam_policy_document" "kms" {
     # See https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default-allow-root-enable-iam
     principals {
       type        = "AWS"
-      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}/root"] #
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"] #
     }
   }
 


### PR DESCRIPTION
This PR resolves an issue with the creation of KMS keys; namely an invalid principal which was down to a `/` where a`:` was appropriate.