### PR TITLE
Allow lambda updates in core-shared-services

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -529,4 +529,10 @@ data "aws_iam_policy_document" "oidc_assume_role_core" {
     resources = ["*"]
     actions   = ["kms:Decrypt"]
   }
+  statement {
+    sid       = "AllowUpdateLambdaCode"
+    effect    = "Allow"
+    resources = ["*"]
+    actions   = ["lambda:UpdateFunctionCode"]
+  }
 }

--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -529,7 +529,7 @@ data "aws_iam_policy_document" "oidc_assume_role_core" {
     resources = ["*"]
     actions   = ["kms:Decrypt"]
   }
-  
+
   # checkov:skip=CKV_AWS_111: "There's no naming convention for lambda functions at the moment"
   statement {
     sid       = "AllowUpdateLambdaCode"

--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -529,6 +529,8 @@ data "aws_iam_policy_document" "oidc_assume_role_core" {
     resources = ["*"]
     actions   = ["kms:Decrypt"]
   }
+  
+  # checkov:skip=CKV_AWS_111: "There's no naming convention for lambda functions at the moment"
   statement {
     sid       = "AllowUpdateLambdaCode"
     effect    = "Allow"


### PR DESCRIPTION
This allows the core-shared-services github-actions role to update lambda code when a new version of the image is released.