### PR TITLE
Give modify dns permissions to testing-ci user

### DIFF
--- a/terraform/environments/core-network-services/iam.tf
+++ b/terraform/environments/core-network-services/iam.tf
@@ -16,6 +16,14 @@ resource "aws_iam_role" "dns" {
           },
           "Action" : "sts:AssumeRole",
           "Condition" : {}
+        },
+        {
+          "Effect" : "Allow",
+          "Principal" : {
+            "AWS" : "arn:aws:iam::${local.environment_management.account_ids["testing-test"]}:user/testing-ci"
+          },
+          "Action" : "sts:AssumeRole",
+          "Condition" : {}
         }
       ]
   })


### PR DESCRIPTION
Tests were failing as the testing-ci user did not have permissions to
assume the modify-dns-records role.