### PR TITLE
Restrict permissions of CICD user

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -94,7 +94,6 @@ data "aws_iam_policy_document" "member-access" {
       "iam:AddClientIDToOpenIDConnectProvider",
       "iam:AddUserToGroup",
       "iam:AttachGroupPolicy",
-      "iam:AttachRolePolicy",
       "iam:AttachUserPolicy",
       "iam:CreateAccountAlias",
       "iam:CreateGroup",

--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -3,10 +3,6 @@ locals {
   account_data = jsondecode(file("../../../../environments/${local.account_name}.json"))
 }
 
-data "aws_iam_user" "cicd_member_user" {
-  user_name = "cicd-member-user"
-}
-
 module "cross-account-access" {
   source = "github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access?ref=v2.0.0"
   providers = {
@@ -144,7 +140,7 @@ data "aws_iam_policy_document" "member-access" {
       "iam:UpdateRole",
       "iam:UpdateRoleDescription"
     ]
-    resources = [data.aws_iam_user.cicd_member_user.arn]
+    resources = [module.cicd-member-user.cicd_user_arn]
   }
 }
 

--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -144,11 +144,6 @@ data "aws_iam_policy_document" "member-access" {
       "iam:UpdateRole",
       "iam:UpdateRoleDescription"
     ]
-    condition {
-      test     = "StringEquals"
-      values   = [data.aws_iam_user.cicd_member_user.arn]
-      variable = "aws:PrincipalARN"
-    }
     resources = [data.aws_iam_user.cicd_member_user.arn]
   }
 }

--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -146,7 +146,7 @@ data "aws_iam_policy_document" "member-access" {
       "iam:UpdateRoleDescription"
     ]
     condition {
-      test     = "StringNotEquals"
+      test     = "StringEquals"
       values   = [data.aws_iam_user.cicd_member_user.arn]
       variable = "aws:PrincipalARN"
     }

--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -95,6 +95,7 @@ data "aws_iam_policy_document" "member-access" {
       "iam:AddClientIDToOpenIDConnectProvider",
       "iam:AddUserToGroup",
       "iam:AttachGroupPolicy",
+      "iam:AttachRolePolicy",
       "iam:AttachUserPolicy",
       "iam:CreateAccountAlias",
       "iam:CreateGroup",

--- a/terraform/modules/iam_baseline/main.tf
+++ b/terraform/modules/iam_baseline/main.tf
@@ -52,3 +52,7 @@ resource "aws_iam_group_membership" "cicd-member" {
 
   group = aws_iam_group.cicd_member_group.name
 }
+
+output "cicd_user_arn" {
+  value = aws_iam_user.cicd_member_user.arn
+}


### PR DESCRIPTION
This PR exists to tighten what the CICD user can do. We had a recent case where a team was able to create and add a role policy to the CICD user but not remove it. We probably don't want to allow the unexpected expansion of what the CICD user can do, so this PR adds a statement preventing the CICD user from making changes to itself (eg, attaching extra role policies).