### PR TITLE
Ignore SCA warnings

### DIFF
--- a/terraform/environments/equip/data.tf
+++ b/terraform/environments/equip/data.tf
@@ -100,6 +100,8 @@ data "terraform_remote_state" "core_network_services" {
   }
 }
 
+# AWS Generated policy for role which is imported
+#tfsec:ignore:aws-iam-no-policy-wildcards
 data "aws_iam_policy_document" "email" {
   #checkov:skip=CKV_AWS_111
   statement {

--- a/terraform/pagerduty/data.tf
+++ b/terraform/pagerduty/data.tf
@@ -35,6 +35,8 @@ data "aws_iam_policy_document" "pagerduty_secret" {
 data "aws_iam_policy_document" "pagerduty_kms" {
   #cannot reference secret in resources for statement as this causes cyclic error
   #checkov:skip=CKV_AWS_108
+  #checkov:skip=CKV_AWS_109: "Constraint is via only mp ou condition"
+  #checkov:skip=CKV_AWS_111: "Constraint is via only mp ou condition"
   statement {
     sid    = "AllowManagementAccountAccess"
     effect = "Allow"


### PR DESCRIPTION
The two warnings here, one is on a policy which is auto generated by SES
and we've just imported it into TF.

The other the condition restricts the access.