### PR TITLE
Add testing keys to module repos

### DIFF
--- a/terraform/github/main.tf
+++ b/terraform/github/main.tf
@@ -74,7 +74,7 @@ module "terraform-module-s3-bucket-replication-role" {
     "iam"
   ]
   required_checks = ["Run Go Unit Tests"]
-  secrets = nonsensitive(local.testing_ci_iam_user_keys)
+  secrets         = nonsensitive(local.testing_ci_iam_user_keys)
 }
 
 module "terraform-module-s3-bucket" {

--- a/terraform/github/main.tf
+++ b/terraform/github/main.tf
@@ -73,6 +73,7 @@ module "terraform-module-s3-bucket-replication-role" {
     "s3-replication",
     "iam"
   ]
+  required_checks = ["Run Go Unit Tests"]
   secrets = nonsensitive(local.testing_ci_iam_user_keys)
 }
 
@@ -85,6 +86,7 @@ module "terraform-module-s3-bucket" {
     "s3",
     "s3-replication"
   ]
+  secrets = nonsensitive(local.testing_ci_iam_user_keys)
 }
 
 module "terraform-module-trusted-advisor" {
@@ -106,6 +108,7 @@ module "terraform-module-bastion-linux" {
     "bastion",
     "linux"
   ]
+  secrets = nonsensitive(local.testing_ci_iam_user_keys)
 }
 
 module "terraform-module-ecs" {
@@ -118,6 +121,7 @@ module "terraform-module-ecs" {
     "linux",
     "windows"
   ]
+  secrets = nonsensitive(local.testing_ci_iam_user_keys)
 }
 
 module "modernisation-platform-ami-builds" {
@@ -143,6 +147,7 @@ module "terraform-module-aws-vm-import" {
     "linux",
     "windows"
   ]
+  secrets = nonsensitive(local.testing_ci_iam_user_keys)
 }
 
 module "terraform-module-lambda-scheduler-stop-start" {
@@ -156,6 +161,7 @@ module "terraform-module-lambda-scheduler-stop-start" {
     "autoscaling-groups",
     "lambda"
   ]
+  secrets = nonsensitive(local.testing_ci_iam_user_keys)
 }
 
 module "modernisation-platform-environments" {


### PR DESCRIPTION
This will allow other modules to be able to run tests against the
testing-test account.

Also setting the unit tests to be a required check for the S3 bucket.
We should add this to the other modules once tests are in place to
ensure tests are always passing.