### PR TITLE
Fix template to work with networking

### DIFF
--- a/terraform/environments/equip/data.tf
+++ b/terraform/environments/equip/data.tf
@@ -1,3 +1,5 @@
+data "aws_region" "current" {}
+
 data "aws_vpc" "shared" {
   tags = {
     "Name" = "${var.networking[0].business-unit}-${local.environment}"
@@ -17,42 +19,42 @@ data "aws_subnets" "shared-data" {
 data "aws_subnet" "private_subnets_a" {
   vpc_id = data.aws_vpc.shared.id
   tags = {
-    "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-private-${local.app_data.accounts[local.environment].region}a"
+    "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-private-${data.aws_region.current.name}a"
   }
 }
 
 data "aws_subnet" "private_subnets_b" {
   vpc_id = data.aws_vpc.shared.id
   tags = {
-    "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-private-${local.app_data.accounts[local.environment].region}b"
+    "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-private-${data.aws_region.current.name}b"
   }
 }
 
 data "aws_subnet" "private_subnets_c" {
   vpc_id = data.aws_vpc.shared.id
   tags = {
-    "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-private-${local.app_data.accounts[local.environment].region}c"
+    "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-private-${data.aws_region.current.name}c"
   }
 }
 
 data "aws_subnet" "public_az_a" {
   vpc_id = data.aws_vpc.shared.id
   tags = {
-    Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-public-${local.app_data.accounts[local.environment].region}a"
+    Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-public-${data.aws_region.current.name}a"
   }
 }
 
 data "aws_subnet" "public_az_b" {
   vpc_id = data.aws_vpc.shared.id
   tags = {
-    Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-public-${local.app_data.accounts[local.environment].region}b"
+    Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-public-${data.aws_region.current.name}b"
   }
 }
 
 data "aws_subnet" "public_az_c" {
   vpc_id = data.aws_vpc.shared.id
   tags = {
-    Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-public-${local.app_data.accounts[local.environment].region}c"
+    Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-public-${data.aws_region.current.name}c"
   }
 }
 

--- a/terraform/environments/equip/locals.tf
+++ b/terraform/environments/equip/locals.tf
@@ -41,19 +41,4 @@ locals {
   # example usage:  
   # example_data = local.application_data.accounts[local.environment].example_var
   application_data = fileexists("./application_variables.json") ? jsondecode(file("./application_variables.json")) : {}
-
-  domain_types = { for dvo in aws_acm_certificate.external.domain_validation_options : dvo.domain_name => {
-    name   = dvo.resource_record_name
-    record = dvo.resource_record_value
-    type   = dvo.resource_record_type
-    }
-  }
-
-  domain_name_main   = [for k, v in local.domain_types : v.name if k == "modernisation-platform.service.justice.gov.uk"]
-  domain_name_sub    = [for k, v in local.domain_types : v.name if k != "modernisation-platform.service.justice.gov.uk"]
-  domain_record_main = [for k, v in local.domain_types : v.record if k == "modernisation-platform.service.justice.gov.uk"]
-  domain_record_sub  = [for k, v in local.domain_types : v.record if k != "modernisation-platform.service.justice.gov.uk"]
-  domain_type_main   = [for k, v in local.domain_types : v.type if k == "modernisation-platform.service.justice.gov.uk"]
-  domain_type_sub    = [for k, v in local.domain_types : v.type if k != "modernisation-platform.service.justice.gov.uk"]
 }
-  

--- a/terraform/templates/data.tf
+++ b/terraform/templates/data.tf
@@ -1,99 +1,103 @@
-data "aws_vpc" "shared" {
-  tags = {
-    "Name" = "${var.networking[0].business-unit}-${local.environment}"
-  }
-}
+# These data sources can be uncommented once initial networking account set up is complete
 
-data "aws_subnets" "shared-data" {
-  filter {
-    name   = "vpc-id"
-    values = [data.aws_vpc.shared.id]
-  }
-  tags = {
-    Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-data*"
-  }
-}
+# data "aws_region" "current" {}
 
-data "aws_subnet" "private_subnets_a" {
-  vpc_id = data.aws_vpc.shared.id
-  tags = {
-    "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-private-${local.app_data.accounts[local.environment].region}a"
-  }
-}
+# data "aws_vpc" "shared" {
+#   tags = {
+#     "Name" = "${var.networking[0].business-unit}-${local.environment}"
+#   }
+# }
 
-data "aws_subnet" "private_subnets_b" {
-  vpc_id = data.aws_vpc.shared.id
-  tags = {
-    "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-private-${local.app_data.accounts[local.environment].region}b"
-  }
-}
+# data "aws_subnets" "shared-data" {
+#   filter {
+#     name   = "vpc-id"
+#     values = [data.aws_vpc.shared.id]
+#   }
+#   tags = {
+#     Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-data*"
+#   }
+# }
 
-data "aws_subnet" "private_subnets_c" {
-  vpc_id = data.aws_vpc.shared.id
-  tags = {
-    "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-private-${local.app_data.accounts[local.environment].region}c"
-  }
-}
+# data "aws_subnet" "private_subnets_a" {
+#   vpc_id = data.aws_vpc.shared.id
+#   tags = {
+#     "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-private-${data.aws_region.current.name}a"
+#   }
+# }
 
-data "aws_subnet" "public_az_a" {
-  vpc_id = data.aws_vpc.shared.id
-  tags = {
-    Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-public-${local.app_data.accounts[local.environment].region}a"
-  }
-}
+# data "aws_subnet" "private_subnets_b" {
+#   vpc_id = data.aws_vpc.shared.id
+#   tags = {
+#     "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-private-${data.aws_region.current.name}b"
+#   }
+# }
 
-data "aws_subnet" "public_az_b" {
-  vpc_id = data.aws_vpc.shared.id
-  tags = {
-    Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-public-${local.app_data.accounts[local.environment].region}b"
-  }
-}
+# data "aws_subnet" "private_subnets_c" {
+#   vpc_id = data.aws_vpc.shared.id
+#   tags = {
+#     "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-private-${data.aws_region.current.name}c"
+#   }
+# }
 
-data "aws_subnet" "public_az_c" {
-  vpc_id = data.aws_vpc.shared.id
-  tags = {
-    Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-public-${local.app_data.accounts[local.environment].region}c"
-  }
-}
+# data "aws_subnet" "public_az_a" {
+#   vpc_id = data.aws_vpc.shared.id
+#   tags = {
+#     Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-public-${data.aws_region.current.name}a"
+#   }
+# }
 
-data "aws_route53_zone" "external" {
-  provider = aws.core-vpc
+# data "aws_subnet" "public_az_b" {
+#   vpc_id = data.aws_vpc.shared.id
+#   tags = {
+#     Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-public-${data.aws_region.current.name}b"
+#   }
+# }
 
-  name         = "${var.networking[0].business-unit}-${local.environment}.modernisation-platform.service.justice.gov.uk."
-  private_zone = false
-}
+# data "aws_subnet" "public_az_c" {
+#   vpc_id = data.aws_vpc.shared.id
+#   tags = {
+#     Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-public-${data.aws_region.current.name}c"
+#   }
+# }
 
-data "aws_route53_zone" "inner" {
-  provider = aws.core-vpc
+# data "aws_route53_zone" "external" {
+#   provider = aws.core-vpc
 
-  name         = "${var.networking[0].business-unit}-${local.environment}.modernisation-platform.internal."
-  private_zone = true
-}
+#   name         = "${var.networking[0].business-unit}-${local.environment}.modernisation-platform.service.justice.gov.uk."
+#   private_zone = false
+# }
 
-data "aws_route53_zone" "network-services" {
-  provider = aws.core-network-services
+# data "aws_route53_zone" "inner" {
+#   provider = aws.core-vpc
 
-  name         = "modernisation-platform.service.justice.gov.uk."
-  private_zone = false
-}
+#   name         = "${var.networking[0].business-unit}-${local.environment}.modernisation-platform.internal."
+#   private_zone = true
+# }
 
-data "aws_subnets" "shared-public" {
-  filter {
-    name   = "vpc-id"
-    values = [data.aws_vpc.shared.id]
-  }
-  tags = {
-    Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-public*"
-  }
-}
+# data "aws_route53_zone" "network-services" {
+#   provider = aws.core-network-services
 
-data "terraform_remote_state" "core_network_services" {
-  backend = "s3"
-  config = {
-    acl     = "bucket-owner-full-control"
-    bucket  = "modernisation-platform-terraform-state"
-    key     = "environments/accounts/core-network-services/core-network-services-production/terraform.tfstate"
-    region  = "eu-west-2"
-    encrypt = "true"
-  }
-}
+#   name         = "modernisation-platform.service.justice.gov.uk."
+#   private_zone = false
+# }
+
+# data "aws_subnets" "shared-public" {
+#   filter {
+#     name   = "vpc-id"
+#     values = [data.aws_vpc.shared.id]
+#   }
+#   tags = {
+#     Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-public*"
+#   }
+# }
+
+# data "terraform_remote_state" "core_network_services" {
+#   backend = "s3"
+#   config = {
+#     acl     = "bucket-owner-full-control"
+#     bucket  = "modernisation-platform-terraform-state"
+#     key     = "environments/accounts/core-network-services/core-network-services-production/terraform.tfstate"
+#     region  = "eu-west-2"
+#     encrypt = "true"
+#   }
+# }

--- a/terraform/templates/locals.tf
+++ b/terraform/templates/locals.tf
@@ -41,19 +41,4 @@ locals {
   # example usage:  
   # example_data = local.application_data.accounts[local.environment].example_var
   application_data = fileexists("./application_variables.json") ? jsondecode(file("./application_variables.json")) : {}
-
-  domain_types = { for dvo in aws_acm_certificate.external.domain_validation_options : dvo.domain_name => {
-    name   = dvo.resource_record_name
-    record = dvo.resource_record_value
-    type   = dvo.resource_record_type
-    }
-  }
-
-  domain_name_main   = [for k, v in local.domain_types : v.name if k == "modernisation-platform.service.justice.gov.uk"]
-  domain_name_sub    = [for k, v in local.domain_types : v.name if k != "modernisation-platform.service.justice.gov.uk"]
-  domain_record_main = [for k, v in local.domain_types : v.record if k == "modernisation-platform.service.justice.gov.uk"]
-  domain_record_sub  = [for k, v in local.domain_types : v.record if k != "modernisation-platform.service.justice.gov.uk"]
-  domain_type_main   = [for k, v in local.domain_types : v.type if k == "modernisation-platform.service.justice.gov.uk"]
-  domain_type_sub    = [for k, v in local.domain_types : v.type if k != "modernisation-platform.service.justice.gov.uk"]
 }
-  


### PR DESCRIPTION
On new account creation of Equip discovered that the data sources won't
work until the networking ram share step has been run, but this can run
with the data sources uncommented so fails.  Commenting out the
data sources, these can be uncommented as needed by application teams.

Also removed the DNS configuration, this depends on a resource which
doesn't exist yet.  I've opened a new issue to look into how we make DNS
easier for users (#1544)