### PR TITLE
added IAM policy that matches the one autocreated by SES

### DIFF
--- a/terraform/environments/equip/data.tf
+++ b/terraform/environments/equip/data.tf
@@ -102,15 +102,10 @@ data "terraform_remote_state" "core_network_services" {
 
 data "aws_iam_policy_document" "email" {
   statement {
-    sid = "AllowSendingOfEmail"
+    sid = "AmazonSesSendingAccess"
     actions = [
-      "ses:SendEmail",
-      "ses:SendRawEmail"
+      "ses:SendEmail"
     ]
-    principals {
-      identifiers = [format("arn:aws:iam::%s:root", local.environment_management.account_ids[format("%s-production", local.application_name)])]
-      type        = "AWS"
-    }
-    resources = [format("arn:aws:ses:eu-west-2:%s:*:identity/*", data.aws_caller_identity.current.account_id)]
+    resources = ["*"]
   }
 }

--- a/terraform/environments/equip/iam.tf
+++ b/terraform/environments/equip/iam.tf
@@ -11,6 +11,5 @@ resource "aws_iam_access_key" "email" {
 
 resource "aws_iam_user_policy" "email_policy" {
   name   = format("%s-%s-email_policy", local.application_name, local.environment)
-  policy = data.aws_iam_policy_document.email.json
   user   = aws_iam_user.email.name
 }


### PR DESCRIPTION
This PR replaces the more-specific IAM policy previously in place with one that matches what SES automatically attaches to an email user.