### PR TITLE
Add routes for Azure noms-mgmt-live

### DIFF
--- a/terraform/environments/core-network-services/transit_gateway_connections.tf
+++ b/terraform/environments/core-network-services/transit_gateway_connections.tf
@@ -72,16 +72,17 @@ locals {
 
   # To extend the below two data sections, just add additional lines with name and CIDR address to the relevant sections
   egress_pttp_routing_cidrs_non_live_data = {
-    "global-protect" = "10.184.0.0/16",
-    "azure-nomis"    = "10.101.0.0/16",
-    "cloud-platform" = "172.20.0.0/16"
+    "global-protect"  = "10.184.0.0/16",
+    "azure-noms-test" = "10.101.0.0/16",
+    "cloud-platform"  = "172.20.0.0/16"
   }
   egress_pttp_routing_cidrs_live_data = {
-    "global-protect"   = "10.184.0.0/16",
-    "azure-nomis"      = "10.101.0.0/16",
-    "cloud-platform"   = "172.20.0.0/16",
-    "ppud-psn"         = "51.247.0.0/16",
-    "azure-nomis-prod" = "10.40.0.0/18"
+    "global-protect"       = "10.184.0.0/16",
+    "azure-noms-test"      = "10.101.0.0/16",
+    "azure-noms-mgmt-live" = "10.40.128.0/20",
+    "cloud-platform"       = "172.20.0.0/16",
+    "ppud-psn"             = "51.247.0.0/16",
+    "azure-noms-live"      = "10.40.0.0/18"
   }
 }
 


### PR DESCRIPTION
This is needed to allow management instances in the noms-mgmt-live Azure
vnet to connect to Nomis in the production environment.

Also renaming the Nomis routes to match the Azure VNet names to be
clear.