### PR TITLE
Moving write permissions to job level

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -8,12 +8,13 @@ on:
       - 'terraform/modules/**/*.md'
       - '.github/workflows/documentation.yml'
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   docs:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -3,11 +3,12 @@ on:
   pull_request:
     types: [opened, edited, reopened, synchronize]
 
-permissions:
-  contents: write
+permissions: {}
 
 jobs:
   format-code:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/generate-dependabot-file.yml
+++ b/.github/workflows/generate-dependabot-file.yml
@@ -11,9 +11,7 @@ on:
       - 'scripts/generate-dependabot-file.sh'
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 defaults:
   run:
@@ -21,6 +19,9 @@ defaults:
 
 jobs:
   create-and-commit-dependabot-file:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/new-environment-files.yml
+++ b/.github/workflows/new-environment-files.yml
@@ -9,9 +9,7 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 defaults:
   run:
@@ -19,6 +17,9 @@ defaults:
 
 jobs:
   create-and-commit-files:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
As best practice write permissions should be at the job level so that any new jobs don't get write permissions as standard.