### PR TITLE
added extra permission require for resolver deletion

### DIFF
--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -313,6 +313,7 @@ resource "aws_iam_role_policy" "member-delegation" {
           "ec2:DescribeVpcs",
           "ec2:CreateNetworkInterface",
           "ec2:DescribeNetworkInterfaces",
+          "ec2:DeleteNetworkInterface",
           "ec2:CreateNetworkInterfacePermission",
           "ec2:DescribeSecurityGroupReferences",
           "ec2:DescribeSecurityGroups",


### PR DESCRIPTION
In line with https://aws.amazon.com/premiumsupport/knowledge-center/route-53-resolve-action-needed-status/, adds the ability to remove the EC2 Network Interface created as part of the resolver endpoint process