### PR TITLE
Revert "OIDC provider permissions"

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -32,14 +32,13 @@ module "cicd-member-user" {
 
 module "member-access" {
   count  = local.account_data.account-type == "member" && terraform.workspace != "testing-test" ? 1 : 0
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access?ref=v2.1.0"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access?ref=v2.0.0"
   providers = {
     aws = aws.workspace
   }
-  account_id             = local.modernisation_platform_account.id
-  additional_trust_roles = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/github-actions"
-  policy_arn             = aws_iam_policy.member-access[0].id
-  role_name              = "MemberInfrastructureAccess"
+  account_id = local.modernisation_platform_account.id
+  policy_arn = aws_iam_policy.member-access[0].id
+  role_name  = "MemberInfrastructureAccess"
 }
 
 #tfsec:ignore:aws-iam-no-policy-wildcards

--- a/terraform/environments/core-network-services/iam.tf
+++ b/terraform/environments/core-network-services/iam.tf
@@ -16,17 +16,6 @@ resource "aws_iam_role" "dns" {
           },
           "Action" : "sts:AssumeRole",
           "Condition" : {}
-          }, {
-          "Effect" : "Allow",
-          "Principal" : {
-            "AWS" : "arn:aws:iam::*:role/github-actions"
-          },
-          "Action" : "sts:AssumeRole",
-          "Condition" : {
-            "ForAnyValue:StringLike" : {
-              "aws:PrincipalOrgPaths" : ["${data.aws_organizations_organization.root_account.id}/*/${local.environment_management.modernisation_platform_organisation_unit_id}/*"]
-            }
-          }
         },
         {
           "Effect" : "Allow",


### PR DESCRIPTION
Reverts ministryofjustice/modernisation-platform#2091

Does so as this breaks two automated steps due to invalid principals:
https://github.com/ministryofjustice/modernisation-platform/runs/7765852215#step:4:494
https://github.com/ministryofjustice/modernisation-platform/runs/7765848186#step:6:57