### PR TITLE
Fixing OIDC-related issues with new accounts

### DIFF
--- a/scripts/provision-environment-directories.sh
+++ b/scripts/provision-environment-directories.sh
@@ -85,7 +85,7 @@ copy_templates() {
   for file in $templates; do
     filename=$(basename "$file")
 
-    if [ ${filename} != "member-providers.tf" ] && [ ${filename} != "data.tf" ]
+    if [ ${filename} != "member-locals.tf" ] && [ ${filename} != "member-providers.tf" ] && [ ${filename} != "data.tf" ]
     then
       echo "Copying $file to $1, replacing application_name with $application_name"
       sed "s/\$application_name/${application_name}/g" "$file" > "$1/$filename"

--- a/scripts/provision-member-directories.sh
+++ b/scripts/provision-member-directories.sh
@@ -55,7 +55,7 @@ provision_environment_directories() {
 
       mkdir -p "$directory"
       copy_templates "$directory" "$application_name"
-      
+
       # Create workflow file
       echo "Creating workflow file"
       sed "s/\$application_name/$application_name/g" "core-repo/.github/workflows/templates/workflow-template.yml" > "modernisation-platform-environments/.github/workflows/$application_name.yml"
@@ -124,6 +124,9 @@ copy_templates() {
 
   # Rename member providers file
   mv $1/member-providers.tf $1/providers.tf
+
+    # Rename member locals file
+  mv $1/member-locals.tf $1/locals.tf
   # copy application variable file
   cp core-repo/terraform/templates/application_variables.json $1
   # copy template file
@@ -137,7 +140,7 @@ generate_codeowners() {
 echo "Writing codeowners file"
 # Creates a codeowners file in the environments repo to ensure only teams can approve PRs referencing their code
   cat > $codeowners_file << EOL
-# This file is auto-generated here, do not manually amend. 
+# This file is auto-generated here, do not manually amend.
 # https://github.com/ministryofjustice/modernisation-platform/blob/main/scripts/provision-member-directories.sh
 
 * @ministryofjustice/modernisation-platform
@@ -148,13 +151,13 @@ EOL
     directory=/terraform/environments/$application_name
     account_type=$(jq -r '."account-type"' ${environment_json_dir}/${application_name}.json)
     github_slugs=$(jq -r '.environments[].access[].github_slug' ${environment_json_dir}/${application_name}.json | uniq)
-    
+
     if [ "$account_type" = "member" ]; then
       for slug in $github_slugs; do
         echo "Adding $directory @ministryofjustice/$slug @modernisation-platform to codeowners"
         echo "$directory @ministryofjustice/$slug @ministryofjustice/modernisation-platform" >> $codeowners_file
       done
-    fi    
+    fi
 
   done
 

--- a/terraform/environments/maatdb/locals.tf
+++ b/terraform/environments/maatdb/locals.tf
@@ -6,12 +6,6 @@ data "aws_organizations_organization" "root_account" {}
 data "http" "environments_file" {
   url = "https://raw.githubusercontent.com/ministryofjustice/modernisation-platform/main/environments/${local.application_name}.json"
 }
-
-# caller account information to instantiate aws.oidc provider
-data "aws_caller_identity" "oidc_session" {
-  provider = aws.oidc-session
-}
-
 # Retrieve information about the modernisation platform account
 data "aws_caller_identity" "modernisation_platform" {
   provider = aws.modernisation-platform
@@ -23,9 +17,6 @@ locals {
   application_name = "maatdb"
 
   environment_management = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
-
-  # Stores modernisation platform account id for setting up the modernisation-platform provider
-  modernisation_platform_account_id = data.aws_ssm_parameter.modernisation_platform_account_id.value
 
   # This takes the name of the Terraform workspace (e.g. core-vpc-production), strips out the application name (e.g. core-vpc), and checks if
   # the string leftover is `-production`, if it isn't (e.g. core-vpc-non-production => -non-production) then it sets the var to false.

--- a/terraform/templates/locals.tf
+++ b/terraform/templates/locals.tf
@@ -7,11 +7,6 @@ data "http" "environments_file" {
   url = "https://raw.githubusercontent.com/ministryofjustice/modernisation-platform/main/environments/${local.application_name}.json"
 }
 
-# caller account information to instantiate aws.oidc provider
-data "aws_caller_identity" "oidc_session" {
-  provider = aws.oidc-session
-}
-
 # Retrieve information about the modernisation platform account
 data "aws_caller_identity" "modernisation_platform" {
   provider = aws.modernisation-platform
@@ -23,9 +18,6 @@ locals {
   application_name = "$application_name"
 
   environment_management = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
-
-  # Stores modernisation platform account id for setting up the modernisation-platform provider
-  modernisation_platform_account_id = data.aws_ssm_parameter.modernisation_platform_account_id.value
 
   # This takes the name of the Terraform workspace (e.g. core-vpc-production), strips out the application name (e.g. core-vpc), and checks if
   # the string leftover is `-production`, if it isn't (e.g. core-vpc-non-production => -non-production) then it sets the var to false.

--- a/terraform/templates/member-locals.tf
+++ b/terraform/templates/member-locals.tf
@@ -12,6 +12,11 @@ data "aws_caller_identity" "oidc_session" {
   provider = aws.oidc-session
 }
 
+# Get modernisation account id from ssm parameter
+data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  name = "modernisation_platform_account_id"
+}
+
 # Retrieve information about the modernisation platform account
 data "aws_caller_identity" "modernisation_platform" {
   provider = aws.modernisation-platform

--- a/terraform/templates/member_locals.tf
+++ b/terraform/templates/member_locals.tf
@@ -1,0 +1,58 @@
+# This data sources allows us to get the Modernisation Platform account information for use elsewhere
+# (when we want to assume a role in the MP, for instance)
+data "aws_organizations_organization" "root_account" {}
+
+# Get the environments file from the main repository
+data "http" "environments_file" {
+  url = "https://raw.githubusercontent.com/ministryofjustice/modernisation-platform/main/environments/${local.application_name}.json"
+}
+
+# caller account information to instantiate aws.oidc provider
+data "aws_caller_identity" "oidc_session" {
+  provider = aws.oidc-session
+}
+
+# Retrieve information about the modernisation platform account
+data "aws_caller_identity" "modernisation_platform" {
+  provider = aws.modernisation-platform
+}
+
+
+locals {
+
+  application_name = "$application_name"
+
+  environment_management = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
+
+  # Stores modernisation platform account id for setting up the modernisation-platform provider
+  modernisation_platform_account_id = data.aws_ssm_parameter.modernisation_platform_account_id.value
+
+  # This takes the name of the Terraform workspace (e.g. core-vpc-production), strips out the application name (e.g. core-vpc), and checks if
+  # the string leftover is `-production`, if it isn't (e.g. core-vpc-non-production => -non-production) then it sets the var to false.
+  is-production    = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-production"
+  is-preproduction = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-preproduction"
+  is-test          = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-test"
+  is-development   = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-development"
+
+  # Merge tags from the environment json file with additional ones
+  tags = merge(
+    jsondecode(data.http.environments_file.response_body).tags,
+    { "is-production" = local.is-production },
+    { "environment-name" = terraform.workspace },
+    { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
+  )
+
+  environment     = trimprefix(terraform.workspace, "${var.networking[0].application}-")
+  vpc_name        = var.networking[0].business-unit
+  subnet_set      = var.networking[0].set
+  vpc_all         = "${local.vpc_name}-${local.environment}"
+  subnet_set_name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}"
+
+  is_live       = [substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-production" || substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-preproduction" ? "live" : "non-live"]
+  provider_name = "core-vpc-${local.environment}"
+
+  # environment specfic variables
+  # example usage:
+  # example_data = local.application_data.accounts[local.environment].example_var
+  application_data = fileexists("./application_variables.json") ? jsondecode(file("./application_variables.json")) : {}
+}


### PR DESCRIPTION
The environments setup in the modernisation-platform repo and modernisation-platform-environments repo shared platform_secrets.tf and locals.tf template definitions.

These two files have been changed to implement the OIDC changes, which added reference to OIDC resources to the modernisation-platform/terraform/environments/<team-name> directories and
resulted in failures during ram share job.

This PR

- Consoledates all OIDC-related changes to locals.tf and providers.tf
- Creates a member-locals.tf to be used in the environments repo
- Amends the file generation scripts to place the correct versions of locals.tf files in the right repos
- Amends the existing maatdb files with the fixes to allow ram share to run
