### PR TITLE
Delete unneeded OPA tests

### DIFF
--- a/policies/networking/core-vpc.rego
+++ b/policies/networking/core-vpc.rego
@@ -2,25 +2,6 @@ package main
 
 nice_name := replace(replace(input.filename, ".json", ""), "environments-networks/", "")
 
-# Match cidrs against expected.rego
-deny[msg] {
-  input_cidr = input.cidr.transit_gateway
-  expected_cidr = expected["transit_gateway"][nice_name]
-
-  expected_cidr != input_cidr
-
-  msg := sprintf("Transit Gateway CIDR mismatch: `%v` should equal `%v` for `%v`", [input_cidr, expected_cidr, nice_name])
-}
-
-deny[msg] {
-  input_cidr = input.cidr.protected
-  expected_cidr = expected["protected"][nice_name]
-
-  expected_cidr != input_cidr
-
-  msg := sprintf("Protected CIDR mismatch: `%v` should equal `%v` for `%v`", [input_cidr, expected_cidr, nice_name])
-}
-
 deny[msg] {
   expected["subnet_sets"][nice_name][key].cidr != input.cidr.subnet_sets[key].cidr
 
@@ -44,11 +25,6 @@ deny[msg] {
   msg := sprintf("`%v` is missing the `options` key", [input.filename])
 }
 
-# deny[msg] {
-#   not has_field(input.options, "bastion_linux")
-#   msg := sprintf("`%v` is missing the `bastion_linux` key", [input.filename])
-# }
-
 deny[msg] {
   not has_field(input.options, "additional_endpoints")
   msg := sprintf("`%v` is missing the `additional_endpoints` key", [input.filename])
@@ -65,16 +41,6 @@ deny[msg] {
 }
 
 # Invalid type
-deny[msg] {
-  not is_string(input.cidr.transit_gateway)
-  msg := sprintf("`%v` invalid transit_gateway type - must be string", [input.filename])
-}
-
-deny[msg] {
-  not is_string(input.cidr.protected)
-  msg := sprintf("`%v` invalid protected type - must be string", [input.filename])
-}
-
 deny[msg] {
   not is_object(input.cidr.subnet_sets)
   msg := sprintf("`%v` invalid subnet_sets type - must be a object", [input.filename])

--- a/policies/networking/core-vpc_test.rego
+++ b/policies/networking/core-vpc_test.rego
@@ -1,10 +1,8 @@
 package main
 
 sample_input := {
-  "filename": "garden-development.json",
+  "filename": "house-sandbox.json",
   "cidr": {
-    "transit_gateway": "0.0.0.0",
-    "protected": "1.1.1.1",
     "subnet_sets": {
       "general": {
       	"cidr": "2.2.2.2"
@@ -13,16 +11,8 @@ sample_input := {
   }
 }
 
-test_mismatched_transit_gateway_cidr {
-	deny["Transit Gateway CIDR mismatch: `0.0.0.0` should equal `10.233.0.0/26` for `garden-development`"] with input as sample_input
-}
-
-test_mismatched_protected_cidr {
-	deny["Protected CIDR mismatch: `1.1.1.1` should equal `10.238.0.0/23` for `garden-development`"] with input as sample_input
-}
-
 test_mismatched_subnet_sets {
-	deny["Subnet sets mismatch: `2.2.2.2` should equal `10.234.0.0/21` for `garden-development (general)`"] with input as sample_input
+	deny["Subnet sets mismatch: `2.2.2.2` should equal `10.231.8.0/21` for `house-sandbox (general)`"] with input as sample_input
 }
 
 test_no_cidr {
@@ -42,7 +32,6 @@ test_no_options {
 }
 
 test_missing_options_keys {
-  # deny["`example.json` is missing the `bastion_linux` key"] with input as { "filename": "example.json", "options": {} }
   deny["`example.json` is missing the `additional_endpoints` key"] with input as { "filename": "example.json", "options": {} }
   deny["`example.json` is missing the `dns_zone_extend` key"] with input as { "filename": "example.json", "options": {} }
 }
@@ -52,8 +41,6 @@ test_no_nacl {
 }
 
 test_cidr_types {
-  deny["`example.json` invalid transit_gateway type - must be string"] with input as { "filename": "example.json", "cidr": {"transit_gateway": true} }
-  deny["`example.json` invalid protected type - must be string"] with input as { "filename": "example.json", "cidr": {"protected": true} }
   deny["`example.json` invalid subnet_sets type - must be a object"] with input as { "filename": "example.json", "cidr": {"subnet_sets": ""} }
 }
 

--- a/policies/networking/expected.rego
+++ b/policies/networking/expected.rego
@@ -2,32 +2,6 @@ package main
 
 expected =
   {
-  "transit_gateway": {
-    "garden-sandbox": "10.233.0.0/26",
-    "house-sandbox": "10.233.0.64/26",
-    "hmpps-preproduction": "10.233.1.0/26",
-    "platforms-development": "10.233.1.64/26",
-    "hmpps-development": "10.233.1.128/26",
-    "platforms-test": "10.233.1.192/26",
-    "hmpps-test": "10.233.2.0/26",
-    "cica-development": "10.233.2.64/26",
-    "hmpps-production": "10.233.2.128/26",
-    "hmcts-development": "10.233.2.192/26",
-    "hmcts-production": "10.233.3.0/26"
-  },
-  "protected": {
-    "garden-sandbox": "10.238.0.0/23",
-    "house-sandbox": "10.238.2.0/23",
-    "hmpps-preproduction": "10.238.8.0/23",
-    "platforms-development": "10.238.10.0/23",
-    "hmpps-development": "10.238.12.0/23",
-    "platforms-test": "10.238.14.0/23",
-    "hmpps-test": "10.238.16.0/23",
-    "cica-development": "10.238.18.0/23",
-    "hmpps-production": "10.238.20.0/23",
-    "hmcts-development": "10.238.22.0/23",
-    "hmcts-production": "10.238.24.0/23"
-  },
   "subnet_sets": {
     "garden-sandbox": {
       "general": {

--- a/scripts/tests/validate/run-opa-tests.sh
+++ b/scripts/tests/validate/run-opa-tests.sh
@@ -25,7 +25,7 @@ check-environment-files-present() {
 
 check-network-files-present() {
   test_data=`cat policies/networking/expected.rego | sed '1,3d'`
-  business_units=`jq -rn --argjson DATA "${test_data}" '$DATA.protected | keys | .[]' | sort | tr -s '\n' ' '`
+  business_units=`jq -rn --argjson DATA "${test_data}" '$DATA.subnet_sets | keys | .[]' | sort | tr -s '\n' ' '`
   files=`ls -d environments-networks/*.json | sed 's/environments-networks\///g' | sed 's/.json//g' | sort | tr -s '\n' ' '`
 
   if [[ "$files" == "$business_units" ]]


### PR DESCRIPTION
After refactoring the networking code to remove the need to manually
assign protected and transit gateway subnets, adjustments to these tests
were missed.  Also fixing the call as the jq was looking for no existent
keys now.