### PR TITLE
Properly populate port ranges for subnet static rules

### DIFF
--- a/terraform/modules/vpc-nacls/data.tf
+++ b/terraform/modules/vpc-nacls/data.tf
@@ -53,72 +53,92 @@ locals {
     allow_vpc_cidr_in = {
       cidr_block  = data.aws_vpc.current.cidr_block
       egress      = false
+      from_port   = null
       protocol    = "-1"
       rule_action = "allow"
       rule_number = 1000
+      to_port     = null
     },
     allow_vpc_cidr_out = {
       cidr_block  = data.aws_vpc.current.cidr_block
       egress      = true
+      from_port   = null
       protocol    = "-1"
       rule_action = "allow"
       rule_number = 1000
+      to_port     = null
     },
     deny_mp_cidr_in = {
       cidr_block  = "10.26.0.0/15"
       egress      = false
+      from_port   = null
       protocol    = "-1"
       rule_action = "deny"
       rule_number = 3000
+      to_port     = null
     },
     deny_mp_cidr_out = {
       cidr_block  = "10.26.0.0/15"
       egress      = true
+      from_port   = null
       protocol    = "-1"
       rule_action = "deny"
       rule_number = 3000
+      to_port     = null
     },
     allow_10-0-0-0_in = {
       cidr_block  = "10.0.0.0/8"
       egress      = false
+      from_port   = null
       protocol    = "-1"
       rule_action = "allow"
       rule_number = 4000
+      to_port     = null
     },
     allow_10-0-0-0_out = {
       cidr_block  = "10.0.0.0/8"
       egress      = true
+      from_port   = null
       protocol    = "-1"
       rule_action = "allow"
       rule_number = 4000
+      to_port     = null
     },
     allow_172-16-0-0_in = {
       cidr_block  = "172.16.0.0/12"
       egress      = false
+      from_port   = null
       protocol    = "-1"
       rule_action = "allow"
       rule_number = 4100
+      to_port     = null
     },
     allow_172-16-0-0_out = {
       cidr_block  = "172.16.0.0/12"
       egress      = true
+      from_port   = null
       protocol    = "-1"
       rule_action = "allow"
       rule_number = 4100
+      to_port     = null
     },
     allow_192-168-0-0_in = {
       cidr_block  = "192.168.0.0/16"
       egress      = false
+      from_port   = null
       protocol    = "-1"
       rule_action = "allow"
       rule_number = 4200
+      to_port     = null
     },
     allow_192-168-0-0_out = {
       cidr_block  = "192.168.0.0/16"
       egress      = true
+      from_port   = null
       protocol    = "-1"
       rule_action = "allow"
       rule_number = 4200
+      to_port     = null
     },
     allow_0-0-0-0_https_out = {
       cidr_block  = "0.0.0.0/0"

--- a/terraform/modules/vpc-nacls/main.tf
+++ b/terraform/modules/vpc-nacls/main.tf
@@ -38,30 +38,36 @@ resource "aws_network_acl_rule" "data_subnet_static_rules" {
   for_each       = local.static_acl_rules
   cidr_block     = each.value.cidr_block
   egress         = each.value.egress
+  from_port      = each.value.from_port != null ? each.value.from_port : null
   network_acl_id = aws_network_acl.general-data.id
   protocol       = each.value.protocol
   rule_action    = each.value.rule_action
   rule_number    = each.value.rule_number
+  to_port        = each.value.to_port != null ? each.value.to_port : null
 }
 
 resource "aws_network_acl_rule" "private_subnet_static_rules" {
   for_each       = local.static_acl_rules
   cidr_block     = each.value.cidr_block
   egress         = each.value.egress
+  from_port      = each.value.from_port != null ? each.value.from_port : null
   network_acl_id = aws_network_acl.general-private.id
   protocol       = each.value.protocol
   rule_action    = each.value.rule_action
   rule_number    = each.value.rule_number
+  to_port        = each.value.to_port != null ? each.value.to_port : null
 }
 
 resource "aws_network_acl_rule" "public_subnet_static_rules" {
   for_each       = local.static_acl_rules
   cidr_block     = each.value.cidr_block
   egress         = each.value.egress
+  from_port      = each.value.from_port != null ? each.value.from_port : null
   network_acl_id = aws_network_acl.general-public.id
   protocol       = each.value.protocol
   rule_action    = each.value.rule_action
   rule_number    = each.value.rule_number
+  to_port        = each.value.to_port != null ? each.value.to_port : null
 }
 
 resource "aws_network_acl_rule" "public_subnet_internet_access_rules" {


### PR DESCRIPTION
`from_port` and `to_port` values were not being supplied when creating subnet static rules. As we were providing a `protocol` value of `-1` at first, this was fine because no `from_port` or `to_port` was required. However, when we added egress/ingress rules for HTTPS traffic out from subnets, these new rules were created without ports and thus did not work as expected.

This PR adds a conditional value to supply a port value is one is present, or `null` if not value is supplied / required