### PR TITLE
Formatting and SCA ignores

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -321,13 +321,13 @@ module "shield_response_team_role" {
   providers = {
     aws = aws.workspace
   }
-  trusted_role_services = [ "drt.shield.amazonaws.com" ]
+  trusted_role_services = ["drt.shield.amazonaws.com"]
 
   create_role       = true
   role_name         = "AWSSRTSupport"
   role_requires_mfa = false
 
-  custom_role_policy_arns = [ "arn:aws:iam::aws:policy/service-role/AWSShieldDRTAccessPolicy" ]
+  custom_role_policy_arns = ["arn:aws:iam::aws:policy/service-role/AWSShieldDRTAccessPolicy"]
 
   number_of_custom_role_policy_arns = 1
 }

--- a/terraform/github/main.tf
+++ b/terraform/github/main.tf
@@ -221,7 +221,7 @@ module "modernisation-platform-cp-network-test" {
 module "modernisation-platform-terraform-module-template" {
   source      = "./modules/repository"
   name        = "modernisation-platform-terraform-module-template"
-  type         = "template"
+  type        = "template"
   description = "Template repository for creating Terraform modules for use with the Modernisation Platform"
   topics = [
     "aws",

--- a/terraform/github/modules/repository/main.tf
+++ b/terraform/github/modules/repository/main.tf
@@ -39,6 +39,7 @@ resource "github_repository" "default" {
 }
 
 resource "github_branch_protection" "default" {
+  #checkov:skip=CKV_GIT_6:"Following discussions with other teams we will not be enforcing signed commits currently"
   repository_id          = github_repository.default.id
   pattern                = "main"
   enforce_admins         = true
@@ -49,6 +50,7 @@ resource "github_branch_protection" "default" {
     contexts = var.required_checks
   }
 
+  #checkov:skip=CKV_GIT_5:"moj branch protection guidelines do not require 2 reviews"
   required_pull_request_reviews {
     dismiss_stale_reviews           = true
     require_code_owner_reviews      = true


### PR DESCRIPTION
After reviewing with the wider P&A community, there is no desire to
start enforcing signed commits at this stage.

As a team we are happy with only one PR review.