### PR TITLE
Remove need to uncomment data files

### DIFF
--- a/scripts/provision-environment-directories.sh
+++ b/scripts/provision-environment-directories.sh
@@ -85,7 +85,7 @@ copy_templates() {
   for file in $templates; do
     filename=$(basename "$file")
 
-    if [ ${filename} != "member-providers.tf" ]
+    if [ ${filename} != "member-providers.tf" ] && [ ${filename} != "data.tf" ]
     then
       echo "Copying $file to $1, replacing application_name with $application_name"
       sed "s/\$application_name/${application_name}/g" "$file" > "$1/$filename"

--- a/terraform/templates/data.tf
+++ b/terraform/templates/data.tf
@@ -1,124 +1,122 @@
-# These data sources can be uncommented once initial networking account set up is complete
+data "aws_region" "current" {}
 
-# data "aws_region" "current" {}
+data "aws_vpc" "shared" {
+  tags = {
+    "Name" = "${var.networking[0].business-unit}-${local.environment}"
+  }
+}
 
-# data "aws_vpc" "shared" {
-#   tags = {
-#     "Name" = "${var.networking[0].business-unit}-${local.environment}"
-#   }
-# }
+data "aws_subnets" "shared-data" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.shared.id]
+  }
+  tags = {
+    Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-data*"
+  }
+}
 
-# data "aws_subnets" "shared-data" {
-#   filter {
-#     name   = "vpc-id"
-#     values = [data.aws_vpc.shared.id]
-#   }
-#   tags = {
-#     Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-data*"
-#   }
-# }
+data "aws_subnet" "data_subnets_a" {
+  vpc_id = data.aws_vpc.shared.id
+  tags = {
+    "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-data-${data.aws_region.current.name}a"
+  }
+}
 
-# data "aws_subnet" "data_subnets_a" {
-#   vpc_id = data.aws_vpc.shared.id
-#   tags = {
-#     "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-data-${data.aws_region.current.name}a"
-#   }
-# }
+data "aws_subnet" "data_subnets_b" {
+  vpc_id = data.aws_vpc.shared.id
+  tags = {
+    "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-data-${data.aws_region.current.name}b"
+  }
+}
 
-# data "aws_subnet" "data_subnets_b" {
-#   vpc_id = data.aws_vpc.shared.id
-#   tags = {
-#     "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-data-${data.aws_region.current.name}b"
-#   }
-# }
+data "aws_subnet" "data_subnets_c" {
+  vpc_id = data.aws_vpc.shared.id
+  tags = {
+    "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-data-${data.aws_region.current.name}c"
+  }
+}
 
-# data "aws_subnet" "data_subnets_c" {
-#   vpc_id = data.aws_vpc.shared.id
-#   tags = {
-#     "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-data-${data.aws_region.current.name}c"
-#   }
-# }
+data "aws_subnet" "private_subnets_a" {
+  vpc_id = data.aws_vpc.shared.id
+  tags = {
+    "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-private-${data.aws_region.current.name}a"
+  }
+}
 
-# data "aws_subnet" "private_subnets_a" {
-#   vpc_id = data.aws_vpc.shared.id
-#   tags = {
-#     "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-private-${data.aws_region.current.name}a"
-#   }
-# }
+data "aws_subnet" "private_subnets_b" {
+  vpc_id = data.aws_vpc.shared.id
+  tags = {
+    "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-private-${data.aws_region.current.name}b"
+  }
+}
 
-# data "aws_subnet" "private_subnets_b" {
-#   vpc_id = data.aws_vpc.shared.id
-#   tags = {
-#     "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-private-${data.aws_region.current.name}b"
-#   }
-# }
+data "aws_subnet" "private_subnets_c" {
+  vpc_id = data.aws_vpc.shared.id
+  tags = {
+    "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-private-${data.aws_region.current.name}c"
+  }
+}
 
