### PR TITLE
Add TGW propagation statements

### DIFF
--- a/terraform/environments/core-network-services/locals.tf
+++ b/terraform/environments/core-network-services/locals.tf
@@ -29,4 +29,32 @@ locals {
     "hmpps-production-attachment",
     "core-network-services-live_data-attachment",
   ]
+
+  live_tgw_vpc_attachments = [
+    "core-logging-live_data-attachment",
+    "core-network-services-live_data-attachment",
+    "core-security-live_data-attachment",
+    "core-shared-services-live_data-attachment",
+    "hmcts-preproduction-attachment",
+    "hmcts-production-attachment",
+    "hmpps-preproduction-attachment",
+    "hmpps-production-attachment",
+    "hq-production-attachment"
+  ]
+
+  non_live_tgw_vpc_attachments = [
+    "cica-development-attachment",
+    "core-logging-non_live_data-attachment",
+    "core-network-services-non_live_data-attachment",
+    "core-security-non_live_data-attachment",
+    "core-shared-services-non_live_data-attachment",
+    "garden-sandbox-attachment",
+    "hmcts-development-attachment",
+    "hmpps-development-attachment",
+    "hmpps-test-attachment",
+    "house-sandbox-attachment",
+    "hq-development-attachment",
+    "platforms-development-attachment",
+    "platforms-test-attachment"
+  ]
 }

--- a/terraform/environments/core-network-services/transit_gateway_connections.tf
+++ b/terraform/environments/core-network-services/transit_gateway_connections.tf
@@ -149,23 +149,23 @@ data "aws_ec2_transit_gateway_vpc_attachments" "transit_gateway_all" {}
 
 data "aws_ec2_transit_gateway_vpc_attachment" "transit_gateway_all" {
   for_each = toset(data.aws_ec2_transit_gateway_vpc_attachments.transit_gateway_all.ids)
-  id = each.key
+  id       = each.key
 }
 
 resource "aws_ec2_transit_gateway_route_table_propagation" "propagate_live_data" {
-  for_each = data.aws_ec2_transit_gateway_vpc_attachment.transit_gateway_live_data
+  for_each                       = data.aws_ec2_transit_gateway_vpc_attachment.transit_gateway_live_data
   transit_gateway_attachment_id  = each.value["id"]
   transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.route-tables["live_data"].id
 }
 
 resource "aws_ec2_transit_gateway_route_table_propagation" "propagate_non_live_data" {
-  for_each = data.aws_ec2_transit_gateway_vpc_attachment.transit_gateway_non_live_data
+  for_each                       = data.aws_ec2_transit_gateway_vpc_attachment.transit_gateway_non_live_data
   transit_gateway_attachment_id  = each.value["id"]
   transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.route-tables["non_live_data"].id
 }
 
 resource "aws_ec2_transit_gateway_route_table_propagation" "propagate_firewall" {
-  for_each = data.aws_ec2_transit_gateway_vpc_attachments.transit_gateway_all
+  for_each                       = data.aws_ec2_transit_gateway_vpc_attachments.transit_gateway_all
   transit_gateway_attachment_id  = each.key
   transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.external_inspection_out.id
 }

--- a/terraform/environments/core-network-services/transit_gateway_connections.tf
+++ b/terraform/environments/core-network-services/transit_gateway_connections.tf
@@ -148,7 +148,7 @@ data "aws_ec2_transit_gateway_vpc_attachment" "transit_gateway_non_live_data" {
 data "aws_ec2_transit_gateway_vpc_attachments" "transit_gateway_all" {}
 
 data "aws_ec2_transit_gateway_vpc_attachment" "transit_gateway_all" {
-  for_each = data.aws_ec2_transit_gateway_vpc_attachments.transit_gateway_all.id
+  for_each = toset(data.aws_ec2_transit_gateway_vpc_attachments.transit_gateway_all.ids)
   id = each.key
 }
 

--- a/terraform/environments/core-network-services/transit_gateway_connections.tf
+++ b/terraform/environments/core-network-services/transit_gateway_connections.tf
@@ -159,7 +159,7 @@ resource "aws_ec2_transit_gateway_route_table_propagation" "propagate_non_live_d
   transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.route-tables["non_live_data"].id
 }
 
