### PR TITLE
Add RDP permissions to security audit role

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -203,7 +203,8 @@ module "collaborator_security_audit_role" {
   role_requires_mfa = true
 
   custom_role_policy_arns = [
-    "arn:aws:iam::aws:policy/SecurityAudit"
+    "arn:aws:iam::aws:policy/SecurityAudit",
+    "arn:aws:iam::674345106521:policy/ithc_rdp"
   ]
 
   # Allow created users to assume these roles


### PR DESCRIPTION
This is a temporary solution to get Xhibit Portal ITHC ready for Monday.