### PR TITLE
Adding AMI builds repo to MP OIDC provider default role to allow OIDC conversion.

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -504,12 +504,12 @@ module "shield_response_team_role" {
 # Github OIDC provider
 module "github-oidc" {
   count  = (local.account_data.account-type == "member" && terraform.workspace != "testing-test") ? 1 : 0
-  source = "github.com/ministryofjustice/modernisation-platform-github-oidc-provider?ref=v1.2.0"
+  source = "github.com/ministryofjustice/modernisation-platform-github-oidc-provider?ref=v2.0.0"
   providers = {
     aws = aws.workspace
   }
   additional_permissions = data.aws_iam_policy_document.oidc_assume_role_member[0].json
-  github_repository      = "ministryofjustice/modernisation-platform-environments:*"
+  github_repositories    = ["ministryofjustice/modernisation-platform-environments:*"]
   tags_common            = { "Name" = format("%s-oidc", terraform.workspace) }
   tags_prefix            = ""
 }

--- a/terraform/environments/core-shared-services/iam.tf
+++ b/terraform/environments/core-shared-services/iam.tf
@@ -164,9 +164,9 @@ data "aws_iam_policy_document" "instance-scheduler-lambda-function-policy" {
 
 # OIDC Confiuration for core-shared-services
 module "github-oidc" {
-  source                 = "github.com/ministryofjustice/modernisation-platform-github-oidc-provider?ref=v1.2.0"
+  source                 = "github.com/ministryofjustice/modernisation-platform-github-oidc-provider?ref=v2.0.0"
   additional_permissions = data.aws_iam_policy_document.oidc_assume_role_core.json
-  github_repository      = "ministryofjustice/modernisation-platform-instance-scheduler:*"
+  github_repositories    = ["ministryofjustice/modernisation-platform-instance-scheduler:*"]
   tags_common            = { "Name" = format("%s-oidc", terraform.workspace) }
   tags_prefix            = ""
 }

--- a/terraform/modernisation-platform-account/iam.tf
+++ b/terraform/modernisation-platform-account/iam.tf
@@ -369,10 +369,10 @@ resource "aws_iam_role_policy_attachment" "modernisation_account_limited_read" {
 # OIDC resources
 
 module "github-oidc" {
-  source                      = "github.com/ministryofjustice/modernisation-platform-github-oidc-provider?ref=v1.2.0"
+  source                      = "github.com/ministryofjustice/modernisation-platform-github-oidc-provider?ref=v2.0.0"
   additional_permissions      = data.aws_iam_policy_document.oidc-deny-specific-actions.json
   additional_managed_policies = ["arn:aws:iam::aws:policy/AdministratorAccess"]
-  github_repository           = "ministryofjustice/modernisation-platform:*"
+  github_repositories         = ["ministryofjustice/modernisation-platform:*", "modernisation-platform-ami-builds:*"]
   tags_common                 = { "Name" = format("%s-oidc", terraform.workspace) }
   tags_prefix                 = ""
 }


### PR DESCRIPTION
Relevant issue: https://github.com/ministryofjustice/modernisation-platform/issues/2563

* Adding `[Modernisation Platform AMI Builds](https://github.com/ministryofjustice/modernisation-platform-ami-builds)` repository to the modernisation-platform-account OIDC provider to allow those workflows to convert to OIDC
* Updating OIDC module versions in the rest of `delegate-access` and `core-shared-services` code to account for a breaking change in the `github_repositories` variable introduced in [this PR](https://github.com/ministryofjustice/modernisation-platform-github-oidc-provider/pull/13) (this change should not produce any differences from the current terraform state)
