### PR TITLE
Fixing KMS Create Grant permissions on cross-account shared keys.

### DIFF
--- a/terraform/modules/kms/main.tf
+++ b/terraform/modules/kms/main.tf
@@ -99,9 +99,9 @@ data "aws_iam_policy_document" "kms" {
     }
 
     condition {
-      test = "StringNotEquals"
+      test     = "StringNotEquals"
       variable = "kms:GranteePrincipal"
-      values = ["arn:aws:iam::*:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling"]
+      values   = ["arn:aws:iam::*:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling"]
 
     }
   }

--- a/terraform/modules/kms/main.tf
+++ b/terraform/modules/kms/main.tf
@@ -66,6 +66,7 @@ data "aws_iam_policy_document" "kms" {
       "kms:ReEncrypt*",
       "kms:GenerateDataKey*",
       "kms:DescribeKey",
+      "kms:CreateGrant"
     ]
 
     resources = ["*"]
@@ -78,7 +79,7 @@ data "aws_iam_policy_document" "kms" {
   }
 
   statement {
-    effect = "Allow"
+    effect = "Deny"
     actions = [
       "kms:CreateGrant",
     ]
@@ -94,7 +95,14 @@ data "aws_iam_policy_document" "kms" {
     condition {
       test     = "Bool"
       variable = "kms:GrantIsForAWSResource"
-      values   = ["true"]
+      values   = ["false"]
+    }
+
+    condition {
+      test = "StringNotEquals"
+      variable = "kms:GranteePrincipal"
+      values = ["arn:aws:iam::*:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling"]
+
     }
   }
 }


### PR DESCRIPTION

Slack thread for context: https://mojdt.slack.com/archives/C01A7QK5VM1/p1663335087474439

There's currently a limitation set on shared KMS keys which block "kms:CreateGrant" action when the grantee principal is not an AWS service.

However, this prevents the destination accounts from using images encrypted with shared keys from using those images in autoscaling groups because, as outlined [here](https://docs.aws.amazon.com/autoscaling/ec2/userguide/key-policy-requirements-EBS-encryption.html), this requires an intermediary grant, to a role in the destination account.

This change adds "kms:CreateGrant" permission to all member account roots but adds an explicit deny which blocks the action unless the principal grantee is either an AWS service OR the the AWS service role for autoscaling. This allows enough permissions to create intermediary grants but still limits how grants can be created.