### PR TITLE
Edtied permissions for developers based on requirements

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -394,6 +394,10 @@ data "aws_iam_policy_document" "developer-additional" {
       "ec2:CreateTags",
       "s3:PutObject",
       "s3:DeleteObject",
+      "rds:CopyDBSnapshot",
+      "rds:CopyDBClusterSnapshot",
+      "rds:CreateDBSnapshot",
+      "rds:CreateDBClusterSnapshot",
       "aws-marketplace:ViewSubscriptions",
       "support:*",
       "rhelkb:GetRhelURL"


### PR DESCRIPTION
They can now can cop db snapshots, clustered or not, as well as create them, similar to the permissions we give on ec2.