### PR TITLE
Fix equip SES user policy

### DIFF
--- a/terraform/environments/equip/iam.tf
+++ b/terraform/environments/equip/iam.tf
@@ -10,6 +10,18 @@ resource "aws_iam_access_key" "email" {
 }
 
 resource "aws_iam_user_policy" "email_policy" {
-  name = format("%s-%s-email_policy", local.application_name, local.environment)
+  name = "AmazonSesSendingAccess"
   user = aws_iam_user.email.name
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "ses:SendRawEmail",
+        ]
+        Effect   = "Allow"
+        Resource = "*"
+      },
+    ]
+  })
 }


### PR DESCRIPTION
The workflow was failing with:

```
Error: Missing required argument
  on iam.tf line 12, in resource "aws_iam_user_policy" "email_policy":
  12: resource "aws_iam_user_policy" "email_policy" {
The argument "policy" is required, but no definition was found.
```

Added the policy to match the exising inline policy and imported it into
terraform, ran apply and no changes are required in production.