### PR TITLE
Add high and low priority SNS alarm topics in core

### DIFF
--- a/terraform/environments/core-logging/monitoring.tf
+++ b/terraform/environments/core-logging/monitoring.tf
@@ -1,5 +1,4 @@
-module "pagerduty_core_alerts" {
-  source                    = "github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration?ref=v1.0.0"
-  sns_topics                = ["config", "securityhub-alarms", "cloudtrail"]
-  pagerduty_integration_key = local.pagerduty_integration_keys["core_alerts_cloudwatch"]
+module "core_monitoring" {
+  source                     = "../../modules/core-monitoring"
+  pagerduty_integration_keys = local.pagerduty_integration_keys
 }

--- a/terraform/environments/core-network-services/monitoring.tf
+++ b/terraform/environments/core-network-services/monitoring.tf
@@ -1,5 +1,4 @@
-module "pagerduty_core_alerts" {
-  source                    = "github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration?ref=v1.0.0"
-  sns_topics                = ["config", "securityhub-alarms", "cloudtrail"]
-  pagerduty_integration_key = local.pagerduty_integration_keys["core_alerts_cloudwatch"]
+module "core_monitoring" {
+  source                     = "../../modules/core-monitoring"
+  pagerduty_integration_keys = local.pagerduty_integration_keys
 }

--- a/terraform/environments/core-security/monitoring.tf
+++ b/terraform/environments/core-security/monitoring.tf
@@ -1,5 +1,4 @@
-module "pagerduty_core_alerts" {
-  source                    = "github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration?ref=v1.0.0"
-  sns_topics                = ["config", "securityhub-alarms", "cloudtrail"]
-  pagerduty_integration_key = local.pagerduty_integration_keys["core_alerts_cloudwatch"]
+module "core_monitoring" {
+  source                     = "../../modules/core-monitoring"
+  pagerduty_integration_keys = local.pagerduty_integration_keys
 }

--- a/terraform/environments/core-shared-services/monitoring.tf
+++ b/terraform/environments/core-shared-services/monitoring.tf
@@ -1,5 +1,4 @@
-module "pagerduty_core_alerts" {
-  source                    = "github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration?ref=v1.0.0"
-  sns_topics                = ["config", "securityhub-alarms", "cloudtrail"]
-  pagerduty_integration_key = local.pagerduty_integration_keys["core_alerts_cloudwatch"]
+module "core_monitoring" {
+  source                     = "../../modules/core-monitoring"
+  pagerduty_integration_keys = local.pagerduty_integration_keys
 }

--- a/terraform/environments/core-vpc/monitoring.tf
+++ b/terraform/environments/core-vpc/monitoring.tf
@@ -1,5 +1,4 @@
-module "pagerduty_core_alerts" {
-  source                    = "github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration?ref=v1.0.0"
-  sns_topics                = ["config", "securityhub-alarms", "cloudtrail"]
-  pagerduty_integration_key = local.pagerduty_integration_keys["core_alerts_cloudwatch"]
+module "core_monitoring" {
+  source                     = "../../modules/core-monitoring"
+  pagerduty_integration_keys = local.pagerduty_integration_keys
 }

--- a/terraform/modernisation-platform-account/monitoring.tf
+++ b/terraform/modernisation-platform-account/monitoring.tf
@@ -1,5 +1,4 @@
-module "pagerduty_core_alerts" {
-  source                    = "github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration?ref=v1.0.0"
-  sns_topics                = ["config", "securityhub-alarms", "cloudtrail"]
-  pagerduty_integration_key = local.pagerduty_integration_keys["core_alerts_cloudwatch"]
+module "core_monitoring" {
+  source                     = "../modules/core-monitoring"
+  pagerduty_integration_keys = local.pagerduty_integration_keys
 }

--- a/terraform/modules/core-monitoring/README.md
+++ b/terraform/modules/core-monitoring/README.md
@@ -3,4 +3,38 @@
 Terraform module used to create monitoring topics and pagerduty subscriptions for core accounts.
 
 <!-- BEGIN_TF_DOCS -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_pagerduty_core_alerts"></a> [pagerduty\_core\_alerts](#module\_pagerduty\_core\_alerts) | github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration | v1.0.0 |
+| <a name="module_pagerduty_high_priority"></a> [pagerduty\_high\_priority](#module\_pagerduty\_high\_priority) | github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration | v1.0.0 |
+| <a name="module_pagerduty_low_priority"></a> [pagerduty\_low\_priority](#module\_pagerduty\_low\_priority) | github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration | v1.0.0 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_sns_topic.high_priority_alarms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |
+| [aws_sns_topic.low_priority_alarms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_pagerduty_integration_keys"></a> [pagerduty\_integration\_keys](#input\_pagerduty\_integration\_keys) | Map of pagerduty integration keys | `any` | n/a | yes |
+
+## Outputs
+
+No outputs.
 <!-- END_TF_DOCS -->

--- a/terraform/modules/core-monitoring/README.md
+++ b/terraform/modules/core-monitoring/README.md
@@ -1,0 +1,6 @@
+# Core Monitoring
+
+Terraform module used to create monitoring topics and pagerduty subscriptions for core accounts.
+
+<!-- BEGIN_TF_DOCS -->
+<!-- END_TF_DOCS -->

--- a/terraform/modules/core-monitoring/main.tf
+++ b/terraform/modules/core-monitoring/main.tf
@@ -1,0 +1,38 @@
+# SNS topics for high and low priority alarms
+
+# tfsec:ignore:aws-sns-topic-encryption-use-cmk
+resource "aws_sns_topic" "high_priority_alarms" {
+  name              = "high_priority_alarms"
+  kms_master_key_id = "alias/aws/sns"
+}
+
+# tfsec:ignore:aws-sns-topic-encryption-use-cmk
+resource "aws_sns_topic" "low_priority_alarms" {
+  name              = "low_priority_alarms"
+  kms_master_key_id = "alias/aws/sns"
+}
+
+# subscribe to the sns topics the pagerduty service
+module "pagerduty_high_priority" {
+  depends_on = [
+    aws_sns_topic.high_priority_alarms
+  ]
+  source                    = "github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration?ref=v1.0.0"
+  sns_topics                = [aws_sns_topic.high_priority_alarms.name]
+  pagerduty_integration_key = var.pagerduty_integration_keys["high_priority_alarms"]
+}
+
+module "pagerduty_low_priority" {
+  depends_on = [
+    aws_sns_topic.low_priority_alarms
+  ]
+  source                    = "github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration?ref=v1.0.0"
+  sns_topics                = [aws_sns_topic.low_priority_alarms.name]
+  pagerduty_integration_key = var.pagerduty_integration_keys["low_priority_alarms"]
+}
+
+module "pagerduty_core_alerts" {
+  source                    = "github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration?ref=v1.0.0"
+  sns_topics                = ["config", "securityhub-alarms", "cloudtrail"]
+  pagerduty_integration_key = var.pagerduty_integration_keys["core_alerts_cloudwatch"]
+}

--- a/terraform/modules/core-monitoring/variables.tf
+++ b/terraform/modules/core-monitoring/variables.tf
@@ -1,0 +1,3 @@
+variable "pagerduty_integration_keys" {
+  description = "Map of pagerduty integration keys"
+}


### PR DESCRIPTION
These topics will allow us to push alarms to the pagerduty high and low
priority services.

The code was getting repetitive so drying it out by moving to a module.