### PR TITLE
Adding tag protection to github repositories

### DIFF
--- a/terraform/github/modules/repository/main.tf
+++ b/terraform/github/modules/repository/main.tf
@@ -60,8 +60,8 @@ resource "github_branch_protection" "default" {
 }
 
 resource "github_repository_tag_protection" "default" {
-    repository      = github_repository.default.id
-    pattern         = "*"
+  repository = github_repository.default.id
+  pattern    = "*"
 }
 
 # Secrets

--- a/terraform/github/modules/repository/main.tf
+++ b/terraform/github/modules/repository/main.tf
@@ -59,6 +59,11 @@ resource "github_branch_protection" "default" {
   }
 }
 
+resource "github_repository_tag_protection" "default" {
+    repository      = github_repository.default.id
+    pattern         = "*"
+}
+
 # Secrets
 data "github_actions_public_key" "default" {
   repository = github_repository.default.id


### PR DESCRIPTION
Following the GitHub guidance, adding tag protection as detailed here:

https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-tag-protection-rules

Tag protection rules contributors from creating or deleting tags unless they have the admin write permission.