### PR TITLE
Reverting the change in trust policy for InstanceSchedulerAccess

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -191,10 +191,10 @@ module "instance-scheduler-access" {
   providers = {
     aws = aws.workspace
   }
-  account_id = local.environment_management.account_ids["core-shared-services-production"]
+  account_id             = local.environment_management.account_ids["core-shared-services-production"]
   additional_trust_roles = [format("arn:aws:iam::%s:role/InstanceSchedulerLambdaFunctionPolicy", local.environment_management.account_ids["core-shared-services-production"])]
-  policy_arn = aws_iam_policy.instance-scheduler-access[0].id
-  role_name  = "InstanceSchedulerAccess"
+  policy_arn             = aws_iam_policy.instance-scheduler-access[0].id
+  role_name              = "InstanceSchedulerAccess"
 }
 
 #tfsec:ignore:aws-iam-no-policy-wildcards

--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -194,7 +194,7 @@ module "instance-scheduler-access" {
   account_id = local.environment_management.account_ids["core-shared-services-production"]
   additional_trust_roles = concat(
     [format("arn:aws:iam::%s:role/InstanceSchedulerLambdaFunctionPolicy", local.environment_management.account_ids["core-shared-services-production"])],
-  terraform.workspace == "testing-test" ? [format("arn:aws:iam::%s:role/InstanceSchedulerLambdaFunctionPolicy", local.environment_management.account_ids["testing-test"])] : [])
+  terraform.workspace == "testing-test" ? [format("arn:aws:iam::%s:root", local.environment_management.account_ids["testing-test"])] : [])
   policy_arn = aws_iam_policy.instance-scheduler-access[0].id
   role_name  = "InstanceSchedulerAccess"
 }

--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -192,9 +192,7 @@ module "instance-scheduler-access" {
     aws = aws.workspace
   }
   account_id = local.environment_management.account_ids["core-shared-services-production"]
-  additional_trust_roles = concat(
-    [format("arn:aws:iam::%s:role/InstanceSchedulerLambdaFunctionPolicy", local.environment_management.account_ids["core-shared-services-production"])],
-  terraform.workspace == "testing-test" ? [format("arn:aws:iam::%s:root", local.environment_management.account_ids["testing-test"])] : [])
+  additional_trust_roles = [format("arn:aws:iam::%s:role/InstanceSchedulerLambdaFunctionPolicy", local.environment_management.account_ids["core-shared-services-production"])]
   policy_arn = aws_iam_policy.instance-scheduler-access[0].id
   role_name  = "InstanceSchedulerAccess"
 }


### PR DESCRIPTION
As the terratest will run in the testing-test account and assuming the role in testing-test account, an explicit change to the role trust policy isn't needed.

Will achieve the same by adding an sts:AssumeRole permission to the role policy in the test code instead as per https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html#:~:text=To%20allow%20a,role%27s%20trust%20policy.
