### PR TITLE
Update to the latest version of Terraform

### DIFF
--- a/.github/workflows/core-logging-deployment.yml
+++ b/.github/workflows/core-logging-deployment.yml
@@ -36,13 +36,13 @@ jobs:
       - uses: actions/checkout@v3
       - uses: hashicorp/setup-terraform@v2.0.0
         with:
-          terraform_version: 1.0.1
+          terraform_version: "~1"
           terraform_wrapper: false
  
       - name: Run terraform plan in terraform/environments/core-logging
         run: |
           git_dir=`git rev-parse --show-toplevel`
-
+          terraform --version
           # Test if this is a PR or PULL event
           if [ ! -z ${{ github.event.pull_request.number }} ]
           then
@@ -88,11 +88,12 @@ jobs:
       - uses: actions/checkout@v3
       - uses: hashicorp/setup-terraform@v2.0.0
         with:
-          terraform_version: 1.0.1
+          terraform_version: "~1"
           terraform_wrapper: false
 
       - name: Run Terraform apply in terraform/environments/core-logging
         run: |
+          terraform --version
           bash scripts/terraform-init.sh terraform/environments/core-logging
           terraform -chdir="terraform/environments/core-logging" workspace select core-logging-production
           bash scripts/terraform-apply.sh terraform/environments/core-logging

--- a/.github/workflows/core-network-services-deployment.yml
+++ b/.github/workflows/core-network-services-deployment.yml
@@ -36,13 +36,13 @@ jobs:
       - uses: actions/checkout@v3
       - uses: hashicorp/setup-terraform@v2.0.0
         with:
-          terraform_version: 1.0.1
+          terraform_version: "~1"
           terraform_wrapper: false
  
       - name: Run terraform plan in terraform/environments/core-network-services
         run: |
           git_dir=`git rev-parse --show-toplevel`
-
+          terraform --version
           # Test if this is a PR or PULL event
           if [ ! -z ${{ github.event.pull_request.number }} ]
           then
@@ -88,11 +88,12 @@ jobs:
       - uses: actions/checkout@v3
       - uses: hashicorp/setup-terraform@v2.0.0
         with:
-          terraform_version: 1.0.1
+          terraform_version: "~1"
           terraform_wrapper: false
 
       - name: Run Terraform apply in terraform/environments/core-network-services
         run: |
+          terraform --version
           bash scripts/terraform-init.sh terraform/environments/core-network-services
           terraform -chdir="terraform/environments/core-network-services" workspace select core-network-services-production
           bash scripts/terraform-apply.sh terraform/environments/core-network-services

--- a/.github/workflows/core-security-deployment.yml
+++ b/.github/workflows/core-security-deployment.yml
@@ -88,11 +88,12 @@ jobs:
       - uses: actions/checkout@v3
       - uses: hashicorp/setup-terraform@v2.0.0
         with:
-          terraform_version: 1.0.1
+          terraform_version: "~1"
           terraform_wrapper: false
 
       - name: Run Terraform apply in terraform/environments/core-security
         run: |
+          terraform --version
           bash scripts/terraform-init.sh terraform/environments/core-security
           terraform -chdir="terraform/environments/core-security" workspace select core-security-production
           bash scripts/terraform-apply.sh terraform/environments/core-security

--- a/.github/workflows/core-shared-services-deployment.yml
+++ b/.github/workflows/core-shared-services-deployment.yml
@@ -40,13 +40,13 @@ jobs:
       - uses: actions/checkout@v3
       - uses: hashicorp/setup-terraform@v2.0.0
         with:
-          terraform_version: 1.0.1
+          terraform_version: "~1"
           terraform_wrapper: false
  
       - name: Run terraform plan in terraform/environments/core-shared-services
         run: |
           git_dir=`git rev-parse --show-toplevel`
-
+          terraform --version
           # Test if this is a PR or PULL event
           if [ ! -z ${{ github.event.pull_request.number }} ]
           then
