### PR TITLE
Add permissions needed to run plans as collab dev

### DIFF
--- a/source/team-guide/adding-collaborators.html.md.erb
+++ b/source/team-guide/adding-collaborators.html.md.erb
@@ -93,3 +93,35 @@ For this reason collaborator environment reviewers should be manually added to t
 1. Find the required environment and click on it
 1. Under `Environment protection rules` add the required collaborators
 1. Click `Save protection rules`
+
+## Running a Terraform plan locally as a collaborator
+
+To run a Terraform locally as a collaborator, they will need to configure their AWS credentials, and use [AWS Vault](https://github.com/99designs/aws-vault) or a similar tool to run Terraform using MFA.
+
+The collaborator should follow the standard [running terraform plan locally](../user-guide/running-terraform-plan-locally.html) instructions, ignoring the SSO section, running Terraform using AWS Vault and making one further code change:
+
+Under the local plan section of the `providers.tf` file:
+
+```
+######################### Run Terraform Plan Locally Only ##################################
+# To run a Terraform Plan locally, uncomment this bottom section of code and comment out the top section
+
+provider "aws" {
+  region = "eu-west-2"
+}
+```
+
+Add in an assume role block for the main provider with the account number that local plan is for, for example:
+
+```
+######################### Run Terraform Plan Locally Only ##################################
+# To run a Terraform Plan locally, uncomment this bottom section of code and comment out the top section
+
+provider "aws" {
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::<my-account-number>:role/developer"
+  }
+}
+```
+As with all local plan changes, please do not add these changes to version control or the CI/CD GitHub workflows will stop running.

--- a/source/user-guide/running-terraform-plan-locally.html.md.erb
+++ b/source/user-guide/running-terraform-plan-locally.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Running Terraform Plan Locally
-last_reviewed_on: 2021-10-18
+last_reviewed_on: 2021-02-07
 review_in: 3 months
 ---
 

--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -261,15 +261,4 @@ data "aws_iam_policy_document" "developer-additional" {
 
     resources = ["arn:aws:iam::*:user/cicd-member-user"]
   }
-
-  statement {
-    actions = [
-      "sts:AssumeRole"
-    ]
-
-    resources = [
-      "arn:aws:iam::*:role/read-dns-records",
-      "arn:aws:iam::*:role/member-delegation-read-only"
-    ]
-  }
 }

--- a/terraform/modernisation-platform-account/iam.tf
+++ b/terraform/modernisation-platform-account/iam.tf
@@ -243,7 +243,7 @@ data "aws_iam_policy" "ForceMFA" {
 resource "aws_iam_policy" "collaborator_local_plan" {
   name        = "collaborator-local-plan"
   description = "Permissions collaborators need to perform local Terraform plans"
-  policy = data.aws_iam_policy_document.collaborator_local_plan.json
+  policy      = data.aws_iam_policy_document.collaborator_local_plan.json
 }
 
 data "aws_iam_policy_document" "collaborator_local_plan" {

--- a/terraform/modernisation-platform-account/iam.tf
+++ b/terraform/modernisation-platform-account/iam.tf
@@ -231,12 +231,48 @@ module "collaborators_group" {
   group_users = [for user in module.collaborators : user.username]
 
   custom_group_policy_arns = [
-    data.aws_iam_policy.ForceMFA.arn
+    data.aws_iam_policy.ForceMFA.arn,
+    aws_iam_policy.collaborator_local_plan.arn
   ]
 }
 
 data "aws_iam_policy" "ForceMFA" {
   name = "ForceMFA"
+}
+
+resource "aws_iam_policy" "collaborator_local_plan" {
+  name        = "collaborator-local-plan"
+  description = "Permissions collaborators need to perform local Terraform plans"
+  policy = data.aws_iam_policy_document.collaborator_local_plan.json
+}
+
+data "aws_iam_policy_document" "collaborator_local_plan" {
+  statement {
+    sid    = "AssumeRole"
+    effect = "Allow"
+    actions = [
+      "sts:AssumeRole"
+    ]
+    resources = [
+      "arn:aws:iam::*:role/read-dns-records",
+      "arn:aws:iam::*:role/member-delegation-read-only"
+    ]
+  }
+
+  statement {
+    sid = "TerraformStateAccess"
+    actions = [
+      "s3:ListBucket",
+      "s3:GetObject"
+    ]
+
+    resources = [
+      "arn:aws:s3:::modernisation-platform-terraform-state/terraform.tfstate",
+      "arn:aws:s3:::modernisation-platform-terraform-state/environments/members/*",
+      "arn:aws:s3:::modernisation-platform-terraform-state/environments/accounts/core-network-services/*",
+      "arn:aws:s3:::modernisation-platform-terraform-state"
+    ]
+  }
 }
 
 module "collaborators" {

--- a/terraform/modernisation-platform-account/s3.tf
+++ b/terraform/modernisation-platform-account/s3.tf
@@ -165,7 +165,8 @@ data "aws_iam_policy_document" "allow-state-access-from-root-account" {
     resources = [
       module.state-bucket.bucket.arn,
       "${module.state-bucket.bucket.arn}/terraform.tfstate",
-      "${module.state-bucket.bucket.arn}/environments/members/*"
+      "${module.state-bucket.bucket.arn}/environments/members/*",
+      "${module.state-bucket.bucket.arn}/environments/accounts/core-network-services/*"
     ]
 
     principals {


### PR DESCRIPTION
These permissions are required to enable collaborators with developer
access to run terraform plans locally.