### PR TITLE
Add disaster recovery + incident management runbooks

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -68,6 +68,8 @@ This documentation is for anyone interested in the Modernisation Platform and it
 
 ## Runbooks
 - [Main Platform Runbook](runbooks/runbook.html)
+- [Disaster recovery](runbooks/disaster-recovery.html)
+- [How to deal with an incident](runbooks/general-incident.html)
 - [Joining the team](runbooks/joining-the-team.html)
 - [Terraform](runbooks/terraform.html)
 - [Useful scripts](runbooks/useful-scripts.html)
@@ -80,7 +82,6 @@ This documentation is for anyone interested in the Modernisation Platform and it
 - [Adding wider connectivity](runbooks/adding-wider-connectivity.html)
 - [Removing a team member from the Modernisation Platform](runbooks/removing-a-team-member.html)
 - [Querying VPC flow logs](team-guide/querying-vpc-flow-logs.html)
-- [Disaster recovery](runbooks/disaster-recovery.html)
 
 ## Getting help
 - [Ask for help](getting-help)

--- a/source/runbooks/disaster-recovery.html.md.erb
+++ b/source/runbooks/disaster-recovery.html.md.erb
@@ -1,0 +1,60 @@
+---
+title: Disaster Recovery
+last_reviewed_on: 2022-03-31
+review_in: 6 months
+---
+
+# <%= current_page.data.title %>
+
+The purpose of this section of the guide is to clarify what the Modernisation Platform offers in terms of disaster recovery, the processes to initiate different types of recovery, and roles and responsibilities of the Modernisation Platform and Service Teams.
+
+## What does the Modernisation Platform offer in terms of Disaster Recovery?
+
+Modernisation Platform is provided to Service Teams as a managed service. To ensure business continuity, Modernisation Platform has a disaster recovery plan that facilitates quick recovery. Recovery plans have been tested and documented in the [runbooks](../index.html#runbooks) for the following scenarios:
+
+* Complete loss of the platform
+* Loss of an AWS account
+* Loss of networking
+
+Other failures which will not affect the availability of an application, but will impact a teams ability to deploy.
+
+* Loss of Terraform state
+* Loss of access
+* Loss of Github Actions
+* Loss of Github
+
+In the case of all of the above the Modernisation Platform Team is responsible for recovery or raising incidents 
+
+*However, in the event of the loss of the platform or AWS account we may require Service Teams to redeploy their services. This includes redeploying applications, restoring from backups, and any further manual steps required.*  
+
+The Modernisation Platform Team is continually reviewing and identifying risks to our users and the platform. As each threat is identified we are testing and creating recovery plans.
+
+## What isn't covered by the Modernisation Platform?
+
+* Loss or fault of infrastructure created in the member account that is not provided by the Modernisation Platform (anything other than the account baselines and SSO)
+* Restoration of member infrastructure backups.
+* Non production backups, or backups outside of the Modernisation Platform [backup coverage](../concepts/environments/backups.html).
+* Redeployment of applications - The Modernisation Platform doesn't manage member application deployment pipelines. If there is a need to deploy a service as part of any restoration you will be asked to do so by the Modernisation Platform Team.
+* Only retain AWS RDS Snapshots for as long as they are required. Please clean-up any snapshots regularly.
+* 3rd party managed services (e.g. Github, CircleCI, Sentry.io) - These 3rd party managed services will offer some form of back-up and recovery as part of their managed service, however these processes are out of the scope of recovery by the Modernisation Platform. If you need more information please contact [#ask-operations-engineering](https://mojdt.slack.com/archives/C01BUKJSZD4). 
+* Ensure your `owner` tag is kept up to date so that the Modernisation Platform Team knows how best to contact your team.
+* Ensure you team is added to the [#modernisation-platform-update](https://mojdt.slack.com/archives/C02L5MCJ12N) slack channel so that you can ensure you receive important messages from the Modernisation Platform Team.
+
+## Backups and restores
+
+Backup information can be found on our [backup page](../concepts/environments/backups.html).
+Restores to backed up snapshots are the responsibility of the application teams.
+
+## How will we know if there is a Disaster in progress?
+
+If there is a wider issues with the platform we will notify all users via [#modernisation-platform-update](https://mojdt.slack.com/archives/C02L5MCJ12N) channel in line with our operational processes. You should check [#modernisation-platform-update](https://mojdt.slack.com/archives/C02L5MCJ12N) for periodic status updates.
+
+If we identify a specific issue relating to a single service we will contact the team via the `owner` tag detailed in your application tags.
+
+## How do I access these services if we have a problem or if we have any questions?
+
+Please contact us over at [#ask-modernisation-platform](https://mojdt.slack.com/archives/C01A7QK5VM1) slack channel.
+
+## How will we deal with an incident?
+
+See here our [general incident runbook](general-incident.html)

--- a/source/runbooks/general-incident.html.md.erb
+++ b/source/runbooks/general-incident.html.md.erb
@@ -1,0 +1,68 @@
+---
+title: Disaster Recovery
+last_reviewed_on: 2022-03-31
+review_in: 6 months
+---
+
+# <%= current_page.data.title %>
+
+This runbooks outlines general steps to take in the event of a major incident.
+
+Types of incident that would be considered major are:
+
+* Complete loss of the platform
+* Loss of an AWS account
+* Loss of networking
+
+## Identification of an incident
+
+This may come from various sources, users, alerts or other.
+
+## Gather information
+
+Gather all the information on the incident that you can and record it on a Google Docs sheet in the [Incident folder](https://drive.google.com/drive/folders/1zlL8Uoh4jequ9_np_NcthCO6dMsqBqhe), for example:
+
+- Who is affected?
+- What is affected?
+- What is the impact?
+- When did this start?
+- Were there any changes recently?
+- Are there any [AWS health dashboard issues](https://phd.aws.amazon.com/phd/home#/account/dashboard/open-issues)
+
+## Communicate with the team and users
+
+Post in the [#modernisation-platform](https://mojdt.slack.com/archives/C013RM6MFFW) channel using @modernisation_platform_team to make all team members aware.
+Post in the [#modernisation-platform-update](https://mojdt.slack.com/archives/C02L5MCJ12N) channel that an incident has occured, and a brief description of the incident.
+
+Communicate regularly with users, even if there is no resolution to keep them aware of progress.
+
+If the incident is a security incident [report it to the security team](https://intranet.justice.gov.uk/guidance/security/report-a-security-incident/).
+
+Example message:
+
+```
+:alert: Incident - Transit Gateway Failure :alert:
+Issue: We have identified issues with the transit gateway connection to the wider MoJ
+Impact: Applications that communicate across the wider MoJ network my have issues or stop working
+We are working to resolved this problem, a support ticket with AWS has been raised and escalated. Further updates will be posted in this channel.
+```
+
+## Attempt to resolve the issue
+
+Ensure any attempts to resolve the issue are in code and reviewed, or if any manual intervention is needed, this is agreed with the team and done as a pairing session.
+
+It is important that you do not make any changes until action is agreed by another team member. Incidents can quickly be made worst if the incorrect course of action is taken.
+
+## Log a support ticket
+
+If the incident cannot be resolved within the team or if the issue lies with a 3rd party log a support ticket with the 3rd party.
+For AWS support, log a call in the AWS account affected.
+
+3rd Party | How to log a support ticket | Escalation process
+---|---|---
+AWS| [Creating a support case](https://docs.aws.amazon.com/awssupport/latest/user/case-management.html)| On the case, or post in #ext-awssupport
+
+## Resolution
+
+- When the incident is resolved let users know.
+- Arrange a time for an incident retro so that any lessons from the incident can be learned.


### PR DESCRIPTION
We need to ensure all platform engineers know what to do when there is
an incident.  We can add more runbooks on how to resolve specific
incidents as we go and learn what sort of things cause incidents and how
to resolve them.