### PR TITLE
trimmed endpoint list for hmpps

### DIFF
--- a/environments-networks/hmpps-development.json
+++ b/environments-networks/hmpps-development.json
@@ -14,7 +14,6 @@
   "options": {
     "bastion_linux": true,
     "additional_endpoints": [
-      "com.amazonaws.eu-west-2.email",
       "com.amazonaws.eu-west-2.email-smtp"
     ],
     "dns_zone_extend": []

--- a/environments-networks/hmpps-production.json
+++ b/environments-networks/hmpps-production.json
@@ -15,7 +15,6 @@
   "options": {
     "bastion_linux": false,
     "additional_endpoints": [
-      "com.amazonaws.eu-west-2.email",
       "com.amazonaws.eu-west-2.email-smtp"
     ],
     "dns_zone_extend": []


### PR DESCRIPTION
Removed email endpoint; SMTP mail should flow through email-smtp endpoint.
See support record for context: https://us-east-1.console.aws.amazon.com/support/home?region=eu-west-2#/case/?displayId=10265461951&language=en