### PR TITLE
Decrease scope of permissions for state bucket

### DIFF
--- a/terraform/modernisation-platform-account/s3.tf
+++ b/terraform/modernisation-platform-account/s3.tf
@@ -162,7 +162,11 @@ data "aws_iam_policy_document" "allow-state-access-from-root-account" {
       "s3:GetObject",
       "s3:ListBucket"
     ]
-    resources = [module.state-bucket.bucket.arn, "${module.state-bucket.bucket.arn}/*"]
+    resources = [
+      module.state-bucket.bucket.arn, 
+      "${module.state-bucket.bucket.arn}/terraform.tfstate",
+      "${module.state-bucket.bucket.arn}/environments/members/*"
+    ]
 
     principals {
       type        = "AWS"

--- a/terraform/modernisation-platform-account/s3.tf
+++ b/terraform/modernisation-platform-account/s3.tf
@@ -163,7 +163,7 @@ data "aws_iam_policy_document" "allow-state-access-from-root-account" {
       "s3:ListBucket"
     ]
     resources = [
-      module.state-bucket.bucket.arn, 
+      module.state-bucket.bucket.arn,
       "${module.state-bucket.bucket.arn}/terraform.tfstate",
       "${module.state-bucket.bucket.arn}/environments/members/*"
     ]


### PR DESCRIPTION
The permissions to read the state buckets were introduced to allow
developers to run plans locally, however, they only need access to the
top level state file and the member environment state files for this.