### PR TITLE
Add logic to skip alias if taken

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -4,7 +4,7 @@ locals {
 }
 
 resource "aws_iam_account_alias" "alias" {
-  count         = local.account_data.account-type != "member-unrestricted" ? 1 : 0
+  count         = (local.account_data.account-type != "member-unrestricted") && !(contains(local.skip_alias, terraform.workspace)) ? 1 : 0
   provider      = aws.workspace
   account_alias = terraform.workspace
 }

--- a/terraform/environments/bootstrap/delegate-access/locals.tf
+++ b/terraform/environments/bootstrap/delegate-access/locals.tf
@@ -15,4 +15,8 @@ locals {
     component     = "delegate-access"
     source-code   = "https://github.com/ministryofjustice/modernisation-platform/tree/main/terraform/environments/bootstrap/delegate-access"
   }
+  # skip the following alias creation if the alias is used by another account (they are globally unique)
+  skip_alias = [
+    "nomis-production"
+  ]
 }


### PR DESCRIPTION
Alias are globally unique, there is a chance that another AWS account
has the same naming convention and uses an alias.  This provides and
option to list out alias to skip.