### PR TITLE
Allow outgoing traffic on 443

### DIFF
--- a/terraform/modules/vpc-hub/main.tf
+++ b/terraform/modules/vpc-hub/main.tf
@@ -70,14 +70,16 @@ locals {
     for rule in local.nacl_rules : join("-", values(rule)) => rule
   }
 
-  # Private NACLs. Do not allow communicating with public internet addresses.
+  # Private NACLs. Do not allow communicating with public internet addresses except for outgoing https.
   private_nacl_rules = [
     { egress = false, action = "allow", protocol = -1, from_port = 0, to_port = 0, rule_num = 510, cidr = "10.0.0.0/8" },
     { egress = false, action = "allow", protocol = -1, from_port = 0, to_port = 0, rule_num = 520, cidr = "172.16.0.0/12" },
     { egress = false, action = "allow", protocol = -1, from_port = 0, to_port = 0, rule_num = 530, cidr = "192.168.0.0/16" },
-    { egress = true, action = "allow", protocol = -1, from_port = 0, to_port = 0, rule_num = 540, cidr = "10.0.0.0/8" },
-    { egress = true, action = "allow", protocol = -1, from_port = 0, to_port = 0, rule_num = 550, cidr = "172.16.0.0/12" },
-    { egress = true, action = "allow", protocol = -1, from_port = 0, to_port = 0, rule_num = 560, cidr = "192.168.0.0/16" }
+    { egress = true, action = "allow", protocol = -1, from_port = 0, to_port = 0, rule_num = 510, cidr = "10.0.0.0/8" },
+    { egress = true, action = "allow", protocol = -1, from_port = 0, to_port = 0, rule_num = 520, cidr = "172.16.0.0/12" },
+    { egress = true, action = "allow", protocol = -1, from_port = 0, to_port = 0, rule_num = 530, cidr = "192.168.0.0/16" },
+    { egress = false, action = "allow", protocol = 6, from_port = 1024, to_port = 65535, rule_num = 910, cidr = "0.0.0.0/0" },
+    { egress = true, action = "allow", protocol = 6, from_port = 443, to_port = 443, rule_num = 910, cidr = "0.0.0.0/0" }
   ]
 
   # Private NACL rules with keys
@@ -325,6 +327,7 @@ resource "aws_network_acl" "private" {
 }
 
 # Private NACLs rules
+#tfsec:ignore:aws-vpc-no-public-ingress-acl
 resource "aws_network_acl_rule" "private" {
   for_each = local.private_nacl_rules_expanded
 
@@ -415,6 +418,7 @@ resource "aws_network_acl" "data" {
 }
 
 # Data NACLs rules
+#tfsec:ignore:aws-vpc-no-public-ingress-acl
 resource "aws_network_acl_rule" "data" {
   for_each = local.private_nacl_rules_expanded
 


### PR DESCRIPTION
The restriction of all traffic to and from 0.0.0.0/0 caused the
core-shared-services calls to S3 Gateway endpoints to fail.  This is
because S3 Gateway endpoints use public IPs (even though the traffic is
routed privately
https://docs.aws.amazon.com/AmazonS3/latest/userguide/privatelink-interface-endpoints.html)
This change adds in rules to allow outgoing traffic to port 443, and
incoming traffic from S3 (on ephemeral ports
https://aws.amazon.com/premiumsupport/knowledge-center/connect-s3-vpc-endpoint/#Network_ACL_rules)