### PR TITLE
Remove automation for terraform in unrestricted accounts

### DIFF
--- a/scripts/git-create-environments.sh
+++ b/scripts/git-create-environments.sh
@@ -101,9 +101,9 @@ main() {
       echo
       environment="${application}-${env}"
       echo "Processing environment: ${environment}"
-      # Check if not core repo
+      # Check it's a member environment
       account_type=$(jq -r '."account-type"' ${json_file})
-      if [ "${account_type}" != "core" ]
+      if [ "${account_type}" = "member" ]
       then
         # Get environment github team slugs
         teams=$(jq -r --arg e "${env}" '.environments[] | select( .name == $e ) | .access[].github_slug' $json_file)

--- a/scripts/provision-member-directories.sh
+++ b/scripts/provision-member-directories.sh
@@ -42,11 +42,11 @@ provision_environment_directories() {
     echo "This is the directory: $directory"
     account_type=$(jq -r '."account-type"' ${environment_json_dir}/${application_name}.json)
 
-    if [ -d $directory ] || [ "$account_type" = "core" ]; then
+    if [ -d $directory ] || [ "$account_type" != "member" ]; then
 
       # Do nothing if a directory already exists
       echo ""
-      echo "Ignoring $directory, it already exists or is a core account"
+      echo "Ignoring $directory, it already exists or is a core account or unrestricted account"
       echo ""
     else
       # Create the directory and copy files if it doesn't exist
@@ -146,7 +146,7 @@ EOL
     account_type=$(jq -r '."account-type"' ${environment_json_dir}/${application_name}.json)
     github_slugs=$(jq -r '.environments[].access[].github_slug' ${environment_json_dir}/${application_name}.json | uniq)
     
-    if [ "$account_type" != "core" ]; then
+    if [ "$account_type" = "member" ]; then
       for slug in $github_slugs; do
         echo "Adding $directory @$slug @modernisation-platform to codeowners"
         echo "$directory @$slug @modernisation-platform" >> $codeowners_file

--- a/scripts/provision-terraform-workspaces.sh
+++ b/scripts/provision-terraform-workspaces.sh
@@ -115,13 +115,13 @@ do
     fi
 
     ACCOUNT_TYPE=$(jq -r '."account-type"' ${JSON_FILE})
-    if [[ "${RETURN_CODE_MEMBER_REPO}" -ne 0 && "${ACCOUNT_TYPE}" != "core" ]]
+    if [[ "${RETURN_CODE_MEMBER_REPO}" -ne 0 && "${ACCOUNT_TYPE}" == "member" ]]
     then
       echo -en "MEMBER ACCOUNT IN ENVIRONMENTS REPO - ${APPLICATION}-${ENV} - ${YELLOW}CREATING${NORMAL}\n"
       terraform -chdir="${TERRAFORM_PATH}" init > /dev/null
       terraform -chdir="${TERRAFORM_PATH}" workspace new "${APPLICATION}-${ENV}"
     else
-      [[ ${ACCOUNT_TYPE} != "core" ]] && RESPONSE_TEXT="EXISTS" || RESPONSE_TEXT="CORE ACCOUNT - NOT REQUIRED IN MEMBER REPO"
+      [[ ${ACCOUNT_TYPE} == "member" ]] && RESPONSE_TEXT="EXISTS" || RESPONSE_TEXT="CORE ACCOUNT - NOT REQUIRED IN MEMBER REPO"
       echo -en "MEMBER ACCOUNT IN ENVIRONMENTS REPO - ${APPLICATION}-${ENV} - ${GREEN}${RESPONSE_TEXT}${NORMAL}\n"
     fi
   done


### PR DESCRIPTION
We initially set up the modernisation-platform-environments repo to
include automation for generating terraform for the unrestricted member
accounts. However as time goes on and we are applying updates to code,
we are finding that no one is using this code, and also as they have
full access to the accounts, they are able to do things that break the
infrastructure that we're trying to automate.

Therefore we have decided to remove all member automation for the
unrestricted accounts, these will be soley managed out side of the
platform.  Our efforts will be focused on moving these to member
accounts if that is sensible rather than trying to do a hybrid approach.