### PR TITLE
Add shield advanced and DDoS monitoring to mp zone

### DIFF
--- a/.github/workflows/core-logging-deployment.yml
+++ b/.github/workflows/core-logging-deployment.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - 'terraform/environments/core-logging/**'
       - 'terraform/modules/vpc-hub/**'
+      - 'terraform/modules/core-monitoring/**'
       - '.github/workflows/core-logging-deployment.yml'
   pull_request:
     branches:
@@ -15,6 +16,7 @@ on:
     paths:
       - 'terraform/environments/core-logging/**'
       - 'terraform/modules/vpc-hub/**'
+      - 'terraform/modules/core-monitoring/**'
       - '.github/workflows/core-logging-deployment.yml'
   workflow_dispatch:
 

--- a/.github/workflows/core-network-services-deployment.yml
+++ b/.github/workflows/core-network-services-deployment.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - 'terraform/environments/core-network-services/**'
       - 'terraform/modules/vpc-hub/**'
+      - 'terraform/modules/core-monitoring/**'
       - '.github/workflows/core-network-services-deployment.yml'
   pull_request:
     branches:
@@ -15,6 +16,7 @@ on:
     paths:
       - 'terraform/environments/core-network-services/**'
       - 'terraform/modules/vpc-hub/**'
+      - 'terraform/modules/core-monitoring/**'
       - '.github/workflows/core-network-services-deployment.yml'
   workflow_dispatch:
 

--- a/.github/workflows/core-security-deployment.yml
+++ b/.github/workflows/core-security-deployment.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - 'terraform/environments/core-security/**'
       - 'terraform/modules/vpc-hub/**'
+      - 'terraform/modules/core-monitoring/**'
       - '.github/workflows/core-security-deployment.yml'
   pull_request:
     branches:
@@ -15,6 +16,7 @@ on:
     paths:
       - 'terraform/environments/core-security/**'
       - 'terraform/modules/vpc-hub/**'
+      - 'terraform/modules/core-monitoring/**'
       - '.github/workflows/core-security-deployment.yml'
   workflow_dispatch:
 

--- a/.github/workflows/core-shared-services-deployment.yml
+++ b/.github/workflows/core-shared-services-deployment.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - 'terraform/environments/core-shared-services/**'
       - 'terraform/modules/vpc-hub/**'
+      - 'terraform/modules/core-monitoring/**'
       - '.github/workflows/core-shared-services-deployment.yml'
   pull_request:
     branches:
@@ -15,6 +16,7 @@ on:
     paths:
       - 'terraform/environments/core-shared-services/**'
       - 'terraform/modules/vpc-hub/**'
+      - 'terraform/modules/core-monitoring/**'
       - '.github/workflows/core-shared-services-deployment.yml'
   workflow_run:
     workflows: ["Terraform: New environment"]

--- a/.github/workflows/core-vpc-development-deployment.yml
+++ b/.github/workflows/core-vpc-development-deployment.yml
@@ -12,6 +12,13 @@ on:
       - 'terraform/environments/**/subnet-share.tf'
       - '!terraform/environments/core-*/**'
       - 'terraform/environments/core-vpc/**'
+      - 'terraform/modules/core-monitoring/**'
+      - 'terraform/modules/dns-zone/**'
+      - 'terraform/modules/dns-zone-extend/**'
+      - 'terraform/modules/vpc-tgw-routing/**'
+      - 'terraform/modules/vpc-nacls/**'
+      - 'terraform/modules/ram-resource-share/**'
+      - 'terraform/modules/core-vpc-tgw-routes/**'
   pull_request:
     branches:
       - main
@@ -22,6 +29,13 @@ on:
       - 'terraform/environments/**/subnet-share.tf'
       - '!terraform/environments/core-*/**'
       - 'terraform/environments/core-vpc/**'
+      - 'terraform/modules/core-monitoring/**'
+      - 'terraform/modules/dns-zone/**'
+      - 'terraform/modules/dns-zone-extend/**'
+      - 'terraform/modules/vpc-tgw-routing/**'
+      - 'terraform/modules/vpc-nacls/**'
+      - 'terraform/modules/ram-resource-share/**'
+      - 'terraform/modules/core-vpc-tgw-routes/**'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/core-vpc-preproduction-deployment.yml
+++ b/.github/workflows/core-vpc-preproduction-deployment.yml
@@ -12,6 +12,13 @@ on:
       - 'terraform/environments/**/subnet-share.tf'
       - '!terraform/environments/core-*/**'
       - 'terraform/environments/core-vpc/**'
