### PR TITLE
amend policy SID to remove spaces

### DIFF
--- a/terraform/environments/equip/data.tf
+++ b/terraform/environments/equip/data.tf
@@ -102,7 +102,7 @@ data "terraform_remote_state" "core_network_services" {
 
 data "aws_iam_policy_document" "email" {
   statement {
-    sid = "Allow sending of email"
+    sid = "AllowSendingOfEmail"
     actions = [
       "ses:SendEmail",
       "ses:SendRawEmail"


### PR DESCRIPTION
Fix IAM policy for email user as SID contains spaces which are unsupported