### PR TITLE
Dynamic vpc route propagation

### DIFF
--- a/terraform/environments/core-network-services/transit-gateway.tf
+++ b/terraform/environments/core-network-services/transit-gateway.tf
@@ -84,14 +84,6 @@ resource "aws_ec2_transit_gateway_route_table_association" "association" {
   transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.route-tables[each.key].id
 }
 
-# Propogate routes from the VPC attachment to the route table
-resource "aws_ec2_transit_gateway_route_table_propagation" "propagation" {
-  for_each = local.networking
-
-  transit_gateway_attachment_id  = aws_ec2_transit_gateway_vpc_attachment.attachments[each.key].id
-  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.route-tables[each.key].id
-}
-
 #########################
 # Routes for VPC attachments
 #########################

--- a/terraform/environments/core-network-services/transit_gateway_connections.tf
+++ b/terraform/environments/core-network-services/transit_gateway_connections.tf
@@ -127,25 +127,25 @@ resource "aws_ec2_transit_gateway_peering_attachment_accepter" "PTTP-Production"
 ######################
 # TGW Route tables
 ######################
-# Create Transit Gateway external-inspection-in routing table
+# Create Transit Gateway route table for ingress via external (non-MP) locations
 resource "aws_ec2_transit_gateway_route_table" "external_inspection_in" {
   transit_gateway_id = aws_ec2_transit_gateway.transit-gateway.id
 
   tags = merge(
     local.tags,
     {
-      Name = "external-inspection-in"
+      Name = "external"
     }
   )
 }
-# Create Transit Gateway external-inspection-out routing table
+# Create Transit Gateway firewall VPC routing table
 resource "aws_ec2_transit_gateway_route_table" "external_inspection_out" {
   transit_gateway_id = aws_ec2_transit_gateway.transit-gateway.id
 
   tags = merge(
     local.tags,
     {
-      Name = "external-inspection-out"
+      Name = "firewall"
     }
   )
 }

--- a/terraform/environments/core-network-services/transit_gateway_connections.tf
+++ b/terraform/environments/core-network-services/transit_gateway_connections.tf
@@ -160,6 +160,18 @@ resource "aws_ec2_transit_gateway_route_table_propagation" "propagate-hmpps-prod
   transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.external_inspection_in.id
 }
 
+resource "aws_ec2_transit_gateway_route_table_propagation" "propagate_live_data_vpcs" {
+  for_each = local.tgw_live_data_attachments
+  transit_gateway_attachment_id  = each.key
+  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.route-tables["live_data"].id
+}
+
+resource "aws_ec2_transit_gateway_route_table_propagation" "propagate_non_live_data_vpcs" {
+  for_each = local.tgw_non_live_data_attachments
+  transit_gateway_attachment_id  = each.key
+  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.route-tables["non_live_data"].id
+}
+
 # add external egress routes for non-live-data TGW route table to PTTP attachment
 resource "aws_ec2_transit_gateway_route" "tgw_external_egress_routes_for_non_live_data_to_PTTP" {
   for_each = local.egress_pttp_routing_cidrs_non_live_data

--- a/terraform/environments/core-network-services/transit_gateway_connections.tf
+++ b/terraform/environments/core-network-services/transit_gateway_connections.tf
@@ -161,19 +161,19 @@ resource "aws_ec2_transit_gateway_route_table_propagation" "propagate-hmpps-prod
 }
 
 resource "aws_ec2_transit_gateway_route_table_propagation" "propagate_live_data_vpcs" {
-  for_each = local.tgw_live_data_attachments
+  for_each                       = local.tgw_live_data_attachments
   transit_gateway_attachment_id  = each.key
   transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.route-tables["live_data"].id
 }
 
 resource "aws_ec2_transit_gateway_route_table_propagation" "propagate_non_live_data_vpcs" {
-  for_each = local.tgw_non_live_data_attachments
+  for_each                       = local.tgw_non_live_data_attachments
   transit_gateway_attachment_id  = each.key
   transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.route-tables["non_live_data"].id
 }
 
 resource "aws_ec2_transit_gateway_route_table_propagation" "propagate_firewall" {
-  for_each = data.aws_ec2_transit_gateway_vpc_attachment.transit_gateway_all
+  for_each                       = data.aws_ec2_transit_gateway_vpc_attachment.transit_gateway_all
   transit_gateway_attachment_id  = each.key
   transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.external_inspection_out.id
 }

--- a/terraform/environments/core-network-services/transit_gateway_connections.tf
+++ b/terraform/environments/core-network-services/transit_gateway_connections.tf
@@ -172,6 +172,12 @@ resource "aws_ec2_transit_gateway_route_table_propagation" "propagate_non_live_d
   transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.route-tables["non_live_data"].id
 }
 
+resource "aws_ec2_transit_gateway_route_table_propagation" "propagate_firewall" {
+  for_each = data.aws_ec2_transit_gateway_vpc_attachment.transit_gateway_all
+  transit_gateway_attachment_id  = each.key
+  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.external_inspection_out.id
+}
+
 # add external egress routes for non-live-data TGW route table to PTTP attachment
 resource "aws_ec2_transit_gateway_route" "tgw_external_egress_routes_for_non_live_data_to_PTTP" {
   for_each = local.egress_pttp_routing_cidrs_non_live_data


### PR DESCRIPTION
* Solves #1397 
* Amend name tags for two transit gateway route tables to better clarify their purposes
* Programatically retrieve `transit_gateway_attachment_id` and populate two separate local values with the contents
* Add `aws_ec2_transit_gateway_route_table_propagation` statements that use local values for `live_data` / `non_live_data` route tables.
* Add `aws_ec2_transit_gateway_route_table_propagation` statement to give firewall VPC knowledge of all attached VPCs.
* Remove statements superseded by these new propagation statements