### PR TITLE
Change ppud access to developer

### DIFF
--- a/environments/ppud.json
+++ b/environments/ppud.json
@@ -6,7 +6,7 @@
       "access": [
         {
           "github_slug": "modernisation-platform",
-          "level": "sandbox"
+          "level": "developer"
         }
       ]
     },


### PR DESCRIPTION
We currently don't have a sandbox role for collaborators so it makes
sense to keep this account with developer access.