### PR TITLE
added missing KMS permission

### DIFF
--- a/terraform/modules/kms/main.tf
+++ b/terraform/modules/kms/main.tf
@@ -61,6 +61,7 @@ data "aws_iam_policy_document" "kms" {
     effect = "Allow"
     actions = [
       "kms:CreateGrant",
+      "kms:ListGrants",
       "kms:Encrypt",
       "kms:Decrypt",
       "kms:ReEncrypt*",


### PR DESCRIPTION
Discovered that, in some situations, `kms:ListGrants` was required for use of per-business-unit KMS keys.
https://github.com/hashicorp/terraform-provider-aws/issues/4141#issuecomment-506216964