### PR TITLE
Revert "Add temporary permission to github-actions policy to test SCP. #2111"

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -515,6 +515,6 @@ data "aws_iam_policy_document" "oidc_assume_role" {
     effect    = "Allow"
     resources = ["arn:aws:s3:::modernisation-platform-terraform-state/environments/members/*"]
     actions = ["s3:PutObject",
-    "s3:PutObjectAcl", "s3:PutBucketAcl"]
+    "s3:PutObjectAcl"]
   }
 }


### PR DESCRIPTION
Reverts ministryofjustice/modernisation-platform#2352

Testing completed. 
- github-actions is able to amend the policy that attaches to the role
- MemberInfrastructureAccess is unable to delete the OIDC provider.