@@ -92,11 +92,12 @@ jobs:
       - uses: actions/checkout@v3
       - uses: hashicorp/setup-terraform@v2.0.0
         with:
-          terraform_version: 1.0.1
+          terraform_version: "~1"
           terraform_wrapper: false
 
       - name: Run Terraform apply in terraform/environments/core-shared-services
         run: |
+          terraform --version
           bash scripts/terraform-init.sh terraform/environments/core-shared-services
           terraform -chdir="terraform/environments/core-shared-services" workspace select core-shared-services-production
           bash scripts/terraform-apply.sh terraform/environments/core-shared-services

--- a/.github/workflows/core-vpc-development-deployment.yml
+++ b/.github/workflows/core-vpc-development-deployment.yml
@@ -55,11 +55,12 @@ jobs:
       - uses: actions/checkout@v3
       - uses: hashicorp/setup-terraform@v2.0.0
         with:
-          terraform_version: 1.0.1
+          terraform_version: "~1"
           terraform_wrapper: false
 
       - name: Run core-vpc terraform plan
         run: |
+          terraform --version
           # Test if this is a PR or PULL event
 
           #USE IF RUNNING IN GITHUB ACTIONS
@@ -93,11 +94,12 @@ jobs:
       - uses: actions/checkout@v3
       - uses: hashicorp/setup-terraform@v2.0.0
         with:
-          terraform_version: 1.0.1
+          terraform_version: "~1"
           terraform_wrapper: false
 
       - name: Run Terraform apply in terraform/environments/core-vpc
         run: |
+          terraform --version
           bash scripts/terraform-init.sh terraform/environments/core-vpc
           terraform -chdir="terraform/environments/core-vpc" workspace select "core-vpc-${TF_ENV}"
           bash scripts/terraform-apply.sh terraform/environments/core-vpc -target=module.vpc

--- a/.github/workflows/core-vpc-preproduction-deployment.yml
+++ b/.github/workflows/core-vpc-preproduction-deployment.yml
@@ -55,11 +55,12 @@ jobs:
       - uses: actions/checkout@v3
       - uses: hashicorp/setup-terraform@v2.0.0
         with:
-          terraform_version: 1.0.1
+          terraform_version: "~1"
           terraform_wrapper: false
 
       - name: Run core-vpc terraform plan
         run: |
+          terraform --version
           # Test if this is a PR or PULL event
 
           #USE IF RUNNING IN GITHUB ACTIONS
@@ -93,11 +94,12 @@ jobs:
       - uses: actions/checkout@v3
       - uses: hashicorp/setup-terraform@v2.0.0
         with:
-          terraform_version: 1.0.1
+          terraform_version: "~1"
           terraform_wrapper: false
 
       - name: Run Terraform apply in terraform/environments/core-vpc
         run: |
+          terraform --version
           bash scripts/terraform-init.sh terraform/environments/core-vpc
           terraform -chdir="terraform/environments/core-vpc" workspace select "core-vpc-${TF_ENV}"
           bash scripts/terraform-apply.sh terraform/environments/core-vpc -target=module.vpc

--- a/.github/workflows/core-vpc-production-deployment.yml
+++ b/.github/workflows/core-vpc-production-deployment.yml
@@ -55,11 +55,12 @@ jobs:
       - uses: actions/checkout@v3
       - uses: hashicorp/setup-terraform@v2.0.0
         with:
-          terraform_version: 1.0.1
+          terraform_version: "~1"
           terraform_wrapper: false
 
       - name: Run core-vpc terraform plan
         run: |
+          terraform --version
           # Test if this is a PR or PULL event
 
           #USE IF RUNNING IN GITHUB ACTIONS
@@ -93,11 +94,12 @@ jobs:
       - uses: actions/checkout@v3
       - uses: hashicorp/setup-terraform@v2.0.0
         with:
-          terraform_version: 1.0.1
+          terraform_version: "~1"
           terraform_wrapper: false
 
       - name: Run Terraform apply in terraform/environments/core-vpc
         run: |
