### PR TITLE
Enable Instance Scheduling for remaining accounts except some

### DIFF
--- a/terraform/environments/core-shared-services/instance-scheduler-lambda-function.tf
+++ b/terraform/environments/core-shared-services/instance-scheduler-lambda-function.tf
@@ -15,8 +15,9 @@ resource "aws_lambda_function" "instance-scheduler-lambda-function" {
   }
   environment {
     variables = {
-      # Enable for: sprinkler-development,cooker-development,example-development,equip-development,performance-hub-development,performance-hub-preproduction
-      "INSTANCE_SCHEDULING_SKIP_ACCOUNTS" = "oasys-development,apex-development,data-and-insights-wepi-development,xhibit-portal-development,nomis-preproduction,testing-test,oasys-preproduction,tariff-development,mlra-development,nomis-development,xhibit-portal-preproduction,delius-iaps-development,ppud-development,refer-monitor-development,digital-prison-reporting-development,oasys-test,threat-and-vulnerability-mgmt-development,nomis-test,ccms-ebs-development,maatdb-development,"
+      # Initially, enabled for: sprinkler-development,cooker-development,example-development,equip-development,performance-hub-development,performance-hub-preproduction
+      # Subsequently, enabled for: oasys-development,data-and-insights-wepi-development,testing-test,oasys-preproduction,tariff-development,delius-iaps-development,ppud-development,refer-monitor-development,digital-prison-reporting-development,oasys-test,threat-and-vulnerability-mgmt-development,
+      "INSTANCE_SCHEDULING_SKIP_ACCOUNTS" = "xhibit-portal-development,xhibit-portal-preproduction,nomis-development,nomis-test,nomis-preproduction,apex-development,ccms-ebs-development,maatdb-development,mlra-development,"
     }
   }
 }

--- a/terraform/environments/core-shared-services/instance-scheduler-lambda-function.tf
+++ b/terraform/environments/core-shared-services/instance-scheduler-lambda-function.tf
@@ -16,8 +16,8 @@ resource "aws_lambda_function" "instance-scheduler-lambda-function" {
   environment {
     variables = {
       # Initially, enabled for: sprinkler-development,cooker-development,example-development,equip-development,performance-hub-development,performance-hub-preproduction
-      # Subsequently, enabled for: oasys-development,data-and-insights-wepi-development,testing-test,oasys-preproduction,tariff-development,delius-iaps-development,ppud-development,refer-monitor-development,digital-prison-reporting-development,oasys-test,threat-and-vulnerability-mgmt-development,
-      "INSTANCE_SCHEDULING_SKIP_ACCOUNTS" = "xhibit-portal-development,xhibit-portal-preproduction,nomis-development,nomis-test,nomis-preproduction,apex-development,ccms-ebs-development,maatdb-development,mlra-development,"
+      # Subsequently, enabled for: oasys-development,data-and-insights-wepi-development,testing-test,oasys-preproduction,tariff-development,delius-iaps-development,ppud-development,refer-monitor-development,digital-prison-reporting-development,oasys-test,threat-and-vulnerability-mgmt-development,apex-development,ccms-ebs-development,maatdb-development,mlra-development,
+      "INSTANCE_SCHEDULING_SKIP_ACCOUNTS" = "xhibit-portal-development,xhibit-portal-preproduction,nomis-development,nomis-test,nomis-preproduction,"
     }
   }
 }


### PR DESCRIPTION
Enable Instance Scheduling for remaining accounts except xhibit-portal-development,xhibit-portal-preproduction,nomis-development,nomis-test,nomis-preproduction,apex-development,ccms-ebs-development,maatdb-development,mlra-development,

The accounts that will be enabled are: oasys-development,data-and-insights-wepi-development,testing-test,oasys-preproduction,tariff-development,delius-iaps-development,ppud-development,refer-monitor-development,digital-prison-reporting-development,oasys-test,threat-and-vulnerability-mgmt-development,