### PR TITLE
added prevent_destroy to tgw and vpc attachment resources

### DIFF
--- a/terraform/environments/core-network-services/firewall.tf
+++ b/terraform/environments/core-network-services/firewall.tf
@@ -503,4 +503,8 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "external_inspection_in" {
       Name = "external-inspection-in"
     }
   )
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }

--- a/terraform/environments/core-network-services/transit-gateway.tf
+++ b/terraform/environments/core-network-services/transit-gateway.tf
@@ -17,6 +17,10 @@ resource "aws_ec2_transit_gateway" "transit-gateway" {
       Name = "Modernisation Platform: Transit Gateway"
     },
   )
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 #########################
@@ -47,6 +51,10 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "attachments" {
       Name = each.key
     },
   )
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 #########################
@@ -64,6 +72,10 @@ resource "aws_ec2_transit_gateway_route_table" "route-tables" {
       Name = each.key
     },
   )
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 # Associate the route table with the VPC attachment

--- a/terraform/environments/core-network-services/transit_gateway_connections.tf
+++ b/terraform/environments/core-network-services/transit_gateway_connections.tf
@@ -97,6 +97,10 @@ resource "aws_ec2_transit_gateway_peering_attachment_accepter" "PTTP-Production"
     Name = "PTTP-Transit-Gateway-attachment-accepter"
     Side = "Acceptor"
   }
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 ######################

--- a/terraform/modules/ec2-tgw-attachment/main.tf
+++ b/terraform/modules/ec2-tgw-attachment/main.tf
@@ -45,6 +45,10 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "default" {
     Name = "${var.vpc_name}-attachment"
   })
 
+  lifecycle {
+    prevent_destroy = true
+  }
+
   depends_on = [
     time_sleep.wait_60_seconds
   ]


### PR DESCRIPTION
* Prevent important Transit Gateway components from being destroyed inadvertently with `prevent_destroy` lifecycle rules