### PR TITLE
Glue permissions are required to create an Athena db

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -62,6 +62,7 @@ data "aws_iam_policy_document" "member-access" {
       "elasticloadbalancing:*",
       "events:*",
       "glacier:*",
+      "glue:*",
       "guardduty:get*",
       "iam:*",
       "kms:*",


### PR DESCRIPTION
The database is required to be able to query loadbalancer access logs