### PR TITLE
Resolve the bastion host key change warning

### DIFF
--- a/source/user-guide/accessing-ec2s.html.md.erb
+++ b/source/user-guide/accessing-ec2s.html.md.erb
@@ -68,6 +68,8 @@ Host glados-test-bastion
      ProxyCommand sh -c "aws ssm start-session --target $(aws ec2 describe-instances --no-cli-pager --filters "Name=tag:Name,Values=bastion_linux" --query 'Reservations[0].Instances[0].InstanceId' --profile glados-test-developer) --document-name AWS-StartSSHSession --parameters 'portNumber=%p' --profile glados-test-developer --region eu-west-2"
 ```
 
+>Note: The bastion server is re-created on daily basis which causes the host identification to change. When the user connects to the bastion using SSH, the SSH client warns about the host identification change. In the above, the configuration `StrictHostKeyChecking no`, `UserKnownHostsFile /dev/null` and `LogLevel QUIET` is added to prevent the `WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!` by the SSH client. If we didn't add the above, the user would have to manually remove the old host key from `~/.ssh/known_hosts` on daily basis, which could be annoying.
+
 6) SSH to the bastion using the following command:
 
 ```

--- a/source/user-guide/accessing-ec2s.html.md.erb
+++ b/source/user-guide/accessing-ec2s.html.md.erb
@@ -60,6 +60,9 @@ Once the bastion has been built in the environemnt, these steps outline the addi
 
 ```
 Host glados-test-bastion
+     StrictHostKeyChecking no
+     UserKnownHostsFile /dev/null
+     LogLevel QUIET
      IdentityFile ~/.ssh/id_rsa
      User jane
      ProxyCommand sh -c "aws ssm start-session --target $(aws ec2 describe-instances --no-cli-pager --filters "Name=tag:Name,Values=bastion_linux" --query 'Reservations[0].Instances[0].InstanceId' --profile glados-test-developer) --document-name AWS-StartSSHSession --parameters 'portNumber=%p' --profile glados-test-developer --region eu-west-2"


### PR DESCRIPTION
New bastion is re-created on daily basis. The result is that when the user SSH to the bastion, he/she has to remove the old host key from known_hosts every time bastion is reset:


```
ssh sprinkler-sandbox-bastion
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
@    WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!     @
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
IT IS POSSIBLE THAT SOMEONE IS DOING SOMETHING NASTY!
Someone could be eavesdropping on you right now (man-in-the-middle attack)!
It is also possible that a host key has just been changed.
The fingerprint for the ECDSA key sent by the remote host is
SHA256:EFrOMMDrFFu37+1oISNRxSvKRKM+XhYg1qVpTaeQlas.
Please contact your system administrator.
Add correct host key in /Users/george.fountopoulos/.ssh/known_hosts to get rid of this message.
Offending ECDSA key in /Users/george.fountopoulos/.ssh/known_hosts:12
ECDSA host key for sprinkler-sandbox-bastion has changed and you have requested strict checking.
Host key verification failed.
This might be annoying for the end user.
```

This might be annoying for the end user.