### PR TITLE
Resolve issue with replacing FW rule group

### DIFF
--- a/terraform/modules/firewall-policy/main.tf
+++ b/terraform/modules/firewall-policy/main.tf
@@ -44,6 +44,9 @@ resource "aws_networkfirewall_rule_group" "stateful" {
       }
     }
   }
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_networkfirewall_logging_configuration" "main" {


### PR DESCRIPTION
Without an explicit `create_before_destroy` lifecycle statement, terraform will try to destroy the existing network firewall rule group, and fail as the rule group cannot be destroyed while in use. This should change the behaviour to create a new rule group, replace the original rule group, and then delete the original resource