### PR TITLE
allow member accounts to make use of data lifecycle manager

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -58,6 +58,7 @@ data "aws_iam_policy_document" "member-access" {
       "autoscaling:*",
       "cloudfront:*",
       "cloudwatch:*",
+      "dlm:*",
       "dynamodb:*",
       "ebs:*",
       "ec2:Describe*",


### PR DESCRIPTION
* Add `dlm:*` to policy document for MemberInfrastructureAccess