### PR TITLE
Create generic pagerduty user

### DIFF
--- a/terraform/pagerduty/locals.tf
+++ b/terraform/pagerduty/locals.tf
@@ -13,6 +13,11 @@ locals {
       email = "david.sibley${local.digital_email_suffix}"
       role  = "user"
     },
+    modernisation_platform = {
+      name  = "Modernisation Platform Team"
+      email = "modernisation-platform${local.digital_email_suffix}"
+      role  = "user"
+    },
   }
 
   digital_email_suffix = "@digital.justice.gov.uk"
@@ -60,8 +65,4 @@ data "pagerduty_user" "jack_stockley" {
 
 data "pagerduty_user" "jake_mulley" {
   email = "jake.mulley${local.digital_email_suffix}"
-}
-
-data "pagerduty_user" "platforms" {
-  email = "platforms${local.digital_email_suffix}"
 }

--- a/terraform/pagerduty/policy-schedules.tf
+++ b/terraform/pagerduty/policy-schedules.tf
@@ -28,8 +28,7 @@ resource "pagerduty_escalation_policy" "low_priority" {
     escalation_delay_in_minutes = 10
     target {
       type = "user_reference"
-      id   = pagerduty_user.pager_duty_users["david_elliott"].id
-      #id   = pagerduty_user.platforms.id
+      id   = pagerduty_user.pager_duty_users["modernisation_platform"].id
     }
   }
 }


### PR DESCRIPTION
PagerDuty requires that a user is always assigned to a service, since we
do not want to get low priority notifications, they are assigned to this
user.

The notifications still go through to the slack channel, but this user's
notifications have been removed (so we won't get the emails coming
through)