### PR TITLE
Allow access to pagerduty secret for other accounts

### DIFF
--- a/terraform/pagerduty/aws.tf
+++ b/terraform/pagerduty/aws.tf
@@ -5,6 +5,7 @@
 resource "aws_secretsmanager_secret" "pagerduty_integration_keys" {
   # checkov:skip=CKV_AWS_149:No requirement currently to encrypt this secret with customer-managed KMS key
   name        = "pagerduty_integration_keys"
+  policy      = data.aws_iam_policy_document.pagerduty.json
   description = "Pager Duty integration keys"
   tags        = local.tags
 }

--- a/terraform/pagerduty/aws.tf
+++ b/terraform/pagerduty/aws.tf
@@ -4,9 +4,10 @@
 #tfsec:ignore:aws-ssm-secret-use-customer-key
 resource "aws_secretsmanager_secret" "pagerduty_integration_keys" {
   # checkov:skip=CKV_AWS_149:No requirement currently to encrypt this secret with customer-managed KMS key
+  description = "Pager Duty integration keys"
+  kms_key_id  = data.aws_kms_alias.environment-management.target_key_id
   name        = "pagerduty_integration_keys"
   policy      = data.aws_iam_policy_document.pagerduty.json
-  description = "Pager Duty integration keys"
   tags        = local.tags
 }
 

--- a/terraform/pagerduty/aws.tf
+++ b/terraform/pagerduty/aws.tf
@@ -5,9 +5,9 @@
 resource "aws_secretsmanager_secret" "pagerduty_integration_keys" {
   # checkov:skip=CKV_AWS_149:No requirement currently to encrypt this secret with customer-managed KMS key
   description = "Pager Duty integration keys"
-  kms_key_id  = data.aws_kms_alias.environment-management.target_key_id
+  kms_key_id  = aws_kms_key.pagerduty.id
   name        = "pagerduty_integration_keys"
-  policy      = data.aws_iam_policy_document.pagerduty.json
+  policy      = data.aws_iam_policy_document.pagerduty_secret.json
   tags        = local.tags
 }
 

--- a/terraform/pagerduty/data.tf
+++ b/terraform/pagerduty/data.tf
@@ -4,7 +4,7 @@ data "aws_organizations_organization" "root_account" {}
 
 # Get secret by name for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  name     = "environment_management"
