### PR TITLE
Update on call schedules

### DIFF
--- a/terraform/pagerduty/locals.tf
+++ b/terraform/pagerduty/locals.tf
@@ -32,11 +32,10 @@ locals {
 
   modernisation_platform_users = merge(local.existing_users, tomap(pagerduty_user.pager_duty_users))
 
-  oncall_users = concat(
-    [
-      pagerduty_user.pager_duty_users["david_elliott"].id
-    ]
-  )
+  # oncall users local shortcut to make schedules a bit neater
+  david_elliott  = pagerduty_user.pager_duty_users["david_elliott"].id
+  david_sibley   = pagerduty_user.pager_duty_users["david_sibley"].id
+  stephen_linden = data.pagerduty_user.stephen_linden.id
 
   tags = {
     business-unit = "Platforms"


### PR DESCRIPTION
Update the on call schedule to start next week.  Add the modernisation
platform user as a base layer, so that there is always someone on call
(you can't have a schedule with no oncall user).  Schedules can be
manually overwritten in pagerduty for holidays etc.