### PR TITLE
Update on call hours

### DIFF
--- a/source/team/operational-processes.html.md.erb
+++ b/source/team/operational-processes.html.md.erb
@@ -9,11 +9,11 @@ review_in: 6 months
 # <%= current_page.data.title %>
 
 ### Hours of support
-Our hours of providing support are 9am - 5pm. During this time we will work on support requests from teams and make sure someone is available to answer questions in Slack channel [#ask-modernisation-platform](https://mojdt.slack.com/archives/C013RM6MFFW).
+Our hours of providing support are 9am - 4pm. During this time we will work on support requests from teams and make sure someone is available to answer questions in Slack channel [#ask-modernisation-platform](https://mojdt.slack.com/archives/C013RM6MFFW).
 
 Outside of these hours we will respond to high priority incidents as per our [on call](#our-on-call-process) process.
 
-*During support hours (9AM - 5PM)*
+*During support hours (9AM - 4PM)*
 
 At least one engineer to:
 
@@ -28,7 +28,7 @@ The whole support team to:
 - Work on user requests for larger work
 - Work on support backlog stories
 
-*Before ending the day (5PM)*
+*Before ending the day (4PM)*
 
 At least one engineer to:
 
@@ -73,7 +73,7 @@ We will be doing this work between 10AM and 11AM
 Team members who are on call manage an on call rota in [PagerDuty](https://www.pagerduty.com/). The on call rota consists of a primary engineer and a secondary engineer.
 Team members that are new to the rota should ensure that they have a secondary who has enough knowledge and experience of the process to support them.
 
-The on-call hours are 7AM–9AM and 5PM–10PM weekdays, 7AM-10PM weekends and bank holidays.
+The on-call hours are 7AM–9AM and 4PM–10PM weekdays, 7AM-10PM weekends and bank holidays.
 
 On call team members will respond to high priority incidents during on call hours and will work on those incidents.
 If the engineer is not able to resolve the issue they will:


### PR DESCRIPTION
As a team the Modernisation platform generally is an early start team.
Updating the support and on-call hours to reflect this and ensure this
is clear for users.