### PR TITLE
Refactor TGW attachment tagging

### DIFF
--- a/terraform/environments/core-logging/transit-gateway-attachment.tf
+++ b/terraform/environments/core-logging/transit-gateway-attachment.tf
@@ -39,5 +39,8 @@ module "vpc_attachment" {
   vpc_id     = module.vpc[each.key].vpc_id
   vpc_name   = "${each.key}-${terraform.workspace}"
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    format("%s-%s-attachment", each.key, terraform.workspace)
+  )
 }

--- a/terraform/environments/core-logging/transit-gateway-attachment.tf
+++ b/terraform/environments/core-logging/transit-gateway-attachment.tf
@@ -41,6 +41,6 @@ module "vpc_attachment" {
 
   tags = merge(
     local.tags,
-    format("%s-%s-attachment", each.key, terraform.workspace)
+    { "Name" = format("%s-%s-attachment", each.key, terraform.workspace) }
   )
 }

--- a/terraform/environments/core-security/transit-gateway-attachment.tf
+++ b/terraform/environments/core-security/transit-gateway-attachment.tf
@@ -39,5 +39,8 @@ module "vpc_attachment" {
   vpc_id     = module.vpc[each.key].vpc_id
   vpc_name   = "${each.key}-${terraform.workspace}"
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    format("%s-%s-attachment", each.key, terraform.workspace)
+  )
 }

--- a/terraform/environments/core-security/transit-gateway-attachment.tf
+++ b/terraform/environments/core-security/transit-gateway-attachment.tf
@@ -41,6 +41,6 @@ module "vpc_attachment" {
 
   tags = merge(
     local.tags,
-    format("%s-%s-attachment", each.key, terraform.workspace)
+    { "Name" = format("%s-%s-attachment", each.key, terraform.workspace) }
   )
 }

--- a/terraform/environments/core-shared-services/transit-gateway-attachment.tf
+++ b/terraform/environments/core-shared-services/transit-gateway-attachment.tf
@@ -39,6 +39,6 @@ module "vpc_attachment" {
 
   tags = merge(
     local.tags,
-    format("%s-%s-attachment", each.key, terraform.workspace)
+    { "Name" = format("%s-%s-attachment", each.key, terraform.workspace) }
   )
 }

--- a/terraform/environments/core-shared-services/transit-gateway-attachment.tf
+++ b/terraform/environments/core-shared-services/transit-gateway-attachment.tf
@@ -37,5 +37,8 @@ module "vpc_attachment" {
   vpc_id     = module.vpc[each.key].vpc_id
   vpc_name   = "${each.key}-${terraform.workspace}"
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    format("%s-%s-attachment", each.key, terraform.workspace)
+  )
 }

--- a/terraform/environments/core-vpc/transit-gateway-attachment.tf
+++ b/terraform/environments/core-vpc/transit-gateway-attachment.tf
@@ -46,5 +46,8 @@ module "vpc_attachment" {
   vpc_id     = module.vpc[each.key].vpc_id
   vpc_name   = each.key
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    format("%s-%s-attachment", each.key, terraform.workspace)
+  )
 }

--- a/terraform/environments/core-vpc/transit-gateway-attachment.tf
+++ b/terraform/environments/core-vpc/transit-gateway-attachment.tf
@@ -48,6 +48,6 @@ module "vpc_attachment" {
 
   tags = merge(
     local.tags,
-    format("%s-%s-attachment", each.key, terraform.workspace)
+    { "Name" = format("%s-%s-attachment", each.key, terraform.workspace) }
   )
 }

--- a/terraform/modules/ec2-tgw-attachment/main.tf
+++ b/terraform/modules/ec2-tgw-attachment/main.tf
@@ -64,10 +64,11 @@ resource "aws_ec2_transit_gateway_route_table_association" "default" {
 
 ## Retag the new Transit Gateway VPC attachment in the Transit Gateway host
 resource "aws_ec2_tag" "retag" {
+  for_each = var.tags
   provider = aws.transit-gateway-host
 
   resource_id = aws_ec2_transit_gateway_vpc_attachment.default.id
 
-  key   = "Name"
-  value = "${var.vpc_name}-attachment"
+  key   = each.key
+  value = each.value
 }


### PR DESCRIPTION
* Use a `for_each` loop to take multiple tags in for TGW VPC attachments
* Refactor where the attachment module is called to supply both the name, and the local tag values