### PR TITLE
Feature/tfsec

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -90,7 +90,6 @@ data "aws_iam_policy_document" "member-access" {
       "iam:AddClientIDToOpenIDConnectProvider",
       "iam:AddUserToGroup",
       "iam:AttachGroupPolicy",
-      "iam:AttachRolePolicy",
       "iam:AttachUserPolicy",
       "iam:CreateAccountAlias",
       "iam:CreateGroup",

--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -95,6 +95,7 @@ data "aws_iam_policy_document" "member-access" {
       "iam:AddClientIDToOpenIDConnectProvider",
       "iam:AddUserToGroup",
       "iam:AttachGroupPolicy",
+      "iam:AttachRolePolicy",
       "iam:AttachUserPolicy",
       "iam:CreateAccountAlias",
       "iam:CreateGroup",

--- a/terraform/modernisation-platform-account/iam.tf
+++ b/terraform/modernisation-platform-account/iam.tf
@@ -38,6 +38,7 @@ resource "aws_iam_policy" "deny-specific-actions" {
 }
 
 # Create a CI group to attach the policy to
+#tfsec:ignore:aws-iam-enforce-mfa
 resource "aws_iam_group" "ci" {
   name = "ci"
 }
@@ -178,6 +179,7 @@ resource "aws_iam_policy" "member-ci-policy" {
 }
 
 # Create a member CI group to attach the policy to
+#tfsec:ignore:aws-iam-enforce-mfa
 resource "aws_iam_group" "member-ci" {
   name = "member-ci"
 }

--- a/terraform/modernisation-platform-account/iam.tf
+++ b/terraform/modernisation-platform-account/iam.tf
@@ -90,7 +90,7 @@ data "aws_iam_policy_document" "member-ci-policy" {
     effect  = "Allow"
     actions = ["sts:AssumeRole"]
     resources = [
-      "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/MemberInfrastructureAccess",
+      "arn:aws:iam::*:role/MemberInfrastructureAccess",
       "arn:aws:iam::${local.environment_management.account_ids["core-vpc-development"]}:role/member-delegation-*-development",
       "arn:aws:iam::${local.environment_management.account_ids["core-vpc-test"]}:role/member-delegation-*-test",
       "arn:aws:iam::${local.environment_management.account_ids["core-vpc-preproduction"]}:role/member-delegation-*-preproduction",

--- a/terraform/modernisation-platform-account/iam.tf
+++ b/terraform/modernisation-platform-account/iam.tf
@@ -84,12 +84,13 @@ resource "aws_iam_access_key" "ci" {
 # Member CI User
 
 # Member CI policy
+#tfsec:ignore:aws-iam-no-policy-wildcards
 data "aws_iam_policy_document" "member-ci-policy" {
   statement {
     effect  = "Allow"
     actions = ["sts:AssumeRole"]
     resources = [
-      "arn:aws:iam::*:role/MemberInfrastructureAccess",
+      "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/MemberInfrastructureAccess",
       "arn:aws:iam::${local.environment_management.account_ids["core-vpc-development"]}:role/member-delegation-*-development",
       "arn:aws:iam::${local.environment_management.account_ids["core-vpc-test"]}:role/member-delegation-*-test",
       "arn:aws:iam::${local.environment_management.account_ids["core-vpc-preproduction"]}:role/member-delegation-*-preproduction",
@@ -256,8 +257,12 @@ data "aws_iam_policy_document" "collaborator_local_plan" {
       "sts:AssumeRole"
     ]
     resources = [
-      "arn:aws:iam::*:role/read-dns-records",
-      "arn:aws:iam::*:role/member-delegation-read-only"
+      "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/read-dns-records",
+      "arn:aws:iam::${local.environment_management.account_ids["core-vpc-development"]}:role/member-delegation-read-only",
+      "arn:aws:iam::${local.environment_management.account_ids["core-vpc-test"]}:role/member-delegation-read-only",
+      "arn:aws:iam::${local.environment_management.account_ids["core-vpc-preproduction"]}:role/member-delegation-read-only",
+      "arn:aws:iam::${local.environment_management.account_ids["core-vpc-production"]}:role/member-delegation-read-only",
+      "arn:aws:iam::${local.environment_management.account_ids["core-vpc-sandbox"]}:role/member-delegation-read-only",
     ]
   }
 

--- a/terraform/modules/iam_baseline/main.tf
+++ b/terraform/modules/iam_baseline/main.tf
@@ -3,6 +3,7 @@ resource "aws_iam_user" "cicd_member_user" {
   name = "cicd-member-user"
 }
 
+#tfsec:ignore:aws-iam-enforce-mfa
 resource "aws_iam_group" "cicd_member_group" {
   name = "cicd-member-group"
 }

--- a/terraform/modules/iam_baseline/main.tf
+++ b/terraform/modules/iam_baseline/main.tf
@@ -8,10 +8,11 @@ resource "aws_iam_group" "cicd_member_group" {
   name = "cicd-member-group"
 }
 
+#tfsec:ignore:aws-iam-no-policy-wildcards
 resource "aws_iam_policy" "policy" {
   name        = "cicd-member-policy"
   description = "IAM Policy for CICD member user"
-  policy = jsonencode({ #tfsec:ignore:AWS099
+  policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
       {

--- a/terraform/modules/vpc-hub/main.tf
+++ b/terraform/modules/vpc-hub/main.tf
@@ -214,6 +214,7 @@ resource "aws_network_acl" "public" {
 }
 
 # Public NACLs rules
+#tfsec:ignore:aws-vpc-no-public-ingress-acl tfsec:ignore:aws-vpc-no-excessive-port-access
 resource "aws_network_acl_rule" "public" {
   for_each = local.nacl_rules_expanded
 
@@ -227,6 +228,7 @@ resource "aws_network_acl_rule" "public" {
   to_port        = each.value.to_port
 }
 
+#tfsec:ignore:aws-vpc-no-excessive-port-access
 resource "aws_network_acl_rule" "public-local-ingress" {
   network_acl_id = aws_network_acl.public.id
   rule_number    = 210
@@ -236,6 +238,7 @@ resource "aws_network_acl_rule" "public-local-ingress" {
   cidr_block     = var.vpc_cidr
 }
 
+#tfsec:ignore:aws-vpc-no-excessive-port-access
 resource "aws_network_acl_rule" "public-local-egress" {
   network_acl_id = aws_network_acl.public.id
   rule_number    = 210
@@ -307,6 +310,7 @@ resource "aws_network_acl" "private" {
 }
 
 # Private NACLs rules
+#tfsec:ignore:aws-vpc-no-public-ingress-acl
 resource "aws_network_acl_rule" "private" {
   for_each = local.nacl_rules_expanded
 
@@ -320,6 +324,7 @@ resource "aws_network_acl_rule" "private" {
   to_port        = each.value.to_port
 }
 
+#tfsec:ignore:aws-vpc-no-excessive-port-access
 resource "aws_network_acl_rule" "private-local-ingress" {
   network_acl_id = aws_network_acl.private.id
   rule_number    = 210
@@ -329,6 +334,7 @@ resource "aws_network_acl_rule" "private-local-ingress" {
   cidr_block     = var.vpc_cidr
 }
 
+#tfsec:ignore:aws-vpc-no-excessive-port-access
 resource "aws_network_acl_rule" "private-local-egress" {
   network_acl_id = aws_network_acl.private.id
   rule_number    = 210
@@ -395,6 +401,7 @@ resource "aws_network_acl" "data" {
 }
 
 # Data NACLs rules
+#tfsec:ignore:aws-vpc-no-public-ingress-acl
 resource "aws_network_acl_rule" "data" {
   for_each = local.nacl_rules_expanded
 
@@ -408,6 +415,7 @@ resource "aws_network_acl_rule" "data" {
   to_port        = each.value.to_port
 }
 
+#tfsec:ignore:aws-vpc-no-excessive-port-access
 resource "aws_network_acl_rule" "data-local-ingress" {
   network_acl_id = aws_network_acl.data.id
   rule_number    = 210
@@ -417,6 +425,7 @@ resource "aws_network_acl_rule" "data-local-ingress" {
   cidr_block     = var.vpc_cidr
 }
 
+#tfsec:ignore:aws-vpc-no-excessive-port-access
 resource "aws_network_acl_rule" "data-local-egress" {
   network_acl_id = aws_network_acl.data.id
   rule_number    = 210
@@ -483,6 +492,7 @@ resource "aws_network_acl" "transit-gateway" {
 }
 
 # Transit Gateway NACLs rules
+#tfsec:ignore:aws-vpc-no-public-ingress-acl
 resource "aws_network_acl_rule" "transit-gateway" {
   for_each = local.nacl_rules_expanded
 
@@ -496,6 +506,7 @@ resource "aws_network_acl_rule" "transit-gateway" {
   to_port        = each.value.to_port
 }
 
+#tfsec:ignore:aws-vpc-no-excessive-port-access
 resource "aws_network_acl_rule" "transit-gateway-local-ingress" {
   network_acl_id = aws_network_acl.transit-gateway.id
   rule_number    = 210
@@ -505,6 +516,7 @@ resource "aws_network_acl_rule" "transit-gateway-local-ingress" {
   cidr_block     = var.vpc_cidr
 }
 
+#tfsec:ignore:aws-vpc-no-excessive-port-access
 resource "aws_network_acl_rule" "transit-gateway-local-egress" {
   network_acl_id = aws_network_acl.transit-gateway.id
   rule_number    = 210

--- a/terraform/pagerduty/aws.tf
+++ b/terraform/pagerduty/aws.tf
@@ -1,6 +1,7 @@
 # Pagerduty integration keys
 # When a new integration is created there is a uniq key that is created which is required for the endpoint
 # to push notifications to pagerduty.  Add any additional integrations to the json secret below
+#tfsec:ignore:aws-ssm-secret-use-customer-key
 resource "aws_secretsmanager_secret" "pagerduty_integration_keys" {
   # checkov:skip=CKV_AWS_149:No requirement currently to encrypt this secret with customer-managed KMS key
   name        = "pagerduty_integration_keys"
@@ -17,6 +18,7 @@ resource "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {
 
 # Pagerduty token
 # Required for Terraform to make api calls to pagerduty, set in the console, new tokens available from #ops-engineering
+#tfsec:ignore:aws-ssm-secret-use-customer-key
 resource "aws_secretsmanager_secret" "pagerduty_token" {
   # checkov:skip=CKV_AWS_149:No requirement currently to encrypt this secret with customer-managed KMS key
   name        = "pagerduty_token"


### PR DESCRIPTION
* Tightens IAM policy
* Adds `tfsec:ignore` where checks are at odds with the intent of the terraform code. EG, allowing traffic in and out of a public subnet from the internet