### PR TITLE
Make Github OIDC conditional based on member type

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -400,7 +400,7 @@ module "github-oidc" {
 }
 
 data "aws_iam_policy_document" "oidc_assume_role" {
-  count  = local.account_data.account-type == "member" ? 1 : 0
+  count = local.account_data.account-type == "member" ? 1 : 0
   statement {
     sid    = "AllowOIDCToAssumeRoles"
     effect = "Allow"

--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -35,7 +35,7 @@ module "member-access" {
     aws = aws.workspace
   }
   account_id             = local.modernisation_platform_account.id
-  additional_trust_roles = [module.github-oidc.github_actions_role]
+  additional_trust_roles = [module.github-oidc[0].github_actions_role]
   policy_arn             = aws_iam_policy.member-access[0].id
   role_name              = "MemberInfrastructureAccess"
 }
@@ -388,6 +388,7 @@ module "shield_response_team_role" {
 
 # Github OIDC provider
 module "github-oidc" {
+  count  = local.account_data.account-type == "member" ? 1 : 0
   source = "github.com/ministryofjustice/modernisation-platform-github-oidc-provider?ref=v1.1.0"
   providers = {
     aws = aws.workspace

--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -393,13 +393,14 @@ module "github-oidc" {
   providers = {
     aws = aws.workspace
   }
-  additional_permissions = data.aws_iam_policy_document.oidc_assume_role.json
+  additional_permissions = data.aws_iam_policy_document.oidc_assume_role[0].json
   github_repository      = "ministryofjustice/modernisation-platform-environments:*"
   tags_common            = { "Name" = format("%s-oidc", terraform.workspace) }
   tags_prefix            = ""
 }
 
 data "aws_iam_policy_document" "oidc_assume_role" {
+  count  = local.account_data.account-type == "member" ? 1 : 0
   statement {
     sid    = "AllowOIDCToAssumeRoles"
     effect = "Allow"

--- a/terraform/environments/bootstrap/delegate-access/locals.tf
+++ b/terraform/environments/bootstrap/delegate-access/locals.tf
@@ -12,7 +12,7 @@ locals {
   environment_management         = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
   application_name               = try(regex("^bichard*.|^remote-supervisio*.", terraform.workspace), replace(terraform.workspace, "/-([[:alnum:]]+)$/", ""))
   business_unit                  = jsondecode(data.http.environments_file.response_body).tags.business-unit
-  application_environment        = substr(terraform.workspace, length(local.application_name) + 1, -1)
+  application_environment        = length(regexall("^bichard*.|^remote-supervisio*.", terraform.workspace)) > 0 ? terraform.workspace : substr(terraform.workspace, length(local.application_name) + 1, -1)
 
   environments = {
     business-unit = "Platforms"


### PR DESCRIPTION
* Resolve issue where `application_environment` is incorrectly created for legacy accounts
* Ensure only `member` type accounts are provided with Github OIDC resources