### PR TITLE
Decrease alert sensitivity

### DIFF
--- a/terraform/environments/core-network-services/monitoring.tf
+++ b/terraform/environments/core-network-services/monitoring.tf
@@ -115,7 +115,7 @@ resource "aws_cloudwatch_metric_alarm" "production_attachment_no_traffic_5_minut
   namespace          = "AWS/TransitGateway"
   period             = "60"
   statistic          = "Sum"
-  threshold          = "1"
+  threshold          = "3"
   treat_missing_data = "breaching"
   tags               = local.tags
 }

--- a/terraform/environments/core-network-services/monitoring.tf
+++ b/terraform/environments/core-network-services/monitoring.tf
@@ -105,7 +105,7 @@ resource "aws_cloudwatch_metric_alarm" "production_attachment_no_traffic_5_minut
   alarm_description   = format("Low traffic detected for VPC attachment %s", each.value.tags.Name)
   alarm_name          = format("NoVPCAttachmentTraffic-%s", each.value.tags.Name)
   comparison_operator = "LessThanOrEqualToThreshold"
-  datapoints_to_alarm = "1"
+  datapoints_to_alarm = "3"
   dimensions = {
     TransitGateway           = aws_ec2_transit_gateway.transit-gateway.id
     TransitGatewayAttachment = each.value["id"]
@@ -115,7 +115,7 @@ resource "aws_cloudwatch_metric_alarm" "production_attachment_no_traffic_5_minut
   namespace          = "AWS/TransitGateway"
   period             = "60"
   statistic          = "Sum"
-  threshold          = "3"
+  threshold          = "1"
   treat_missing_data = "breaching"
   tags               = local.tags
 }


### PR DESCRIPTION
Our current alarms alert if one datapoint is missed, or polls as `0`, in a 5 minute window. The net effect of this is that in any rolling five minute window an alert can trigger if no traffic is detected. Our goal with these alerts was to warn us if a major even occurred in a VPC (such as a routing change or ACL / security change) stopped traffic flowing through the Transit Gateway. The alert is so sensitive that so far we've only had one situation where the alert has been legitimate.