### PR TITLE
updated skip-locals list, removed set -x from scripts

### DIFF
--- a/scripts/setup-baseline.sh
+++ b/scripts/setup-baseline.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -euxo pipefail
+set -euo pipefail
 
 #set parameters
 directory="$1"

--- a/scripts/terraform-init.sh
+++ b/scripts/terraform-init.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -ex
+set -e
 
 # This script runs terraform init with input set to false and no color outputs, suitable for running as part of a CI/CD pipeline.
 # You need to pass through a Terraform directory as an argument, e.g.

--- a/scripts/terraform-plan.sh
+++ b/scripts/terraform-plan.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 set -o pipefail
-set -ex
+set -e
 
 # This script runs terraform plan with input set to false and no color outputs, suitable for running as part of a CI/CD pipeline.
 # You need to pass through a Terraform directory as an argument, e.g.

--- a/terraform/environments/bootstrap/delegate-access/locals.tf
+++ b/terraform/environments/bootstrap/delegate-access/locals.tf
@@ -16,8 +16,9 @@ locals {
     source-code   = "https://github.com/ministryofjustice/modernisation-platform/tree/main/terraform/environments/bootstrap/delegate-access"
   }
   # skip the following alias creation if the alias is used by another account (they are globally unique)
-  skip_alias = [
+  skip_alias = sort([
+    "apex-development",
     "nomis-production",
     "testing-test"
-  ]
+  ])
 }


### PR DESCRIPTION
* Use `sort()` function to ensure list of skipped aliases is always presented consistently
* Removed `set -x` where used for debugging