+          terraform --version
           bash scripts/terraform-init.sh terraform/environments/core-vpc
           terraform -chdir="terraform/environments/core-vpc" workspace select "core-vpc-${TF_ENV}"
           bash scripts/terraform-apply.sh terraform/environments/core-vpc -target=module.vpc

--- a/.github/workflows/core-vpc-test-deployment.yml
+++ b/.github/workflows/core-vpc-test-deployment.yml
@@ -55,11 +55,12 @@ jobs:
       - uses: actions/checkout@v3
       - uses: hashicorp/setup-terraform@v2.0.0
         with:
-          terraform_version: 1.0.1
+          terraform_version: "~1"
           terraform_wrapper: false
 
       - name: Run core-vpc terraform plan
         run: |
+          terraform --version
           # Test if this is a PR or PULL event
 
           #USE IF RUNNING IN GITHUB ACTIONS
@@ -93,11 +94,12 @@ jobs:
       - uses: actions/checkout@v3
       - uses: hashicorp/setup-terraform@v2.0.0
         with:
-          terraform_version: 1.0.1
+          terraform_version: "~1"
           terraform_wrapper: false
 
       - name: Run Terraform apply in terraform/environments/core-vpc
         run: |
+          terraform --version
           bash scripts/terraform-init.sh terraform/environments/core-vpc
           terraform -chdir="terraform/environments/core-vpc" workspace select "core-vpc-${TF_ENV}"
           bash scripts/terraform-apply.sh terraform/environments/core-vpc -target=module.vpc

--- a/.github/workflows/modernisation-platform-account.yml
+++ b/.github/workflows/modernisation-platform-account.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: hashicorp/setup-terraform@v2.0.0
         with:
-          terraform_version: 1.0.1
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: terraform init
         run: bash scripts/terraform-init.sh terraform/modernisation-platform-account

--- a/.github/workflows/new-environment.yml
+++ b/.github/workflows/new-environment.yml
@@ -37,11 +37,12 @@ jobs:
       - uses: actions/checkout@v3
       - uses: hashicorp/setup-terraform@v2.0.0
         with:
-          terraform_version: 1.0.1
+          terraform_version: "~1"
           terraform_wrapper: false
 
       - name: Run terraform plan for root terraform/environments
         run: |
+          terraform --version
           # Test if this is a PR or PULL event
 
           #USE IF RUNNING IN GITHUB ACTIONS
@@ -75,7 +76,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: hashicorp/setup-terraform@v2.0.0
         with:
-          terraform_version: 1.0.1
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Run terraform init in terraform/environments
         run: bash scripts/terraform-init.sh terraform/environments
@@ -102,7 +103,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: hashicorp/setup-terraform@v2.0.0
         with:
-          terraform_version: 1.0.1
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: configure aws
         uses: aws-actions/configure-aws-credentials@v1.6.1
@@ -135,7 +136,7 @@ jobs:
           fetch-depth: 0
       - uses: hashicorp/setup-terraform@v2.0.0
         with:
-          terraform_version: 1.0.1
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: get new account(s)
         id: new_account
@@ -177,7 +178,7 @@ jobs:
           fetch-depth: 0
       - uses: hashicorp/setup-terraform@v2.0.0
         with:
-          terraform_version: 1.0.1
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: get new account(s)
         id: new_account
@@ -219,7 +220,7 @@ jobs:
           fetch-depth: 0
       - uses: hashicorp/setup-terraform@v2.0.0
         with:
-          terraform_version: 1.0.1
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: get new account(s)
         id: new_account

--- a/.github/workflows/scheduled-baseline.yml
+++ b/.github/workflows/scheduled-baseline.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: hashicorp/setup-terraform@v2.0.0
         with:
-          terraform_version: 1.0.1
+          terraform_version: "~1"
           terraform_wrapper: false
       - run: bash scripts/terraform-init.sh terraform/environments/bootstrap/delegate-access
       - run: bash scripts/loop-through-terraform-workspaces.sh terraform/environments/bootstrap/delegate-access plan
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: hashicorp/setup-terraform@v2.0.0
         with:
