### PR TITLE
Corrected wrong case in alarm argument

### DIFF
--- a/terraform/environments/core-network-services/monitoring.tf
+++ b/terraform/environments/core-network-services/monitoring.tf
@@ -115,7 +115,7 @@ resource "aws_cloudwatch_metric_alarm" "production_attachment_no_traffic_5_minut
   period             = "60"
   statistic          = "Sum"
   threshold          = "1"
-  treat_missing_data = "Breaching"
+  treat_missing_data = "breaching"
   tags               = local.tags
 }
 


### PR DESCRIPTION
* `treat_missing_data` for CloudWatch Metric Alarm argument changed to correct case