### PR TITLE
remove new propagation statements

### DIFF
--- a/terraform/environments/core-network-services/locals.tf
+++ b/terraform/environments/core-network-services/locals.tf
@@ -30,31 +30,4 @@ locals {
     "core-network-services-live_data-attachment",
   ]
 
-  live_tgw_vpc_attachments = [
-    "core-logging-live_data-attachment",
-    "core-network-services-live_data-attachment",
-    "core-security-live_data-attachment",
-    "core-shared-services-live_data-attachment",
-    "hmcts-preproduction-attachment",
-    "hmcts-production-attachment",
-    "hmpps-preproduction-attachment",
-    "hmpps-production-attachment",
-    "hq-production-attachment"
-  ]
-
-  non_live_tgw_vpc_attachments = [
-    "cica-development-attachment",
-    "core-logging-non_live_data-attachment",
-    "core-network-services-non_live_data-attachment",
-    "core-security-non_live_data-attachment",
-    "core-shared-services-non_live_data-attachment",
-    "garden-sandbox-attachment",
-    "hmcts-development-attachment",
-    "hmpps-development-attachment",
-    "hmpps-test-attachment",
-    "house-sandbox-attachment",
-    "hq-development-attachment",
-    "platforms-development-attachment",
-    "platforms-test-attachment"
-  ]
 }

--- a/terraform/environments/core-network-services/transit_gateway_connections.tf
+++ b/terraform/environments/core-network-services/transit_gateway_connections.tf
@@ -129,45 +129,11 @@ resource "aws_ec2_transit_gateway_route_table" "external_inspection_out" {
   )
 }
 
-data "aws_ec2_transit_gateway_vpc_attachment" "transit_gateway_live_data" {
-  for_each = toset(local.live_tgw_vpc_attachments)
-  filter {
-    name   = "tag:Name"
-    values = [each.key]
-  }
-}
-
-data "aws_ec2_transit_gateway_vpc_attachment" "transit_gateway_non_live_data" {
-  for_each = toset(local.non_live_tgw_vpc_attachments)
-  filter {
-    name   = "tag:Name"
-    values = [each.key]
-  }
-}
-
 data "aws_ec2_transit_gateway_vpc_attachments" "transit_gateway_all" {}
 
 data "aws_ec2_transit_gateway_vpc_attachment" "transit_gateway_all" {
   for_each = toset(data.aws_ec2_transit_gateway_vpc_attachments.transit_gateway_all.ids)
   id       = each.key
-}
-
-resource "aws_ec2_transit_gateway_route_table_propagation" "propagate_live_data" {
-  for_each                       = data.aws_ec2_transit_gateway_vpc_attachment.transit_gateway_live_data
-  transit_gateway_attachment_id  = each.value["id"]
-  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.route-tables["live_data"].id
-}
-
-resource "aws_ec2_transit_gateway_route_table_propagation" "propagate_non_live_data" {
-  for_each                       = data.aws_ec2_transit_gateway_vpc_attachment.transit_gateway_non_live_data
-  transit_gateway_attachment_id  = each.value["id"]
-  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.route-tables["non_live_data"].id
-}
-
-resource "aws_ec2_transit_gateway_route_table_propagation" "propagate_firewall" {
-  for_each                       = data.aws_ec2_transit_gateway_vpc_attachments.transit_gateway_all
-  transit_gateway_attachment_id  = each.key
-  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.external_inspection_out.id
 }
 
 resource "aws_ec2_transit_gateway_route_table_propagation" "propagate-hmpps-test" {


### PR DESCRIPTION
While the branch that added static lists for route propagation planned successfully, the application of the branch raised some errors that can be seen in the logs. These appeared to reference the `core-network-services` attachments, and some entries in the resource to populate the firewall route table.

This PR removes those propagation statements and the static lists with related data calls, leaving in place the data calls required to create dynamic lists.