### PR TITLE
Adding testing-ci user to the trust for the ModPlatformAccess role

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -14,9 +14,10 @@ module "cross-account-access" {
   providers = {
     aws = aws.workspace
   }
-  account_id = local.modernisation_platform_account.id
-  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
-  role_name  = "ModernisationPlatformAccess"
+  account_id             = local.modernisation_platform_account.id
+  policy_arn             = "arn:aws:iam::aws:policy/AdministratorAccess"
+  role_name              = "ModernisationPlatformAccess"
+  additional_trust_roles = terraform.workspace == "testing-test" ? ["arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:user/testing-ci"] : []
 
 }
 


### PR DESCRIPTION
This is to allow testing-ci user to assume the role to test OIDC provider module.
