### PR TITLE
Allow member-ci access to the pagerduty int keys

### DIFF
--- a/terraform/modernisation-platform-account/iam.tf
+++ b/terraform/modernisation-platform-account/iam.tf
@@ -169,7 +169,10 @@ data "aws_iam_policy_document" "member-ci-policy" {
       "secretsmanager:ListSecretVersionIds",
       "secretsmanager:ListSecrets"
     ]
-    resources = ["arn:aws:secretsmanager:eu-west-2:${data.aws_caller_identity.current.account_id}:secret:environment_management-??????"]
+    resources = [
+      "arn:aws:secretsmanager:eu-west-2:${data.aws_caller_identity.current.account_id}:secret:environment_management-??????",
+      "arn:aws:secretsmanager:eu-west-2:${data.aws_caller_identity.current.account_id}:secret:pagerduty_integration_keys-??????"
+    ]
   }
 }
 


### PR DESCRIPTION
In order for the environments repo to be able to access pager duty
integration keys the member-ci user needs permissions to this secret.