### PR TITLE
Correct CloudWatch alarm dimensions

### DIFF
--- a/terraform/environments/core-network-services/monitoring.tf
+++ b/terraform/environments/core-network-services/monitoring.tf
@@ -107,6 +107,7 @@ resource "aws_cloudwatch_metric_alarm" "production_attachment_no_traffic_5_minut
   comparison_operator = "LessThanOrEqualToThreshold"
   datapoints_to_alarm = "1"
   dimensions = {
+    TransitGateway = aws_ec2_transit_gateway.transit-gateway.id
     TransitGatewayAttachment = each.key
   }
   evaluation_periods = "5"

--- a/terraform/environments/core-network-services/monitoring.tf
+++ b/terraform/environments/core-network-services/monitoring.tf
@@ -107,7 +107,7 @@ resource "aws_cloudwatch_metric_alarm" "production_attachment_no_traffic_5_minut
   comparison_operator = "LessThanOrEqualToThreshold"
   datapoints_to_alarm = "1"
   dimensions = {
-    TransitGateway = aws_ec2_transit_gateway.transit-gateway.id
+    TransitGateway           = aws_ec2_transit_gateway.transit-gateway.id
     TransitGatewayAttachment = each.key
   }
   evaluation_periods = "5"


### PR DESCRIPTION
* CloudWatch Metric Alarm dimensions need to state both the TransitGateway ID and the VPC attachment ID in order to correctly read the metric for review.