### PR TITLE
Allow deployment of latest container image in instance scheduler workflow

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -529,4 +529,12 @@ data "aws_iam_policy_document" "oidc_assume_role_core" {
     resources = ["*"]
     actions   = ["kms:Decrypt"]
   }
+
+  # This is for the Instance Scheduler Lambda Function workflow to be able to deploy the latest container image
+  statement {
+    sid       = "AllowOIDCToUpdateLambdaFunctionCode"
+    effect    = "Allow"
+    resources = ["arn:aws:lambda:eu-west-2:${local.environment_management.account_ids["core-shared-services-production"]}:function:instance-scheduler-lambda-function"]
+    actions   = ["lambda:UpdateFunctionCode"]
+  }
 }


### PR DESCRIPTION
This is for the Instance Scheduler Lambda Function workflow to be able to deploy the latest container image.

Running

    aws lambda update-function-code --function-name instance-scheduler-lambda-function --image-uri instance-scheduler-ecr-repo:latest

From github actions throws the error (https://github.com/ministryofjustice/modernisation-platform-instance-scheduler/actions/runs/3280550024/jobs/5401467323):

```
Throws the error: An error occurred (AccessDeniedException) when calling the UpdateFunctionCode operation: User: arn:aws:sts::***:assumed-role/github-actions/githubactionsrolesession is not authorized to perform: lambda:UpdateFunctionCode on resource: arn:aws:lambda:eu-west-2:***:function:instance-scheduler-lambda-function because no identity-based policy allows the lambda:UpdateFunctionCode action
                  Error: Process completed with exit code 254.
```