### PR TITLE
Trigger core-shared-services workflow on new account

### DIFF
--- a/.github/workflows/core-shared-services-deployment.yml
+++ b/.github/workflows/core-shared-services-deployment.yml
@@ -16,6 +16,10 @@ on:
       - 'terraform/environments/core-shared-services/**'
       - 'terraform/modules/vpc-hub/**'
       - '.github/workflows/core-shared-services-deployment.yml'
+  workflow_run:
+    workflows: ["Terraform: New environment"]
+    types: [completed]
+    branches: [main]
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
The core shared services account creates a key per business unit which
is shared to the accounts for that business unit. The TF pulls these
accounts from the environments secret, but this only happens when the TF
is run. This will ensure when new accounts are added to the
modernisation platform, the core-shared-services workflow runs again
getting the latest account numbers.

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run