### PR TITLE
Allow member-ci user to iam:ListAccountAliases

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -65,6 +65,7 @@ data "aws_iam_policy_document" "member-access" {
       "glue:*",
       "guardduty:get*",
       "iam:*",
+      "iam:ListAccountAliases",
       "kms:*",
       "lambda:*",
       "logs:*",


### PR DESCRIPTION
Allow member-ci user to iam:ListAccountAliases. Related error:
Switched to workspace "sprinkler-development".
Error: failed get account alias: AccessDenied: User: arn:aws:iam::946070829339:user/member-ci is not authorized to perform: iam:ListAccountAliases on resource: *
	status code: 403, request id: 57ff0700-601c-4471-bcc2-002773ad5e73
Error: Process completed with exit code 255.