### PR TITLE
added stub github usernames where not supplied

### DIFF
--- a/collaborators.json
+++ b/collaborators.json
@@ -20,7 +20,7 @@
     },
     {
       "username": "lewis.smith",
-      "github-username": "",
+      "github-username": "#no-username-supplied",
       "accounts": [
         {
           "account-name": "xhibit-portal-development",
@@ -54,7 +54,7 @@
     },
     {
       "username": "thomas.boyle",
-      "github-username": "",
+      "github-username": "#no-username-supplied",
       "accounts": [
         {
           "account-name": "xhibit-portal-development",
@@ -88,7 +88,7 @@
     },
     {
       "username": "thomas.marshall",
-      "github-username": "",
+      "github-username": "#no-username-supplied",
       "accounts": [
         {
           "account-name": "xhibit-portal-development",


### PR DESCRIPTION
This temporarily fixes an issue with the OPA tests for collaborators.json
When a field is picked up as empty, the field fails a test condition. However, we don't always know if we will be supplied with a github username. As a temporary measure I've added comments into these fields