### PR TITLE
added route to ppud psn endpoint via pttp tgw peering

### DIFF
--- a/terraform/environments/core-network-services/firewall.tf
+++ b/terraform/environments/core-network-services/firewall.tf
@@ -274,6 +274,29 @@ resource "aws_networkfirewall_rule_group" "stateless_rules" {
             }
           }
         }
+        stateless_rule { # PSN PPUD to MP HMPPS
+          priority = 400
+          rule_definition {
+            actions = ["aws:pass"]
+            match_attributes {
+              source {
+                address_definition = "51.247.2.115/32" # PSN PPUD
+              }
+              source_port {
+                from_port = 443
+                to_port   = 443
+              }
+              destination {
+                address_definition = "10.27.8.0/21" # HMPPS Production
+              }
+              destination_port {
+                from_port = 1024
+                to_port   = 65535
+              }
+              protocols = [6]
+            }
+          }
+        }
       }
     }
   }

--- a/terraform/environments/core-network-services/transit_gateway_connections.tf
+++ b/terraform/environments/core-network-services/transit_gateway_connections.tf
@@ -80,6 +80,7 @@ locals {
     "global-protect" = "10.184.0.0/16",
     "azure-nomis"    = "10.101.0.0/16",
     "cloud-platform" = "172.20.0.0/16"
+    "ppud-psn"       = "51.247.2.115/32"
   }
 }
 


### PR DESCRIPTION
Solves #1382 by adding route via PTTP TGW and firewall rule for returning traffic
Check of existing routes and acl entries in HMPPS VPC and TGW shows that this should meet the requirements for this story.