### PR TITLE
Add automation to generate dependabot file

### DIFF
--- a/.github/workflows/generate-dependabot-file.yml
+++ b/.github/workflows/generate-dependabot-file.yml
@@ -1,0 +1,38 @@
+name: Generate dependabot file 
+
+on:
+  schedule:
+    - cron: "40 22 * * 6"
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/generate-dependabot-file.yml'
+      - 'scripts/generate-dependabot-file.sh'
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  create-and-commit-dependabot-file:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Generate file
+        run: bash ./scripts/generate-dependabot-file.sh
+      - name: Commit changes to GitHub
+        run: bash ./scripts/git-setup.sh
+      - run: bash ./scripts/git-commit.sh .github
+      - run: bash ./scripts/git-pull-request.sh dependabot
+        env:
+          SECRET: ${{ secrets.GITHUB_TOKEN }}
+      - uses: 8398a7/action-slack@v3
+        name: Slack failure notification
+        with:
+          status: ${{ job.status }}
+          fields: workflow,job,repo,commit,message
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: ${{ failure() }}

--- a/scripts/generate-dependabot-file.sh
+++ b/scripts/generate-dependabot-file.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -euo pipefail
+
+dependabot_file=.github/dependabot.yml
+
+# Get a list of Terraform folders
+all_tf_folders=`find . -type f -name '*.tf' | sed 's#/[^/]*$##' | sed 's/.\///'| sort | uniq`
+echo
+echo "All TF folders"
+echo $all_tf_folders
+
+echo "Writing dependabot.yml file"
+# Creates a dependabot file to avoid having to manually add each new TF folder
+# Add any additional fixed entries in this top section
+  cat > $dependabot_file << EOL
+# This file is auto-generated here, do not manually amend. 
+# https://github.com/ministryofjustice/modernisation-platform/blob/main/scripts/generate-dependabot.sh
+
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  # Dependabot doesn't currently support wildcard or multiple directory declarations within
+  # a dependabot configuration, so we need to add all directories individually
+  # See: github.com/dependabot/dependabot-core/issues/2178
+EOL
+
+for folder in $all_tf_folders
+do
+echo "Generating entry for ${folder}"
+echo "- package-ecosystem: \"terraform\"" >> $dependabot_file
+echo "  directory: \"/${folder}\"" >> $dependabot_file
+echo "  schedule:" >> $dependabot_file
+echo "    interval: \"daily\"" >> $dependabot_file
+done


### PR DESCRIPTION
Currently everytime we add a new terraform folder, we have to manually
add the dependabot entry (which we mostly forget to do).  This action
and script will update the dependabot file weekly, to ensure it is up-to-date.