### PR TITLE
Update default action for stateless packets

### DIFF
--- a/terraform/modules/firewall-policy/main.tf
+++ b/terraform/modules/firewall-policy/main.tf
@@ -8,7 +8,7 @@ resource "aws_networkfirewall_firewall_policy" "main" {
       priority     = 1
       resource_arn = aws_networkfirewall_rule_group.stateful.arn
     }
-    stateless_default_actions          = ["aws:pass"]
+    stateless_default_actions          = ["aws:forward_to_sfe"]
     stateless_fragment_default_actions = ["aws:drop"]
   }
 


### PR DESCRIPTION
In line with the AWS documentation [here](https://docs.aws.amazon.com/network-firewall/latest/APIReference/API_RuleDefinition.html) this PR changes the default action for stateless inspection.
In order to make use of stateful rules, the action needs to be updated to forward them to the stateful engine, otherwise they are cleared through the firewall by default without any meaningful inspection being applied.