### PR TITLE
Add shield advanced to core vpc hosted zones

### DIFF
--- a/terraform/environments/core-vpc/monitoring.tf
+++ b/terraform/environments/core-vpc/monitoring.tf
@@ -1,4 +1,28 @@
+# Alarms for core monitoring - cloudtrail, security hub, config
 module "core_monitoring" {
   source                     = "../../modules/core-monitoring"
   pagerduty_integration_keys = local.pagerduty_integration_keys
+}
+
+# SNS topic for Route53 Hosted Zone DDoS monitoring
+# tfsec:ignore:aws-sns-topic-encryption-use-cmk
+resource "aws_sns_topic" "route53_monitoring" {
+  provider          = aws.aws-us-east-1
+  name              = "route53_monitoring"
+  kms_master_key_id = "alias/aws/sns"
+
+  tags = local.tags
+}
+
+# subscribe to the sns topic to the pagerduty service
+module "pagerduty_route53" {
+  providers = {
+    aws = aws.aws-us-east-1
+  }
+  depends_on = [
+    aws_sns_topic.route53_monitoring
+  ]
+  source                    = "github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration?ref=v1.0.0"
+  sns_topics                = [aws_sns_topic.route53_monitoring.name]
+  pagerduty_integration_key = local.is-production ? local.pagerduty_integration_keys["high_priority_alarms"] : local.pagerduty_integration_keys["low_priority_alarms"]
 }

--- a/terraform/environments/core-vpc/providers.tf
+++ b/terraform/environments/core-vpc/providers.tf
@@ -20,3 +20,11 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
 }
+
+provider "aws" {
+  alias  = "aws-us-east-1"
+  region = "us-east-1"
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
+  }
+}

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -217,6 +217,7 @@ module "dns-zone" {
 
   providers = {
     aws.core-network-services = aws.core-network-services
+    aws.aws-us-east-1         = aws.aws-us-east-1
   }
 
   for_each = local.vpcs[terraform.workspace]
@@ -229,6 +230,7 @@ module "dns-zone" {
   accounts                       = { for key, account in each.value.cidr.subnet_sets : key => account.accounts }
   modernisation_platform_account = data.aws_caller_identity.modernisation-platform.account_id
   environments                   = local.environment_management
+  monitoring_sns_topic           = aws_sns_topic.route53_monitoring.arn
 
   # Tags
   tags_common = local.tags

--- a/terraform/modules/dns-zone/variables.tf
+++ b/terraform/modules/dns-zone/variables.tf
@@ -32,3 +32,6 @@ variable "tags_prefix" {
   description = "prefix for name tags"
   type        = string
 }
+
+variable "monitoring_sns_topic" {
+}

--- a/terraform/modules/dns-zone/versions.tf
+++ b/terraform/modules/dns-zone/versions.tf
@@ -3,7 +3,7 @@ terraform {
     aws = {
       version               = ">= 3.47.0"
       source                = "hashicorp/aws"
-      configuration_aliases = [aws.core-network-services]
+      configuration_aliases = [aws.core-network-services, aws.aws-us-east-1]
     }
   }
   required_version = ">= 1.0.1"


### PR DESCRIPTION
This adds the following:

- Enables aws shield advanced on the core-vpc hosted zones
- Creates an SNS topic for route53 notifications
- Adds DDoS alarms