### PR TITLE
Adding GH actions role principal to the lambda function role policy document

### DIFF
--- a/terraform/environments/core-shared-services/iam.tf
+++ b/terraform/environments/core-shared-services/iam.tf
@@ -103,7 +103,7 @@ data "aws_iam_policy_document" "instance-scheduler-lambda-function-assume-role" 
       type        = "Service"
     }
     principals {
-      identifiers = [module.github-oidc.aws_iam_role.github_actions.arn]
+      identifiers = [module.github-oidc.github_actions_role]
       type        = "Federated"
     }
   }

--- a/terraform/environments/core-shared-services/iam.tf
+++ b/terraform/environments/core-shared-services/iam.tf
@@ -102,6 +102,10 @@ data "aws_iam_policy_document" "instance-scheduler-lambda-function-assume-role" 
       identifiers = ["lambda.amazonaws.com"]
       type        = "Service"
     }
+    principals {
+      identifiers = [module.github-oidc.aws_iam_role.github_actions.arn]
+      type        = "Federated"
+    }
   }
 }
 

--- a/terraform/environments/core-shared-services/iam.tf
+++ b/terraform/environments/core-shared-services/iam.tf
@@ -104,7 +104,7 @@ data "aws_iam_policy_document" "instance-scheduler-lambda-function-assume-role" 
     }
     principals {
       identifiers = [module.github-oidc.github_actions_role]
-      type        = "Federated"
+      type        = "AWS"
     }
   }
 }


### PR DESCRIPTION
The lambda role needs to be assumable by GH actions role.