### PR TITLE
Removing interventions-reporting-discovery as not a MOJ team.

### DIFF
--- a/environments/refer-monitor.json
+++ b/environments/refer-monitor.json
@@ -7,6 +7,10 @@
         {
           "github_slug": "hmpps-interventions-dev",
           "level": "sandbox"
+        },
+        {
+          "github_slug": "interventions-reporting-discovery",
+          "level": "sandbox"
         }
       ]
     }

--- a/environments/refer-monitor.json
+++ b/environments/refer-monitor.json
@@ -7,10 +7,6 @@
         {
           "github_slug": "hmpps-interventions-dev",
           "level": "sandbox"
-        },
-        {
-          "github_slug": "interventions-reporting-discovery",
-          "level": "sandbox"
         }
       ]
     }

--- a/policies/networking/core-vpc.rego
+++ b/policies/networking/core-vpc.rego
@@ -35,11 +35,6 @@ deny[msg] {
   msg := sprintf("`%v` is missing the `dns_zone_extend` key", [input.filename])
 }
 
-deny[msg] {
-  not has_field(input, "nacl")
-  msg := sprintf("`%v` is missing the `nacl` key", [input.filename])
-}
-
 # Invalid type
 deny[msg] {
   not is_object(input.cidr.subnet_sets)

--- a/terraform/github/locals.tf
+++ b/terraform/github/locals.tf
@@ -67,7 +67,6 @@ locals {
     "data-and-insights-hub",
     "hmpps-digital-prison-reporting",
     "hmpps-interventions-dev",
-    "interventions-reporting-discovery",
     "hmpps-migration"
   ]
 }


### PR DESCRIPTION
`nacl` in the network definition json is not required any longer since the refactoring done last sprint.