### PR TITLE
Change DPR to sandbox account

### DIFF
--- a/environments/digital-prison-reporting.json
+++ b/environments/digital-prison-reporting.json
@@ -6,7 +6,7 @@
       "access": [
         {
           "github_slug": "hmpps-digital-prison-reporting",
-          "level": "developer"
+          "level": "sandbox"
         }
       ]
     }


### PR DESCRIPTION
Agreed with the DPR team to switch to a sandbox environment and disable auto-nuke for the remainder of the PoC period (Dec 2022).

This will enable them to finish the PoC quicker.  Either sandbox to be removed or auto-nuke to be re-enabled after this time.