### PR TITLE
remove Christine Elliot from members list 

### DIFF
--- a/terraform/github/locals.tf
+++ b/terraform/github/locals.tf
@@ -26,7 +26,6 @@ locals {
     "kcbotsh",
     "seanprivett",
     "SteveMarshall",
-    "christine-elliott",
     "ScottSeaward"
   ]
 


### PR DESCRIPTION
Having Christine included now that she's left the team meant that terraform apply runs were failing