### PR TITLE
Adjust permissions and add resources to enable SSO plans/applies

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -534,7 +534,7 @@ data "aws_iam_policy_document" "oidc_assume_role_core" {
   statement {
     sid       = "AllowUpdateLambdaCode"
     effect    = "Allow"
-    resources = ["*"]
+    resources = ["arn:aws:lambda:eu-west-2:${local.environment_management.account_ids["core-shared-services-production"]}:function:*"]
     actions   = ["lambda:UpdateFunctionCode"]
   }
 }

--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -17,7 +17,7 @@ module "cross-account-access" {
   account_id             = local.modernisation_platform_account.id
   policy_arn             = "arn:aws:iam::aws:policy/AdministratorAccess"
   role_name              = "ModernisationPlatformAccess"
-  additional_trust_roles = concat(tolist(data.aws_iam_roles.sso-admin-access.arns), try([module.github-oidc[0].github_actions_role], []), terraform.workspace == "testing-test" ? ["arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:user/testing-ci"] : [])
+  additional_trust_roles = concat(tolist(data.aws_iam_roles.mp-sso-admin-access.arns), try([module.github-oidc[0].github_actions_role], []), terraform.workspace == "testing-test" ? ["arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:user/testing-ci"] : [])
 
 }
 
@@ -36,7 +36,7 @@ module "member-access" {
     aws = aws.workspace
   }
   account_id             = local.modernisation_platform_account.id
-  additional_trust_roles = [module.github-oidc[0].github_actions_role, one(data.aws_iam_roles.sso-admin-access.arns)]
+  additional_trust_roles = [module.github-oidc[0].github_actions_role, one(data.aws_iam_roles.member-sso-admin-access.arns)]
   policy_arn             = aws_iam_policy.member-access[0].id
   role_name              = "MemberInfrastructureAccess"
 }

--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -10,7 +10,7 @@ resource "aws_iam_account_alias" "alias" {
 }
 
 module "cross-account-access" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access?ref=v2.2.0"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access?ref=v2.3.0"
   providers = {
     aws = aws.workspace
   }
@@ -31,7 +31,7 @@ module "cicd-member-user" {
 
 module "member-access" {
   count  = local.account_data.account-type == "member" && terraform.workspace != "testing-test" ? 1 : 0
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access?ref=v2.2.0"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access?ref=v2.3.0"
   providers = {
     aws = aws.workspace
   }
@@ -187,7 +187,7 @@ resource "aws_iam_policy" "member-access" {
 
 module "instance-scheduler-access" {
   count  = local.account_data.account-type == "member" ? 1 : 0
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access?ref=v2.2.0"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access?ref=v2.3.0"
   providers = {
     aws = aws.workspace
   }

--- a/terraform/environments/bootstrap/delegate-access/locals.tf
+++ b/terraform/environments/bootstrap/delegate-access/locals.tf
@@ -2,7 +2,7 @@
 # (when we want to assume a role in the MP, for instance)
 data "aws_organizations_organization" "root_account" {}
 data "aws_iam_roles" "sso-admin-access" {
-  provider    = aws.workspace
+  alias       = "modernisation-platform"
   name_regex  = "AWSReservedSSO_AdministratorAccess_.*"
   path_prefix = "/aws-reserved/sso.amazonaws.com/"
 }

--- a/terraform/environments/bootstrap/delegate-access/locals.tf
+++ b/terraform/environments/bootstrap/delegate-access/locals.tf
@@ -1,8 +1,17 @@
 # This data sources allows us to get the Modernisation Platform account information for use elsewhere
 # (when we want to assume a role in the MP, for instance)
 data "aws_organizations_organization" "root_account" {}
-data "aws_iam_roles" "sso-admin-access" {
-  alias       = "modernisation-platform"
+
+# to allow member account AdministratorAccessRole to do local plans/applies in modernisation-platform-environments repo
+data "aws_iam_roles" "member-sso-admin-access" {
+  provider    = aws.workspace
+  name_regex  = "AWSReservedSSO_AdministratorAccess_.*"
+  path_prefix = "/aws-reserved/sso.amazonaws.com/"
+}
+
+# to allow Modernisation Platform AdministratorAccessRole to do local plans/applies in modernistion-platform repo
+data "aws_iam_roles" "mp-sso-admin-access" {
+  provider    = aws.modernisation-platform
   name_regex  = "AWSReservedSSO_AdministratorAccess_.*"
   path_prefix = "/aws-reserved/sso.amazonaws.com/"
 }

--- a/terraform/modernisation-platform-account/locals.tf
+++ b/terraform/modernisation-platform-account/locals.tf
@@ -1,6 +1,9 @@
 data "aws_organizations_organization" "root_account" {}
 data "aws_caller_identity" "current" {}
-
+data "aws_iam_roles" "sso-admin-access" {
+  name_regex  = "AWSReservedSSO_AdministratorAccess_.*"
+  path_prefix = "/aws-reserved/sso.amazonaws.com/"
+}
 locals {
   root_account                 = data.aws_organizations_organization.root_account
   environment_management       = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)

--- a/terraform/modernisation-platform-account/s3.tf
+++ b/terraform/modernisation-platform-account/s3.tf
@@ -257,7 +257,7 @@ data "aws_iam_policy_document" "allow-state-access-from-root-account" {
     effect  = "Allow"
     actions = ["s3:PutObject"]
     resources = [
-      "${module.state-bucket.bucket.arn}/environments/members/*",
+      "${module.state-bucket.bucket.arn}/environments/members/*"
     ]
 
     principals {
@@ -276,6 +276,19 @@ data "aws_iam_policy_document" "allow-state-access-from-root-account" {
       variable = "aws:PrincipalArn"
       values = [
       "arn:aws:iam::*:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_AdministratorAccess_*"]
+    }
+  }
+  statement {
+    sid     = "AllowMPAdministratorAccessRole"
+    effect  = "Allow"
+    actions = ["s3:PutObject"]
+    resources = [
+      "${module.state-bucket.bucket.arn}/environments/accounts/*",
+    ]
+
+    principals {
+      type        = "AWS"
+      identifiers = tolist(data.aws_iam_roles.sso-admin-access.arns)
     }
   }
 }


### PR DESCRIPTION
Linked Issue: https://github.com/ministryofjustice/modernisation-platform/issues/1859

After a steer from Dave E, a new way forward is to use the MP AdministratorAccess role for modernisation-platform repo local plans and applies. 

To enable this:

- Allow MP AdminstratorAccessRole permission to assume ModernisationPlatformAccess roles
- Give MP AdministratorAccessRole permissions to write to the accounts folder in state file bucket.

Housekeeping:

- Bump cross-account module version (has been tested in cooker, example and sprinker)

Additional relevant PR:

https://github.com/ministryofjustice/aws-root-account/pull/612

