### PR TITLE
Update to latest version of publisher

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
   run:
     runs-on: ubuntu-latest
     container:
-      image: ministryofjustice/tech-docs-github-pages-publisher:1.4
+      image: ministryofjustice/tech-docs-github-pages-publisher:1.5
     steps:
     - uses: actions/checkout@v3
     - name: Publish


### PR DESCRIPTION
Cloud platform is using gem-patches to fix the search issue - https://github.com/ministryofjustice/cloud-platform-user-guide/blob/main/gem-patches/search.js.patch

The latest version of ministryofjustice/tech-docs-github-pages-publisher
comes after this commit making the same gem-patches folder obsolete -
https://github.com/ministryofjustice/tech-docs-github-pages-publisher/commit/6cde709cfd1a900cab3352d36d6e5493c7e11284
so I'm assuming updating will fix the search bar issue.

Closes #1904 