### PR TITLE
Add permissions to token

### DIFF
--- a/.github/workflows/add-issues-to-project.yml
+++ b/.github/workflows/add-issues-to-project.yml
@@ -5,6 +5,7 @@ on:
       - opened
 jobs:
   track_issue:
+    permissions: read-all|write-all
     runs-on: ubuntu-latest
     steps:
       - name: Get project data


### PR DESCRIPTION
The standard token doesn't have enough permissions to run the action,
attempting to see if it works when adding additional permissions.