### PR TITLE
Add environment management info to Github

### DIFF
--- a/.github/workflows/new-environment.yml
+++ b/.github/workflows/new-environment.yml
@@ -33,6 +33,8 @@ jobs:
     env:
       AWS_ACCESS_KEY_ID:  ${{ secrets.PRIVILEGED_AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY:  ${{ secrets.PRIVILEGED_AWS_SECRET_ACCESS_KEY }}
+      TF_VAR_github_token: ${{ secrets.TERRAFORM_GITHUB_TOKEN }}
+
     steps:
       - uses: actions/checkout@v3
       - uses: hashicorp/setup-terraform@v2.0.0
@@ -72,6 +74,7 @@ jobs:
     env:
       AWS_ACCESS_KEY_ID:  ${{ secrets.PRIVILEGED_AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY:  ${{ secrets.PRIVILEGED_AWS_SECRET_ACCESS_KEY }}
+      TF_VAR_github_token: ${{ secrets.TERRAFORM_GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v3
       - uses: hashicorp/setup-terraform@v2.0.0

--- a/terraform/environments/main.tf
+++ b/terraform/environments/main.tf
@@ -23,3 +23,8 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.modernisation_platform_account.id}:role/OrganizationAccountAccessRole"
   }
 }
+
+provider "github" {
+  owner = "ministryofjustice"
+  token = var.github_token
+}

--- a/terraform/environments/secrets.tf
+++ b/terraform/environments/secrets.tf
@@ -105,3 +105,24 @@ data "aws_secretsmanager_secret_version" "environment_management" {
 locals {
   environment_management = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
 }
+
+# Store environment management secret in Github secrets
+resource "github_actions_organization_secret" "environment_management" {
+  # checkov:skip=CKV_SECRET_6: "secret_name is not a secret"
+  secret_name = "MODERNISATION_PLATFORM_ENVIRONMENTS"
+  visibility  = "private"
+  plaintext_value = jsonencode(merge(
+    local.environment_management,
+    { account_ids : module.environments.environment_account_ids }
+  ))
+}
+
+# Restrict access to the secret
+data "github_repository" "modernisation_platform_environments" {
+  full_name = "ministryofjustice/modernisation-platform-environments"
+}
+
+resource "github_actions_organization_secret_repositories" "org_secret_repos" {
+  secret_name             = "MODERNISATION_PLATFORM_ENVIRONMENTS"
+  selected_repository_ids = [data.github_repository.modernisation_platform_environments.repo_id]
+}

--- a/terraform/environments/variables.tf
+++ b/terraform/environments/variables.tf
@@ -1,0 +1,5 @@
+variable "github_token" {
+  description = "Privileged GitHub token"
+  type        = string
+  sensitive   = true
+}


### PR DESCRIPTION
In order to not hard code account numbers, Github needs access to the map of account names to account numbers in the environemnt management json.