### PR TITLE
Add environments_file and OU root account data calls to locals.tf

### DIFF
--- a/terraform/templates/data.tf
+++ b/terraform/templates/data.tf
@@ -1,12 +1,3 @@
-# This data sources allows us to get the Modernisation Platform account information for use elsewhere
-# (when we want to assume a role in the MP, for instance)
-data "aws_organizations_organization" "root_account" {}
-
-# Get the environments file from the main repository
-data "http" "environments_file" {
-  url = "https://raw.githubusercontent.com/ministryofjustice/modernisation-platform/main/environments/${local.application_name}.json"
-}
-
 # Current account data
 data "aws_region" "current" {}
 

--- a/terraform/templates/locals.tf
+++ b/terraform/templates/locals.tf
@@ -1,3 +1,12 @@
+# This data sources allows us to get the Modernisation Platform account information for use elsewhere
+# (when we want to assume a role in the MP, for instance)
+data "aws_organizations_organization" "root_account" {}
+
+# Get the environments file from the main repository
+data "http" "environments_file" {
+  url = "https://raw.githubusercontent.com/ministryofjustice/modernisation-platform/main/environments/${local.application_name}.json"
+}
+
 locals {
 
   application_name = "$application_name"
@@ -29,7 +38,7 @@ locals {
   provider_name = "core-vpc-${local.environment}"
 
   # environment specfic variables
-  # example usage:  
+  # example usage:
   # example_data = local.application_data.accounts[local.environment].example_var
   application_data = fileexists("./application_variables.json") ? jsondecode(file("./application_variables.json")) : {}
 }


### PR DESCRIPTION
Bug identified when creating accounts - the necessary data calls were 
not present in the locals file in the modernisation platform member 
accounts upon account creation. This PR moves the necessary data calls 
back to the locals.tf from data.tf