### PR TITLE
Remove classic link options

### DIFF
--- a/terraform/environments/core-network-services/firewall.tf
+++ b/terraform/environments/core-network-services/firewall.tf
@@ -20,9 +20,7 @@ resource "aws_vpc" "external_inspection" {
   # DNS
   enable_dns_support   = false
   enable_dns_hostnames = false
-  # ClassicLink
-  enable_classiclink             = false
-  enable_classiclink_dns_support = false
+
   # Turn off IPv6
   assign_generated_ipv6_cidr_block = false
 

--- a/terraform/modules/vpc-hub/main.tf
+++ b/terraform/modules/vpc-hub/main.tf
@@ -101,10 +101,6 @@ resource "aws_vpc" "default" {
   enable_dns_support   = true
   enable_dns_hostnames = true
 
-  # ClassicLink
-  enable_classiclink             = false
-  enable_classiclink_dns_support = false
-
   # Turn off IPv6
   assign_generated_ipv6_cidr_block = false
 


### PR DESCRIPTION
EC2-Classic networking has been retired and references to it have been
deprecated in the AWS provider -

https://github.com/hashicorp/terraform-provider-aws/issues/23625

This change fixes deprecation warnings we started getting -

```
Warning: Argument is deprecated

  with module.vpc.aws_vpc.default,
  on ../../modules/vpc-hub/main.tf line 105, in resource "aws_vpc" "default":
 105:   enable_classiclink             = false

With the retirement of EC2-Classic the enable_classiclink attribute has been
deprecated and will be removed in a future version.
```