+  name = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
@@ -32,13 +32,13 @@ data "aws_iam_policy_document" "pagerduty_secret" {
 
 data "aws_iam_policy_document" "pagerduty_kms" {
   statement {
-    sid = "AllowManagementAccountAccess"
+    sid    = "AllowManagementAccountAccess"
     effect = "Allow"
     principals {
       type        = "AWS"
       identifiers = [data.aws_caller_identity.current.account_id, data.aws_organizations_organization.root_account.master_account_id]
     }
-    actions = ["kms:*"]
+    actions   = ["kms:*"]
     resources = [aws_kms_key.pagerduty.arn]
   }
   statement {

--- a/terraform/pagerduty/data.tf
+++ b/terraform/pagerduty/data.tf
@@ -13,6 +13,8 @@ data "aws_secretsmanager_secret_version" "environment_management" {
 }
 
 data "aws_iam_policy_document" "pagerduty_secret" {
+  #cannot reference secret in resources for statement as this causes cyclic error
+  #checkov:skip=CKV_AWS_108
   statement {
     sid    = "ReadOnlyFromModernisationPlatformOU"
     effect = "Allow"
@@ -21,7 +23,7 @@ data "aws_iam_policy_document" "pagerduty_secret" {
       identifiers = ["*"]
     }
     actions   = ["secretsmanager:GetSecretValue", "secretsmanager:GetResourcePolicy", "secretsmanager:DescribeSecret"]
-    resources = [aws_secretsmanager_secret.pagerduty_integration_keys.arn]
+    resources = ["*"]
     condition {
       test     = "ForAnyValue:StringLike"
       variable = "aws:PrincipalOrgPaths"

--- a/terraform/pagerduty/data.tf
+++ b/terraform/pagerduty/data.tf
@@ -21,7 +21,7 @@ data "aws_iam_policy_document" "pagerduty_secret" {
       identifiers = ["*"]
     }
     actions   = ["secretsmanager:GetSecretValue", "secretsmanager:GetResourcePolicy", "secretsmanager:DescribeSecret"]
-    resources = ["*"]
+    resources = [aws_secretsmanager_secret.pagerduty_integration_keys.arn]
     condition {
       test     = "ForAnyValue:StringLike"
       variable = "aws:PrincipalOrgPaths"

--- a/terraform/pagerduty/data.tf
+++ b/terraform/pagerduty/data.tf
@@ -1,21 +1,59 @@
-data "aws_iam_policy_document" "pagerduty" {
+data "aws_caller_identity" "current" {}
+
+data "aws_organizations_organization" "root_account" {}
+
+# Get secret by name for environment management
+data "aws_secretsmanager_secret" "environment_management" {
+  name     = "environment_management"
+}
+
+# Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
+data "aws_secretsmanager_secret_version" "environment_management" {
+  secret_id = data.aws_secretsmanager_secret.environment_management.id
+}
+
+data "aws_iam_policy_document" "pagerduty_secret" {
   statement {
     sid    = "ReadOnlyFromModernisationPlatformOU"
     effect = "Allow"
     principals {
-      type        = "*"
-      identifiers = ["AWS"]
+      type        = "AWS"
+      identifiers = ["*"]
     }
     actions   = ["secretsmanager:GetSecretValue", "secretsmanager:GetResourcePolicy", "secretsmanager:DescribeSecret"]
     resources = ["*"]
     condition {
       test     = "ForAnyValue:StringLike"
-      values   = ["o-b2fpbzyd95/*/ou-j1kx-qxsrh1gv/*"]
       variable = "aws:PrincipalOrgPaths"
+      values   = ["${data.aws_organizations_organization.root_account.id}/*/${local.environment_management.modernisation_platform_organisation_unit_id}/*"]
     }
   }
 }
 
-data "aws_kms_alias" "environment-management" {
-  name = "alias/environment-management"
+data "aws_iam_policy_document" "pagerduty_kms" {
+  statement {
+    sid = "AllowManagementAccountAccess"
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = [data.aws_caller_identity.current.account_id, data.aws_organizations_organization.root_account.master_account_id]
+    }
+    actions = ["kms:*"]
+    resources = [aws_kms_key.pagerduty.arn]
+  }
+  statement {
+    sid    = "AllowModernisationPlatformAccountsToDecrypt"
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+    actions   = ["kms:Decrypt*"]
+    resources = [aws_kms_key.pagerduty.arn]
+    condition {
+      test     = "ForAnyValue:StringLike"
+      variable = "aws:PrincipalOrgPaths"
+      values   = ["${data.aws_organizations_organization.root_account.id}/*/${local.environment_management.modernisation_platform_organisation_unit_id}/*"]
+    }
+  }
 }

--- a/terraform/pagerduty/data.tf
+++ b/terraform/pagerduty/data.tf
@@ -15,3 +15,7 @@ data "aws_iam_policy_document" "pagerduty" {
     }
   }
 }
+
+data "aws_kms_alias" "environment-management" {
+  name = "alias/environment-management"
+}

--- a/terraform/pagerduty/data.tf
+++ b/terraform/pagerduty/data.tf
@@ -1,0 +1,17 @@
+data "aws_iam_policy_document" "pagerduty" {
+  statement {
+    sid    = "ReadOnlyFromModernisationPlatformOU"
+    effect = "Allow"
+    principals {
+      type        = "*"
+      identifiers = ["AWS"]
+    }
+    actions   = ["secretsmanager:GetSecretValue", "secretsmanager:GetResourcePolicy", "secretsmanager:DescribeSecret"]
+    resources = ["*"]
+    condition {
+      test     = "ForAnyValue:StringLike"
+      values   = ["o-b2fpbzyd95/*/ou-j1kx-qxsrh1gv/*"]
+      variable = "aws:PrincipalOrgPaths"
+    }
+  }
+}

--- a/terraform/pagerduty/kms.tf
+++ b/terraform/pagerduty/kms.tf
@@ -4,6 +4,6 @@ resource "aws_kms_key" "pagerduty" {
 }
 
 resource "aws_kms_alias" "pagerduty" {
-  name          = "pagerduty-secret"
+  name          = "alias/pagerduty-secret"
   target_key_id = aws_kms_key.pagerduty.id
 }

--- a/terraform/pagerduty/kms.tf
+++ b/terraform/pagerduty/kms.tf
@@ -1,7 +1,9 @@
 resource "aws_kms_key" "pagerduty" {
-  tags = local.tags
+  enable_key_rotation = true
+  tags                = local.tags
 }
 
 resource "aws_kms_alias" "pagerduty" {
+  name          = "pagerduty-secret"
   target_key_id = aws_kms_key.pagerduty.id
 }

--- a/terraform/pagerduty/kms.tf
+++ b/terraform/pagerduty/kms.tf
@@ -1,0 +1,7 @@
+resource "aws_kms_key" "pagerduty" {
+  tags = local.tags
+}
+
+resource "aws_kms_alias" "pagerduty" {
+  target_key_id = aws_kms_key.pagerduty.id
+}

--- a/terraform/pagerduty/locals.tf
+++ b/terraform/pagerduty/locals.tf
@@ -1,4 +1,7 @@
 locals {
+
+  environment_management = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
+
   pager_duty_users = {
     david_elliott = {
       name  = "David Elliott"


### PR DESCRIPTION
* Add new KMS key an alias for pagerduty secret
* Create cross-account access policy for pagerduty secret
* Add cross-account access policy to pagerduty secret
* Create IAM policy for new KMS key
* Attach policy to new KMS key