+      - 'terraform/modules/core-monitoring/**'
+      - 'terraform/modules/dns-zone/**'
+      - 'terraform/modules/dns-zone-extend/**'
+      - 'terraform/modules/vpc-tgw-routing/**'
+      - 'terraform/modules/vpc-nacls/**'
+      - 'terraform/modules/ram-resource-share/**'
+      - 'terraform/modules/core-vpc-tgw-routes/**'
   pull_request:
     branches:
       - main
@@ -22,6 +29,13 @@ on:
       - 'terraform/environments/**/subnet-share.tf'
       - '!terraform/environments/core-*/**'
       - 'terraform/environments/core-vpc/**'
+      - 'terraform/modules/core-monitoring/**'
+      - 'terraform/modules/dns-zone/**'
+      - 'terraform/modules/dns-zone-extend/**'
+      - 'terraform/modules/vpc-tgw-routing/**'
+      - 'terraform/modules/vpc-nacls/**'
+      - 'terraform/modules/ram-resource-share/**'
+      - 'terraform/modules/core-vpc-tgw-routes/**'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/core-vpc-production-deployment.yml
+++ b/.github/workflows/core-vpc-production-deployment.yml
@@ -12,6 +12,13 @@ on:
       - 'terraform/environments/**/subnet-share.tf'
       - '!terraform/environments/core-*/**'
       - 'terraform/environments/core-vpc/**'
+      - 'terraform/modules/core-monitoring/**'
+      - 'terraform/modules/dns-zone/**'
+      - 'terraform/modules/dns-zone-extend/**'
+      - 'terraform/modules/vpc-tgw-routing/**'
+      - 'terraform/modules/vpc-nacls/**'
+      - 'terraform/modules/ram-resource-share/**'
+      - 'terraform/modules/core-vpc-tgw-routes/**'
   pull_request:
     branches:
       - main
@@ -22,6 +29,13 @@ on:
       - 'terraform/environments/**/subnet-share.tf'
       - '!terraform/environments/core-*/**'
       - 'terraform/environments/core-vpc/**'
+      - 'terraform/modules/core-monitoring/**'
+      - 'terraform/modules/dns-zone/**'
+      - 'terraform/modules/dns-zone-extend/**'
+      - 'terraform/modules/vpc-tgw-routing/**'
+      - 'terraform/modules/vpc-nacls/**'
+      - 'terraform/modules/ram-resource-share/**'
+      - 'terraform/modules/core-vpc-tgw-routes/**'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/core-vpc-test-deployment.yml
+++ b/.github/workflows/core-vpc-test-deployment.yml
@@ -12,6 +12,13 @@ on:
       - 'terraform/environments/**/subnet-share.tf'
       - '!terraform/environments/core-*/**'
       - 'terraform/environments/core-vpc/**'
+      - 'terraform/modules/core-monitoring/**'
+      - 'terraform/modules/dns-zone/**'
+      - 'terraform/modules/dns-zone-extend/**'
+      - 'terraform/modules/vpc-tgw-routing/**'
+      - 'terraform/modules/vpc-nacls/**'
+      - 'terraform/modules/ram-resource-share/**'
+      - 'terraform/modules/core-vpc-tgw-routes/**'
   pull_request:
     branches:
       - main
@@ -22,6 +29,13 @@ on:
       - 'terraform/environments/**/subnet-share.tf'
       - '!terraform/environments/core-*/**'
       - 'terraform/environments/core-vpc/**'
+      - 'terraform/modules/core-monitoring/**'
+      - 'terraform/modules/dns-zone/**'
+      - 'terraform/modules/dns-zone-extend/**'
+      - 'terraform/modules/vpc-tgw-routing/**'
+      - 'terraform/modules/vpc-nacls/**'
+      - 'terraform/modules/ram-resource-share/**'
+      - 'terraform/modules/core-vpc-tgw-routes/**'
   workflow_dispatch:
 
 env:

