### PR TITLE
Add rule to allow outbound traffic to 1521 ALZ

### DIFF
--- a/collaborators.json
+++ b/collaborators.json
@@ -122,7 +122,7 @@
     },
     {
       "username": "matthew.smith",
-      "github-username": "",
+      "github-username": "#no-username-supplied",
       "accounts": [
         {
           "account-name": "xhibit-portal-development",

--- a/environments-networks/hmpps-test.json
+++ b/environments-networks/hmpps-test.json
@@ -105,6 +105,17 @@
     },
     {
       "subnet_set": "general",
+      "egress": true,
+      "subnet_type": "data",
+      "protocol": "tcp",
+      "rule_action": "allow",
+      "rule_number": 241,
+      "cidr_block": "10.101.0.0/16",
+      "from_port": "1521",
+      "to_port": "1521"
+    },
+    {
+      "subnet_set": "general",
       "egress": false,
       "subnet_type": "data",
       "protocol": "tcp",


### PR DESCRIPTION
This will allow the hmpps-test general data subnet to make a connection
to the FixNGo estate via the Azure landing zone on port 1521.

(Added missing username to fix the failing test)