### PR TITLE
Resolve tfsec errors

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -35,6 +35,7 @@ module "member-access" {
   role_name  = "MemberInfrastructureAccess"
 }
 
+#tfsec:ignore:aws-iam-no-policy-wildcards
 data "aws_iam_policy_document" "member-access" {
   statement {
     #checkov:skip=CKV_AWS_108
@@ -43,7 +44,7 @@ data "aws_iam_policy_document" "member-access" {
     #checkov:skip=CKV_AWS_109
     #checkov:skip=CKV_AWS_110
     effect = "Allow"
-    actions = [ #tfsec:ignore:AWS099
+    actions = [
       "acm-pca:*",
       "acm:*",
       "application-autoscaling:*",
@@ -218,6 +219,7 @@ resource "aws_iam_policy" "developer" {
   policy   = data.aws_iam_policy_document.developer-additional.json
 }
 
+#tfsec:ignore:aws-iam-no-policy-wildcards
 data "aws_iam_policy_document" "developer-additional" {
   #checkov:skip=CKV_AWS_108
   #checkov:skip=CKV_AWS_109

--- a/terraform/environments/core-network-services/acm-pca.tf
+++ b/terraform/environments/core-network-services/acm-pca.tf
@@ -38,6 +38,11 @@ resource "aws_s3_bucket_lifecycle_configuration" "acm-pca" {
     id     = "default"
     status = "Enabled"
 
+    filter {
+      object_size_greater_than = 0
+      object_size_less_than    = 0
+    }
+
     transition {
       days          = 30
       storage_class = "GLACIER"
@@ -59,20 +64,24 @@ resource "aws_s3_bucket_public_access_block" "acm-pca" {
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "acm-pca" {
-  bucket = aws_s3_bucket.acm-pca.id
+  bucket                = aws_s3_bucket.acm-pca.id
+  expected_bucket_owner = local.environment_management.account_ids["core-network-services-production"]
 
   rule {
     apply_server_side_encryption_by_default {
       sse_algorithm     = "aws:kms"
       kms_master_key_id = aws_kms_key.acm.arn
     }
+    bucket_key_enabled = false
   }
 }
 
 resource "aws_s3_bucket_versioning" "acm-pca" {
-  bucket = aws_s3_bucket.acm-pca.id
+  bucket                = aws_s3_bucket.acm-pca.id
+  expected_bucket_owner = local.environment_management.account_ids["core-network-services-production"]
   versioning_configuration {
-    status = "Enabled"
+    mfa_delete = "Disabled"
+    status     = "Enabled"
   }
 }
 

--- a/terraform/environments/core-network-services/acm-pca.tf
+++ b/terraform/environments/core-network-services/acm-pca.tf
@@ -9,11 +9,9 @@ provider "aws" {
 
 #Create S3 bucket for ACM
 # TFSec ignores:
-# - AWS098: Ignore warnings regarding not blocking all public access - this is required for CRL
 # - AWS002: Ignore warnings regarding lack of s3 bucket server access logging - considered overkill given bucket purpose and restricted access to bucket
 #tfsec:ignore:AWS098 tfsec:ignore:AWS002 tfsec:ignore:aws-s3-block-public-acls
 resource "aws_s3_bucket" "acm-pca" {
-  #checkov:skip=CKV2_AWS_6:Public access is required when S3 bucket used for acm pca CRL
   #checkov:skip=CKV_AWS_144:Ignore lack of cross-regional replication - not required here - represents an overkill
   #checkov:skip=CKV_AWS_18:Ignore warnings regarding lack of s3 bucket server access logging - considered overkill given bucket purpose and restricted access to bucket
 

--- a/terraform/environments/core-network-services/acm-pca.tf
+++ b/terraform/environments/core-network-services/acm-pca.tf
@@ -33,7 +33,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "acm-pca" {
   bucket = aws_s3_bucket.acm-pca.bucket
 
   rule {
-    id = "default"
+    id     = "default"
     status = "Enabled"
 
     transition {
@@ -49,10 +49,10 @@ resource "aws_s3_bucket_lifecycle_configuration" "acm-pca" {
 }
 
 resource "aws_s3_bucket_public_access_block" "acm-pca" {
-  bucket = aws_s3_bucket.acm-pca.id
-  block_public_acls = true
-  block_public_policy = true
-  ignore_public_acls = true
+  bucket                  = aws_s3_bucket.acm-pca.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
   restrict_public_buckets = true
 }
 

--- a/terraform/environments/core-network-services/acm-pca.tf
+++ b/terraform/environments/core-network-services/acm-pca.tf
@@ -10,11 +10,13 @@ provider "aws" {
 #Create S3 bucket for ACM
 # TFSec ignores:
 # - AWS002: Ignore warnings regarding lack of s3 bucket server access logging - considered overkill given bucket purpose and restricted access to bucket
-#tfsec:ignore:AWS098 tfsec:ignore:AWS002 tfsec:ignore:aws-s3-block-public-acls
+#tfsec:ignore:AWS098 tfsec:ignore:AWS002 tfsec:ignore:aws-s3-block-public-acls tfsec:ignore:aws-s3-enable-bucket-encryption tfsec:ignore:aws-s3-enable-bucket-encryption tfsec:ignore:aws-s3-enable-versioning
 resource "aws_s3_bucket" "acm-pca" {
-  #checkov:skip=CKV_AWS_144:Ignore lack of cross-regional replication - not required here - represents an overkill
   #checkov:skip=CKV_AWS_18:Ignore warnings regarding lack of s3 bucket server access logging - considered overkill given bucket purpose and restricted access to bucket
-
+  #checkov:skip=CKV_AWS_19:Moved to new resource in 4.0 provider
+  #checkov:skip=CKV_AWS_21:Moved to new resource in 4.0 provider
+  #checkov:skip=CKV_AWS_144:Ignore lack of cross-regional replication - not required here - represents an overkill
+  #checkov:skip=CKV_AWS_145:Moved to new resource in 4.0 provider
   bucket_prefix = "acm"
 
   lifecycle {
@@ -66,6 +68,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "acm-pca" {
     }
   }
 }
+
 resource "aws_s3_bucket_versioning" "acm-pca" {
   bucket = aws_s3_bucket.acm-pca.id
   versioning_configuration {

--- a/terraform/environments/core-network-services/acm-pca.tf
+++ b/terraform/environments/core-network-services/acm-pca.tf
@@ -11,7 +11,7 @@ provider "aws" {
 # TFSec ignores:
 # - AWS098: Ignore warnings regarding not blocking all public access - this is required for CRL
 # - AWS002: Ignore warnings regarding lack of s3 bucket server access logging - considered overkill given bucket purpose and restricted access to bucket
-#tfsec:ignore:AWS098 tfsec:ignore:AWS002
+#tfsec:ignore:AWS098 tfsec:ignore:AWS002 tfsec:ignore:aws-s3-block-public-acls
 resource "aws_s3_bucket" "acm-pca" {
   #checkov:skip=CKV2_AWS_6:Public access is required when S3 bucket used for acm pca CRL
   #checkov:skip=CKV_AWS_144:Ignore lack of cross-regional replication - not required here - represents an overkill
@@ -60,6 +60,14 @@ resource "aws_s3_bucket" "acm-pca" {
       Name = "acm-pca"
     },
   )
+}
+
+resource "aws_s3_bucket_public_access_block" "acm-pca" {
+  bucket = aws_s3_bucket.acm-pca.id
+  block_public_acls = true
+  block_public_policy = true
+  ignore_public_acls = true
+  restrict_public_buckets = true
 }
 
 #S3 bucket access policy

--- a/terraform/environments/core-network-services/acm-pca.tf
+++ b/terraform/environments/core-network-services/acm-pca.tf
@@ -10,7 +10,7 @@ provider "aws" {
 #Create S3 bucket for ACM
 # TFSec ignores:
 # - AWS002: Ignore warnings regarding lack of s3 bucket server access logging - considered overkill given bucket purpose and restricted access to bucket
-#tfsec:ignore:AWS098 tfsec:ignore:AWS002 tfsec:ignore:aws-s3-block-public-acls tfsec:ignore:aws-s3-enable-bucket-encryption tfsec:ignore:aws-s3-enable-bucket-encryption tfsec:ignore:aws-s3-enable-versioning
+#tfsec:ignore:AWS098 tfsec:ignore:AWS002 tfsec:ignore:aws-s3-block-public-acls tfsec:ignore:aws-s3-enable-bucket-encryption tfsec:ignore:aws-s3-enable-bucket-encryption tfsec:ignore:aws-s3-enable-versioning tfsec:ignore:aws-s3-encryption-customer-key
 resource "aws_s3_bucket" "acm-pca" {
   #checkov:skip=CKV_AWS_18:Ignore warnings regarding lack of s3 bucket server access logging - considered overkill given bucket purpose and restricted access to bucket
   #checkov:skip=CKV_AWS_19:Moved to new resource in 4.0 provider

--- a/terraform/environments/core-network-services/providers.tf
+++ b/terraform/environments/core-network-services/providers.tf
@@ -8,6 +8,12 @@ provider "aws" {
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
+<<<<<<< HEAD
   alias  = "modernisation-platform"
   region = "eu-west-2"
+=======
+  alias   = "modernisation-platform"
+  region  = "eu-west-2"
+  version = ">= 4.0.0, < 5.0.0"
+>>>>>>> de8f3cc (Commit changes made by code formatters)
 }

--- a/terraform/environments/core-network-services/providers.tf
+++ b/terraform/environments/core-network-services/providers.tf
@@ -4,6 +4,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
+  version = ">= 4.0.0, < 5.0.0"
 }
 
 # AWS provider for the Modernisation Platform, to get things from there if required

--- a/terraform/environments/core-network-services/providers.tf
+++ b/terraform/environments/core-network-services/providers.tf
@@ -8,12 +8,6 @@ provider "aws" {
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
-<<<<<<< HEAD
-  alias  = "modernisation-platform"
-  region = "eu-west-2"
-=======
   alias   = "modernisation-platform"
   region  = "eu-west-2"
-  version = ">= 4.0.0, < 5.0.0"
->>>>>>> de8f3cc (Commit changes made by code formatters)
 }

--- a/terraform/environments/core-network-services/providers.tf
+++ b/terraform/environments/core-network-services/providers.tf
@@ -4,12 +4,10 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
-  version = ">= 4.0.0, < 5.0.0"
 }
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
   alias  = "modernisation-platform"
   region = "eu-west-2"
-  version = ">= 4.0.0, < 5.0.0"
 }

--- a/terraform/environments/core-network-services/providers.tf
+++ b/terraform/environments/core-network-services/providers.tf
@@ -11,4 +11,5 @@ provider "aws" {
 provider "aws" {
   alias  = "modernisation-platform"
   region = "eu-west-2"
+  version = ">= 4.0.0, < 5.0.0"
 }

--- a/terraform/environments/core-network-services/versions.tf
+++ b/terraform/environments/core-network-services/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = ">= 3.47.0, < 4.0.0"
+      version = ">= 4.0.0, < 5.0.0"
       source  = "hashicorp/aws"
     }
   }

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -382,11 +382,13 @@ resource "aws_iam_role" "member_delegation_read_only" {
   )
 }
 
+#We need to be able to read across all hosted zones to have this as a generic role
+#tfsec:ignore:aws-iam-no-policy-wildcards
 resource "aws_iam_role_policy" "member_delegation_read_only" {
   name = "MemberDelegationReadOnly"
   role = aws_iam_role.member_delegation_read_only.name
 
-  policy = jsonencode({ #tfsec:ignore:AWS099 - we need to be able to read across all hosted zones to have this as a generic role
+  policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
       {

--- a/terraform/modules/pagerduty-integration/versions.tf
+++ b/terraform/modules/pagerduty-integration/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = ">= 3.47.0, < 4.0.0"
+      version = ">= 3.47.0"
       source  = "hashicorp/aws"
     }
   }

--- a/terraform/modules/vpc-hub/versions.tf
+++ b/terraform/modules/vpc-hub/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = ">= 3.47.0, < 4.0.0"
+      version = ">= 3.47.0"
       source  = "hashicorp/aws"
     }
   }


### PR DESCRIPTION
* Adds a handful of exclusions for wildcards
* Refactors some exclusions
* Adds a public access block to control access to ACM:PCA bucket based on [AWS Guidance](https://aws.amazon.com/about-aws/whats-new/2021/05/aws-certificate-manager-private-certificate-authority-supports-storing-crls-in-private-s3-buckets/)
* Refactors configuration for ACM bucket to be compliant with v4.0 of Terraform AWS Provider
* Sets AWS provider to use only releases in the v4.x train