### PR TITLE
Migrating core-shared-services OIDC provider to environments/core-shared-services

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -17,7 +17,7 @@ module "cross-account-access" {
   account_id             = local.modernisation_platform_account.id
   policy_arn             = "arn:aws:iam::aws:policy/AdministratorAccess"
   role_name              = "ModernisationPlatformAccess"
-  additional_trust_roles = concat(tolist(data.aws_iam_roles.mp-sso-admin-access.arns), try([module.github-oidc[0].github_actions_role], []), terraform.workspace == "testing-test" ? ["arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:user/testing-ci"] : [])
+  additional_trust_roles = concat(tolist(data.aws_iam_roles.mp-sso-admin-access.arns), terraform.workspace == "testing-test" ? ["arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:user/testing-ci"] : [])
 
 }
 

--- a/terraform/environments/core-shared-services/iam.tf
+++ b/terraform/environments/core-shared-services/iam.tf
@@ -191,7 +191,6 @@ resource "aws_iam_role_policy_attachment" "instance-scheduler-lambda-function" {
 ## END: IAM for Instance Scheduler Lambda Function
 
 # OIDC Confiuration for core-shared-services
-#tfsec:ignore:aws-iam-no-policy-wildcards
 module "github-oidc" {
   source                 = "github.com/ministryofjustice/modernisation-platform-github-oidc-provider?ref=v1.2.0"
   additional_permissions = data.aws_iam_policy_document.oidc_assume_role_core.json
@@ -199,6 +198,8 @@ module "github-oidc" {
   tags_common            = { "Name" = format("%s-oidc", terraform.workspace) }
   tags_prefix            = ""
 }
+#tfsec:ignore:aws-iam-no-policy-wildcards
+
 data "aws_iam_policy_document" "oidc_assume_role_core" {
   # checkov:skip=CKV_AWS_111: "Cannot restrict by KMS alias so leaving open"
   statement {

--- a/terraform/environments/core-shared-services/iam.tf
+++ b/terraform/environments/core-shared-services/iam.tf
@@ -198,14 +198,14 @@ module "github-oidc" {
   tags_common            = { "Name" = format("%s-oidc", terraform.workspace) }
   tags_prefix            = ""
 }
-#tfsec:ignore:aws-iam-no-policy-wildcards
+
 
 data "aws_iam_policy_document" "oidc_assume_role_core" {
   # checkov:skip=CKV_AWS_111: "Cannot restrict by KMS alias so leaving open"
   statement {
     sid       = "AllowOIDCToDecryptKMS"
     effect    = "Allow"
-    resources = ["*"]
+    resources = ["*"] #tfsec:ignore:aws-iam-no-policy-wildcards
     actions   = ["kms:Decrypt"]
   }
 

--- a/terraform/environments/core-shared-services/iam.tf
+++ b/terraform/environments/core-shared-services/iam.tf
@@ -191,7 +191,7 @@ resource "aws_iam_role_policy_attachment" "instance-scheduler-lambda-function" {
 ## END: IAM for Instance Scheduler Lambda Function
 
 # OIDC Confiuration for core-shared-services
-
+#tfsec:ignore:aws-iam-no-policy-wildcards
 module "github-oidc" {
   source = "github.com/ministryofjustice/modernisation-platform-github-oidc-provider?ref=v1.2.0"
   additional_permissions = data.aws_iam_policy_document.oidc_assume_role_core.json

--- a/terraform/environments/core-shared-services/iam.tf
+++ b/terraform/environments/core-shared-services/iam.tf
@@ -194,9 +194,6 @@ resource "aws_iam_role_policy_attachment" "instance-scheduler-lambda-function" {
 
 module "github-oidc" {
   source = "github.com/ministryofjustice/modernisation-platform-github-oidc-provider?ref=v1.2.0"
-  providers = {
-    aws = aws.workspace
-  }
   additional_permissions = data.aws_iam_policy_document.oidc_assume_role_core.json
   github_repository      = "ministryofjustice/modernisation-platform-instance-scheduler:*"
   tags_common            = { "Name" = format("%s-oidc", terraform.workspace) }

--- a/terraform/environments/core-shared-services/instance-scheduler-lambda-function.tf
+++ b/terraform/environments/core-shared-services/instance-scheduler-lambda-function.tf
@@ -2,7 +2,7 @@ resource "aws_lambda_function" "instance-scheduler-lambda-function" {
   #checkov:skip=CKV_AWS_116
   #checkov:skip=CKV_AWS_117
   #checkov:skip=CKV_AWS_272 "Code signing not required"
-  #checkov:skip=CKV_AWS_117 "These lambda envvars aren't sensitive and don't need a cmk. Default AWS KMS key is sufficient"
+  #checkov:skip=CKV_AWS_173 "These lambda envvars aren't sensitive and don't need a cmk. Default AWS KMS key is sufficient"
   function_name                  = "instance-scheduler-lambda-function"
   reserved_concurrent_executions = 0
   image_uri                      = "${local.environment_management.account_ids[terraform.workspace]}.dkr.ecr.eu-west-2.amazonaws.com/${module.instance_scheduler_ecr_repo.ecr_repository_name}:latest"

--- a/terraform/environments/core-shared-services/instance-scheduler-lambda-function.tf
+++ b/terraform/environments/core-shared-services/instance-scheduler-lambda-function.tf
@@ -2,6 +2,7 @@ resource "aws_lambda_function" "instance-scheduler-lambda-function" {
   #checkov:skip=CKV_AWS_116
   #checkov:skip=CKV_AWS_117
   #checkov:skip=CKV_AWS_272 "Code signing not required"
+  #checkov:skip=CKV_AWS_117 "These lambda envvars aren't sensitive and don't need a cmk. Default AWS KMS key is sufficient"
   function_name                  = "instance-scheduler-lambda-function"
   reserved_concurrent_executions = 0
   image_uri                      = "${local.environment_management.account_ids[terraform.workspace]}.dkr.ecr.eu-west-2.amazonaws.com/${module.instance_scheduler_ecr_repo.ecr_repository_name}:latest"


### PR DESCRIPTION
- Move core-shared-services OIDC provider to environments/core-shared-services
- Removing the uneeded try statement.
