### PR TITLE
Update on account deletion process

### DIFF
--- a/source/runbooks/deleting-an-environment.html.md.erb
+++ b/source/runbooks/deleting-an-environment.html.md.erb
@@ -143,74 +143,15 @@ For the following workspaces, switch to the workspace and run a `terraform destr
 
 `modernisation-platform/terraform/environments/<application-name>`
 
-```bash
-$ aws-vault exec modernisation-platform -- .scripts/internal/find-terraform-workspace.sh core-vpc-non-live-data
-Starting a `terraform workspace` search from ./modernisation-platform
+After completing this, you will need to destroy any lingering terraform workspaces in the following:
 
-Searching for Terraform workspaces in ./terraform/environments
+`modernisation-platform/terraform/environments/bootstrap/delegate-access/<application-name>`
 
-Workspace "core-vpc-non-live-data" doesn't exist.
+`modernisation-platform/terraform/environments/bootstrap/secure-baselines/<application-name>`
 
-You can create this workspace with the "new" subcommand.
+`modernisation-platform/terraform/environments/bootstrap/single-sign-on/<application-name>`
 
-Finished searching for Terraform workspaces in ./terraform/environments
-
-...
-
-Searching for Terraform workspaces in ./terraform/environments/bootstrap/delegate-access
-Switched to workspace "default".
-Switched to workspace "core-vpc-non-live-data".
-
-Finished searching for Terraform workspaces in ./terraform/environments/bootstrap/delegate-access
-
-
-Searching for Terraform workspaces in ./terraform/environments/bootstrap/secure-baselines
-Switched to workspace "default".
-Switched to workspace "core-vpc-non-live-data".
-
-Finished searching for Terraform workspaces in ./terraform/environments/bootstrap/secure-baselines
-
-
-Searching for Terraform workspaces in ./terraform/environments/bootstrap/single-sign-on
-Switched to workspace "default".
-Switched to workspace "core-vpc-non-live-data".
-
-Finished searching for Terraform workspaces in ./terraform/environments/bootstrap/single-sign-on
-
-...
-
-Searching for Terraform workspaces in ./terraform/environments/core-vpc
-Switched to workspace "default".
-Switched to workspace "core-vpc-non-live-data".
-
-Finished searching for Terraform workspaces in ./terraform/environments/core-vpc
-
-...
-```
-
-If a workspace doesn't exist by that name, this script will return:
-
-```bash
-Searching for Terraform workspaces in ./terraform/modernisation-platform-account
-
-Workspace "core-vpc-non-live-data" doesn't exist.
-
-You can create this workspace with the "new" subcommand.
-
-Finished searching for Terraform workspaces in ./terraform/modernisation-platform-account
-```
-
-If a workspace does exist, this script will return:
-
-```bash
-Searching for Terraform workspaces in ./terraform/environments/bootstrap/delegate-access
-Switched to workspace "default".
-Switched to workspace "core-vpc-non-live-data".
-
-Finished searching for Terraform workspaces in ./terraform/environments/bootstrap/delegate-access
-```
-
-You need to go through all of the directories where the workspace appears and run:
+For example: 
 
 ```bash
 terraform workspace delete -force core-vpc-non-live-data
@@ -234,7 +175,7 @@ After following the above steps, you need to move the account to the closed acco
 
 This is to move the account out of an organizational unit where there is an SCP preventing any actions by the root user.
 
-Log into the AWS Console and navigate to AWS Oraganizations, find the account and move it to the `root` OU.
+Log into the AWS Console and navigate to AWS Organizations, find the account and move it to the `root` OU.
 
 Now the AWS account can be deleted.
 

--- a/source/runbooks/deleting-an-environment.html.md.erb
+++ b/source/runbooks/deleting-an-environment.html.md.erb
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#modernisation-platform"
 title: Deleting an environment (AWS account)
-last_reviewed_on: 2022-03-03
+last_reviewed_on: 2022-08-10
 review_in: 6 month
 ---
 
@@ -137,23 +137,11 @@ Before merging in these changes, complete the rest of the steps in this document
 
 ## Find and delete the Terraform workspaces for the environment
 
