### PR TITLE
Remove the testing-ci user from the mp account

### DIFF
--- a/terraform/modernisation-platform-account/iam.tf
+++ b/terraform/modernisation-platform-account/iam.tf
@@ -230,62 +230,6 @@ resource "aws_iam_access_key" "member-ci" {
   }
 }
 
-### Testing CI user - user to be used for automated tests, access limited to the testing account and essential core resources
-# Create a testing CI user
-resource "aws_iam_user" "testing_ci" {
-  name = "testing-ci"
-  tags = local.tags
-}
-
-# Add the testing CI user to the CI group, this ensures the tests run with the same permissions as members will have
-resource "aws_iam_user_group_membership" "testing_ci" {
-  user = aws_iam_user.testing_ci.name
-  groups = [
-    aws_iam_group.member-ci.name
-  ]
-}
-
-# Add policy directly to the user restricting access to only the testing-test account
-data "aws_iam_policy_document" "testing_ci_policy" {
-  statement {
-    effect  = "Deny"
-    actions = ["sts:AssumeRole"]
-    not_resources = [
-      "arn:aws:iam::${local.environment_management.account_ids["testing-test"]}:role/MemberInfrastructureAccess",
-      "arn:aws:iam::${local.environment_management.account_ids["core-vpc-development"]}:role/member-delegation-*-development",
-      "arn:aws:iam::${local.environment_management.account_ids["core-vpc-test"]}:role/member-delegation-*-test",
-      "arn:aws:iam::${local.environment_management.account_ids["core-vpc-preproduction"]}:role/member-delegation-*-preproduction",
-      "arn:aws:iam::${local.environment_management.account_ids["core-vpc-production"]}:role/member-delegation-*-production",
-      "arn:aws:iam::${local.environment_management.account_ids["core-vpc-sandbox"]}:role/member-delegation-*-sandbox",
-      "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/modify-dns-records"
-    ]
-  }
-}
-
-resource "aws_iam_policy" "testing_ci_policy" {
-  name        = "TestingCiRestrictActions"
-  description = "Allowed actions for the testing_ci user"
-  policy      = data.aws_iam_policy_document.testing_ci_policy.json
-}
-
-resource "aws_iam_user_policy_attachment" "testing_ci_attach" {
-  # checkov:skip=CKV_AWS_40: "policy is only used for this user"
-  user       = aws_iam_user.testing_ci.name
-  policy_arn = aws_iam_policy.testing_ci_policy.arn
-}
-
-# Create access keys for the CI user
-# NOTE: These are extremely sensitive keys. Do not output these anywhere publicly accessible.
-resource "aws_iam_access_key" "testing_ci" {
-  user = aws_iam_user.testing_ci.name
-
-  # Setting the meta lifecycle argument allows us to periodically run `terraform taint aws_iam_access_key.ci`, and run
-  # terraform apply to create new keys before these ones are destroyed.
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
 ### Collaborators
 
 # Attach created users to a AWS IAM group, with several policies

--- a/terraform/modernisation-platform-account/secrets.tf
+++ b/terraform/modernisation-platform-account/secrets.tf
@@ -46,7 +46,6 @@ resource "aws_secretsmanager_secret_version" "member_ci_iam_user_keys" {
   })
 }
 
-# Testing CI user
 # Tfsec ignore
 # - AWS095: No requirement currently to encrypt this secret with customer-managed KMS key
 #tfsec:ignore:AWS095

--- a/terraform/modernisation-platform-account/secrets.tf
+++ b/terraform/modernisation-platform-account/secrets.tf
@@ -46,24 +46,6 @@ resource "aws_secretsmanager_secret_version" "member_ci_iam_user_keys" {
   })
 }
 
-# Tfsec ignore
-# - AWS095: No requirement currently to encrypt this secret with customer-managed KMS key
-#tfsec:ignore:AWS095
-resource "aws_secretsmanager_secret" "testing_ci_iam_user_keys" {
-  # checkov:skip=CKV_AWS_149:No requirement currently to encrypt this secret with customer-managed KMS key
-  name        = "testing_ci_iam_user_keys"
-  description = "Access keys for the testing CI user, this secret is used by GitHub to set the correct repository secrets."
-  tags        = local.tags
-}
-
-resource "aws_secretsmanager_secret_version" "testing_ci_iam_user_keys" {
-  secret_id = aws_secretsmanager_secret.testing_ci_iam_user_keys.id
-  secret_string = jsonencode({
-    AWS_ACCESS_KEY_ID     = aws_iam_access_key.testing_ci.id
-    AWS_SECRET_ACCESS_KEY = aws_iam_access_key.testing_ci.secret
-  })
-}
-
 # Slack channel modernisation-platform-notifications webhook url for sending notifications to slack
 # Not adding a secret version as this url is provided by slack and cannot be added programatically
 # Secret should be manually set in the console.


### PR DESCRIPTION
This user has now been replaced by the testing-ci user in the
testing-test account.