### PR TITLE
Skip testing account for member directories

### DIFF
--- a/scripts/provision-member-directories.sh
+++ b/scripts/provision-member-directories.sh
@@ -42,7 +42,7 @@ provision_environment_directories() {
     echo "This is the directory: $directory"
     account_type=$(jq -r '."account-type"' ${environment_json_dir}/${application_name}.json)
 
-    if [ -d $directory ] || [ "$account_type" != "member" ]; then
+    if [ -d $directory ] || [ "$account_type" != "member" ] || [ "$application_name" == "testing" ]; then
 
       # Do nothing if a directory already exists
       echo ""


### PR DESCRIPTION
The testing account is only used for automated testing.  There is no
reason to have a testing directory generated here.  Adding this line as
the automation kept on trying to create it after we deleted it.