### PR TITLE
OIDC refactor in core-vpc-test-deployment and core-network-services-deployment workflows

### DIFF
--- a/.github/workflows/core-network-services-deployment.yml
+++ b/.github/workflows/core-network-services-deployment.yml
@@ -21,9 +21,13 @@ on:
   workflow_dispatch:
 
 env:
-  AWS_ACCESS_KEY_ID:  ${{ secrets.AWS_ACCESS_KEY_ID }}
-  AWS_SECRET_ACCESS_KEY:  ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   TF_IN_AUTOMATION: true
+  AWS_REGION: "eu-west-2"
+  ENVIRONMENT_MANAGEMENT: ${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENTS }}
+
+permissions:
+  id-token: write # This is required for requesting the JWT
+  contents: read # This is required for actions/checkout
 
 defaults:
   run:
@@ -33,8 +37,21 @@ jobs:
   core-network-services-deployment-plan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: hashicorp/setup-terraform@v2.0.3
+      - name: Checkout Repository
+        uses: actions/checkout@v3.1.0
+
+      - name: Set Account Number
+        run: echo "ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+          role-session-name: githubactionsrolesession
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v2.0.3
         with:
           terraform_version: "~1"
           terraform_wrapper: false
@@ -85,8 +102,21 @@ jobs:
     if: github.event.ref == 'refs/heads/main'
     needs: [core-network-services-deployment-plan]
     steps:
-      - uses: actions/checkout@v3
-      - uses: hashicorp/setup-terraform@v2.0.3
+      - name: Checkout Repository
+        uses: actions/checkout@v3.1.0
+
+      - name: Set Account Number
+        run: echo "ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+          role-session-name: githubactionsrolesession
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v2.0.3
         with:
           terraform_version: "~1"
           terraform_wrapper: false
@@ -97,8 +127,9 @@ jobs:
           bash scripts/terraform-init.sh terraform/environments/core-network-services
           terraform -chdir="terraform/environments/core-network-services" workspace select core-network-services-production
           bash scripts/terraform-apply.sh terraform/environments/core-network-services
-      - uses: 8398a7/action-slack@v3
-        name: Slack failure notification
+
+      - name: Slack failure notification
+        uses: 8398a7/action-slack@v3
         with:
           status: ${{ job.status }}
           fields: workflow,job,repo,commit,message

--- a/.github/workflows/core-vpc-test-deployment.yml
+++ b/.github/workflows/core-vpc-test-deployment.yml
@@ -39,10 +39,14 @@ on:
   workflow_dispatch:
 
 env:
-  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   TF_IN_AUTOMATION: true
   TF_ENV: "test"
+  AWS_REGION: "eu-west-2"
+  ENVIRONMENT_MANAGEMENT: ${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENTS }}
+
+permissions:
+  id-token: write # This is required for requesting the JWT
+  contents: read # This is required for actions/checkout
 
 defaults:
   run:
@@ -52,8 +56,21 @@ jobs:
   core-vpc-test-deployment-plan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: hashicorp/setup-terraform@v2.0.3
+      - name: Checkout Repository
+        uses: actions/checkout@v3.1.0
+
+      - name: Set Account Number
+        run: echo "ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+          role-session-name: githubactionsrolesession
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v2.0.3
         with:
           terraform_version: "~1"
           terraform_wrapper: false
@@ -91,8 +108,21 @@ jobs:
     if: github.event.ref == 'refs/heads/main'
     needs: [ core-vpc-test-deployment-plan ]
     steps:
-      - uses: actions/checkout@v3
-      - uses: hashicorp/setup-terraform@v2.0.3
+      - name: Checkout Repository
+        uses: actions/checkout@v3.1.0
+
+      - name: Set Account Number
+        run: echo "ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+          role-session-name: githubactionsrolesession
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v2.0.3
         with:
           terraform_version: "~1"
           terraform_wrapper: false
@@ -106,8 +136,9 @@ jobs:
           echo "Target apply finished"
           bash scripts/terraform-apply.sh terraform/environments/core-vpc
           echo "Terraform apply finished"
-      - uses: 8398a7/action-slack@v3
-        name: Slack failure notification
+
+      - name: Slack failure notification
+        uses: 8398a7/action-slack@v3
         with:
           status: ${{ job.status }}
           fields: workflow,job,repo,commit,message
@@ -120,14 +151,26 @@ jobs:
     if: github.event.ref == 'refs/heads/main'
     needs: [ core-vpc-test-deployment-apply ]
     steps:
-      - name: checkout
-        uses: actions/checkout@v3
+      - name: Checkout Repository
+        uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 0
-      - name: get changed files
+
+      - name: Set Account Number
+        run: echo "ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+          role-session-name: githubactionsrolesession
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Get changed files
         id: new_account
         run: |
           echo "::set-output name=files::$(git diff --no-commit-id --name-only --diff-filter=AM -r @^ | awk '{print $1}' | grep ".json" |  cut -c 1- | tr -d : | xargs -I {} grep application {} |  awk '{team=$2; print team "-test"}' | tr -d , | tr -d '"'| uniq | xargs -I {} grep -R -o -h {} environments-networks | uniq)"
+
       - name: Set RAM assocation for member account
         run: |
           accounts=(${{ steps.new_account.outputs.files }})
@@ -142,8 +185,9 @@ jobs:
           echo "[+] There were no AWS member accounts to process"
           exit 0
           fi
-      - uses: 8398a7/action-slack@v3
-        name: Slack failure notification
+
+      - name: Slack failure notification
+        uses: 8398a7/action-slack@v3
         with:
           status: ${{ job.status }}
           fields: workflow,job,repo,commit,message


### PR DESCRIPTION
Refactoring the following workflows to use GH actions OIDC for AWS credentials:
- core-vpc-test-deployment (I have missed it in the previous PR)
- core-network-services-deployment

Additionally, improving workflow code readability by adding some consistency and spacing.