### PR TITLE
Switch monitored TGW attachments to use curated list

### DIFF
--- a/terraform/environments/core-network-services/locals.tf
+++ b/terraform/environments/core-network-services/locals.tf
@@ -19,4 +19,17 @@ locals {
     is-production = local.is-production
     owner         = "Modernisation Platform: modernisation-platform@digital.justice.gov.uk"
   }
+
+  active_tgw_peering_attachments = [
+    "PTTP-Transit-Gateway-attachment-accepter"
+  ]
+
+  active_tgw_vpc_attachments = [
+    "core-logging-live_data-attachment",
+    "core-security-live_data-attachment",
+    "core-shared-services-live_data-attachment",
+    "hmcts-production-attachment",
+    "hmpps-production-attachment",
+    "live_data",
+  ]
 }


### PR DESCRIPTION
* Use curated list to only include high priority attachments seeing active use