### PR TITLE
Add a new template repository for terraform module

### DIFF
--- a/terraform/github/main.tf
+++ b/terraform/github/main.tf
@@ -218,6 +218,18 @@ module "modernisation-platform-cp-network-test" {
   ]
 }
 
+module "modernisation-platform-terraform-module-template" {
+  source      = "./modules/repository"
+  name        = "modernisation-platform-terraform-module-template"
+  type         = "template"
+  description = "Template repository for creating Terraform modules for use with the Modernisation Platform"
+  topics = [
+    "aws",
+    "terraform",
+    "module"
+  ]
+}
+
 # Everyone, with access to the above repositories
 module "core-team" {
   source      = "./modules/team"
@@ -241,7 +253,8 @@ module "core-team" {
     module.modernisation-platform-environments.repository.name,
     module.modernisation-platform-infrastructure-test.repository.name,
     module.modernisation-platform-terraform-member-vpc.repository.name,
-    module.modernisation-platform-cp-network-test.repository.name
+    module.modernisation-platform-cp-network-test.repository.name,
+    module.modernisation-platform-terraform-module-template.repository.name
   ]
 
   maintainers = local.maintainers

--- a/terraform/github/modules/repository/main.tf
+++ b/terraform/github/modules/repository/main.tf
@@ -14,7 +14,7 @@ resource "github_repository" "default" {
   has_projects           = var.type == "core" ? true : false
   has_wiki               = var.type == "core" ? true : false
   has_downloads          = true
-  is_template            = false
+  is_template            = var.type == "template" ? true : false
   allow_merge_commit     = true
   allow_squash_merge     = true
   allow_rebase_merge     = true

--- a/terraform/github/modules/repository/variables.tf
+++ b/terraform/github/modules/repository/variables.tf
@@ -27,7 +27,7 @@ variable "topics" {
 
 variable "type" {
   type        = string
-  description = "Type of repository: `core`, `module`. Defaults to `module`"
+  description = "Type of repository: `core`, `module`, `template`. Defaults to `module`"
   default     = "module"
 }
 


### PR DESCRIPTION
We are creating more and more modules, with many additional things such
as terradocs, SCA, dependabot etc that is not included with the standard
MoJ repo.

This will make it quicker and more consistent to build