-          terraform_version: 1.0.1
+          terraform_version: "~1"
           terraform_wrapper: false
       - run: bash scripts/terraform-init.sh terraform/environments/bootstrap/secure-baselines
       - run: bash scripts/loop-through-terraform-workspaces.sh terraform/environments/bootstrap/secure-baselines plan
@@ -73,7 +73,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: hashicorp/setup-terraform@v2.0.0
         with:
-          terraform_version: 1.0.1
+          terraform_version: "~1"
           terraform_wrapper: false
       - run: bash scripts/terraform-init.sh terraform/environments/bootstrap/single-sign-on
       - run: bash scripts/loop-through-terraform-workspaces.sh terraform/environments/bootstrap/single-sign-on plan

--- a/.github/workflows/templates/workflow-template.yml
+++ b/.github/workflows/templates/workflow-template.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@v1.3.2
         with:
-          terraform_version: 1.0.1
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform plan - development
         run: |
@@ -59,7 +59,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@v1.3.2
         with:
-          terraform_version: 1.0.1
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform apply - development
         run: |
@@ -80,7 +80,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@v1.3.2
         with:
-          terraform_version: 1.0.1
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform plan - test
         run: |
@@ -103,7 +103,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@v1.3.2
         with:
-          terraform_version: 1.0.1
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform apply - test
         run: |
@@ -125,7 +125,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@v1.3.2
         with:
-          terraform_version: 1.0.1
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform plan - preproduction
         run: |
@@ -148,7 +148,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@v1.3.2
         with:
-          terraform_version: 1.0.1
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform apply - preproduction
         run: |
@@ -169,7 +169,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@v1.3.2
         with:
-          terraform_version: 1.0.1
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform plan - production
         run: |
@@ -192,7 +192,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@v1.3.2
         with:
-          terraform_version: 1.0.1
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform apply - production
         run: |

--- a/.github/workflows/terraform-github.yml
+++ b/.github/workflows/terraform-github.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: hashicorp/setup-terraform@v2.0.0
         with:
-          terraform_version: 1.0.1
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: terraform init
         run: bash scripts/terraform-init.sh terraform/github

--- a/.github/workflows/terraform-pagerduty.yml
+++ b/.github/workflows/terraform-pagerduty.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: hashicorp/setup-terraform@v2.0.0
         with:
-          terraform_version: 1.0.1
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: terraform init
         run: bash scripts/terraform-init.sh terraform/pagerduty

--- a/terraform/environments/analytical-platform-data/versions.tf
+++ b/terraform/environments/analytical-platform-data/versions.tf
@@ -5,5 +5,5 @@ terraform {
       source  = "hashicorp/aws"
     }
   }
-  required_version = ">= 1.0.1"
+  required_version = "~> 1.0"
 }

--- a/terraform/environments/analytical-platform-management/versions.tf
+++ b/terraform/environments/analytical-platform-management/versions.tf
@@ -5,5 +5,5 @@ terraform {
       source  = "hashicorp/aws"
     }
   }
-  required_version = ">= 1.0.1"
+  required_version = "~> 1.0"
 }

--- a/terraform/environments/bichard7/versions.tf
+++ b/terraform/environments/bichard7/versions.tf
@@ -5,5 +5,5 @@ terraform {
       source  = "hashicorp/aws"
     }
   }
-  required_version = ">= 1.0.1"
+  required_version = "~> 1.0"
 }

--- a/terraform/environments/bootstrap/delegate-access/versions.tf
+++ b/terraform/environments/bootstrap/delegate-access/versions.tf
@@ -5,5 +5,5 @@ terraform {
       source  = "hashicorp/aws"
     }
   }
-  required_version = ">= 1.0.1"
+  required_version = "~> 1.0"
 }

