### PR TITLE
Add new OPA test to check valid Access level

### DIFF
--- a/policies/collaborators/collaborators_test.rego
+++ b/policies/collaborators/collaborators_test.rego
@@ -27,5 +27,5 @@ test_empty_values {
 }
 
 test_unexpected_access {
-  deny["`example.json` uses an unexpected access: got `incorrect-access`, expected one of: read-only, developer"] with input as { "filename": "example.json", "users" :[{"accounts": [{"access": "incorrect-access"}]}] }
+  deny["`example.json` uses an unexpected access: got `incorrect-access`, expected one of: read-only, developer, security-audit"] with input as { "filename": "example.json", "users" :[{"accounts": [{"access": "incorrect-access"}]}] }
 }

--- a/policies/environments/environment-definitions.rego
+++ b/policies/environments/environment-definitions.rego
@@ -11,6 +11,13 @@ allowed_business_units := [
   "CJSE"
 ]
 
+allowed_access := [
+  "view-only",
+  "developer",
+  "sandbox",
+  "administrator"
+]
+
 deny[msg] {
   without_filename := object.remove(input, ["filename"])
 
@@ -69,4 +76,10 @@ deny[msg] {
 deny[msg] {
   not has_field(input.tags, "owner")
   msg := sprintf("`%v` is missing the `owner` tag", [input.filename])
+}
+
+deny[msg] {
+  access:=input.environments[_].access[_].level
+  not array_contains(allowed_access, access)
+  msg := sprintf("`%v` uses an unexpected access level: got `%v`, expected one of: %v", [input.filename, access, concat(", ", allowed_access) ])
 }

--- a/policies/environments/environment-definitions_test.rego
+++ b/policies/environments/environment-definitions_test.rego
@@ -39,3 +39,7 @@ test_business_units_length{
 test_business_units_character{
   deny["`example.json` Business unit name does not meet requirements"] with input as { "filename": "example.json", "tags": { "business-unit": "Platforms4" } }
 }
+
+test_unexpected_access {
+  deny["`example.json` uses an unexpected access level: got `incorrect-access`, expected one of: view-only, developer, sandbox, administrator"] with input as { "filename": "example.json", "environments": [{"access": [{"level": "incorrect-access"}]}]}
+}


### PR DESCRIPTION
A recent error when creating an environment could have been avoided with
better validation of the json file.  This test should prevent the same
thing happening again.