### PR TITLE
updated script to include gomod dependency checks for tests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -72,6 +72,10 @@ updates:
     schedule:
       interval: "daily"
   - package-ecosystem: "terraform"
+    directory: "/terraform/environments/example"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "terraform"
     directory: "/terraform/environments/mi-platform"
     schedule:
       interval: "daily"
@@ -189,5 +193,21 @@ updates:
       interval: "daily"
   - package-ecosystem: "terraform"
     directory: "/terraform/templates"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "gomod"
+    directory: "/terraform/environments/core-logging/test"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "gomod"
+    directory: "/terraform/environments/core-network-services/test"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "gomod"
+    directory: "/terraform/environments/core-security/test"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "gomod"
+    directory: "/terraform/environments/core-shared-services/test"
     schedule:
       interval: "daily"

--- a/scripts/generate-dependabot-file.sh
+++ b/scripts/generate-dependabot-file.sh
@@ -6,12 +6,16 @@ dependabot_file=.github/dependabot.yml
 
 # Get a list of Terraform folders
 all_tf_folders=`find . -type f -name '*.tf' | sed 's#/[^/]*$##' | sed 's/.\///'| sort | uniq`
+all_env_test_folders=`find ./terraform/environments/*/test -name 'go.mod' | sed 's#/[^/]*$##' | sed 's/.\///'| sort | uniq`
 echo
 echo "All TF folders"
 echo $all_tf_folders
+echo
+echo "All environment test folders"
+echo $all_env_test_folders
 
 echo "Writing dependabot.yml file"
-# Creates a dependabot file to avoid having to manually add each new TF folder
+# Creates a dependabot file to avoid having to manually add each new TF folder or go.mod file
 # Add any additional fixed entries in this top section
   cat > $dependabot_file << EOL
 # This file is auto-generated here, do not manually amend. 
@@ -33,6 +37,15 @@ for folder in $all_tf_folders
 do
 echo "Generating entry for ${folder}"
 echo "  - package-ecosystem: \"terraform\"" >> $dependabot_file
+echo "    directory: \"/${folder}\"" >> $dependabot_file
+echo "    schedule:" >> $dependabot_file
+echo "      interval: \"daily\"" >> $dependabot_file
+done
+
+for folder in $all_env_test_folders
+do
+echo "Generating entry for ${folder}"
+echo "  - package-ecosystem: \"gomod\"" >> $dependabot_file
 echo "    directory: \"/${folder}\"" >> $dependabot_file
 echo "    schedule:" >> $dependabot_file
 echo "      interval: \"daily\"" >> $dependabot_file

--- a/scripts/generate-dependabot-file.sh
+++ b/scripts/generate-dependabot-file.sh
@@ -6,7 +6,7 @@ dependabot_file=.github/dependabot.yml
 
 # Get a list of Terraform folders
 all_tf_folders=`find . -type f -name '*.tf' | sed 's#/[^/]*$##' | sed 's/.\///'| sort | uniq`
-all_env_test_folders=`find ./terraform/environments/*/test -type f -name 'go.mod' | sed 's#/[^/]*$##' | sed 's/.\///'| sort | uniq`
+all_env_test_folders=`find . -type f -name 'go.mod' | sed 's#/[^/]*$##' | sed 's/.\///'| sort | uniq`
 echo
 echo "All TF folders"
 echo $all_tf_folders

--- a/scripts/generate-dependabot-file.sh
+++ b/scripts/generate-dependabot-file.sh
@@ -6,7 +6,7 @@ dependabot_file=.github/dependabot.yml
 
 # Get a list of Terraform folders
 all_tf_folders=`find . -type f -name '*.tf' | sed 's#/[^/]*$##' | sed 's/.\///'| sort | uniq`
-all_env_test_folders=`find ./terraform/environments/*/test -name 'go.mod' | sed 's#/[^/]*$##' | sed 's/.\///'| sort | uniq`
+all_env_test_folders=`find ./terraform/environments/*/test -type f -name 'go.mod' | sed 's#/[^/]*$##' | sed 's/.\///'| sort | uniq`
 echo
 echo "All TF folders"
 echo $all_tf_folders


### PR DESCRIPTION
* Add some content to `generate-dependabot-file.sh` to find and populate entries for `go` dependencies such as those used in tests