### PR TITLE
Restrict CreateGrant permission in instance scheduler role

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -221,9 +221,20 @@ data "aws_iam_policy_document" "instance-scheduler-access" {
     effect    = "Allow"
     resources = ["*"]
     actions = [
-      "kms:Decrypt",
+      "kms:Decrypt"
+    ]
+  }
+  # checkov:skip=CKV_AWS_111: "Will need to potentially create grants on multiple keys"
+  statement {
+    actions = [
       "kms:CreateGrant"
     ]
+    resources = ["*"]
+    condition {
+      test     = "Bool"
+      variable = "kms:GrantIsForAWSResource"
+      values   = ["true"]
+    }
   }
 }
 


### PR DESCRIPTION
Instance Scheduler needs kms:CreateGrant permissions to manage encrypted ebs volumes. The grantee in this instance is the EC2 service, so it's possible to lock the permission down using `kms:GrantIsForAWSResource` condition.