### PR TITLE
Add full slug for codeowners template

### DIFF
--- a/scripts/provision-member-directories.sh
+++ b/scripts/provision-member-directories.sh
@@ -137,7 +137,7 @@ echo "Writing codeowners file"
 # This file is auto-generated here, do not manually amend. 
 # https://github.com/ministryofjustice/modernisation-platform/blob/main/scripts/provision-member-directories.sh
 
-* @modernisation-platform
+* @ministryofjustice/modernisation-platform
 EOL
 
   for file in $environment_json_dir/*.json; do
@@ -148,18 +148,18 @@ EOL
     
     if [ "$account_type" = "member" ]; then
       for slug in $github_slugs; do
-        echo "Adding $directory @$slug @modernisation-platform to codeowners"
-        echo "$directory @$slug @modernisation-platform" >> $codeowners_file
+        echo "Adding $directory @ministryofjustice/$slug @modernisation-platform to codeowners"
+        echo "$directory @ministryofjustice/$slug @ministryofjustice/modernisation-platform" >> $codeowners_file
       done
     fi    
 
   done
 
   cat >> $codeowners_file << EOL
-**/providers.tf @modernisation-platform
-**/backend.tf @modernisation-platform
-**/subnet_share.tf @modernisation-platform
-**/networking.auto.tfvars.json @modernisation-platform
+**/providers.tf @ministryofjustice/modernisation-platform
+**/backend.tf @ministryofjustice/modernisation-platform
+**/subnet_share.tf @ministryofjustice/modernisation-platform
+**/networking.auto.tfvars.json @ministryofjustice/modernisation-platform
 EOL
 
 }


### PR DESCRIPTION
The codeowners file for the environments repo is invalid as it doesn't
give the full organisation slug for the team.

Fixing here for future generations and will amend the current file.