### PR TITLE
Restrict GitHub tokens permissions

### DIFF
--- a/.github/workflows/add-issues-to-project.yml
+++ b/.github/workflows/add-issues-to-project.yml
@@ -3,6 +3,9 @@ on:
   issues:
     types:
       - opened
+
+permissions: {}
+
 jobs:
   track_issue:
     runs-on: ubuntu-latest

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -8,6 +8,10 @@ on:
       - 'terraform/modules/**/*.md'
       - '.github/workflows/documentation.yml'
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
     types: [opened, edited, reopened, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   format-code:
     runs-on: ubuntu-latest

--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -4,7 +4,7 @@ on:
     types: [opened, edited, reopened, synchronize]
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   format-code:

--- a/.github/workflows/generate-dependabot-file.yml
+++ b/.github/workflows/generate-dependabot-file.yml
@@ -11,6 +11,10 @@ on:
       - 'scripts/generate-dependabot-file.sh'
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pull-requests: write
+
 defaults:
   run:
     shell: bash

--- a/.github/workflows/generate-dependabot-file.yml
+++ b/.github/workflows/generate-dependabot-file.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 defaults:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -4,6 +4,10 @@ on:
   pull_request_target:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   triage:
     runs-on: ubuntu-latest

--- a/.github/workflows/new-environment-files.yml
+++ b/.github/workflows/new-environment-files.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 defaults:

--- a/.github/workflows/new-environment-files.yml
+++ b/.github/workflows/new-environment-files.yml
@@ -9,6 +9,10 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pull-requests: write
+
 defaults:
   run:
     shell: bash

--- a/.github/workflows/new-member-environment-files.yml
+++ b/.github/workflows/new-member-environment-files.yml
@@ -9,6 +9,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 defaults:
   run:
     shell: bash
@@ -33,7 +36,7 @@ jobs:
         run: bash ./core-repo/scripts/git-setup.sh ./modernisation-platform-environments
       - run: bash ./core-repo/scripts/git-commit.sh . ./modernisation-platform-environments
         env:  
-          TERRAFORM_GITHUB_TOKEN: ${{ secrets.TERRAFORM_GITHUB_TOKEN }}
+          TERRAFORM_GITHUB_TOKEN: ${{ secrets.TERRAFORM_GITHUB_TOKEN }} # use this token as writing to a different repo
       - run: bash ./core-repo/scripts/git-pull-request.sh terraform/environments ./modernisation-platform-environments
         env:
           TERRAFORM_GITHUB_TOKEN: ${{ secrets.TERRAFORM_GITHUB_TOKEN }}

--- a/.github/workflows/opa-policies.yml
+++ b/.github/workflows/opa-policies.yml
@@ -12,6 +12,9 @@ on:
       - 'environments/**.json'
       - '.github/workflows/opa-policies.yml'
 
+permissions:
+  contents: read
+
 defaults:
   run:
     shell: bash

--- a/.github/workflows/terraform-pagerduty.yml
+++ b/.github/workflows/terraform-pagerduty.yml
@@ -16,6 +16,10 @@ on:
     types: [opened, edited, reopened, synchronize]
   workflow_dispatch:
 
+permissions:
+  id-token: write # This is required for requesting the JWT
+  contents: read # This is required for actions/checkout
+
 defaults:
   run:
     shell: bash
@@ -29,10 +33,6 @@ jobs:
       TF_IN_AUTOMATION: true
       AWS_REGION: "eu-west-2"
       ENVIRONMENT_MANAGEMENT: ${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENTS }}
-
-    permissions:
-      id-token: write # This is required for requesting the JWT
-      contents: read # This is required for actions/checkout
 
     steps:
       - name: Checkout Repository

--- a/.github/workflows/terraform-static-analysis.yml
+++ b/.github/workflows/terraform-static-analysis.yml
@@ -12,8 +12,13 @@ on:
       - 'terraform/**'
       - '.github/workflows/terraform-static-analysis.yml'
 
+permissions:
+  contents: read
+
 jobs:
   terraform-static-analysis:
+    permissions:
+      pull-requests: write
     name: Terraform Static Analysis
     runs-on: ubuntu-latest
     if: github.event_name != 'workflow_dispatch' && github.event_name != 'schedule'

--- a/terraform/modules/firewall-policy/README.md
+++ b/terraform/modules/firewall-policy/README.md
@@ -1,0 +1,46 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.4 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_cloudwatch_log_group.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_networkfirewall_firewall_policy.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/networkfirewall_firewall_policy) | resource |
+| [aws_networkfirewall_logging_configuration.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/networkfirewall_logging_configuration) | resource |
+| [aws_networkfirewall_rule_group.stateful](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/networkfirewall_rule_group) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_cloudwatch_log_group_name"></a> [cloudwatch\_log\_group\_name](#input\_cloudwatch\_log\_group\_name) | Name of CloudWatch log group to ship logs to | `string` | n/a | yes |
+| <a name="input_fw_arn"></a> [fw\_arn](#input\_fw\_arn) | ARN of firewall for logging configuration | `string` | n/a | yes |
+| <a name="input_fw_policy_name"></a> [fw\_policy\_name](#input\_fw\_policy\_name) | n/a | `string` | n/a | yes |
+| <a name="input_fw_rulegroup_capacity"></a> [fw\_rulegroup\_capacity](#input\_fw\_rulegroup\_capacity) | n/a | `string` | `"10000"` | no |
+| <a name="input_fw_rulegroup_name"></a> [fw\_rulegroup\_name](#input\_fw\_rulegroup\_name) | n/a | `string` | n/a | yes |
+| <a name="input_rules"></a> [rules](#input\_rules) | A map of values supplied to create firewall rules | `map(any)` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | A map of keys and values used to create resource metadata tags | `map(any)` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_fw_policy_arn"></a> [fw\_policy\_arn](#output\_fw\_policy\_arn) | n/a |
+<!-- END_TF_DOCS -->


### PR DESCRIPTION
Restricting in line with GitHub security hardening guidelines

contents:read vs contents:write

Terraform documenter failed when writing changes to a PR when contents
was set to read.  Assuming that other things that need to write to a PR
also need write permission, adding this in.  After everything is
confirmed as working as is, we can then start changing things to read
and see if they break.