### PR TITLE
Add Cloudwatch Alarm & PagerDuty integration for TGW Attachments

### DIFF
--- a/terraform/environments/core-network-services/monitoring.tf
+++ b/terraform/environments/core-network-services/monitoring.tf
@@ -30,7 +30,7 @@ module "pagerduty_route53" {
 }
 
 # hosted zone DDoS monitoring
-resource "aws_cloudwatch_metric_alarm" "ddos_attack_modernisation_paltform_public_hosted_zone" {
+resource "aws_cloudwatch_metric_alarm" "ddos_attack_modernisation_platform_public_hosted_zone" {
   provider = aws.aws-us-east-1
 
   alarm_name          = "DDoSDetected-modernisation-platform-public-hosted-zone"

--- a/terraform/environments/core-network-services/monitoring.tf
+++ b/terraform/environments/core-network-services/monitoring.tf
@@ -92,14 +92,14 @@ data "aws_ec2_transit_gateway_vpc_attachments" "transit_gateway_production" {
     values = ["available"]
   }
   filter {
-    name = "tag:is-production"
+    name   = "tag:is-production"
     values = ["true"]
   }
 }
 
 data "aws_ec2_transit_gateway_vpc_attachment" "transit_gateway_production" {
   for_each = toset(data.aws_ec2_transit_gateway_vpc_attachments.transit_gateway_production.ids)
-  id = each.key
+  id       = each.key
 }
 
 resource "aws_cloudwatch_metric_alarm" "production_attachment_no_traffic_5_minutes" {

--- a/terraform/environments/core-network-services/monitoring.tf
+++ b/terraform/environments/core-network-services/monitoring.tf
@@ -72,3 +72,23 @@ resource "aws_cloudwatch_metric_alarm" "ddos_attack_application_public_hosted_zo
   }
   tags = local.tags
 }
+
+## Transit Gateway monitoring
+resource "aws_cloudwatch_metric_alarm" "attachment_no_traffic_5_minutes" {
+  for_each            = aws_ec2_transit_gateway_vpc_attachment.attachments
+  alarm_description   = format("Low traffic detected on VPC attachment %s", each.value.tags.Name)
+  alarm_name          = format("NoVPCAttachmentTraffic-%s", each.value.tags.Name)
+  comparison_operator = "LessThanOrEqualToThreshold"
+  datapoints_to_alarm = "1"
+  dimensions = {
+    TransitGatewayAttachment = each.value.id
+  }
+  evaluation_periods = "5"
+  metric_name        = "BytesIn"
+  namespace          = "AWS/TransitGateway"
+  period             = "60"
+  statistic          = "Sum"
+  threshold          = "1"
+  treat_missing_data = "notBreaching"
+  tags               = local.tags
+}

--- a/terraform/environments/core-network-services/monitoring.tf
+++ b/terraform/environments/core-network-services/monitoring.tf
@@ -122,6 +122,7 @@ resource "aws_cloudwatch_metric_alarm" "production_attachment_no_traffic_5_minut
   tags               = local.tags
 }
 
+# tfsec:ignore:aws-sns-enable-topic-encryption
 resource "aws_sns_topic" "tgw_monitoring_production" {
   #checkov:skip=CKV_AWS_26:"encrypted topics do not work with pagerduty subscription"
   provider = aws.aws-us-east-1

--- a/terraform/environments/core-network-services/monitoring.tf
+++ b/terraform/environments/core-network-services/monitoring.tf
@@ -81,9 +81,14 @@ data "aws_ec2_transit_gateway_vpc_attachments" "transit-gateway" {
   }
 }
 
+data "aws_ec2_transit_gateway_vpc_attachment" "transit-gateway" {
+  for_each = toset(data.aws_ec2_transit_gateway_vpc_attachments.transit-gateway.ids)
+  id = each.key
+}
+
 resource "aws_cloudwatch_metric_alarm" "attachment_no_traffic_5_minutes" {
-  for_each            = toset(data.aws_ec2_transit_gateway_vpc_attachments.transit-gateway.ids)
-  alarm_description   = format("Low traffic detected on VPC attachment %s", each.key)
+  for_each            = data.aws_ec2_transit_gateway_vpc_attachment.transit-gateway
+  alarm_description   = format("Low traffic detected for VPC attachment %s", each.value.tags.Name)
   alarm_name          = format("NoVPCAttachmentTraffic-%s", each.key)
   comparison_operator = "LessThanOrEqualToThreshold"
   datapoints_to_alarm = "1"

--- a/terraform/environments/core-network-services/monitoring.tf
+++ b/terraform/environments/core-network-services/monitoring.tf
@@ -22,7 +22,7 @@ module "pagerduty_route53" {
     aws = aws.aws-us-east-1
   }
   depends_on = [
-    aws_sns_topic.route53_monitoring,
+    aws_sns_topic.route53_monitoring
   ]
   source                    = "github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration?ref=v1.0.0"
   sns_topics                = [aws_sns_topic.route53_monitoring.name]


### PR DESCRIPTION
* Create a rich list of Transit Gateway attachments matching `is-production:true`
* Use the list of production Transit Gateway attachments to create CloudWatch metric alarms
* CloudWatch alarms will report when `PacketsIn` on an attachment is below `1` for five minutes.
* SNS topic will receive these alarms and pass through PagerDuty integration to `high priority alarms`
* Solves #1988 