### PR TITLE
Adding permissions for quicksight, as they are required by refer-moni…

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -95,6 +95,7 @@ data "aws_iam_policy_document" "member-access" {
       "logs:*",
       "organizations:Describe*",
       "organizations:List*",
+      "quicksight:*",
       "rds-db:*",
       "rds:*",
       "route53:*",


### PR DESCRIPTION
Adding permissions for quicksight, as they are required by refer-monitor. A corresponding change will need to be made in the aws-root-account repo.

This has been requested by the team, so hopefully will work.