### PR TITLE
Add "kms:CreateGrant" to instance scheduler role

### DIFF
--- a/terraform/environments/core-shared-services/iam.tf
+++ b/terraform/environments/core-shared-services/iam.tf
@@ -173,7 +173,10 @@ data "aws_iam_policy_document" "instance-scheduler-lambda-function-policy" {
     sid       = "AllowToDecryptKMS"
     effect    = "Allow"
     resources = ["*"]
-    actions   = ["kms:Decrypt"]
+    actions   = [
+      "kms:Decrypt",
+      "kms:CreateGrant"
+    ]
   }
 }
 

--- a/terraform/environments/core-shared-services/iam.tf
+++ b/terraform/environments/core-shared-services/iam.tf
@@ -173,7 +173,7 @@ data "aws_iam_policy_document" "instance-scheduler-lambda-function-policy" {
     sid       = "AllowToDecryptKMS"
     effect    = "Allow"
     resources = ["*"]
-    actions   = [
+    actions = [
       "kms:Decrypt",
       "kms:CreateGrant"
     ]


### PR DESCRIPTION
Add "kms:CreateGrant" to instance scheduler role to try fixing the issue
State transition reason: Server.InternalError
State transition message: Client.InternalError: Client error on launch