### PR TITLE
Update user guidance to refer to MoJ

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -2,10 +2,10 @@
 host: https://user-guide.modernisation-platform.service.justice.gov.uk
 
 # Header-related options
-show_govuk_logo: true
-service_name: Modernisation Platform
+show_govuk_logo: false
+service_name: MoJ Modernisation Platform
 service_link: /
-phase: Alpha
+phase:
 
 # Links to show on right-hand-side of header
 header_links:


### PR DESCRIPTION
Remove the .GOV and Alpha which has caused some confusion, added in MoJ
for the main title to clarify that we are part of the MoJ not .GOV UK.