### PR TITLE
Ignore code signing for lambda

### DIFF
--- a/terraform/environments/core-logging/athena.tf
+++ b/terraform/environments/core-logging/athena.tf
@@ -256,6 +256,7 @@ resource "aws_lambda_function" "athena_table_update" {
   # checkov:skip=CKV_AWS_50: "X-ray tracing is not required"
   # checkov:skip=CKV_AWS_117: "Lambda is not environment specific"
   # checkov:skip=CKV_AWS_116: "DLQ not required"
+  # checkov:skip=CKV_AWS_272: "Code signing not required"
   depends_on = [
     module.s3-bucket-athena
 

--- a/terraform/modernisation-platform-account/lambda.tf
+++ b/terraform/modernisation-platform-account/lambda.tf
@@ -7,6 +7,7 @@ data "archive_file" "instance_scheduler_zip" {
 resource "aws_lambda_function" "instance-scheduler" {
   #checkov:skip=CKV_AWS_116
   #checkov:skip=CKV_AWS_117
+  #checkov:skip=CKV_AWS_272 "Code signing not required"
   filename                       = "golang-instance-scheduler.zip"
   function_name                  = "golang-instance-scheduler"
   handler                        = "main"


### PR DESCRIPTION
We have strict controls already in place to ensure only code deployed to lambda only goes through GitHub with an approval.  We do not need extra code signing for lambda.