### PR TITLE
Update core security to TF 1.2.4

### DIFF
--- a/.github/workflows/core-security-deployment.yml
+++ b/.github/workflows/core-security-deployment.yml
@@ -36,13 +36,13 @@ jobs:
       - uses: actions/checkout@v3
       - uses: hashicorp/setup-terraform@v2.0.0
         with:
-          terraform_version: 1.0.1
+          terraform_version: "~1"
           terraform_wrapper: false
  
       - name: Run terraform plan in terraform/environments/core-security
         run: |
           git_dir=`git rev-parse --show-toplevel`
-
+          terraform --version
           # Test if this is a PR or PULL event
           if [ ! -z ${{ github.event.pull_request.number }} ]
           then

--- a/terraform/environments/core-security/versions.tf
+++ b/terraform/environments/core-security/versions.tf
@@ -5,5 +5,5 @@ terraform {
       source  = "hashicorp/aws"
     }
   }
-  required_version = ">= 1.0.1"
+  required_version = "~> 1.0"
 }


### PR DESCRIPTION
Updating to the latest version of TF.  Note the difference in versioning specification.  Tested as follows to prove - 

Terraform version(which checks the version of TF complies):

```
required_version = "~> 0"
using terraform 1.0.1
Plan completes!
```
And obviously...
```
required_version = "~> 1"
using terraform 1.0.1
Plan completes!
```
So to follow up...
```
required_version = "~> 2"
using terraform 1.0.1
Plan fails

```
So for the terraform action version which impacts the installed version of terraform, I tried:
`terraform_version: "~0"`
And that got TF version:
`Terraform v0.15.5`

Then I tried:
`terraform_version: "~1"`
And that got TF version:
`Terraform v1.2.4`

Then I tried:
`terraform_version: "~1.0"`
And got:
`Terraform v1.0.11`