### PR TITLE
Adding CreateGrant permission to dev role for shared keys

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -408,6 +408,18 @@ data "aws_iam_policy_document" "developer-additional" {
 
     resources = ["arn:aws:iam::*:user/cicd-member-user"]
   }
+
+  statement {
+    actions = [
+      "kms:CreateGrant"
+    ]
+    resources = ["arn:aws:kms:*:${local.environment_management.account_ids["core-shared-services-production"]}:key/*"]
+    condition {
+      test     = "Bool"
+      variable = "kms:GrantIsForAWSResource"
+      values   = ["true"]
+    }
+  }
 }
 
 # AWS Shield Advanced SRT (Shield Response Team) support role


### PR DESCRIPTION
In order to start instances with EBS volumes encrypted with shared KMS keys, developers need to be able to create a grant to the instance.
Adding this permission to the dev role along with a restriction on the types of resources that can get the grant.

For reference: https://aws.amazon.com/premiumsupport/knowledge-center/kms-iam-ec2-permission/