### PR TITLE
Update hmpps-test NACLS

### DIFF
--- a/environments-networks/hmpps-test.json
+++ b/environments-networks/hmpps-test.json
@@ -135,6 +135,28 @@
       "cidr_block": "172.20.0.0/16",
       "from_port": "1024",
       "to_port": "65535"
+    },
+    {
+      "subnet_set": "general",
+      "egress": false,
+      "subnet_type": "private",
+      "protocol": "tcp",
+      "rule_action": "allow",
+      "rule_number": 250,
+      "cidr_block": "172.20.0.0/16",
+      "from_port": "9100",
+      "to_port": "9100"
+    },
+    {
+      "subnet_set": "general",
+      "egress": true,
+      "subnet_type": "private",
+      "protocol": "tcp",
+      "rule_action": "allow",
+      "rule_number": 250,
+      "cidr_block": "172.20.0.0/16",
+      "from_port": "1024",
+      "to_port": "65535"
     }
   ]
 }


### PR DESCRIPTION
Allow traffic to hmpps-test on port 9100 and return traffic on ephemeral
ports for cloud platform CIDR range so that Nomis can scrape metric
data.