### PR TITLE
Add HQ VPCs and general subnet sets

### DIFF
--- a/.github/workflows/core-vpc-development-deployment.yml
+++ b/.github/workflows/core-vpc-development-deployment.yml
@@ -75,7 +75,7 @@ jobs:
           terraform -chdir="terraform/environments/core-vpc" workspace select "core-vpc-${TF_ENV}"
 
           #RUN TERRAFORM PLAN
-          PLAN=`bash scripts/terraform-plan.sh terraform/environments/core-vpc "-target=module.vpc -target=module.vpc_tgw_routing -target=module.core-vpc-tgw-routes -target=module.dns-zone -target=module.dns_zone_extend -target=module.vpc_nacls -target=module.pagerduty_core_alerts" | tee /dev/stderr | grep '^Plan: \|^No changes.'`
+          PLAN=`bash scripts/terraform-plan.sh terraform/environments/core-vpc "-target=module.vpc -target=module.vpc_tgw_routing -target=module.core-vpc-tgw-routes -target=module.dns-zone -target=module.dns_zone_extend -target=module.pagerduty_core_alerts" | tee /dev/stderr | grep '^Plan: \|^No changes.'`
           PLAN="> TERRAFORM PLAN RESULT - core-vpc - ${TF_ENV}
           ${PLAN}"
           bash scripts/update-pr-comments.sh "${PLAN}"

--- a/.github/workflows/core-vpc-preproduction-deployment.yml
+++ b/.github/workflows/core-vpc-preproduction-deployment.yml
@@ -75,7 +75,7 @@ jobs:
           terraform -chdir="terraform/environments/core-vpc" workspace select "core-vpc-${TF_ENV}"
 
           #RUN TERRAFORM PLAN
-          PLAN=`bash scripts/terraform-plan.sh terraform/environments/core-vpc "-target=module.vpc -target=module.vpc_tgw_routing -target=module.core-vpc-tgw-routes -target=module.dns-zone -target=module.dns_zone_extend -target=module.vpc_nacls -target=module.pagerduty_core_alerts" | tee /dev/stderr | grep '^Plan: \|^No changes.'`
+          PLAN=`bash scripts/terraform-plan.sh terraform/environments/core-vpc "-target=module.vpc -target=module.vpc_tgw_routing -target=module.core-vpc-tgw-routes -target=module.dns-zone -target=module.dns_zone_extend -target=module.pagerduty_core_alerts" | tee /dev/stderr | grep '^Plan: \|^No changes.'`
           PLAN="> TERRAFORM PLAN RESULT - core-vpc - ${TF_ENV}
           ${PLAN}"
           bash scripts/update-pr-comments.sh "${PLAN}"

--- a/.github/workflows/core-vpc-production-deployment.yml
+++ b/.github/workflows/core-vpc-production-deployment.yml
@@ -75,7 +75,7 @@ jobs:
           terraform -chdir="terraform/environments/core-vpc" workspace select "core-vpc-${TF_ENV}"
 
           #RUN TERRAFORM PLAN
-          PLAN=`bash scripts/terraform-plan.sh terraform/environments/core-vpc "-target=module.vpc -target=module.vpc_tgw_routing -target=module.core-vpc-tgw-routes -target=module.dns-zone -target=module.dns_zone_extend -target=module.vpc_nacls -target=module.pagerduty_core_alerts" | tee /dev/stderr | grep '^Plan: \|^No changes.'`
+          PLAN=`bash scripts/terraform-plan.sh terraform/environments/core-vpc "-target=module.vpc -target=module.vpc_tgw_routing -target=module.core-vpc-tgw-routes -target=module.dns-zone -target=module.dns_zone_extend -target=module.pagerduty_core_alerts" | tee /dev/stderr | grep '^Plan: \|^No changes.'`
           PLAN="> TERRAFORM PLAN RESULT - core-vpc - ${TF_ENV}
           ${PLAN}"
           bash scripts/update-pr-comments.sh "${PLAN}"

--- a/.github/workflows/core-vpc-test-deployment.yml
+++ b/.github/workflows/core-vpc-test-deployment.yml
@@ -75,7 +75,7 @@ jobs:
           terraform -chdir="terraform/environments/core-vpc" workspace select "core-vpc-${TF_ENV}"
 
           #RUN TERRAFORM PLAN
