### PR TITLE
Removing write access for ops eng team to MP module repositories

### DIFF
--- a/terraform/github/locals.tf
+++ b/terraform/github/locals.tf
@@ -51,7 +51,6 @@ locals {
   # But if not we will need to automate the updating of this list based on slugs in the environment json files.
   application_teams = [
     "all-org-members",
-    "operations-engineering",
     "performance-hub-developers",
     "studio-webops",
     "cica",


### PR DESCRIPTION
Removing write access for ops eng team to MP module repositories, as they have removed themselves manually already.
Additionally, they do not have accounts in our platform anymore.