### PR TITLE
Allow the member-ci user to access the nuke_account_ids secret 

### DIFF
--- a/terraform/modernisation-platform-account/iam.tf
+++ b/terraform/modernisation-platform-account/iam.tf
@@ -171,7 +171,8 @@ data "aws_iam_policy_document" "member-ci-policy" {
     ]
     resources = [
       "arn:aws:secretsmanager:eu-west-2:${data.aws_caller_identity.current.account_id}:secret:environment_management-??????",
-      "arn:aws:secretsmanager:eu-west-2:${data.aws_caller_identity.current.account_id}:secret:pagerduty_integration_keys-??????"
+      "arn:aws:secretsmanager:eu-west-2:${data.aws_caller_identity.current.account_id}:secret:pagerduty_integration_keys-??????",
+      "arn:aws:secretsmanager:eu-west-2:${data.aws_caller_identity.current.account_id}:secret:nuke_account_ids-??????"
     ]
   }
 }


### PR DESCRIPTION
to resolve the error:

An error occurred (AccessDeniedException) when calling the GetSecretValue operation: User: arn:aws:iam::<account id>:user/member-ci is not authorized to perform: secretsmanager:GetSecretValue on resource: nuke_account_ids because no identity-based policy allows the secretsmanager:GetSecretValue action