-Run `find-terraform-workspaces.sh <workspace name>` to quickly return where workspaces for an AWS account exist:
-
-This should be run from the modernisation platform root directory, using appropriate credetials (eg AWS Vault)
-
-Note, whilst this script will find all of the workspaces, it will take a while to run, currently most accounts will only have workspaces in the following locations:
-
-`modernisation-platform/terraform/environments/bootstrap/delegate-access`
-
-`modernisation-platform/terraform/environments/bootstrap/secure-baselines`
-
-`modernisation-platform/terraform/environments/bootstrap/single-sign-on`
-
-`modernisation-platform/terraform/environments/<application-name>`
-
 For the following workspaces, switch to the workspace and run a `terraform destroy` to ensure any resources such as DNS entries created in shared accounts are deleted and not orphaned.
 
 `modernisation-platform-environments/terraform/environments/<application-name>`
+
+`modernisation-platform/terraform/environments/<application-name>`
 
 ```bash
 $ aws-vault exec modernisation-platform -- .scripts/internal/find-terraform-workspace.sh core-vpc-non-live-data
@@ -254,9 +242,10 @@ Now the AWS account can be deleted.
 
 >This process cannot be undone. Proceed carefully.
 
-Follow the [AWS documentation on closing an AWS account](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_accounts_close.html). You will need:
+Follow the [AWS documentation on closing an AWS account](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/close-account.html#closing-the-account). You will need:
 
 - access to the AWS account's root email address (_not_ the AWS Organizations root account)
+- the ability to read password reset emails
 
 ## Move the account to the closed accounts organizational unit
 

--- a/source/runbooks/deleting-an-environment.html.md.erb
+++ b/source/runbooks/deleting-an-environment.html.md.erb
@@ -143,7 +143,7 @@ For the following workspaces, switch to the workspace and run a `terraform destr
 
 `modernisation-platform/terraform/environments/<application-name>`
 
-After completing this, you will need to destroy any lingering terraform workspaces in the following:
+After completing this, you will need to delete the terraform workspaces in the following:
 
 `modernisation-platform/terraform/environments/bootstrap/delegate-access/<application-name>`
 

--- a/source/runbooks/deleting-an-environment.html.md.erb
+++ b/source/runbooks/deleting-an-environment.html.md.erb
@@ -7,7 +7,7 @@ review_in: 6 month
 
 # <%= current_page.data.title %>
 
->Note: This process is cannot be undone. All resources in an AWS account will be deleted.
+> Note: This process is cannot be undone. All resources in an AWS account will be deleted.
 
 In the Modernisation Platform, we run a pipeline to create AWS accounts using the `aws_organizations_account` Terraform resource.
 
@@ -157,7 +157,7 @@ For example:
 terraform workspace delete -force core-vpc-non-live-data
 ```
 
->This will not delete the resources that are set up by the Terraform configuration. It will only delete the Terraform reference to the workspace. You will need to delete the AWS account properly.
+> This will not delete the resources that are set up by the Terraform configuration. It will only delete the Terraform reference to the workspace. You will need to delete the AWS account properly.
 
 If you delete the last environment and there are no more environments for the application, you should delete all of the environment files in the following folders:
 
@@ -171,7 +171,7 @@ After following the above steps, you need to move the account to the closed acco
 
 ## Move the account to the root organizational unit
 
->Note that a user with root account permissions will need to do this.
+> Note that a user with root account permissions will need to do this.
 
 This is to move the account out of an organizational unit where there is an SCP preventing any actions by the root user.
 
@@ -181,7 +181,7 @@ Now the AWS account can be deleted.
 
 ## Delete the actual AWS account
 
->This process cannot be undone. Proceed carefully.
+> This process cannot be undone. Proceed carefully.
 
 Follow the [AWS documentation on closing an AWS account](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/close-account.html#closing-the-account). You will need:
 
@@ -190,7 +190,7 @@ Follow the [AWS documentation on closing an AWS account](https://docs.aws.amazon
 
 ## Move the account to the closed accounts organizational unit
 
->Note that a user with root account permissions will need to do this.
+> Note that a user with root account permissions will need to do this.
 
 Log into the AWS Console and navigate to AWS Oraganizations, find the account and move it to the `Closed accounts` OU.
 

--- a/source/runbooks/deleting-an-environment.html.md.erb
+++ b/source/runbooks/deleting-an-environment.html.md.erb
@@ -151,6 +151,9 @@ After completing this, you will need to destroy any lingering terraform workspac
 
 `modernisation-platform/terraform/environments/bootstrap/single-sign-on/<application-name>`
 
+`modernisation-platform-environments/terraform/environments/<application-name>`
+
+`modernisation-platform/terraform/environments/<application-name>`
 For example: 
 
 ```bash


### PR DESCRIPTION
* Referenced script no longer exists, so references have been removed
* Updated reference to documentation for account deletion as an Organization-centric view is not necessarily appropriate; an account can be deleted without that access as a root user