### PR TITLE
Secure baselines plan+apply taking ~60m, running up against token expiration.

### DIFF
--- a/.github/workflows/scheduled-baseline.yml
+++ b/.github/workflows/scheduled-baseline.yml
@@ -40,15 +40,15 @@ jobs:
       - run: bash scripts/terraform-init.sh terraform/environments/bootstrap/delegate-access
       - run: bash scripts/loop-through-terraform-workspaces.sh terraform/environments/bootstrap/delegate-access plan
       - run: bash scripts/loop-through-terraform-workspaces.sh terraform/environments/bootstrap/delegate-access apply
-      - uses: 8398a7/action-slack@v3
-        name: Slack failure notification
+      - name: Slack failure notification
+        uses: 8398a7/action-slack@v3
         with:
           status: ${{ job.status }}
           fields: workflow,job,repo,commit,message
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         if: ${{ failure() }}
-  secure-baselines:
+  secure-baselines-plan:
     runs-on: ubuntu-latest
     needs: [delegate-access]
     steps:
@@ -68,9 +68,36 @@ jobs:
           terraform_wrapper: false
       - run: bash scripts/terraform-init.sh terraform/environments/bootstrap/secure-baselines
       - run: bash scripts/loop-through-terraform-workspaces.sh terraform/environments/bootstrap/secure-baselines plan
+      - name: Slack failure notification
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: workflow,job,repo,commit,message
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: ${{ failure() }}
+  secure-baselines-apply:
+    runs-on: ubuntu-latest
+    needs: [secure-baselines-plan]
+    steps:
+      - uses: actions/checkout@v3.1.0
+      - name: Set Account Number
+        run: echo "ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+          role-session-name: githubactionsrolesession
+          aws-region: ${{ env.AWS_REGION }}
+      - uses: hashicorp/setup-terraform@v2.0.3
+        with:
+          terraform_version: "~1"
+          terraform_wrapper: false
+      - run: bash scripts/terraform-init.sh terraform/environments/bootstrap/secure-baselines
       - run: bash scripts/loop-through-terraform-workspaces.sh terraform/environments/bootstrap/secure-baselines apply
-      - uses: 8398a7/action-slack@v3
-        name: Slack failure notification
+      - name: Slack failure notification
+        uses: 8398a7/action-slack@v3
         with:
           status: ${{ job.status }}
           fields: workflow,job,repo,commit,message
@@ -97,8 +124,8 @@ jobs:
       - run: bash scripts/terraform-init.sh terraform/environments/bootstrap/single-sign-on
       - run: bash scripts/loop-through-terraform-workspaces.sh terraform/environments/bootstrap/single-sign-on plan
       - run: bash scripts/loop-through-terraform-workspaces.sh terraform/environments/bootstrap/single-sign-on apply
-      - uses: 8398a7/action-slack@v3
-        name: Slack failure notification
+      - name: Slack failure notification
+        uses: 8398a7/action-slack@v3
         with:
           status: ${{ job.status }}
           fields: workflow,job,repo,commit,message


### PR DESCRIPTION
https://github.com/ministryofjustice/modernisation-platform/actions/runs/3435363726/attempts/1

The above run failed because the token expired before the job could complete. I'm seeing runtimes of between 45 and 55 minutes fairly regularly. Splitting them out is a clean way of fixing without adjusting token TTL which isn't needed for anything else.
