### PR TITLE
Add backup information

### DIFF
--- a/source/disaster-recovery/backups.html.md.erb
+++ b/source/disaster-recovery/backups.html.md.erb
@@ -1,0 +1,33 @@
+---
+title: Backups
+last_reviewed_on: 2022-03-24
+review_in: 6 months
+---
+
+# <%= current_page.data.title %>
+
+We use [AWS Backup](https://aws.amazon.com/backup/) to automatically back up production resources accross all the Modernisation Platform environments.
+
+## What is backed up?
+
+Resource | Type of backup
+---|---|
+EC2 Instance | AMI
+EBS Volume | Snapshot
+RDS Instance | Snapshot
+
+Any of the above resources which are have the tag - `is-production = true` will be backed up.
+
+## Backup Schedule
+
+Backups are taken daily at 00:30.
+
+## Retention period
+
+Backups are retained for 4 months.  After one month they will be transferred to cold storage.
+
+## How to find your backups
+
+You can view your backups my navigating to AWS Backup in the AWS console and clicking "Backup vaults".
+
+You can also view backups via the normal methods for viewing snapshots and AMIs (eg. EC2, Elastic Block Store, Snapshots)

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -29,12 +29,13 @@ This documentation is for anyone interested in the Modernisation Platform and it
 - [Creating resources](user-guide/creating-resources.html)
 - [Deploying your infrastructure](user-guide/deploying-your-infrastructure.html)
 - [Deploying your application](user-guide/deploying-your-application.html)
-- [Running Terraform plan locally](user-guide/running-terraform-plan-locally.html)
-- [Accessing EC2s](user-guide/accessing-ec2s.html)
 - [Standard environment diagram](user-guide/environment-diagram.html)
-- [Wider MoJ Connectivity](user-guide/wider-moj-connectivity.html)
 - [Working as a Collaborator](user-guide/working-as-a-collaborator.html)
 
+### How to guides
+- [Running Terraform plan locally](user-guide/running-terraform-plan-locally.html)
+- [Accessing EC2s](user-guide/accessing-ec2s.html)
+- [Wider MoJ Connectivity](user-guide/wider-moj-connectivity.html)
 
 ## Concepts
 
@@ -56,6 +57,9 @@ This documentation is for anyone interested in the Modernisation Platform and it
 - [Repositories](concepts/sdlc/repositories.html)
 - [Core Workflow (CI/CD)](concepts/sdlc/core-workflow.html)
 - [User Workflow (CI/CD)](concepts/sdlc/user-workflow.html)
+
+## Disaster Recovery
+- [Backups](disaster-recovery/backups.html)
 
 ## Modernisation Platform Team information
 - [Our alliance](team/alliance.html)


### PR DESCRIPTION
Added a new disaster recovery section and information about the backups
that we take.  We can also add runbooks and other DR information here.

Added a new section for how to guides, the getting started section was
getting crowded with things that not all users needed.  By splitting
this out we can have a more details list of guides explaining how to do
different things and keep the getting started for the basics.