--- a/terraform/environments/bootstrap/secure-baselines/versions.tf
+++ b/terraform/environments/bootstrap/secure-baselines/versions.tf
@@ -5,5 +5,5 @@ terraform {
       source  = "hashicorp/aws"
     }
   }
-  required_version = ">= 1.0.1"
+  required_version = "~> 1.0"
 }

--- a/terraform/environments/bootstrap/single-sign-on/versions.tf
+++ b/terraform/environments/bootstrap/single-sign-on/versions.tf
@@ -5,5 +5,5 @@ terraform {
       source  = "hashicorp/aws"
     }
   }
-  required_version = ">= 1.0.1"
+  required_version = "~> 1.0"
 }

--- a/terraform/environments/cooker/versions.tf
+++ b/terraform/environments/cooker/versions.tf
@@ -5,5 +5,5 @@ terraform {
       source  = "hashicorp/aws"
     }
   }
-  required_version = ">= 1.0.1"
+  required_version = "~> 1.0"
 }

--- a/terraform/environments/core-logging/versions.tf
+++ b/terraform/environments/core-logging/versions.tf
@@ -5,5 +5,5 @@ terraform {
       source  = "hashicorp/aws"
     }
   }
-  required_version = ">= 1.0.1"
+  required_version = "~> 1.0"
 }

--- a/terraform/environments/core-network-services/versions.tf
+++ b/terraform/environments/core-network-services/versions.tf
@@ -5,5 +5,5 @@ terraform {
       source  = "hashicorp/aws"
     }
   }
-  required_version = ">= 1.0.1"
+  required_version = "~> 1.0"
 }

--- a/terraform/environments/core-sandbox/versions.tf
+++ b/terraform/environments/core-sandbox/versions.tf
@@ -5,5 +5,5 @@ terraform {
       source  = "hashicorp/aws"
     }
   }
-  required_version = ">= 1.0.1"
+  required_version = "~> 1.0"
 }

--- a/terraform/environments/core-shared-services/versions.tf
+++ b/terraform/environments/core-shared-services/versions.tf
@@ -5,5 +5,5 @@ terraform {
       source  = "hashicorp/aws"
     }
   }
-  required_version = ">= 1.0.1"
+  required_version = "~> 1.0"
 }

--- a/terraform/environments/core-vpc/versions.tf
+++ b/terraform/environments/core-vpc/versions.tf
@@ -5,5 +5,5 @@ terraform {
       source  = "hashicorp/aws"
     }
   }
-  required_version = ">= 1.0.1"
+  required_version = "~> 1.0"
 }

--- a/terraform/environments/equip/versions.tf
+++ b/terraform/environments/equip/versions.tf
@@ -5,5 +5,5 @@ terraform {
       source  = "hashicorp/aws"
     }
   }
-  required_version = ">= 1.0.1"
+  required_version = "~> 1.0"
 }

--- a/terraform/environments/example/versions.tf
+++ b/terraform/environments/example/versions.tf
@@ -5,5 +5,5 @@ terraform {
       source  = "hashicorp/aws"
     }
   }
-  required_version = ">= 1.0.1"
+  required_version = "~> 1.0"
 }

--- a/terraform/environments/mi-platform/versions.tf
+++ b/terraform/environments/mi-platform/versions.tf
@@ -5,5 +5,5 @@ terraform {
       source  = "hashicorp/aws"
     }
   }
-  required_version = ">= 1.0.1"
+  required_version = "~> 1.0"
 }

--- a/terraform/environments/nomis/versions.tf
+++ b/terraform/environments/nomis/versions.tf
@@ -5,5 +5,5 @@ terraform {
       source  = "hashicorp/aws"
     }
   }
-  required_version = ">= 1.0.1"
+  required_version = "~> 1.0"
 }

--- a/terraform/environments/performance-hub/versions.tf
+++ b/terraform/environments/performance-hub/versions.tf
@@ -5,5 +5,5 @@ terraform {
       source  = "hashicorp/aws"
     }
   }
