### PR TITLE
Trim monitored attachments

### DIFF
--- a/terraform/environments/core-network-services/firewall.tf
+++ b/terraform/environments/core-network-services/firewall.tf
@@ -500,7 +500,7 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "external_inspection_in" {
   tags = merge(
     local.tags,
     {
-      Name = "external-inspection-in"
+      Name = "inspection-attachment"
     }
   )
 

--- a/terraform/environments/core-network-services/locals.tf
+++ b/terraform/environments/core-network-services/locals.tf
@@ -25,9 +25,9 @@ locals {
   ]
 
   active_tgw_vpc_attachments = [
-    #"inspection-attachment",
+    "inspection-attachment",
     "hmcts-production-attachment",
     "hmpps-production-attachment",
-    #"core-network-services-live_data-attachment",
+    "core-network-services-live_data-attachment",
   ]
 }

--- a/terraform/environments/core-network-services/locals.tf
+++ b/terraform/environments/core-network-services/locals.tf
@@ -28,6 +28,6 @@ locals {
     #"inspection-attachment",
     "hmcts-production-attachment",
     "hmpps-production-attachment",
-    #"live_data",
+    #"core-network-services-live_data-attachment",
   ]
 }

--- a/terraform/environments/core-network-services/locals.tf
+++ b/terraform/environments/core-network-services/locals.tf
@@ -25,11 +25,9 @@ locals {
   ]
 
   active_tgw_vpc_attachments = [
-    "core-logging-live_data-attachment",
-    "core-security-live_data-attachment",
-    "core-shared-services-live_data-attachment",
+    #"inspection-attachment",
     "hmcts-production-attachment",
     "hmpps-production-attachment",
-    "live_data",
+    #"live_data",
   ]
 }

--- a/terraform/environments/core-network-services/transit-gateway.tf
+++ b/terraform/environments/core-network-services/transit-gateway.tf
@@ -47,9 +47,7 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "attachments" {
 
   tags = merge(
     local.tags,
-    {
-      Name = each.key
-    },
+    { "Name" = format("%s-%s-attachment", local.application_name, each.key) }
   )
 
   lifecycle {


### PR DESCRIPTION
* Monitor only the production-related attachments
* Clean up naming conventions a little more