### PR TITLE
remove creation of static TGW routes from vpc-tgw-routing module

### DIFF
--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -157,10 +157,7 @@ module "vpc_tgw_routing" {
 
   route_table             = data.aws_route_table.main-public
   subnet_sets             = { for key, subnet in each.value.cidr.subnet_sets : key => subnet.cidr }
-  tgw_vpc_attachment      = module.vpc_attachment[each.key].tgw_vpc_attachment
-  tgw_route_table         = module.vpc_attachment[each.key].tgw_route_table
   tgw_id                  = data.aws_ec2_transit_gateway.transit-gateway.id
-  external_inspection_out = data.aws_ec2_transit_gateway_route_table.external_inspection_out.id
 
   depends_on = [module.vpc_attachment, module.vpc]
 }

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -155,9 +155,9 @@ module "vpc_tgw_routing" {
     aws = aws.core-network-services
   }
 
-  route_table             = data.aws_route_table.main-public
-  subnet_sets             = { for key, subnet in each.value.cidr.subnet_sets : key => subnet.cidr }
-  tgw_id                  = data.aws_ec2_transit_gateway.transit-gateway.id
+  route_table = data.aws_route_table.main-public
+  subnet_sets = { for key, subnet in each.value.cidr.subnet_sets : key => subnet.cidr }
+  tgw_id      = data.aws_ec2_transit_gateway.transit-gateway.id
 
   depends_on = [module.vpc_attachment, module.vpc]
 }

--- a/terraform/modules/vpc-tgw-routing/main.tf
+++ b/terraform/modules/vpc-tgw-routing/main.tf
@@ -1,23 +1,7 @@
-resource "aws_ec2_transit_gateway_route" "example" {
-  for_each = tomap(var.subnet_sets)
-
-  destination_cidr_block         = each.value
-  transit_gateway_attachment_id  = var.tgw_vpc_attachment
-  transit_gateway_route_table_id = var.tgw_route_table
-}
-
 resource "aws_route" "main" {
   for_each = tomap(var.subnet_sets)
 
   route_table_id         = var.route_table.id
   destination_cidr_block = each.value
   transit_gateway_id     = var.tgw_id
-}
-
-resource "aws_ec2_transit_gateway_route" "external_inspection_out" {
-  for_each = tomap(var.subnet_sets)
-
-  destination_cidr_block         = each.value
-  transit_gateway_attachment_id  = var.tgw_vpc_attachment
-  transit_gateway_route_table_id = var.external_inspection_out
 }

--- a/terraform/modules/vpc-tgw-routing/variables.tf
+++ b/terraform/modules/vpc-tgw-routing/variables.tf
@@ -3,21 +3,6 @@ variable "subnet_sets" {
   type        = map(any)
 }
 
-variable "tgw_vpc_attachment" {
-  description = "Transit Gateway VPC attachment ID"
-  type        = string
-}
-
-variable "tgw_route_table" {
-  description = "Transit Gateway route table ID"
-  type        = string
-}
-
-variable "external_inspection_out" {
-  description = "Transit Gateway route table ID for internal-inspection-out"
-  type        = string
-}
-
 variable "route_table" {
   description = "Route Table"
 }


### PR DESCRIPTION
This removes the creation of static routes in the relevant `live_data` / `non_live_data` route table as well as the `firewall` route table. These routes are now supplied through dynamic propagation, so the static routes are no longer required.