### PR TITLE
Add equip hosted zone

### DIFF
--- a/terraform/environments/core-network-services/route53.tf
+++ b/terraform/environments/core-network-services/route53.tf
@@ -1,8 +1,13 @@
 locals {
   modernisation-platform-domain          = "modernisation-platform.service.justice.gov.uk"
   modernisation-platform-internal-domain = "modernisation-platform.internal"
+
+  application-zones = {
+    equip = "equip.service.justice.gov.uk"
+  }  
 }
 
+# Main Modernisation Platform zones
 resource "aws_route53_zone" "modernisation-platform" {
   name = local.modernisation-platform-domain
   tags = local.tags
@@ -17,6 +22,20 @@ resource "aws_route53_zone" "modernisation-platform-internal" {
   }
 
   tags = local.tags
+}
+
+# Application hosted zones
+resource "aws_route53_zone" "application_zones" {
+  for_each = local.application-zones
+
+  name = each.value
+
+  tags = merge(
+    local.tags,
+    {
+      Name = "${each.key}-hosted-zone"
+    }
+  )
 }
 
 # Remote Supervision NS delegation


### PR DESCRIPTION
Adding the equip.service.justice.gov.uk as a hosted zone in the
platform.

Adding in this account rather than the application account as going
forward we can keep all the higher level domains in one place rather
than scattered through the application accounts.

Application accounts have providers to write records here already.

Added as a for_each block to simplify adding additional zones.