### PR TITLE
Possible missing permissions for quicksight, aws docs.

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -58,6 +58,7 @@ data "aws_iam_policy_document" "member-access" {
       "cloudfront:*",
       "cloudwatch:*",
       "dlm:*",
+      "ds:*",
       "dynamodb:*",
       "ebs:*",
       "ec2:Describe*",


### PR DESCRIPTION
https://docs.aws.amazon.com/quicksight/latest/user/iam-policy-examples.html#security_iam_id-based-policy-examples-all-access-enterprise-edition


Hints at some other permissions? It looks like we have all but ds. 