### PR TITLE
amended how modernisation platform account ID is referenced

### DIFF
--- a/source/user-guide/accessing-the-aws-console.html.md.erb
+++ b/source/user-guide/accessing-the-aws-console.html.md.erb
@@ -25,7 +25,7 @@ Next authorise GitHub
 
 ![Authorise GitHub](../images/authorise-github.png)
 
-You are now logged in to the single sign on. 
+You are now logged in to the single sign on.
 
 Click on `AWS Account` to view a list of the accounts you have available to you.
 

--- a/source/user-guide/creating-resources.html.md.erb
+++ b/source/user-guide/creating-resources.html.md.erb
@@ -27,13 +27,13 @@ These resources are preconfigured with a backend, providers etc, all that you ne
  - For any files created in your application folder, your GitHub team will have permissions to create and merge pull requests.
  - Your GitHub team will be assigned as a [codeowner](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners) for your application folder, so someone in your team will be required to review any pull requests before they can be merged.
 
-## Restrictions 
-- The following files you will not be able to amend without an approving review from the Modernisation Platform team. 
+## Restrictions
+- The following files you will not be able to amend without an approving review from the Modernisation Platform team.
   - `providers.tf`
   - `backend.tf`
   - `subnet_share.tf`
   - `networking.auto.tfvars.json`
- 
+
 - The ability to create some resources will be restricted and will require assistance from the Modernisation Platform team.
 
 ## Next Steps

--- a/source/user-guide/deploying-your-application.html.md.erb
+++ b/source/user-guide/deploying-your-application.html.md.erb
@@ -30,7 +30,7 @@ You can create and rotate AWS credentials to add to your application deployment 
 1. Click on the “security credentials” tab from the summary and you should see a list of options
 
 1. The modernisation-platform-developer role has permission to create a new AWS key for this user. To do this, click on “Create access key
-                    
+
 1. This will auto-generate a new AWS secret key for this user. This key allows for programmatic access to has access to this account. ( Note. This is key is your responsibility. Please do not store the key locally and make sure the .csv file is deleted once you have transferred the key over to your CI/CD tool ).
 
 1. Once you have the new key, please make the original key inactive by selecting the “make inactive” action next to the key pair

--- a/source/user-guide/getting-aws-credentials.html.md.erb
+++ b/source/user-guide/getting-aws-credentials.html.md.erb
@@ -11,11 +11,9 @@ You can obtain temporary AWS credentials to use the AWS CLI or other command lin
 
 To have access to your AWS credentials you will need to be a member of the GitHub team specified when the [environment was created](./creating-environments.html#github-team-slug)
 
-
 Note - you do not need to obtain AWS credentials to deploy infrastructure, this is done via GitHub Workflows (see [deploying you infrastructure](deploying-your-infrastructure.html).
 
 If you need credentials to make an application deployment, a CI user is created as part of the initial account set up, see [here](obtaining-deployment-credentials.html) for obtaining the credentials for that user.
-
 
 1. [Log in to the AWS Console](accessing-the-aws-console.html)
 

--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -184,7 +184,7 @@ module "instance-scheduler-access" {
     aws = aws.workspace
   }
   account_id             = local.modernisation_platform_account.id
-  additional_trust_roles = [format("arn:aws:iam::%s:role/LambdaInstanceSchedulerPolicy", local.environment_management.account_ids["modernisation_platform_account_id"])]
+  additional_trust_roles = [format("arn:aws:iam::%s:role/LambdaInstanceSchedulerPolicy", local.environment_management.modernisation_platform_account_id)]
   policy_arn             = aws_iam_policy.instance-scheduler-access[0].id
   role_name              = "InstanceSchedulerAccess"
 }


### PR DESCRIPTION
* `modernisation_platform_account_id` reference updated to reflect where it sits in the json