--- a/terraform/environments/core-network-services/monitoring.tf
+++ b/terraform/environments/core-network-services/monitoring.tf
@@ -1,4 +1,74 @@
+# monitoring for aws config, cloudtrail, security hub
 module "core_monitoring" {
   source                     = "../../modules/core-monitoring"
   pagerduty_integration_keys = local.pagerduty_integration_keys
+}
+
+# Route53 monitoring
+
+# SNS topic for Route53 Hosted Zone DDoS monitoring
+# tfsec:ignore:aws-sns-enable-topic-encryption
+resource "aws_sns_topic" "route53_monitoring" {
+  #checkov:skip=CKV_AWS_26:"encrypted topics do not work with pagerduty subscription"
+  provider          = aws.aws-us-east-1
+  name              = "route53_monitoring"
+
+  tags = local.tags
+}
+
+# subscribe to the sns topic to the pagerduty service
+module "pagerduty_route53" {
+  providers = {
+    aws = aws.aws-us-east-1
+  }
+  depends_on = [
+    aws_sns_topic.route53_monitoring
+  ]
+  source                    = "github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration?ref=v1.0.0"
+  sns_topics                = [aws_sns_topic.route53_monitoring.name]
+  pagerduty_integration_key = local.pagerduty_integration_keys["high_priority_alarms"]
+}
+
+# hosted zone DDoS monitoring
+resource "aws_cloudwatch_metric_alarm" "ddos_attack_modernisation_paltform_public_hosted_zone" {
+  provider = aws.aws-us-east-1
+
+  alarm_name          = "DDoSDetected-modernisation-platform-public-hosted-zone"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  datapoints_to_alarm = "1"
+  evaluation_periods  = "20"
+  metric_name         = "DDoSDetected"
+  namespace           = "AWS/DDoSProtection"
+  period              = "60"
+  statistic           = "Sum"
+  threshold           = "1"
+  alarm_description   = "Alarm for DDoS events detected on resource ${aws_route53_zone.modernisation-platform.arn}"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [aws_sns_topic.route53_monitoring.arn]
+  dimensions = {
+    ResourceArn = aws_route53_zone.modernisation-platform.arn
+  }
+  tags = local.tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "ddos_attack_application_public_hosted_zone" {
+  for_each = aws_route53_zone.application_zones
+  provider = aws.aws-us-east-1
+
+  alarm_name          = "DDoSDetected-${each.value.tags.Name}"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  datapoints_to_alarm = "1"
+  evaluation_periods  = "20"
+  metric_name         = "DDoSDetected"
+  namespace           = "AWS/DDoSProtection"
+  period              = "60"
+  statistic           = "Sum"
+  threshold           = "1"
+  alarm_description   = "Alarm for DDoS events detected on resource ${each.value.arn}"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [aws_sns_topic.route53_monitoring.arn]
+  dimensions = {
+    ResourceArn = each.value.arn
+  }
+  tags = local.tags
 }

--- a/terraform/environments/core-network-services/providers.tf
+++ b/terraform/environments/core-network-services/providers.tf
@@ -11,3 +11,11 @@ provider "aws" {
   alias  = "modernisation-platform"
   region = "eu-west-2"
 }
+
+provider "aws" {
+  alias  = "aws-us-east-1"
+  region = "us-east-1"
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
+  }
+}

--- a/terraform/environments/core-network-services/route53.tf
+++ b/terraform/environments/core-network-services/route53.tf
@@ -38,6 +38,23 @@ resource "aws_route53_zone" "application_zones" {
   )
 }
 
+# Shield advanced protection
+resource "aws_shield_protection" "modernisation_platform_public_hosted_zone" {
+  name         = "modernisation-platform-public-hosted-zone"
+  resource_arn = aws_route53_zone.modernisation-platform.arn
+
+  tags = local.tags
+}
+
+resource "aws_shield_protection" "application_public_hosted_zone" {
+  for_each = aws_route53_zone.application_zones
+
+  name         = each.value.tags.Name
+  resource_arn = each.value.arn
+
+  tags = local.tags
+}
+
 # Remote Supervision NS delegation
 resource "aws_route53_record" "remote-supervision-production" {
   allow_overwrite = true

--- a/terraform/environments/core-vpc/monitoring.tf
+++ b/terraform/environments/core-vpc/monitoring.tf
@@ -7,6 +7,7 @@ module "core_monitoring" {
 # SNS topic for Route53 Hosted Zone DDoS monitoring
 # tfsec:ignore:aws-sns-enable-topic-encryption
 resource "aws_sns_topic" "route53_monitoring" {
+  #checkov:skip=CKV_AWS_26:"encrypted topics do not work with pagerduty subscription"
   provider          = aws.aws-us-east-1
   name              = "route53_monitoring"
 

--- a/terraform/modules/core-monitoring/main.tf
+++ b/terraform/modules/core-monitoring/main.tf
@@ -3,11 +3,13 @@
 
 # tfsec:ignore:aws-sns-enable-topic-encryption
 resource "aws_sns_topic" "high_priority_alarms" {
+  #checkov:skip=CKV_AWS_26:"encrypted topics do not work with pagerduty subscription"
   name              = "high_priority_alarms"
 }
 
 # tfsec:ignore:aws-sns-enable-topic-encryption
 resource "aws_sns_topic" "low_priority_alarms" {
+  #checkov:skip=CKV_AWS_26:"encrypted topics do not work with pagerduty subscription"
   name              = "low_priority_alarms"
 }
 


### PR DESCRIPTION
This PR does the following:

- Add shield advanced protection to the modernisation-platform hosted
zone
- Add shield advanced to application hosted zones
- Add DDoS monitoring for the above
- Add missing paths to trigger github builds
- Add checkov skips for encrypting sns topics, these do not work with
pagerduty subscriptions if they are encrypted.