### PR TITLE
Add role for AWS Shield advanced SRT support

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -313,3 +313,21 @@ data "aws_iam_policy_document" "developer-additional" {
     resources = ["arn:aws:iam::*:user/cicd-member-user"]
   }
 }
+
+# AWS Shield Advanced SRT (Shield Response Team) support role
+module "shield_response_team_role" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
+  version = "~> 4"
+  providers = {
+    aws = aws.workspace
+  }
+  trusted_role_services = [ "drt.shield.amazonaws.com" ]
+
+  create_role       = true
+  role_name         = "AWSSRTSupport"
+  role_requires_mfa = false
+
+  custom_role_policy_arns = [ "arn:aws:iam::aws:policy/service-role/AWSShieldDRTAccessPolicy" ]
+
+  number_of_custom_role_policy_arns = 1
+}


### PR DESCRIPTION
This role per account allows the AWS Shield advanced SRT (shield response team) to
access data to help troubleshoot and develop mitigations for DDoS
attacks.

See details here - https://docs.aws.amazon.com/waf/latest/developerguide/ddos-srt-access.html

Note, SRT access still has to be manually enabled in the console per
account here https://us-east-1.console.aws.amazon.com/wafv2/shieldv2#/overview