### PR TITLE
Add testing-ci secrets to load balancer module

### DIFF
--- a/terraform/github/main.tf
+++ b/terraform/github/main.tf
@@ -201,6 +201,8 @@ module "terraform-module-aws-loadbalancer" {
     "loadbalancer",
     "logging"
   ]
+  required_checks = ["Run Go Unit Tests"]
+  secrets         = nonsensitive(local.testing_ci_iam_user_keys)
 }
 
 module "modernisation-platform-terraform-member-vpc" {

--- a/terraform/github/modules/repository/main.tf
+++ b/terraform/github/modules/repository/main.tf
@@ -11,7 +11,7 @@ resource "github_repository" "default" {
   homepage_url           = var.homepage_url
   visibility             = var.visibility
   has_issues             = true
-  has_projects           = var.type == "core" ? true : false
+  has_projects           = true
   has_wiki               = var.type == "core" ? true : false
   has_downloads          = true
   is_template            = var.type == "template" ? true : false


### PR DESCRIPTION
Also change has project to true

This always reverts to true for some org level reason, so if we set it
to false for non core repos we just end up with loads of changes every
time we run this code.