### PR TITLE
Update offer to include Github team reponsibility

### DIFF
--- a/source/user-guide/our-offer-to-you.html.md.erb
+++ b/source/user-guide/our-offer-to-you.html.md.erb
@@ -2,7 +2,7 @@
 owner_slack: "#modernisation-platform"
 title: Our offer to you
 weight: 1
-last_reviewed_on: 2022-02-16
+last_reviewed_on: 2022-06-16
 review_in: 6 months
 ---
 
@@ -52,6 +52,7 @@ We expect application teams to:
 - ensure applications remain deployable end-to-end from their source code
 - regularly assess whether the service is still meeting user needs, and make appropriate efforts to improve, replace or decommission the service if not
 - provide their own specialist skills, such as DBAs, in their own teams, if required
+- maintain their application Github teams and remove users when they leave or no longer require access
 
 ## Shared responsibility diagram
 


### PR DESCRIPTION
Following on from the risk register, it was highliged that we don't
control members application teams which have access to their
infrastruture.  This updates the offer to make it clear responsibility
for maintaining application github teams is with the application team.