### PR TITLE
Athena permissions are required to build a database

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -48,6 +48,7 @@ data "aws_iam_policy_document" "member-access" {
       "acm-pca:*",
       "acm:*",
       "application-autoscaling:*",
+      "athena:*",
       "autoscaling:*",
       "cloudfront:*",
       "cloudwatch:*",


### PR DESCRIPTION
in order to query loadbalancer access logs