### PR TITLE
Convert templates for OIDC and matrix workflow. #2039 #2350

### DIFF
--- a/.github/workflows/templates/workflow-template.yml
+++ b/.github/workflows/templates/workflow-template.yml
@@ -2,7 +2,7 @@
 name: $application_name
 on:
   push:
-    branches: 
+    branches:
       - main
     paths:
       - 'terraform/environments/$application_name/**'
@@ -16,189 +16,162 @@ on:
       - '.github/workflows/$application_name.yml'
   workflow_dispatch:
 env:
-  AWS_ACCESS_KEY_ID:  ${{ secrets.AWS_ACCESS_KEY_ID }}
-  AWS_SECRET_ACCESS_KEY:  ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   TF_IN_AUTOMATION: true
+  AWS_REGION: "eu-west-2"
+  ENVIRONMENT_MANAGEMENT: ${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENTS }}
+permissions:
+  id-token: write # This is required for requesting the JWT
+  contents: read # This is required for actions/checkout
 defaults:
   run:
     shell: bash
 
 jobs:
-  
+
+  plan-dev-test:
+    strategy:
+      matrix:
+        include:
+          - environment: development
+          # - environment: test
+    name: Plan - ${{  matrix.environment }}
+    runs-on: ubuntu-latest
+    if: github.ref != 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+    env:
+      TF_ENV: ${{ matrix.environment }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3.1.0
+      - name: Set Account Number
+        run: echo "ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${GITHUB_WORKFLOW}-${TF_ENV}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+          role-session-name: githubactionsrolesession
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Load and Configure Terraform
+        uses: hashicorp/setup-terraform@v2.0.0
+        with:
+          terraform_version: "~1"
+          terraform_wrapper: false
+      - name: Plan - ${{ matrix.environment }}
+        run: |
+          terraform --version
+          echo "Terraform plan - ${TF_ENV}"
+          bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
+          terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
+          bash scripts/terraform-plan.sh terraform/environments/$GITHUB_WORKFLOW
+
   # These jobs run when creating a pull request
-  plan-development:
-    name: Plan Development - $application_name
+  deploy-dev-test:
+    needs: plan-dev-test
+    if: success()
+    strategy:
+      matrix:
+        include:
+          - environment: development
+          # - environment: test
+    name: Apply - ${{  matrix.environment }}
     runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/main' || github.event_name == 'workflow_dispatch'
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v2.3.4
-      - name: Load and Configure Terraform
-        uses: hashicorp/setup-terraform@v1.3.2
-        with:
-          terraform_version: "~1"
-          terraform_wrapper: false
-      - name: Terraform plan - development
-        run: |
-          echo "Terraform plan - ${TF_ENV}"
-          bash scripts/terraform-init.sh terraform/environments/$application_name
-          terraform -chdir="terraform/environments/$application_name" workspace select "$application_name-${TF_ENV}"
-          bash scripts/terraform-plan.sh terraform/environments/$application_name
-        env:
-          TF_ENV: development
-
-  deploy-development:
-    name: Deploy Development - $application_name
-    runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+    env:
+      TF_ENV: ${{ matrix.environment }}
     environment:
-      name: $application_name-development
+      name: ${{ github.workflow }}-${{ matrix.environment }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v3.1.0
+      - name: Set Account Number
+        run: echo "ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${GITHUB_WORKFLOW}-${TF_ENV}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+          role-session-name: githubactionsrolesession
+          aws-region: ${{ env.AWS_REGION }}
       - name: Load and Configure Terraform
-        uses: hashicorp/setup-terraform@v1.3.2
+        uses: hashicorp/setup-terraform@v2.0.0
         with:
           terraform_version: "~1"
           terraform_wrapper: false
-      - name: Terraform apply - development
+      - name: Apply - ${{ matrix.environment }}
         run: |
+          terraform --version
           echo "Terraform apply - ${TF_ENV}"
-          bash scripts/terraform-init.sh terraform/environments/$application_name
-          terraform -chdir="terraform/environments/$application_name" workspace select "$application_name-${TF_ENV}"
-          bash scripts/terraform-apply.sh terraform/environments/$application_name
-        env:
-          TF_ENV: development
+          bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
+          terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
+          bash scripts/terraform-apply.sh terraform/environments/$GITHUB_WORKFLOW
 
-  plan-test:
-    name: Plan Test - $application_name
-    runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/main' || github.event_name == 'workflow_dispatch'
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v2.3.4
-      - name: Load and Configure Terraform
-        uses: hashicorp/setup-terraform@v1.3.2
-        with:
-          terraform_version: "~1"
-          terraform_wrapper: false
-      - name: Terraform plan - test
-        run: |
-          echo "Terraform plan - ${TF_ENV}"
-          bash scripts/terraform-init.sh terraform/environments/$application_name
-          terraform -chdir="terraform/environments/$application_name" workspace select "$application_name-${TF_ENV}"
-          bash scripts/terraform-plan.sh terraform/environments/$application_name
-        env:
-          TF_ENV: test
-
-  deploy-test:
-    name: Deploy Test - $application_name
-    runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/main' || github.event_name == 'workflow_dispatch'
-    environment:
-      name: $application_name-test
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v2.3.4
-      - name: Load and Configure Terraform
-        uses: hashicorp/setup-terraform@v1.3.2
-        with:
-          terraform_version: "~1"
-          terraform_wrapper: false
-      - name: Terraform apply - test
-        run: |
-          echo "Terraform apply - ${TF_ENV}"
-          bash scripts/terraform-init.sh terraform/environments/$application_name
-          terraform -chdir="terraform/environments/$application_name" workspace select "$application_name-${TF_ENV}"
-          bash scripts/terraform-apply.sh terraform/environments/$application_name
-        env:
-          TF_ENV: test
-
-  # These jobs run after merging to main
-  plan-preproduction:
-    name: Plan Preproduction - $application_name
+#  # Plan + deploy for pre-production and production environments, only from main
+  plan-preprod-prod:
+    strategy:
+      matrix:
+        include:
+          - environment: preproduction
+          - environment: production
+    name: Plan - ${{  matrix.environment }}
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
+    env:
+      TF_ENV: ${{ matrix.environment }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v3.1.0
+      - name: Set Account Number
+        run: echo "ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${GITHUB_WORKFLOW}-${TF_ENV}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+          role-session-name: githubactionsrolesession
+          aws-region: ${{ env.AWS_REGION }}
       - name: Load and Configure Terraform
-        uses: hashicorp/setup-terraform@v1.3.2
+        uses: hashicorp/setup-terraform@v2.0.0
         with:
           terraform_version: "~1"
           terraform_wrapper: false
-      - name: Terraform plan - preproduction
+      - name: Plan - ${{ matrix.environment }}
         run: |
+          terraform --version
           echo "Terraform plan - ${TF_ENV}"
-          bash scripts/terraform-init.sh terraform/environments/$application_name
-          terraform -chdir="terraform/environments/$application_name" workspace select "$application_name-${TF_ENV}"
-          bash scripts/terraform-plan.sh terraform/environments/$application_name
-        env:
-          TF_ENV: preproduction
-
-  deploy-preproduction:
-    name: Deploy Preproduction - $application_name
+          bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
+          terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
+          bash scripts/terraform-plan.sh terraform/environments/$GITHUB_WORKFLOW
+  # These jobs run when creating a pull request
+  deploy-preprod-prod:
+    needs: plan-preprod-prod
+    if: success()
+    strategy:
+      matrix:
+        include:
+          - environment: preproduction
+          - environment: production
+    name: Apply - ${{  matrix.environment }}
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    env:
+      TF_ENV: ${{ matrix.environment }}
     environment:
-      name: $application_name-preproduction
+      name: ${{ github.workflow }}-${{ matrix.environment }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v3.1.0
+      - name: Set Account Number
+        run: echo "ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${GITHUB_WORKFLOW}-${TF_ENV}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+          role-session-name: githubactionsrolesession
+          aws-region: ${{ env.AWS_REGION }}
       - name: Load and Configure Terraform
-        uses: hashicorp/setup-terraform@v1.3.2
+        uses: hashicorp/setup-terraform@v2.0.0
         with:
           terraform_version: "~1"
           terraform_wrapper: false
-      - name: Terraform apply - preproduction
+      - name: Apply - ${{ matrix.environment }}
         run: |
+          terraform --version
           echo "Terraform apply - ${TF_ENV}"
-          bash scripts/terraform-init.sh terraform/environments/$application_name
-          terraform -chdir="terraform/environments/$application_name" workspace select "$application_name-${TF_ENV}"
-          bash scripts/terraform-apply.sh terraform/environments/$application_name
-        env:
-          TF_ENV: preproduction
-  
-  plan-production:
-    name: Plan Production - $application_name
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v2.3.4
-      - name: Load and Configure Terraform
-        uses: hashicorp/setup-terraform@v1.3.2
-        with:
-          terraform_version: "~1"
-          terraform_wrapper: false
-      - name: Terraform plan - production
-        run: |
-          echo "Terraform plan - ${TF_ENV}"
-          bash scripts/terraform-init.sh terraform/environments/$application_name
-          terraform -chdir="terraform/environments/$application_name" workspace select "$application_name-${TF_ENV}"
-          bash scripts/terraform-plan.sh terraform/environments/$application_name
-        env:
-          TF_ENV: production
-
-  deploy-production:
-    name: Deploy Production - $application_name
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
-    environment:
-      name: $application_name-production
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v2.3.4
-      - name: Load and Configure Terraform
-        uses: hashicorp/setup-terraform@v1.3.2
-        with:
-          terraform_version: "~1"
-          terraform_wrapper: false
-      - name: Terraform apply - production
-        run: |
-          echo "Terraform apply - ${TF_ENV}"
-          bash scripts/terraform-init.sh terraform/environments/$application_name
-          terraform -chdir="terraform/environments/$application_name" workspace select "$application_name-${TF_ENV}"
-          bash scripts/terraform-apply.sh terraform/environments/$application_name
-        env:
-          TF_ENV: production
+          bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
+          terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
+          bash scripts/terraform-apply.sh terraform/environments/$GITHUB_WORKFLOW

--- a/.github/workflows/templates/workflow-template.yml
+++ b/.github/workflows/templates/workflow-template.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         include:
           - environment: development
-          # - environment: test
+          - environment: test
     name: Plan - ${{  matrix.environment }}
     runs-on: ubuntu-latest
     if: github.ref != 'refs/heads/main' || github.event_name == 'workflow_dispatch'
@@ -71,7 +71,7 @@ jobs:
       matrix:
         include:
           - environment: development
-          # - environment: test
+          - environment: test
     name: Apply - ${{  matrix.environment }}
     runs-on: ubuntu-latest
     env:

--- a/terraform/templates/locals.tf
+++ b/terraform/templates/locals.tf
@@ -7,11 +7,25 @@ data "http" "environments_file" {
   url = "https://raw.githubusercontent.com/ministryofjustice/modernisation-platform/main/environments/${local.application_name}.json"
 }
 
+# caller account information to instantiate aws.oidc provider
+data "aws_caller_identity" "oidc_session" {
+  provider = aws.oidc-session
+}
+
+# Retrieve information about the modernisation platform account
+data "aws_caller_identity" "modernisation_platform" {
+  provider = aws.modernisation-platform
+}
+
+
 locals {
 
   application_name = "$application_name"
 
   environment_management = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
+
+  # Stores modernisation platform account id for setting up the modernisation-platform provider
+  modernisation_platform_account_id = data.aws_ssm_parameter.modernisation_platform_account_id.value
 
   # This takes the name of the Terraform workspace (e.g. core-vpc-production), strips out the application name (e.g. core-vpc), and checks if
   # the string leftover is `-production`, if it isn't (e.g. core-vpc-non-production => -non-production) then it sets the var to false.

--- a/terraform/templates/member-providers.tf
+++ b/terraform/templates/member-providers.tf
@@ -1,9 +1,14 @@
-######################### Run Terraform via CICD ##################################
+# ######################### Run Terraform via CICD ##################################
 # AWS provider for the workspace you're working in (every resource will default to using this, unless otherwise specified)
+provider "aws" {
+  alias  = "oidc-session"
+  region = "eu-west-2"
+}
+
 provider "aws" {
   region = "eu-west-2"
   assume_role {
-    role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/MemberInfrastructureAccess"
+    role_arn = "arn:aws:iam::${data.aws_caller_identity.oidc_session.id}:role/MemberInfrastructureAccess"
   }
 }
 
@@ -12,6 +17,9 @@ provider "aws" {
   alias                  = "modernisation-platform"
   region                 = "eu-west-2"
   skip_get_ec2_platforms = true
+  assume_role {
+    role_arn = "arn:aws:iam::${local.modernisation_platform_account_id}:role/modernisation-account-limited-read-member-access"
+  }
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
@@ -37,10 +45,25 @@ provider "aws" {
 
 
 ######################### Run Terraform Plan Locally Only ##################################
-# To run a Terraform Plan locally, uncomment this bottom section of code and comment out the top section
+# # To run a Terraform Plan locally, uncomment this bottom section of code and comment out the top section
 
 # provider "aws" {
 #   region = "eu-west-2"
+# }
+
+# provider "aws" {
+#   alias  = "oidc-session"
+#   region = "eu-west-2"
+# }
+
+# # AWS provider for the Modernisation Platform, to get things from there if required
+# provider "aws" {
+#   alias                  = "modernisation-platform"
+#   region                 = "eu-west-2"
+#   skip_get_ec2_platforms = true
+#   assume_role {
+#     role_arn = "arn:aws:iam::${local.modernisation_platform_account_id}:role/modernisation-account-limited-read-member-access"
+#   }
 # }
 
 # # AWS provider for core-vpc-<environment>, to share VPCs into this account

--- a/terraform/templates/platform_secrets.tf
+++ b/terraform/templates/platform_secrets.tf
@@ -1,5 +1,9 @@
-######################### Run Terraform via CICD ##################################
-# Get secret by name for environment management
+# Get modernisation account id from ssm parameter
+data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  name = "modernisation_platform_account_id"
+}
+
+# Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
   provider = aws.modernisation-platform
   name     = "environment_management"
@@ -10,24 +14,3 @@ data "aws_secretsmanager_secret_version" "environment_management" {
   provider  = aws.modernisation-platform
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
-######################### Run Terraform via CICD ##################################
-
-
-######################### Run Terraform Plan Locally Only ##################################
-# To run a Terraform Plan locally, uncomment this bottom section of code and comment out the top section
-
-# # Get secret by arn for environment management
-# data "aws_ssm_parameter" "environment_management_arn" {
-#   name = "environment_management_arn"
-# }
-
-# data "aws_secretsmanager_secret" "environment_management" {
-#   arn = data.aws_ssm_parameter.environment_management_arn.value
-# }
-
-# # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
-# data "aws_secretsmanager_secret_version" "environment_management" {
-#   secret_id = data.aws_secretsmanager_secret.environment_management.id
-# }
-
-######################### Run Terraform Plan Locally Only ##################################


### PR DESCRIPTION
Changes:

.github/workflows/templates/workflow-template.yml

- AWS secrets env vars have been removed
- plan and deploy jobs have been amended to use a different AWS authentication action
- plan and deploy jobs have been refactored to use the new matrix strategy to improve code quality

templates/providers.tf

- changed provider definition to use oidc
- amended local plan provider definitions for compatibility

templates/platform_secrets.tf

- changed secret definitions to allow retrieval from modernisation-platform account
- removed commented out section as changes to secrets are no longer required to run local plans

templates/locals.tf

- added a datasource to lookup OIDC session information
- added a new local to retrieve the account id of modernisation-platform account (using a datasource creates a cycle)

 

