### PR TITLE
Remove MP OUs SCP prevent root access policy

### DIFF
--- a/source/team-guide/deleting-an-environment.html.md.erb
+++ b/source/team-guide/deleting-an-environment.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Deleting an environment (AWS account)
-last_reviewed_on: 2021-10-27
-review_in: 3 month
+last_reviewed_on: 2022-02-22
+review_in: 6 month
 ---
 
 # <%= current_page.data.title %>
@@ -23,6 +23,8 @@ Therefore, there are a few things to do to delete an environment, in this order:
 ## Getting the root IAM user's email address
 
 You need the root IAM user's email address to delete the AWS account in the last step, so note it down.
+
+You can get this from the SSO log on page if you have access to the account via SSO, if not it can be found in the Terraform state.
 
 To do this, `cd` into `terraform environments` and find the resource in the state:
 
@@ -235,62 +237,23 @@ If you delete the last environment and there are no more environments for the ap
 
 `modernisation-platform-environments/.github/workflows/<application-name>`
 
+After following the above steps, you need to move the account to the closed accounts OU before deleting the actual AWS account that the environment was linked to.
+
+## Move the account to the closed accounts organizational unit
+
+>Note that a user with root account permissions will need to do this.
+
+Log into the AWS Console and navigate to AWS Oraganizations, find the account and move it to the `Closed accounts` OU.
+
+Now the AWS account can be deleted.
+
 ## Delete the actual AWS account
 
 >This process cannot be undone. Proceed carefully.
 
-After following the above steps, you need to delete the actual AWS account that the environment was linked to.
-
-Before the account can be deleted by the root user, a policy needs to be temporarily detached that is designed to _prevent_ access from the root user.
-
-To do this, complete the following steps, comprising AWS CLI commands.
-> Note, all of the following AWS CLI commands can only be run by a user that has access to the AWS Organizations Management account
-
-- Identify the policy id 
-
-### Member accounts
-```bash
-aws organizations list-policies --filter SERVICE_CONTROL_POLICY --query "Policies[?Name=='Modernisation Platform Member OU SCP - Prevent Root'].[Id,Name]" --output text
-```
-
-### Member unrestricted accounts
-```bash
-aws organizations list-policies --filter SERVICE_CONTROL_POLICY --query "Policies[?Name=='Modernisation Platform Member Unrestricted OU SCP - Prevent Root'].[Id,Name]" --output text
-```
-
-### Core accounts
-```bash
-aws organizations list-policies --filter SERVICE_CONTROL_POLICY --query "Policies[?Name=='Modernisation Platform Core OU SCP - Prevent Root'].[Id,Name]" --output text
-```
-
-- Identify the target id (an OU) associated with the policy, replacing \<policyId\> (starting "p-"), from the command above
-
-```bash
-aws organizations list-targets-for-policy --policy-id <policyId> --query "Targets[*].[Name,TargetId]" --output text
-```
-
-- Detach the policy preventing root access from the Modernisation Platform OU, replacing \<policyId\> with the policy id and \<targetId\> with the target id, both identified above
-
-```bash
-aws organizations detach-policy --policy-id <policyId> --target-id <targetId>
-```
-
-Now the AWS account can be deleted.
 Follow the [AWS documentation on closing an AWS account](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_accounts_close.html). You will need:
 
 - access to the AWS account's root email address (_not_ the AWS Organizations root account)
-
-Finally, re-instate the policy (detached from the Modernisation Platform OU above), attaching it back to the Modernisation Platform OU.
-Run the following command.
-
-```bash
-aws organizations attach-policy --policy-id <policyId> --target-id <targetId>
-```
-
-## Move the account to the closed accounts organizational unit
-
-If the account is the last account for an application, you will need to move the account from the application organizational unit to the "Closed account" organizational unit, so that the application organizational unit can be deleted.
-Note that a user with root account permissions will need to do this.
 
 ## Merge in your file changes
 

--- a/terraform/environments/scp_mp_core.tf
+++ b/terraform/environments/scp_mp_core.tf
@@ -16,33 +16,6 @@ data "aws_iam_policy_document" "scp_mp_core_ou" {
   }
 }
 
-# Separate policy for preventing root access (so it can be detached separately if need be)
-data "aws_iam_policy_document" "scp_mp_core_ou_prevent_root" {
-  version = "2012-10-17"
-
-  statement {
-    effect    = "Deny"
-    actions   = ["*"]
-    resources = ["*"]
-    condition {
-      test     = "ForAnyValue:StringLike"
-      variable = "aws:PrincipalOrgPaths"
-      values   = ["${data.aws_organizations_organization.root_account.id}/*/${local.modernisation_platform_ou_id}/*"]
-    }
-    # For testing this against a specific account, follow this method
-    # condition {
-    #   test     = "ForAnyValue:StringLike"
-    #   variable = "aws:PrincipalOrgPaths"
-    #   values   = ["${data.aws_organizations_organization.root_account.id}/*/${local.modernisation_platform_ou_id}/*/<member ou id>/*"] 
-    # } 
-    condition {
-      test     = "StringLike"
-      variable = "aws:PrincipalArn"
-      values   = ["arn:aws:iam::*:root"]
-    }
-  }
-}
-
 # This policy will only be applied to accounts within the "Modernisation Platform Core" ou
 # The default policy
 resource "aws_organizations_policy" "scp_mp_core_ou" {
@@ -58,29 +31,9 @@ resource "aws_organizations_policy" "scp_mp_core_ou" {
   }
 }
 