-# data "aws_subnet" "private_subnets_c" {
-#   vpc_id = data.aws_vpc.shared.id
-#   tags = {
-#     "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-private-${data.aws_region.current.name}c"
-#   }
-# }
+data "aws_subnet" "public_subnets_a" {
+  vpc_id = data.aws_vpc.shared.id
+  tags = {
+    Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-public-${data.aws_region.current.name}a"
+  }
+}
 
-# data "aws_subnet" "public_subnets_a" {
-#   vpc_id = data.aws_vpc.shared.id
-#   tags = {
-#     Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-public-${data.aws_region.current.name}a"
-#   }
-# }
+data "aws_subnet" "public_subnets_b" {
+  vpc_id = data.aws_vpc.shared.id
+  tags = {
+    Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-public-${data.aws_region.current.name}b"
+  }
+}
 
-# data "aws_subnet" "public_subnets_b" {
-#   vpc_id = data.aws_vpc.shared.id
-#   tags = {
-#     Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-public-${data.aws_region.current.name}b"
-#   }
-# }
+data "aws_subnet" "public_subnets_c" {
+  vpc_id = data.aws_vpc.shared.id
+  tags = {
+    Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-public-${data.aws_region.current.name}c"
+  }
+}
 
-# data "aws_subnet" "public_subnets_c" {
-#   vpc_id = data.aws_vpc.shared.id
-#   tags = {
-#     Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-public-${data.aws_region.current.name}c"
-#   }
-# }
+data "aws_route53_zone" "external" {
+  provider = aws.core-vpc
 
-# data "aws_route53_zone" "external" {
-#   provider = aws.core-vpc
+  name         = "${var.networking[0].business-unit}-${local.environment}.modernisation-platform.service.justice.gov.uk."
+  private_zone = false
+}
 
-#   name         = "${var.networking[0].business-unit}-${local.environment}.modernisation-platform.service.justice.gov.uk."
-#   private_zone = false
-# }
+data "aws_route53_zone" "inner" {
+  provider = aws.core-vpc
 
-# data "aws_route53_zone" "inner" {
-#   provider = aws.core-vpc
+  name         = "${var.networking[0].business-unit}-${local.environment}.modernisation-platform.internal."
+  private_zone = true
+}
 
-#   name         = "${var.networking[0].business-unit}-${local.environment}.modernisation-platform.internal."
-#   private_zone = true
-# }
+data "aws_route53_zone" "network-services" {
+  provider = aws.core-network-services
 
-# data "aws_route53_zone" "network-services" {
-#   provider = aws.core-network-services
+  name         = "modernisation-platform.service.justice.gov.uk."
+  private_zone = false
+}
 
-#   name         = "modernisation-platform.service.justice.gov.uk."
-#   private_zone = false
-# }
+data "aws_subnets" "shared-public" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.shared.id]
+  }
+  tags = {
+    Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-public*"
+  }
+}
 
-# data "aws_subnets" "shared-public" {
-#   filter {
-#     name   = "vpc-id"
-#     values = [data.aws_vpc.shared.id]
-#   }
-#   tags = {
-#     Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-public*"
-#   }
-# }
-
-# data "terraform_remote_state" "core_network_services" {
-#   backend = "s3"
-#   config = {
-#     acl     = "bucket-owner-full-control"
-#     bucket  = "modernisation-platform-terraform-state"
-#     key     = "environments/accounts/core-network-services/core-network-services-production/terraform.tfstate"
-#     region  = "eu-west-2"
-#     encrypt = "true"
-#   }
-# }
+data "terraform_remote_state" "core_network_services" {
+  backend = "s3"
+  config = {
+    acl     = "bucket-owner-full-control"
+    bucket  = "modernisation-platform-terraform-state"
+    key     = "environments/accounts/core-network-services/core-network-services-production/terraform.tfstate"
+    region  = "eu-west-2"
+    encrypt = "true"
+  }
+}


### PR DESCRIPTION
These data sources were causing issues in the inital networking setup as
they didn't exist yet so they were commented out temporarily.

This uncomments them and just doesn't copy them now to the main repo
where the networking runs.

Closes #1608