### PR TITLE
Remove the obsolete repository lambda-scheduler-stop-start

### DIFF
--- a/terraform/github/main.tf
+++ b/terraform/github/main.tf
@@ -163,20 +163,6 @@ module "terraform-module-aws-vm-import" {
   secrets = nonsensitive(local.testing_ci_iam_user_keys)
 }
 
-module "terraform-module-lambda-scheduler-stop-start" {
-  source      = "./modules/repository"
-  name        = "modernisation-platform-terraform-lambda-scheduler-stop-start"
-  description = "Module for stopping and starting instance, rds resources and autoscaling groups with lambda function"
-  topics = [
-    "aws",
-    "ec2",
-    "rds",
-    "autoscaling-groups",
-    "lambda"
-  ]
-  secrets = nonsensitive(local.testing_ci_iam_user_keys)
-}
-
 module "modernisation-platform-environments" {
   source      = "./modules/repository"
   name        = "modernisation-platform-environments"
@@ -296,7 +282,6 @@ module "core-team" {
     module.terraform-module-bastion-linux.repository.name,
     module.terraform-module-ecs.repository.name,
     module.terraform-module-aws-vm-import.repository.name,
-    module.terraform-module-lambda-scheduler-stop-start.repository.name,
     module.terraform-module-aws-loadbalancer.repository.name,
     module.modernisation-platform-ami-builds.repository.name,
     module.modernisation-platform-environments.repository.name,


### PR DESCRIPTION
Remove the obsolete repository modernisation-platform-terraform-lambda-scheduler-stop-start If I recall correctly, we originally created this repository in order to maintain a fork of the third party repository https://github.com/diodonfrost/terraform-aws-lambda-scheduler-stop-start Since we could not trust third party code to use it directly, the idea was to use a fork.