### PR TITLE
Fixing AWS user refs & adding detail to PR approvals

### DIFF
--- a/source/concepts/sdlc/user-workflow.html.md.erb
+++ b/source/concepts/sdlc/user-workflow.html.md.erb
@@ -50,7 +50,7 @@ The code and AWS account is protected in a few different ways which work togethe
 #### CODEOWNERS
 
 Your GitHub team will be assigned as a [codeowner](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners) for your application folder, so someone in your team or the Modernisation Platform team will be required to review any pull requests before they can be merged.
-Your Github team will be able to approve a majority of pull requests. Approvals from the modernisation platform team members are only required in cases where a change might impact other customers or core platform components such as any files in the `.github` folder, as well as `providers.tf`, `backend.tf` and `networking.auto.tfvars.json` files in you application directory.
+Your Github team will be able to approve a majority of pull requests. Approvals from the modernisation platform team members are only required in cases where a change might impact other customers or core platform components such as any files in the `.github` folder, as well as `providers.tf`, `backend.tf` and `networking.auto.tfvars.json` files in you application directory. For specific rules please see the [CODEOWNERS](https://github.com/ministryofjustice/modernisation-platform-environments/blob/main/.github/CODEOWNERS) file. 
 
 #### GitHub Environments
 

--- a/source/concepts/sdlc/user-workflow.html.md.erb
+++ b/source/concepts/sdlc/user-workflow.html.md.erb
@@ -49,7 +49,7 @@ The code and AWS account is protected in a few different ways which work togethe
 
 #### CODEOWNERS
 
-Your GitHub team will be assigned as a [codeowner](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners) for your application folder, so someone in your team or the Modernisation Platform team will be required to review any pull requests before they can be merged. 
+Your GitHub team will be assigned as a [codeowner](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners) for your application folder, so someone in your team or the Modernisation Platform team will be required to review any pull requests before they can be merged.
 Your Github team will be able to approve a majority of pull requests. Approvals from the modernisation platform team members are only required in cases where a change might impact other customers or core platform components such as any files in the `.github` folder, as well as `providers.tf`, `backend.tf` and `networking.auto.tfvars.json` files in you application directory.
 
 #### GitHub Environments
@@ -77,7 +77,7 @@ Legacy applications often use "Click Ops" to make application deployments.  Whil
 
 To allow automated access to your AWS account we provide a "CI/CD (Continuous integration / continuous delivery)" user - `cicd-member-user`.
 
-This user has restricted access to your AWS account, with the minimum permissions needed to do things like push a new image to an ECR repo. 
+This user has restricted access to your AWS account, with the minimum permissions needed to do things like push a new image to an ECR repo.
 
 The application pipeline is the responsibility of the application owner, details on how to obtain AWS credentials for the `cicd-member-user` are detailed [here](../../user-guide/deploying-your-application.html)
 ## Diagram

--- a/source/concepts/sdlc/user-workflow.html.md.erb
+++ b/source/concepts/sdlc/user-workflow.html.md.erb
@@ -50,7 +50,7 @@ The code and AWS account is protected in a few different ways which work togethe
 #### CODEOWNERS
 
 Your GitHub team will be assigned as a [codeowner](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners) for your application folder, so someone in your team or the Modernisation Platform team will be required to review any pull requests before they can be merged.
-Your Github team will be able to approve a majority of pull requests. Approvals from the modernisation platform team members are only required in cases where a change might impact other customers or core platform components such as any files in the `.github` folder, as well as `providers.tf`, `backend.tf` and `networking.auto.tfvars.json` files in you application directory. For specific rules please see the [CODEOWNERS](https://github.com/ministryofjustice/modernisation-platform-environments/blob/main/.github/CODEOWNERS) file. 
+Your Github team will be able to approve a majority of pull requests. Approvals from the modernisation platform team members are only required in cases where a change might impact other customers or core platform components such as any files in the `.github` folder, as well as `providers.tf`, `backend.tf` and `networking.auto.tfvars.json` files in you application directory. For specific rules please see the [CODEOWNERS](https://github.com/ministryofjustice/modernisation-platform-environments/blob/main/.github/CODEOWNERS) file.
 
 #### GitHub Environments
 

--- a/source/concepts/sdlc/user-workflow.html.md.erb
+++ b/source/concepts/sdlc/user-workflow.html.md.erb
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#modernisation-platform"
 title: User Workflow (CI/CD)
-last_reviewed_on: 2022-05-18
+last_reviewed_on: 2022-11-09
 review_in: 6 months
 ---
 
@@ -49,7 +49,8 @@ The code and AWS account is protected in a few different ways which work togethe
 
 #### CODEOWNERS
 
-Your GitHub team will be assigned as a [codeowner](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners) for your application folder, so someone in your team or the Modernisation Platform team will be required to review any pull requests before they can be merged.
+Your GitHub team will be assigned as a [codeowner](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners) for your application folder, so someone in your team or the Modernisation Platform team will be required to review any pull requests before they can be merged. 
+Your Github team will be able to approve a majority of pull requests. Approvals from the modernisation platform team members are only required in cases where a change might impact other customers or core platform components such as any files in the `.github` folder, as well as `providers.tf`, `backend.tf` and `networking.auto.tfvars.json` files in you application directory.
 
 #### GitHub Environments
 
@@ -57,7 +58,7 @@ GitHub environments prevents any workflow being deployed to your environments un
 
 #### AWS IAM (Identity and Access Management)
 
-Each account has an IAM role `ModernisationPlatformAccess` which allows the AWS CI user `member-ci` to create resources in each AWS account.
+Each account has an IAM role `MemberInfrastructureAccess` which allows the GitHub workflows to create resources in each AWS account.
 Each application workflow will use the role for the relevant account, ensuring one account can't create resources in another.
 
 For modifying DNS entries a role `dns-<business-unit>-<environment>` is used, allowing only changes the DNS hosted zone for your business unit.

--- a/source/concepts/sdlc/user-workflow.html.md.erb
+++ b/source/concepts/sdlc/user-workflow.html.md.erb
@@ -50,7 +50,7 @@ The code and AWS account is protected in a few different ways which work togethe
 #### CODEOWNERS
 
 Your GitHub team will be assigned as a [codeowner](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners) for your application folder, so someone in your team or the Modernisation Platform team will be required to review any pull requests before they can be merged.
-Your Github team will be able to approve a majority of pull requests. Approvals from the modernisation platform team members are only required in cases where a change might impact other customers or core platform components such as any files in the `.github` folder, as well as `providers.tf`, `backend.tf` and `networking.auto.tfvars.json` files in you application directory. For specific rules please see the [CODEOWNERS](https://github.com/ministryofjustice/modernisation-platform-environments/blob/main/.github/CODEOWNERS) file.
+Your Github team will be able to approve a majority of pull requests. Approvals from the modernisation platform team members are only required in cases where a change might impact other customers or core platform components such as any files in the `.github` folder, as well as `providers.tf`, `backend.tf` and `networking.auto.tfvars.json` files in your application directory. For specific rules please see the [CODEOWNERS](https://github.com/ministryofjustice/modernisation-platform-environments/blob/main/.github/CODEOWNERS) file.
 
 #### GitHub Environments
 


### PR DESCRIPTION
- removing a reference to ci user that's been replaced by OIDC
- adding more detail to who can approve PRs.