### PR TITLE
added NACL rule for http traffic in to equip dev

### DIFF
--- a/environments-networks/hmpps-development.json
+++ b/environments-networks/hmpps-development.json
@@ -15,5 +15,17 @@
     "additional_endpoints": [],
     "dns_zone_extend": []
   },
-  "nacl": []
+  "nacl": [
+    {
+      "subnet_set": "general",
+      "egress": false,
+      "subnet_type": "public",
+      "protocol": "tcp",
+      "rule_action": "allow",
+      "rule_number": 920,
+      "cidr_block": "0.0.0.0/0",
+      "from_port": "80",
+      "to_port": "80"
+    }
+  ]
 }


### PR DESCRIPTION
Allow traffic in to public subnets with a destination port of `tcp:80`.

Primarily added at the request of the Equip team who will redirect calls on `tcp:80` to `tcp:443`.