### PR TITLE
applied abspath function 

### DIFF
--- a/terraform/modernisation-platform-account/lambda.tf
+++ b/terraform/modernisation-platform-account/lambda.tf
@@ -1,13 +1,13 @@
 data "archive_file" "instance_scheduler_zip" {
   type        = "zip"
-  source_dir  = "${path.module}/lambda/golang-instance-scheduler"
-  output_path = "${path.module}/lambda/files/golang_instance_scheduler.zip"
+  source_dir  = abspath("${path.module}/lambda/golang-instance-scheduler")
+  output_path = abspath("${path.module}/lambda/files/golang_instance_scheduler.zip")
 }
 
 resource "aws_lambda_function" "instance-scheduler" {
   #checkov:skip=CKV_AWS_116
   #checkov:skip=CKV_AWS_117
-  filename                       = "${path.module}/lambda/files/golang-instance-scheduler.zip"
+  filename                       = abspath("${path.module}/lambda/files/golang-instance-scheduler.zip")
   function_name                  = "golang-instance-scheduler"
   handler                        = "main"
   reserved_concurrent_executions = 0


### PR DESCRIPTION
* Using `abspath()` function forces the provision of the absolute path for the lambda function