### PR TITLE
Remove encryption from SNS topics

### DIFF
--- a/terraform/environments/core-vpc/monitoring.tf
+++ b/terraform/environments/core-vpc/monitoring.tf
@@ -5,11 +5,10 @@ module "core_monitoring" {
 }
 
 # SNS topic for Route53 Hosted Zone DDoS monitoring
-# tfsec:ignore:aws-sns-topic-encryption-use-cmk
+# tfsec:ignore:aws-sns-enable-topic-encryption
 resource "aws_sns_topic" "route53_monitoring" {
   provider          = aws.aws-us-east-1
   name              = "route53_monitoring"
-  kms_master_key_id = "alias/aws/sns"
 
   tags = local.tags
 }

--- a/terraform/modules/core-monitoring/main.tf
+++ b/terraform/modules/core-monitoring/main.tf
@@ -1,15 +1,14 @@
 # SNS topics for high and low priority alarms
+# Encryption disabled as it doesn't work with pagerduty
 
-# tfsec:ignore:aws-sns-topic-encryption-use-cmk
+# tfsec:ignore:aws-sns-enable-topic-encryption
 resource "aws_sns_topic" "high_priority_alarms" {
   name              = "high_priority_alarms"
-  kms_master_key_id = "alias/aws/sns"
 }
 
-# tfsec:ignore:aws-sns-topic-encryption-use-cmk
+# tfsec:ignore:aws-sns-enable-topic-encryption
 resource "aws_sns_topic" "low_priority_alarms" {
   name              = "low_priority_alarms"
-  kms_master_key_id = "alias/aws/sns"
 }
 
 # subscribe to the sns topics the pagerduty service


### PR DESCRIPTION
With encryption enabled pagerduty does not process the alarm.