### PR TITLE
correctly populate IAM statement conditions

### DIFF
--- a/terraform/environments/core-network-services/iam.tf
+++ b/terraform/environments/core-network-services/iam.tf
@@ -33,11 +33,14 @@ resource "aws_iam_role" "dns" {
           "Action" : "sts:AssumeRole",
           "Condition" : {
             "ForAnyValue:StringLike" : {
-              "aws:PrincipalOrgPaths" : ["${data.aws_organizations_organization.root_account.id}/*/${local.environment_management.modernisation_platform_organisation_unit_id}/*"]
+              "aws:PrincipalOrgPaths" : [
+                "${data.aws_organizations_organization.root_account.id}/*/${local.environment_management.modernisation_platform_organisation_unit_id}/*"
+              ]
             },
             "ForAnyValue:StringLike" : {
               "aws:PrincipalArn" : ["aws:arn:iam::*:role/github-actions"]
             }
+          }
         }
       ]
   })

--- a/terraform/environments/core-network-services/iam.tf
+++ b/terraform/environments/core-network-services/iam.tf
@@ -4,6 +4,7 @@ data "aws_iam_role" "vpc-flow-log" {
 
 # Role to allow ci/cd to update DNS records for ACM certificate validation
 resource "aws_iam_role" "dns" {
+  #checkov:skip=CKV_AWS_60:Wildcard constrained by condition checks
   name = "modify-dns-records"
   assume_role_policy = jsonencode(
     {

--- a/terraform/environments/core-network-services/iam.tf
+++ b/terraform/environments/core-network-services/iam.tf
@@ -34,13 +34,10 @@ resource "aws_iam_role" "dns" {
           "Condition" : {
             "ForAnyValue:StringLike" : {
               "aws:PrincipalOrgPaths" : ["${data.aws_organizations_organization.root_account.id}/*/${local.environment_management.modernisation_platform_organisation_unit_id}/*"]
-            }
-          },
-          "Condition" : {
+            },
             "ForAnyValue:StringLike" : {
               "aws:PrincipalArn" : ["aws:arn:iam::*:role/github-actions"]
             }
-          }
         }
       ]
   })


### PR DESCRIPTION
* Fixes previous version where two conditions were applied, but conditions must exist in one condition block