### PR TITLE
Additional Resources to allow SSO Plans

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -35,7 +35,7 @@ data "aws_iam_policy_document" "sso-administrator-access" {
     condition {
       test     = "ForAnyValue:StringLike"
       variable = "aws:PrincipalOrgPaths"
-      values   = ["${local.root_account.id}/*/${local.modernisation_platform_ou_id}/*"]
+      values   = ["${data.aws_organizations_organization.root_account.id}/*/${local.environment_management.modernisation_platform_organisation_unit_id}/*"]
     }
 
     condition {

--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -14,10 +14,10 @@ module "cross-account-access" {
   providers = {
     aws = aws.workspace
   }
-  account_id             = local.modernisation_platform_account.id
-  policy_arn             = "arn:aws:iam::aws:policy/AdministratorAccess"
-  role_name              = "ModernisationPlatformAccess"
-  additional_trust_roles = concat(try([module.github-oidc[0].github_actions_role], []), terraform.workspace == "testing-test" ? ["arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:user/testing-ci"] : [])
+  account_id                  = local.modernisation_platform_account.id
+  policy_arn                  = "arn:aws:iam::aws:policy/AdministratorAccess"
+  role_name                   = "ModernisationPlatformAccess"
+  additional_trust_roles      = concat(try([module.github-oidc[0].github_actions_role], []), terraform.workspace == "testing-test" ? ["arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:user/testing-ci"] : [])
   additional_trust_statements = [data.aws_iam_policy_document.sso-administrator-access.json]
 }
 

--- a/terraform/modernisation-platform-account/iam.tf
+++ b/terraform/modernisation-platform-account/iam.tf
@@ -456,11 +456,11 @@ data "aws_iam_policy_document" "oidc-deny-specific-actions" {
 
 # Role for running terraform in MP without superadmin
 module "cross-account-access" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access?ref=v2.3.0"
-  account_id             = data.aws_caller_identity.current.account_id
-  policy_arn             = "arn:aws:iam::aws:policy/AdministratorAccess"
-  role_name              = "ModernisationPlatformAccess"
-  additional_trust_roles = []
+  source                      = "github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access?ref=v2.3.0"
+  account_id                  = data.aws_caller_identity.current.account_id
+  policy_arn                  = "arn:aws:iam::aws:policy/AdministratorAccess"
+  role_name                   = "ModernisationPlatformAccess"
+  additional_trust_roles      = []
   additional_trust_statements = [data.aws_iam_policy_document.sso-administrator-access.json]
 
 }

--- a/terraform/modernisation-platform-account/s3.tf
+++ b/terraform/modernisation-platform-account/s3.tf
@@ -258,6 +258,7 @@ data "aws_iam_policy_document" "allow-state-access-from-root-account" {
     actions = ["s3:PutObject"]
     resources = [
       "${module.state-bucket.bucket.arn}/environments/members/*",
+      "${module.state-bucket.bucket.arn}/environments/accounts/*",
     ]
 
     principals {

--- a/terraform/modernisation-platform-account/secrets.tf
+++ b/terraform/modernisation-platform-account/secrets.tf
@@ -8,6 +8,13 @@ data "aws_secretsmanager_secret_version" "environment_management" {
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
 
+resource "aws_ssm_parameter" "environment_management_arn" {
+  name  = "environment_management_arn"
+  type  = "SecureString"
+  value = data.aws_secretsmanager_secret.environment_management.arn
+
+  tags = local.tags
+}
 # Core CI User
 # Tfsec ignore
 # - AWS095: No requirement currently to encrypt this secret with customer-managed KMS key


### PR DESCRIPTION
Linked issue: https://github.com/ministryofjustice/modernisation-platform/issues/1859

- Gives state access to the SSO Administrator role
- Adds a permissive role in Modernisation Platform to be assumed when running terraform in MP
- Adding environment-secret-arn SSM parameter to MP to simplify platform_secrets.tf
- Bumping the version of the cross-account-role module (tested with sprinkler, cooker and example)
- Adding a custom trust statement to ModernisationPlatformAccess role
