### PR TITLE
Create assumable role githubreadonly with managed policies

### DIFF
--- a/terraform/modernisation-platform-account/iam.tf
+++ b/terraform/modernisation-platform-account/iam.tf
@@ -396,7 +396,7 @@ data "aws_iam_policy_document" "github_actions_assume_role_policy" {
     condition {
       test     = "ForAnyValue:StringLike"
       variable = "aws:PrincipalArn"
-      values   = [
+      values = [
         "arn:aws:iam::*:role/github-actions",
         "arn:aws:iam::${data.aws_caller_identity.current.id}:role/superadmin"
       ]

--- a/terraform/modernisation-platform-account/locals.tf
+++ b/terraform/modernisation-platform-account/locals.tf
@@ -2,10 +2,10 @@ data "aws_organizations_organization" "root_account" {}
 data "aws_caller_identity" "current" {}
 
 locals {
-  root_account               = data.aws_organizations_organization.root_account
-  environment_management     = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
+  root_account                 = data.aws_organizations_organization.root_account
+  environment_management       = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
   modernisation_platform_ou_id = local.environment_management.modernisation_platform_organisation_unit_id
-  pagerduty_integration_keys = jsondecode(data.aws_secretsmanager_secret_version.pagerduty_integration_keys.secret_string)
+  pagerduty_integration_keys   = jsondecode(data.aws_secretsmanager_secret_version.pagerduty_integration_keys.secret_string)
 
   root_users_with_state_access = [
     "arn:aws:iam::${local.root_account.master_account_id}:user/ModernisationPlatformOrganisationManagement",

--- a/terraform/modernisation-platform-account/locals.tf
+++ b/terraform/modernisation-platform-account/locals.tf
@@ -4,6 +4,7 @@ data "aws_caller_identity" "current" {}
 locals {
   root_account               = data.aws_organizations_organization.root_account
   environment_management     = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
+  modernisation_platform_ou_id = local.environment_management.modernisation_platform_organisation_unit_id
   pagerduty_integration_keys = jsondecode(data.aws_secretsmanager_secret_version.pagerduty_integration_keys.secret_string)
 
   root_users_with_state_access = [


### PR DESCRIPTION
This is for the github-actions role within the member SSO accounts to be able to assume this githubreadonly role to make the initial OIDC request through the AWS provider.

This will enable us to get things from the main mp account when using
github actions role from the local account or when using the superadmin
role when running locally