### PR TITLE
Fix uneeded alarm regarding api calls

### DIFF
--- a/terraform/modernisation-platform-account/providers.tf
+++ b/terraform/modernisation-platform-account/providers.tf
@@ -1,82 +1,98 @@
 # AWS providers
 provider "aws" {
-  region = "ap-northeast-1"
-  alias  = "modernisation-platform-ap-northeast-1"
+  region                 = "ap-northeast-1"
+  alias                  = "modernisation-platform-ap-northeast-1"
+  skip_get_ec2_platforms = true
 }
 
 provider "aws" {
-  region = "ap-northeast-2"
-  alias  = "modernisation-platform-ap-northeast-2"
+  region                 = "ap-northeast-2"
+  alias                  = "modernisation-platform-ap-northeast-2"
+  skip_get_ec2_platforms = true
 }
 
 provider "aws" {
-  region = "ap-south-1"
-  alias  = "modernisation-platform-ap-south-1"
+  region                 = "ap-south-1"
+  alias                  = "modernisation-platform-ap-south-1"
+  skip_get_ec2_platforms = true
 }
 
 provider "aws" {
-  region = "ap-southeast-1"
-  alias  = "modernisation-platform-ap-southeast-1"
+  region                 = "ap-southeast-1"
+  alias                  = "modernisation-platform-ap-southeast-1"
+  skip_get_ec2_platforms = true
 }
 
 provider "aws" {
-  region = "ap-southeast-2"
-  alias  = "modernisation-platform-ap-southeast-2"
+  region                 = "ap-southeast-2"
+  alias                  = "modernisation-platform-ap-southeast-2"
+  skip_get_ec2_platforms = true
 }
 
 provider "aws" {
-  region = "ca-central-1"
-  alias  = "modernisation-platform-ca-central-1"
+  region                 = "ca-central-1"
+  alias                  = "modernisation-platform-ca-central-1"
+  skip_get_ec2_platforms = true
 }
 
 provider "aws" {
-  region = "eu-central-1"
-  alias  = "modernisation-platform-eu-central-1"
+  region                 = "eu-central-1"
+  alias                  = "modernisation-platform-eu-central-1"
+  skip_get_ec2_platforms = true
 }
 
 provider "aws" {
-  region = "eu-north-1"
-  alias  = "modernisation-platform-eu-north-1"
+  region                 = "eu-north-1"
+  alias                  = "modernisation-platform-eu-north-1"
+  skip_get_ec2_platforms = true
 }
 
 provider "aws" {
-  region = "eu-west-1"
-  alias  = "modernisation-platform-eu-west-1"
+  region                 = "eu-west-1"
+  alias                  = "modernisation-platform-eu-west-1"
+  skip_get_ec2_platforms = true
 }
 
 provider "aws" {
-  region = "eu-west-2"
-  alias  = "modernisation-platform-eu-west-2"
+  region                 = "eu-west-2"
+  alias                  = "modernisation-platform-eu-west-2"
+  skip_get_ec2_platforms = true
 }
 
 provider "aws" {
-  region = "eu-west-3"
-  alias  = "modernisation-platform-eu-west-3"
+  region                 = "eu-west-3"
+  alias                  = "modernisation-platform-eu-west-3"
+  skip_get_ec2_platforms = true
 }
 
 provider "aws" {
-  region = "sa-east-1"
-  alias  = "modernisation-platform-sa-east-1"
+  region                 = "sa-east-1"
+  alias                  = "modernisation-platform-sa-east-1"
+  skip_get_ec2_platforms = true
 }
 
 provider "aws" {
-  region = "us-east-1"
-  alias  = "modernisation-platform-us-east-1"
+  region                 = "us-east-1"
+  alias                  = "modernisation-platform-us-east-1"
+  skip_get_ec2_platforms = true
 }
 
 provider "aws" {
-  region = "us-east-2"
-  alias  = "modernisation-platform-us-east-2"
+  region                 = "us-east-2"
+  alias                  = "modernisation-platform-us-east-2"
+  skip_get_ec2_platforms = true
 }
 
 provider "aws" {
-  region = "us-west-1"
-  alias  = "modernisation-platform-us-west-1"
+  region                 = "us-west-1"
+  alias                  = "modernisation-platform-us-west-1"
+  skip_get_ec2_platforms = true
 }
 
 provider "aws" {
-  region = "us-west-2"
-  alias  = "modernisation-platform-us-west-2"
+  region                 = "us-west-2"
+  alias                  = "modernisation-platform-us-west-2"
+  skip_get_ec2_platforms = true
 }
 
 # AWS provider for core-logging

--- a/terraform/modules/dns-zone/versions.tf
+++ b/terraform/modules/dns-zone/versions.tf
@@ -1,9 +1,9 @@
 terraform {
   required_providers {
     aws = {
-      version = ">= 3.47.0"
-      source  = "hashicorp/aws"
-      configuration_aliases = [ aws.core-network-services ]
+      version               = ">= 3.47.0"
+      source                = "hashicorp/aws"
+      configuration_aliases = [aws.core-network-services]
     }
   }
   required_version = ">= 1.0.1"


### PR DESCRIPTION
Incidents like this - https://moj-digital-tools.pagerduty.com/incidents/Q38DC32KBA0XF3
are caused due to terraform trying to check supported EC2 platforms when
it doesn't have permission in these regions.  We don't need to do this
for these regions so skipping this check to quieten down the alarms.

https://registry.terraform.io/providers/hashicorp/aws/latest/docs

Similar to https://github.com/ministryofjustice/modernisation-platform/pull/1329