### PR TITLE
Update TGW routes for Nomis

### DIFF
--- a/terraform/environments/core-network-services/transit_gateway_connections.tf
+++ b/terraform/environments/core-network-services/transit_gateway_connections.tf
@@ -51,16 +51,15 @@ locals {
 
   # To extend the below two data sections, just add additional lines with name and CIDR address to the relevant sections
   egress_pttp_routing_cidrs_non_live_data = {
-    "global-protect"  = "10.184.0.0/16",
     "azure-noms-test" = "10.101.0.0/16",
+    "azure-noms-mgmt" = "10.102.0.0/16",
+    "global-protect"  = "10.184.0.0/16",
     "cloud-platform"  = "172.20.0.0/16",
     "laa-development" = "10.202.0.0/20"
   }
 
   egress_pttp_routing_cidrs_live_data = {
     "azure-fixngo-live" = "10.40.0.0/16",
-    "azure-noms-test"   = "10.101.0.0/16",
-    "azure-noms-mgmt"   = "10.102.0.0/16",
     "global-protect"    = "10.184.0.0/16",
     "cloud-platform"    = "172.20.0.0/16",
     "ppud-psn"          = "51.247.0.0/16",

--- a/terraform/environments/core-network-services/transit_gateway_connections.tf
+++ b/terraform/environments/core-network-services/transit_gateway_connections.tf
@@ -58,12 +58,12 @@ locals {
   }
 
   egress_pttp_routing_cidrs_live_data = {
-    "global-protect"       = "10.184.0.0/16",
-    "azure-noms-test"      = "10.101.0.0/16",
-    "azure-noms-mgmt-live" = "10.40.128.0/20",
-    "cloud-platform"       = "172.20.0.0/16",
-    "ppud-psn"             = "51.247.0.0/16",
-    "azure-noms-live"      = "10.40.0.0/18"
+    "azure-noms"      = "10.40.0.0/16",
+    "azure-noms-test" = "10.101.0.0/16",
+    "azure-noms-mgmt" = "10.102.0.0/16",
+    "global-protect"  = "10.184.0.0/16",
+    "cloud-platform"  = "172.20.0.0/16",
+    "ppud-psn"        = "51.247.0.0/16",
   }
 
   tgw_live_data_attachments = {

--- a/terraform/environments/core-network-services/transit_gateway_connections.tf
+++ b/terraform/environments/core-network-services/transit_gateway_connections.tf
@@ -58,7 +58,7 @@ locals {
   }
 
   egress_pttp_routing_cidrs_live_data = {
-    "azure-noms"      = "10.40.0.0/16",
+    "azure-fixngo"    = "10.40.0.0/16",
     "azure-noms-test" = "10.101.0.0/16",
     "azure-noms-mgmt" = "10.102.0.0/16",
     "global-protect"  = "10.184.0.0/16",

--- a/terraform/environments/core-network-services/transit_gateway_connections.tf
+++ b/terraform/environments/core-network-services/transit_gateway_connections.tf
@@ -58,12 +58,12 @@ locals {
   }
 
   egress_pttp_routing_cidrs_live_data = {
-    "azure-fixngo"    = "10.40.0.0/16",
-    "azure-noms-test" = "10.101.0.0/16",
-    "azure-noms-mgmt" = "10.102.0.0/16",
-    "global-protect"  = "10.184.0.0/16",
-    "cloud-platform"  = "172.20.0.0/16",
-    "ppud-psn"        = "51.247.0.0/16",
+    "azure-fixngo-live" = "10.40.0.0/16",
+    "azure-noms-test"   = "10.101.0.0/16",
+    "azure-noms-mgmt"   = "10.102.0.0/16",
+    "global-protect"    = "10.184.0.0/16",
+    "cloud-platform"    = "172.20.0.0/16",
+    "ppud-psn"          = "51.247.0.0/16",
   }
 
   tgw_live_data_attachments = {


### PR DESCRIPTION
As per #2375, this PR amends the routes for Nomis for live VPCs (`production` / `preproduction`).
Also, the order of the routes has been amended somewhat. It's not exactly alphabetised, but the routes are mostly in order (private routes, public routes, in numerical order)