### PR TITLE
Add role for shared services account

### DIFF
--- a/terraform/environments/core-shared-services/iam.tf
+++ b/terraform/environments/core-shared-services/iam.tf
@@ -33,3 +33,58 @@ resource "aws_iam_instance_profile" "image_builder" {
   name = "image-builder"
   role = aws_iam_role.image_builder.name
 }
+
+# Role to allow member developer SSO user to perform required shared services tasks
+resource "aws_iam_role" "member_shared_services" {
+  name = "member-shared-services"
+  assume_role_policy = jsonencode( # checkov:skip=CKV_AWS_60: "the policy is secured with the condition"
+    {
+      "Version" : "2012-10-17",
+      "Statement" : [
+        {
+          "Effect" : "Allow",
+          "Principal" : {
+            "AWS" : "*"
+          },
+          "Action" : "sts:AssumeRole",
+          "Condition" : {
+            "ForAnyValue:StringLike" : {
+              "aws:PrincipalOrgPaths" : ["${data.aws_organizations_organization.root_account.id}/*/${local.environment_management.modernisation_platform_organisation_unit_id}/*"]
+            }
+          }
+        }
+      ]
+  })
+
+  tags = merge(
+    local.tags,
+    {
+      Name = "member-shared-services"
+    },
+  )
+}
+
+#tfsec:ignore:aws-iam-no-policy-wildcards
+resource "aws_iam_role_policy" "member_shared_services" {
+  name = "MemberSharedServices"
+  role = aws_iam_role.member_shared_services.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "imagebuilder:StartImagePipelineExecution",
+          "support:Describe*"
+        ],
+        "Resource" : "*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "member_shared_services_readonly" {
+  role       = aws_iam_role.member_shared_services.name
+  policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+}


### PR DESCRIPTION
This adds a new role to give readonly permissions, EC2 image builder
imaage start permissions and support read only permissions to any users
in accounts in the modernisation platform organisational unit.

This is required to enable members to start and troubleshoot their image
builder pipelines.