### PR TITLE
Adding testing-test permissions to pull from ecr and assume lambda scheduling role.

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -191,12 +191,12 @@ module "instance-scheduler-access" {
   providers = {
     aws = aws.workspace
   }
-  account_id             = local.environment_management.account_ids["core-shared-services-production"]
+  account_id = local.environment_management.account_ids["core-shared-services-production"]
   additional_trust_roles = concat(
     [format("arn:aws:iam::%s:role/InstanceSchedulerLambdaFunctionPolicy", local.environment_management.account_ids["core-shared-services-production"])],
-    terraform.workspace == "testing-test" ? [format("arn:aws:iam::%s:role/InstanceSchedulerLambdaFunctionPolicy", local.environment_management.account_ids["testing-test"])] : [] )
-  policy_arn             = aws_iam_policy.instance-scheduler-access[0].id
-  role_name              = "InstanceSchedulerAccess"
+  terraform.workspace == "testing-test" ? [format("arn:aws:iam::%s:role/InstanceSchedulerLambdaFunctionPolicy", local.environment_management.account_ids["testing-test"])] : [])
+  policy_arn = aws_iam_policy.instance-scheduler-access[0].id
+  role_name  = "InstanceSchedulerAccess"
 }
 
 #tfsec:ignore:aws-iam-no-policy-wildcards

--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -192,7 +192,9 @@ module "instance-scheduler-access" {
     aws = aws.workspace
   }
   account_id             = local.environment_management.account_ids["core-shared-services-production"]
-  additional_trust_roles = [format("arn:aws:iam::%s:role/InstanceSchedulerLambdaFunctionPolicy", local.environment_management.account_ids["core-shared-services-production"])]
+  additional_trust_roles = concat(
+    [format("arn:aws:iam::%s:role/InstanceSchedulerLambdaFunctionPolicy", local.environment_management.account_ids["core-shared-services-production"])],
+    terraform.workspace == "testing-test" ? [format("arn:aws:iam::%s:role/InstanceSchedulerLambdaFunctionPolicy", local.environment_management.account_ids["testing-test"])] : [] )
   policy_arn             = aws_iam_policy.instance-scheduler-access[0].id
   role_name              = "InstanceSchedulerAccess"
 }

--- a/terraform/environments/core-shared-services/ecr_repos.tf
+++ b/terraform/environments/core-shared-services/ecr_repos.tf
@@ -47,7 +47,8 @@ module "instance_scheduler_ecr_repo" {
   ]
 
   pull_principals = [
-    local.environment_management.account_ids["core-shared-services-production"]
+    local.environment_management.account_ids["core-shared-services-production"],
+    local.environment_management.account_ids["testing-test"] # to enable terratest runs
   ]
 
   enable_retrieval_policy_for_lambdas = ["arn:aws:lambda:eu-west-2:${local.environment_management.account_ids["core-shared-services-production"]}:function:*"]


### PR DESCRIPTION
In order to run terratest on the lambda module, `testing-test` needs some additional permissions:

* pull an image from ECR repo
* Assume the InstanceSchedulerAccess role