-# The policy preventing root access
-resource "aws_organizations_policy" "scp_mp_core_ou_prevent_root" {
-  name        = "Modernisation Platform Core OU SCP - Prevent Root"
-  description = "Prevents root user access for all OUs and accounts under the Modernisation Platform Core OU"
-  type        = "SERVICE_CONTROL_POLICY"
-  content     = data.aws_iam_policy_document.scp_mp_core_ou_prevent_root.json
-
-  tags = {
-    business-unit = "Platforms"
-    component     = "SERVICE_CONTROL_POLICY"
-    source-code   = local.github_repository
-  }
-}
-
 # Enrol all accounts within the Modernisation Platform Core OU (current and future) to the Modernisation Platform Core OU SCP
 # The policy attachment for the default policy
 resource "aws_organizations_policy_attachment" "scp_mp_core_ou" {
   policy_id = aws_organizations_policy.scp_mp_core_ou.id
-  target_id = module.environments.modernisation_platform_core_ou_id
-}
-
-# The policy attachment for the policy preventing root access
-resource "aws_organizations_policy_attachment" "scp_mp_core_ou_prevent_root" {
-  policy_id = aws_organizations_policy.scp_mp_core_ou_prevent_root.id
   target_id = module.environments.modernisation_platform_core_ou_id
 }

--- a/terraform/environments/scp_mp_member.tf
+++ b/terraform/environments/scp_mp_member.tf
@@ -13,33 +13,6 @@ data "aws_iam_policy_document" "scp_mp_member_ou" {
   }
 }
 
-# Separate policy for preventing root access (so it can be detached separately if need be)
-data "aws_iam_policy_document" "scp_mp_member_ou_prevent_root" {
-  version = "2012-10-17"
-
-  statement {
-    effect    = "Deny"
-    actions   = ["*"]
-    resources = ["*"]
-    condition {
-      test     = "ForAnyValue:StringLike"
-      variable = "aws:PrincipalOrgPaths"
-      values   = ["${data.aws_organizations_organization.root_account.id}/*/${local.modernisation_platform_ou_id}/*"]
-    }
-    # For testing this against a specific account, follow this method
-    # condition {
-    #   test     = "ForAnyValue:StringLike"
-    #   variable = "aws:PrincipalOrgPaths"
-    #   values   = ["${data.aws_organizations_organization.root_account.id}/*/${local.modernisation_platform_ou_id}/*/<member ou id>/*"] 
-    # } 
-    condition {
-      test     = "StringLike"
-      variable = "aws:PrincipalArn"
-      values   = ["arn:aws:iam::*:root"]
-    }
-  }
-}
-
 # This policy will only be applied to accounts within the "Modernisation Platform Member" ou
 # The default policy
 resource "aws_organizations_policy" "scp_mp_member_ou" {
@@ -55,30 +28,9 @@ resource "aws_organizations_policy" "scp_mp_member_ou" {
   }
 }
 
-# The policy preventing root access
-resource "aws_organizations_policy" "scp_mp_member_ou_prevent_root" {
-  name        = "Modernisation Platform Member OU SCP - Prevent Root"
-  description = "Prevents root user access for all OUs and accounts under the Modernisation Platform Member OU"
-  type        = "SERVICE_CONTROL_POLICY"
-  content     = data.aws_iam_policy_document.scp_mp_member_ou_prevent_root.json
-
-  tags = {
-    business-unit = "Platforms"
-    component     = "SERVICE_CONTROL_POLICY"
-    source-code   = local.github_repository
-  }
-}
-
-
 # Enrol all accounts within the Modernisation Platform Member OU (current and future) to the Modernisation Platform Member OU SCP
 # The default policy
 resource "aws_organizations_policy_attachment" "scp_mp_member_ou" {
   policy_id = aws_organizations_policy.scp_mp_member_ou.id
-  target_id = module.environments.modernisation_platform_member_ou_id
-}
-
-# The policy preventing root access
-resource "aws_organizations_policy_attachment" "scp_mp_member_ou_prevent_root" {
-  policy_id = aws_organizations_policy.scp_mp_member_ou_prevent_root.id
   target_id = module.environments.modernisation_platform_member_ou_id
 }