-          PLAN=`bash scripts/terraform-plan.sh terraform/environments/core-vpc "-target=module.vpc -target=module.vpc_tgw_routing -target=module.core-vpc-tgw-routes -target=module.dns-zone -target=module.dns_zone_extend -target=module.vpc_nacls -target=module.pagerduty_core_alerts" | tee /dev/stderr | grep '^Plan: \|^No changes.'`
+          PLAN=`bash scripts/terraform-plan.sh terraform/environments/core-vpc "-target=module.vpc -target=module.vpc_tgw_routing -target=module.core-vpc-tgw-routes -target=module.dns-zone -target=module.dns_zone_extend -target=module.pagerduty_core_alerts" | tee /dev/stderr | grep '^Plan: \|^No changes.'`
           PLAN="> TERRAFORM PLAN RESULT - core-vpc - ${TF_ENV}
           ${PLAN}"
           bash scripts/update-pr-comments.sh "${PLAN}"

--- a/cidr-allocation.md
+++ b/cidr-allocation.md
@@ -32,7 +32,7 @@
 | 10.26.24.0      | /21  | hmpps development - general          |
 | 10.26.32.0      | /21  | cica development - general           |
 | 10.26.40.0      | /21  | hmcts development - general          |
-| 10.26.48.0      | /21  | -                                    |
+| 10.26.48.0      | /21  | hq development - general             |
 | 10.26.56.0      | /21  | -                                    |
 | 10.26.64.0      | /21  | -                                    |
 | 10.26.72.0      | /21  | -                                    |
@@ -68,7 +68,7 @@
 | 10.27.8.0       | /21  | hmpps production - general           |
 | 10.27.16.0      | /21  | hmcts production - general           |
 | 10.27.24.0      | /21  | hmcts preproduction - general        |
-| 10.27.32.0      | /21  | -                                    |
+| 10.27.32.0      | /21  | hq production - general              |
 | 10.27.40.0      | /21  | -                                    |
 | 10.27.48.0      | /21  | -                                    |
 | 10.27.56.0      | /21  | -                                    |

--- a/environments-networks/hq-development.json
+++ b/environments-networks/hq-development.json
@@ -1,0 +1,18 @@
+{
+  "cidr": {
+    "subnet_sets": {
+      "general": {
+        "cidr": "10.26.48.0/21",
+        "accounts": [
+          "threat-and-vulnerability-mgmt-development"
+        ]
+      }
+    }
+  },
+  "options": {
+    "bastion_linux": true,
+    "additional_endpoints": [],
+    "dns_zone_extend": []
+  },
+  "nacl": []
+}

--- a/environments-networks/hq-production.json
+++ b/environments-networks/hq-production.json
@@ -1,0 +1,18 @@
+{
+  "cidr": {
+    "subnet_sets": {
+      "general": {
+        "cidr": "10.27.32.0/21",
+        "accounts": [
+          "threat-and-vulnerability-mgmt-production"
+        ]
+      }
+    }
+  },
+  "options": {
+    "bastion_linux": true,
+    "additional_endpoints": [],
+    "dns_zone_extend": []
+  },
+  "nacl": []
+}

--- a/policies/networking/expected.rego
+++ b/policies/networking/expected.rego
@@ -1,7 +1,7 @@
 package main
 
 expected =
-  {
+{
   "subnet_sets": {
     "garden-sandbox": {
       "general": {
@@ -99,6 +99,22 @@ expected =
         "cidr": "10.27.24.0/21",
         "accounts": [
           "xhibit-portal-preproduction"
+        ]
+      }
+    },
+    "hq-development": {
+      "general": {
+        "cidr": "10.26.48.0/21",
+        "accounts": [
+          "threat-and-vulnerability-mgmt-development"
+        ]
+      }
+    },
+    "hq-production": {
+      "general": {
+        "cidr": "10.27.32.0/21",
+        "accounts": [
+          "threat-and-vulnerability-mgmt-production"
         ]
       }
     }


### PR DESCRIPTION
Also add the new security accounts to these subnet sets.

[Modify targeted plan to remove nacls module](https://github.com/ministryofjustice/modernisation-platform/pull/1822/commits/99253ba254c3be8d8c19f1c15830318a11170b98) 

The following error:

```
Error: Invalid for_each argument

  on ../../modules/vpc-nacls/main.tf line 32, in resource "aws_network_acl_rule" "open_endpoint_cidrs_for_data_subnets_egress":
  32:   for_each = {
  33:     for key, data in var.cidrs_for_s3_endpoints :
  34:     "${data.name}-${key}" => data
  35:   }
    ├────────────────
    │ var.cidrs_for_s3_endpoints is a list of dynamic, known only after apply
```

Comes about as the vpc needs to be created before the data look-up is
valid.  We have come across this before and resolved it by running a
targetted plan, then a targetted apply to create the vpc resources then
a full apply to build out the rest.  Following this same pattern to
remove the nacl module from the targetted plan so it doesn't fail.

Adding as a risk on the register that we are not seeing the full plan
when approving these PRs.