### PR TITLE
Correctly state condition keys for IAM Policy

### DIFF
--- a/terraform/environments/core-network-services/iam.tf
+++ b/terraform/environments/core-network-services/iam.tf
@@ -34,11 +34,7 @@ resource "aws_iam_role" "dns" {
           "Action" : "sts:AssumeRole",
           "Condition" : {
             "ForAnyValue:StringLike" : {
-              "aws:PrincipalOrgPaths" : [
-                "${data.aws_organizations_organization.root_account.id}/*/${local.environment_management.modernisation_platform_organisation_unit_id}/*"
-              ]
-            },
-            "ForAnyValue:StringLike" : {
+              "aws:PrincipalOrgPaths" : ["${data.aws_organizations_organization.root_account.id}/*/${local.environment_management.modernisation_platform_organisation_unit_id}/*"],
               "aws:PrincipalArn" : ["aws:arn:iam::*:role/github-actions"]
             }
           }


### PR DESCRIPTION
* Correctly concatenates the two condition operators used for securing wildcard access to the `modify-dns-rule`