### PR TITLE
Fix issue with new lines

### DIFF
--- a/scripts/internal/get-security-hub-findings/main.go
+++ b/scripts/internal/get-security-hub-findings/main.go
@@ -110,9 +110,9 @@ func getFindings(client *securityhub.Client, accountName string, productName str
 					*finding.AwsAccountId,
 					finding.Severity.Label,
 					*finding.ProductName,
-					*finding.Title,
+					strings.ReplaceAll(*finding.Title, "\n", ""),
 					*finding.Resources[0].Id,
-					*finding.Description,
+					strings.ReplaceAll(*finding.Description, "\n", ""),
 					*finding.Remediation.Recommendation.Text,
 					url,
 				)
@@ -122,7 +122,7 @@ func getFindings(client *securityhub.Client, accountName string, productName str
 					*finding.AwsAccountId,
 					finding.Severity.Label,
 					*finding.ProductName,
-					*finding.Title,
+					strings.ReplaceAll(*finding.Title, "\n", ""),
 					*finding.Resources[0].Id,
 				)
 			}


### PR DESCRIPTION
Inspector has new lines in the title for some findings, which causes issues when importing the findings to a Google sheet.