### PR TITLE
Add account alias for member accounts

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -3,6 +3,11 @@ locals {
   account_data = jsondecode(file("../../../../environments/${local.account_name}.json"))
 }
 
+resource "aws_iam_account_alias" "alias" {
+  count         = local.account_data.account-type == "member" ? 1 : 0
+  account_alias = terraform.workspace
+}
+
 module "cross-account-access" {
   source = "github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access?ref=v2.0.0"
   providers = {


### PR DESCRIPTION
The account alias is needed for the aws nuke, part of the sandbox
functionality, it is currently manually added, this change means the
alias will already be present and the manual step can be removed.

The name will follow our account name and workspace naming convention eg sprinkler-development

Closes #1704