-resource "aws_ec2_transit_gateway_route_table_propagation" "propagate-firewall" {
+resource "aws_ec2_transit_gateway_route_table_propagation" "propagate_firewall" {
   for_each = data.aws_ec2_transit_gateway_vpc_attachments.transit_gateway_all
   transit_gateway_attachment_id  = each.key
   transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.external_inspection_out.id

--- a/terraform/environments/core-network-services/transit_gateway_connections.tf
+++ b/terraform/environments/core-network-services/transit_gateway_connections.tf
@@ -129,6 +129,42 @@ resource "aws_ec2_transit_gateway_route_table" "external_inspection_out" {
   )
 }
 
+data "aws_ec2_transit_gateway_vpc_attachment" "transit_gateway_live_data" {
+  for_each = toset(local.live_tgw_vpc_attachments)
+  filter {
+    name   = "tag:Name"
+    values = [each.key]
+  }
+}
+
+data "aws_ec2_transit_gateway_vpc_attachment" "transit_gateway_non_live_data" {
+  for_each = toset(local.non_live_tgw_vpc_attachments)
+  filter {
+    name   = "tag:Name"
+    values = [each.key]
+  }
+}
+
+data "aws_ec2_transit_gateway_vpc_attachments" "transit_gateway_all" {}
+
+resource "aws_ec2_transit_gateway_route_table_propagation" "propagate_live_data" {
+  for_each = data.aws_ec2_transit_gateway_vpc_attachment.transit_gateway_live_data
+  transit_gateway_attachment_id  = each.value["id"]
+  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.route-tables["live_data"].id
+}
+
+resource "aws_ec2_transit_gateway_route_table_propagation" "propagate_non_live_data" {
+  for_each = data.aws_ec2_transit_gateway_vpc_attachment.transit_gateway_non_live_data
+  transit_gateway_attachment_id  = each.value["id"]
+  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.route-tables["non_live_data"].id
+}
+
+resource "aws_ec2_transit_gateway_route_table_propagation" "propagate-firewall" {
+  for_each = data.aws_ec2_transit_gateway_vpc_attachments.transit_gateway_all
+  transit_gateway_attachment_id  = each.key
+  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.external_inspection_out.id
+}
+
 resource "aws_ec2_transit_gateway_route_table_propagation" "propagate-hmpps-test" {
   transit_gateway_attachment_id  = data.aws_ec2_transit_gateway_vpc_attachment.hmpps-test.id
   transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.external_inspection_in.id

--- a/terraform/environments/core-network-services/transit_gateway_connections.tf
+++ b/terraform/environments/core-network-services/transit_gateway_connections.tf
@@ -147,6 +147,11 @@ data "aws_ec2_transit_gateway_vpc_attachment" "transit_gateway_non_live_data" {
 
 data "aws_ec2_transit_gateway_vpc_attachments" "transit_gateway_all" {}
 
+data "aws_ec2_transit_gateway_vpc_attachment" "transit_gateway_all" {
+  for_each = data.aws_ec2_transit_gateway_vpc_attachments.transit_gateway_all.id
+  id = each.key
+}
+
 resource "aws_ec2_transit_gateway_route_table_propagation" "propagate_live_data" {
   for_each = data.aws_ec2_transit_gateway_vpc_attachment.transit_gateway_live_data
   transit_gateway_attachment_id  = each.value["id"]


### PR DESCRIPTION
* Add two statically typed lists with `live_data` and `non_live_data` VPCs
* Add data call to create a list of all TGW attachment IDs
* Add data call to create map of all TGW attachment attributes 
* Adds propagation statements to populate route tables with relevant attachments