### PR TITLE
Create a resource share for the environment management secret

### DIFF
--- a/terraform/environments/core-shared-services/iam.tf
+++ b/terraform/environments/core-shared-services/iam.tf
@@ -161,7 +161,7 @@ data "aws_iam_policy_document" "instance-scheduler-lambda-function-policy" {
       "secretsmanager:ListSecretVersionIds"
     ]
     resources = [
-      "*"
+      format("arn:aws:secretsmanager:eu-west-2:%s:secret:environment_management*", local.environment_management.modernisation_platform_account_id)
    ]
   }
 }

--- a/terraform/environments/core-shared-services/iam.tf
+++ b/terraform/environments/core-shared-services/iam.tf
@@ -138,6 +138,32 @@ data "aws_iam_policy_document" "instance-scheduler-lambda-function-policy" {
       "arn:aws:iam::*:role/MemberInfrastructureAccess"
     ]
   }
+  statement {
+    sid    = "AllowAccessParameter"
+    effect = "Allow"
+    actions = [
+      "ssm:DescribeParameters",
+      "ssm:GetParameter",
+      "ssm:GetParameters",
+      "ssm:GetParametersByPath"
+    ]
+    resources = [
+      format("arn:aws:ssm:*:%s:parameter/environment_management_arn", data.aws_caller_identity.current.account_id)
+    ]
+  }
+  statement {
+    sid    = "AllowAccessEnvironmentManagementSecret"
+    effect = "Allow"
+    actions = [
+      "secretsmanager:GetResourcePolicy",
+      "secretsmanager:GetSecretValue",
+      "secretsmanager:DescribeSecret",
+      "secretsmanager:ListSecretVersionIds"
+    ]
+    resources = [
+      "*"
+   ]
+  }
 }
 
 resource "aws_iam_role" "instance-scheduler-lambda-function" {

--- a/terraform/modernisation-platform-account/secrets.tf
+++ b/terraform/modernisation-platform-account/secrets.tf
@@ -8,20 +8,6 @@ data "aws_secretsmanager_secret_version" "environment_management" {
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
 
-# Create a resource share for the environment management secret
-resource "aws_ram_resource_share" "environment_management" {
-  name                      = "environment_management"
-  allow_external_principals = false
-
-  tags = local.tags
-}
-
-# Attach the environment management secret to the resource share
-resource "aws_ram_resource_association" "environment_management" {
-  resource_arn       = data.aws_secretsmanager_secret.environment_management.arn
-  resource_share_arn = aws_ram_resource_share.environment_management.id
-}
-
 # Core CI User
 # Tfsec ignore
 # - AWS095: No requirement currently to encrypt this secret with customer-managed KMS key

--- a/terraform/modernisation-platform-account/secrets.tf
+++ b/terraform/modernisation-platform-account/secrets.tf
@@ -8,6 +8,20 @@ data "aws_secretsmanager_secret_version" "environment_management" {
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
 
+# Create a resource share for the environment management secret
+resource "aws_ram_resource_share" "environment_management" {
+  name                      = "environment_management"
+  allow_external_principals = false
+
+  tags = local.tags
+}
+
+# Attach the environment management secret to the resource share
+resource "aws_ram_resource_association" "environment_management" {
+  resource_arn       = data.aws_secretsmanager_secret.environment_management.arn
+  resource_share_arn = aws_ram_resource_share.environment_management.id
+}
+
 # Core CI User
 # Tfsec ignore
 # - AWS095: No requirement currently to encrypt this secret with customer-managed KMS key


### PR DESCRIPTION
This is needed so that the instance scheduler lambda function that runs within the core-shared-services-production account can access the secret.