-  required_version = ">= 1.0.1"
+  required_version = "~> 1.0"
 }

--- a/terraform/environments/ppud/versions.tf
+++ b/terraform/environments/ppud/versions.tf
@@ -5,5 +5,5 @@ terraform {
       source  = "hashicorp/aws"
     }
   }
-  required_version = ">= 1.0.1"
+  required_version = "~> 1.0"
 }

--- a/terraform/environments/remote-supervision/versions.tf
+++ b/terraform/environments/remote-supervision/versions.tf
@@ -5,5 +5,5 @@ terraform {
       source  = "hashicorp/aws"
     }
   }
-  required_version = ">= 1.0.1"
+  required_version = "~> 1.0"
 }

--- a/terraform/environments/sprinkler/versions.tf
+++ b/terraform/environments/sprinkler/versions.tf
@@ -5,5 +5,5 @@ terraform {
       source  = "hashicorp/aws"
     }
   }
-  required_version = ">= 1.0.1"
+  required_version = "~> 1.0"
 }

--- a/terraform/environments/tariff/versions.tf
+++ b/terraform/environments/tariff/versions.tf
@@ -5,5 +5,5 @@ terraform {
       source  = "hashicorp/aws"
     }
   }
-  required_version = ">= 1.0.1"
+  required_version = "~> 1.0"
 }

--- a/terraform/environments/testing/versions.tf
+++ b/terraform/environments/testing/versions.tf
@@ -5,5 +5,5 @@ terraform {
       source  = "hashicorp/aws"
     }
   }
-  required_version = ">= 1.0.1"
+  required_version = "~> 1.0"
 }

--- a/terraform/environments/threat-and-vulnerability-mgmt/versions.tf
+++ b/terraform/environments/threat-and-vulnerability-mgmt/versions.tf
@@ -5,5 +5,5 @@ terraform {
       source  = "hashicorp/aws"
     }
   }
-  required_version = ">= 1.0.1"
+  required_version = "~> 1.0"
 }

--- a/terraform/environments/versions.tf
+++ b/terraform/environments/versions.tf
@@ -5,5 +5,5 @@ terraform {
       source  = "hashicorp/aws"
     }
   }
-  required_version = ">= 1.0.1"
+  required_version = "~> 1.0"
 }

--- a/terraform/environments/xhibit-portal/versions.tf
+++ b/terraform/environments/xhibit-portal/versions.tf
@@ -5,5 +5,5 @@ terraform {
       source  = "hashicorp/aws"
     }
   }
-  required_version = ">= 1.0.1"
+  required_version = "~> 1.0"
 }

--- a/terraform/github/versions.tf
+++ b/terraform/github/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.1"
+  required_version = "~> 1.0"
   required_providers {
     aws = {
       version = ">= 4.0.0, < 5.0.0"

--- a/terraform/modernisation-platform-account/versions.tf
+++ b/terraform/modernisation-platform-account/versions.tf
@@ -5,5 +5,5 @@ terraform {
       source  = "hashicorp/aws"
     }
   }
-  required_version = ">= 1.0.1"
+  required_version = "~> 1.0"
 }


### PR DESCRIPTION
We also want to ensure we can automatically update for minor version
changes.

Note the difference in versioning specification.  Tested as follows to prove -

Terraform version(which checks the version of TF complies):

```
required_version = "~> 0"
using terraform 1.0.1
Plan completes!
```
And obviously...
```
required_version = "~> 1"
using terraform 1.0.1
Plan completes!
```
So to follow up...
```
required_version = "~> 2"
using terraform 1.0.1
Plan fails

```
So for the terraform action version which impacts the installed version of terraform, I tried:
`terraform_version: "~0"`
And that got TF version:
`Terraform v0.15.5`

Then I tried:
`terraform_version: "~1"`
And that got TF version:
`Terraform v1.2.4`

Then I tried:
`terraform_version: "~1.0"`
And got:
`Terraform v1.0.11`