### PR TITLE
Widen route to PSN on TGW

### DIFF
--- a/terraform/environments/core-network-services/transit_gateway_connections.tf
+++ b/terraform/environments/core-network-services/transit_gateway_connections.tf
@@ -80,7 +80,7 @@ locals {
     "global-protect" = "10.184.0.0/16",
     "azure-nomis"    = "10.101.0.0/16",
     "cloud-platform" = "172.20.0.0/16"
-    "ppud-psn"       = "51.247.2.115/32"
+    "ppud-psn"       = "51.247.0.0/16"
   }
 }
 


### PR DESCRIPTION
This PR widens the range of addresses being routed from the ModPlatform TGW to the PTTP TGW for PSN endpoints