### PR TITLE
Enable MP collaborator devs to amend autoscaling groups

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -279,6 +279,7 @@ data "aws_iam_policy_document" "developer-additional" {
   statement {
     actions = [
       "acm:ImportCertificate",
+      "autoscaling:UpdateAutoScalingGroup",
       "secretsmanager:GetResourcePolicy",
       "secretsmanager:GetSecretValue",
       "secretsmanager:DescribeSecret",


### PR DESCRIPTION
This will allow developers to turn the bastion on after 9pm or make
emergency changes to scale out the number of instances.

Note any manual changes will be short lived as the next Terraform run will
overwrite any changes with the coded ones.