### PR TITLE
Restricting what KMS grants can be created for

### DIFF
--- a/.github/workflows/core-shared-services-deployment.yml
+++ b/.github/workflows/core-shared-services-deployment.yml
@@ -9,6 +9,7 @@ on:
       - 'terraform/environments/core-shared-services/**'
       - 'terraform/modules/vpc-hub/**'
       - 'terraform/modules/core-monitoring/**'
+      - 'terraform/modules/kms/**'
       - '.github/workflows/core-shared-services-deployment.yml'
   pull_request:
     branches:

--- a/terraform/modules/kms/main.tf
+++ b/terraform/modules/kms/main.tf
@@ -60,7 +60,6 @@ data "aws_iam_policy_document" "kms" {
   statement {
     effect = "Allow"
     actions = [
-      "kms:CreateGrant",
       "kms:ListGrants",
       "kms:Encrypt",
       "kms:Decrypt",
@@ -75,6 +74,27 @@ data "aws_iam_policy_document" "kms" {
     principals {
       type        = "AWS"
       identifiers = var.business_unit_account_ids
+    }
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "kms:CreateGrant",
+    ]
+
+    resources = ["*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = var.business_unit_account_ids
+    }
+
+    # ensure grants can only be created for AWS resources
+    condition {
+      test     = "Bool"
+      variable = "kms:GrantIsForAWSResource"
+      values   = ["true"]
     }
   }
 }


### PR DESCRIPTION
After looking at the KMS CreateGrant permission issue where the
developer role didn't have the correct permissions to create grants, it
appears this policy at present is to open, allowing grants to be created
for things other than AWS resources, see documentation here -
https://aws.amazon.com/premiumsupport/knowledge-center/kms-iam-ec2-permission/