### PR TITLE
Add documentation for shared KMS keys

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -41,6 +41,7 @@ This documentation is for anyone interested in the Modernisation Platform and it
 - [How to configure DNS for public services](user-guide/how-to-configure-dns.html)
 - [How to import a public SSL certificate into AWS Certificate Manager](user-guide/certificate-import.html)
 - [How to view core account/shared resources as a Member Developer](user-guide/member-read-only-core-accounts.html)
+- [How to use shared KMS keys](user-guide/how-to-use-shared-kms-keys.html)
 
 ## Concepts
 

--- a/source/user-guide/how-to-use-shared-kms-keys.html.md.erb
+++ b/source/user-guide/how-to-use-shared-kms-keys.html.md.erb
@@ -38,6 +38,6 @@ This uses the following data source in data.tf
 
 ```
 data "aws_kms_key" "general_shared" {
-	key_id = "arn:aws:kms:eu-west-2:${local.environment_management.account_ids["core-shared-services-production"]}:alias/general-${var.networking[0].business-unit}"
+  key_id = "arn:aws:kms:eu-west-2:${local.environment_management.account_ids["core-shared-services-production"]}:alias/general-${var.networking[0].business-unit}"
 }
 ```

--- a/source/user-guide/how-to-use-shared-kms-keys.html.md.erb
+++ b/source/user-guide/how-to-use-shared-kms-keys.html.md.erb
@@ -1,0 +1,43 @@
+---
+owner_slack: "#modernisation-platform"
+title: How to use shared KMS keys
+last_reviewed_on: 2022-10-28
+review_in: 6 months
+---
+
+# <%= current_page.data.title %>
+
+## Introduction
+
+Sometimes you may need to share encrypted things between accounts, like snapshots.  To do this you can either create your own [KMS key](https://aws.amazon.com/kms/) and share to the relevant accounts, or you can use one of the shared keys provided per business unit.
+
+## Shared per business unit KMS keys
+
+KMS keys are created for each business unit (eg HMPPS, LAA). These keys are shared to all of the accounts in the business unit, so anything encrypted with these keys can be shared between accounts in the business unit. The shared keys are located in the core-shared-services account.
+
+|Key alias|Recommended usage|
+|---|---|
+|`general-<business-unit>`| General encryption |
+|`ebs-<business-unit>`| Encrypt EBS volumes and snapshots |
+|`rds-<business-unit>`| Encrypt RDS databases and snapshots |
+
+## How to use
+
+To use the shared KMS key, reference the data source which is provided in your 'data.tf' file, this will automatically pick up the correct shared key for your business unit.
+
+In your resource requiring encryption:
+
+```
+...
+kms_key_id = data.aws_kms_key.general_shared.arn
+...
+
+```
+
+This uses the following data source in data.tf
+
+```
+data "aws_kms_key" "general_shared" {
+	key_id = "arn:aws:kms:eu-west-2:${local.environment_management.account_ids["core-shared-services-production"]}:alias/general-${var.networking[0].business-unit}"
+}
+```

--- a/terraform/templates/data.tf
+++ b/terraform/templates/data.tf
@@ -125,6 +125,19 @@ data "aws_route53_zone" "network-services" {
   private_zone = false
 }
 
+# Shared KMS keys (per business unit)
+data "aws_kms_key" "general_shared" {
+	key_id = "arn:aws:kms:eu-west-2:${local.environment_management.account_ids["core-shared-services-production"]}:alias/general-${var.networking[0].business-unit}"
+}
+
+data "aws_kms_key" "ebs_shared" {
+	key_id = "arn:aws:kms:eu-west-2:${local.environment_management.account_ids["core-shared-services-production"]}:alias/ebs-${var.networking[0].business-unit}"
+}
+
+data "aws_kms_key" "rds_shared" {
+	key_id = "arn:aws:kms:eu-west-2:${local.environment_management.account_ids["core-shared-services-production"]}:alias/rds-${var.networking[0].business-unit}"
+}
+
 # State for core-network-services resource information
 data "terraform_remote_state" "core_network_services" {
   backend = "s3"

--- a/terraform/templates/data.tf
+++ b/terraform/templates/data.tf
@@ -127,15 +127,15 @@ data "aws_route53_zone" "network-services" {
 
 # Shared KMS keys (per business unit)
 data "aws_kms_key" "general_shared" {
-	key_id = "arn:aws:kms:eu-west-2:${local.environment_management.account_ids["core-shared-services-production"]}:alias/general-${var.networking[0].business-unit}"
+  key_id = "arn:aws:kms:eu-west-2:${local.environment_management.account_ids["core-shared-services-production"]}:alias/general-${var.networking[0].business-unit}"
 }
 
 data "aws_kms_key" "ebs_shared" {
-	key_id = "arn:aws:kms:eu-west-2:${local.environment_management.account_ids["core-shared-services-production"]}:alias/ebs-${var.networking[0].business-unit}"
+  key_id = "arn:aws:kms:eu-west-2:${local.environment_management.account_ids["core-shared-services-production"]}:alias/ebs-${var.networking[0].business-unit}"
 }
 
 data "aws_kms_key" "rds_shared" {
-	key_id = "arn:aws:kms:eu-west-2:${local.environment_management.account_ids["core-shared-services-production"]}:alias/rds-${var.networking[0].business-unit}"
+  key_id = "arn:aws:kms:eu-west-2:${local.environment_management.account_ids["core-shared-services-production"]}:alias/rds-${var.networking[0].business-unit}"
 }
 
 # State for core-network-services resource information


### PR DESCRIPTION
Also adds the required data sources to the data.tf, so users don't need to add this themselves.

A further PR to add this data to the existing environments in the environments repo will be required.