--- a/terraform/environments/scp_mp_member_unrestricted.tf
+++ b/terraform/environments/scp_mp_member_unrestricted.tf
@@ -1,5 +1,5 @@
-#  Modernisation Platform Member Unrestriced ou SCP policy
-data "aws_iam_policy_document" "scp_mp_member_unrestriced_ou" {
+#  Modernisation Platform Member Unrestricted ou SCP policy
+data "aws_iam_policy_document" "scp_mp_member_unrestricted_ou" {
   #checkov:skip=CKV_AWS_1:Policy applied to a limited number of accounts
   #checkov:skip=CKV_AWS_49:Policy applied to a limited number of accounts
   #checkov:skip=CKV_AWS_107:Policy applied to a limited number of accounts
@@ -16,40 +16,13 @@ data "aws_iam_policy_document" "scp_mp_member_unrestriced_ou" {
   }
 }
 
-# Separate policy for preventing root access (so it can be detached separately if need be)
-data "aws_iam_policy_document" "scp_mp_member_unrestricted_ou_prevent_root" {
-  version = "2012-10-17"
-
-  statement {
-    effect    = "Deny"
-    actions   = ["*"]
-    resources = ["*"]
-    condition {
-      test     = "ForAnyValue:StringLike"
-      variable = "aws:PrincipalOrgPaths"
-      values   = ["${data.aws_organizations_organization.root_account.id}/*/${local.modernisation_platform_ou_id}/*"]
-    }
-    # For testing this against a specific account, follow this method
-    # condition {
-    #   test     = "ForAnyValue:StringLike"
-    #   variable = "aws:PrincipalOrgPaths"
-    #   values   = ["${data.aws_organizations_organization.root_account.id}/*/${local.modernisation_platform_ou_id}/*/<member ou id>/*"] 
-    # } 
-    condition {
-      test     = "StringLike"
-      variable = "aws:PrincipalArn"
-      values   = ["arn:aws:iam::*:root"]
-    }
-  }
-}
-
-# This policy will only be applied to accounts withing the "Modernisation Platform Member Unrestriced" ou
+# This policy will only be applied to accounts withing the "Modernisation Platform Member Unrestricted" ou
 # The default policy
-resource "aws_organizations_policy" "scp_mp_member_unrestriced_ou" {
-  name        = "Modernisation Platform Member Unrestriced OU SCP"
-  description = "Restricts permissions for all OUs and accounts under the Modernisation Platform Member Unrestriced OU"
+resource "aws_organizations_policy" "scp_mp_member_unrestricted_ou" {
+  name        = "Modernisation Platform Member unrestricted OU SCP"
+  description = "Restricts permissions for all OUs and accounts under the Modernisation Platform Member unrestricted OU"
   type        = "SERVICE_CONTROL_POLICY"
-  content     = data.aws_iam_policy_document.scp_mp_member_unrestriced_ou.json
+  content     = data.aws_iam_policy_document.scp_mp_member_unrestricted_ou.json
 
   tags = {
     business-unit = "Platforms"
@@ -58,30 +31,9 @@ resource "aws_organizations_policy" "scp_mp_member_unrestriced_ou" {
   }
 }
 
-# The policy preventing root access
-resource "aws_organizations_policy" "scp_mp_member_unrestricted_ou_prevent_root" {
-  name        = "Modernisation Platform Member Unrestricted OU SCP - Prevent Root"
-  description = "Prevents root user access for all OUs and accounts under the Modernisation Platform Unrestricted OU"
-  type        = "SERVICE_CONTROL_POLICY"
-  content     = data.aws_iam_policy_document.scp_mp_member_unrestricted_ou_prevent_root.json
-
-  tags = {
-    business-unit = "Platforms"
-    component     = "SERVICE_CONTROL_POLICY"
-    source-code   = local.github_repository
-  }
-}
-
-# Enrol all accounts within the Modernisation Platform Member Unrestriced OU (current and future) to the Modernisation Platform Member Unrestriced OU SCP
+# Enrol all accounts within the Modernisation Platform Member unrestricted OU (current and future) to the Modernisation Platform Member unrestricted OU SCP
 # The policy attachment for the default policy
-resource "aws_organizations_policy_attachment" "scp_mp_member_unrestriced_ou" {
-  policy_id = aws_organizations_policy.scp_mp_member_unrestriced_ou.id
-  target_id = module.environments.modernisation_platform_member_unrestricted_ou_id
-}
-
-# Enrol all accounts within the Modernisation Platform Member Unrestricted OU (current and future) to the Modernisation Platform Member Unrestricted OU SCP
-# The policy attachment for the policy preventing root access
-resource "aws_organizations_policy_attachment" "scp_mp_member_unrestricted_ou_prevent_root" {
-  policy_id = aws_organizations_policy.scp_mp_member_unrestricted_ou_prevent_root.id
+resource "aws_organizations_policy_attachment" "scp_mp_member_unrestricted_ou" {
+  policy_id = aws_organizations_policy.scp_mp_member_unrestricted_ou.id
   target_id = module.environments.modernisation_platform_member_unrestricted_ou_id
 }


### PR DESCRIPTION
This is now implemented at the P&A level so inherited from therefore no
longer required at this level. Updating the userguidance as well to
reflect this.

(also fixed a typo)

Closes #1324