### PR TITLE
Fix failing local plans for dns

### DIFF
--- a/terraform/environments/core-network-services/iam.tf
+++ b/terraform/environments/core-network-services/iam.tf
@@ -46,10 +46,13 @@ resource "aws_iam_role_policy" "dns" {
       {
         Effect = "Allow",
         Action = ["route53:ChangeResourceRecordSets"],
-        Resource = [
-          "arn:aws:route53:::hostedzone/${aws_route53_zone.modernisation-platform.id}",
-          "arn:aws:route53:::hostedzone/${aws_route53_zone.modernisation-platform-internal.id}"
-        ]
+        Resource = concat(
+          [for zone in aws_route53_zone.application_zones : format("arn:aws:route53:::hostedzone/%s", zone.id)],
+          [
+            "arn:aws:route53:::hostedzone/${aws_route53_zone.modernisation-platform.id}",
+            "arn:aws:route53:::hostedzone/${aws_route53_zone.modernisation-platform-internal.id}"
+          ]
+        )
       }
     ]
   })
@@ -98,10 +101,8 @@ resource "aws_iam_role_policy" "read_dns" {
           "route53:Get*",
           "route53:List*"
         ],
-        Resource = [
-          "arn:aws:route53:::hostedzone/${aws_route53_zone.modernisation-platform.id}",
-          "arn:aws:route53:::hostedzone/${aws_route53_zone.modernisation-platform-internal.id}"
-      ] }
+        "Resource" : "*"
+      }
     ]
   })
 }

--- a/terraform/environments/core-network-services/iam.tf
+++ b/terraform/environments/core-network-services/iam.tf
@@ -28,6 +28,7 @@ resource "aws_iam_role" "dns" {
   )
 }
 
+#tfsec:ignore:aws-iam-no-policy-wildcards
 resource "aws_iam_role_policy" "dns" {
   name = "modify-dns-records"
   role = aws_iam_role.dns.id
@@ -88,6 +89,7 @@ resource "aws_iam_role" "read_dns" {
   )
 }
 
+#tfsec:ignore:aws-iam-no-policy-wildcards
 resource "aws_iam_role_policy" "read_dns" {
   name = "ReadDNSRecords"
   role = aws_iam_role.read_dns.id


### PR DESCRIPTION
```
Error finding Route 53 Hosted Zone: AccessDenied: User: arn:aws:sts:::assumed-role/read-dns-records/aws-go-sdk is not authorized to perform: route53:ListHostedZones because no identity-based policy allows the route53:ListHostedZones action
```

The above error was occuring on local plans, this is due to the addition
of application hosted zones not being added to the policy.

This changes to give get and list permissions to everything, and for the
write role add in the application zones.