### PR TITLE
Fix image_uri issue.

### DIFF
--- a/terraform/environments/core-shared-services/iam.tf
+++ b/terraform/environments/core-shared-services/iam.tf
@@ -105,6 +105,7 @@ data "aws_iam_policy_document" "instance-scheduler-lambda-function-assume-role" 
   }
 }
 
+#tfsec:ignore:aws-iam-no-policy-wildcards
 data "aws_iam_policy_document" "instance-scheduler-lambda-function-policy" {
   statement {
     sid    = "AllowLambdaToCreateLogGroup"

--- a/terraform/environments/core-shared-services/instance-scheduler-lambda-function.tf
+++ b/terraform/environments/core-shared-services/instance-scheduler-lambda-function.tf
@@ -6,7 +6,7 @@ resource "aws_lambda_function" "instance-scheduler-lambda-function" {
   handler                        = "main"
   reserved_concurrent_executions = 0
   runtime                        = "go1.x"
-  image_uri                      = "${module.instance_scheduler_ecr_repo.ecr_repository_name}:latest"
+  image_uri                      = "${local.environment_management.account_ids[terraform.workspace]}.dkr.ecr.eu-west-2.amazonaws.com/${module.instance_scheduler_ecr_repo.ecr_repository_name}:latest"
   package_type                   = "Image"
   role                           = aws_iam_role.instance-scheduler-lambda-function.arn
   tracing_config {


### PR DESCRIPTION
Plan: 4 to add, 0 to change, 0 to destroy.
aws_iam_role.instance-scheduler-lambda-function: Creating...

Error: error creating Lambda Function (1): InvalidParameterValueException: Source image instance-scheduler-ecr-repo:latest is not valid. Provide a valid source image. {
  RespMetadata: {
    StatusCode: 400,
    RequestID: "a1f03d5c-f72b-4e7e-a923-7858e8970475"
  },
  Message_: "Source image instance-scheduler-ecr-repo:latest is not valid. Provide a valid source image.",
  Type: "User"
}