### PR TITLE
Adding environents management secret to AMI repo to be consumed by the OIDC github workflow.

### DIFF
--- a/terraform/environments/secrets.tf
+++ b/terraform/environments/secrets.tf
@@ -108,7 +108,7 @@ locals {
 
 # Store environment management secret in Github secrets
 resource "github_actions_secret" "environment_management" {
-  for_each = toset(["modernisation-platform-environments", "modernisation-platform"])
+  for_each = toset(["modernisation-platform-environments", "modernisation-platform", "modernisation-platform-ami-builds"])
   # checkov:skip=CKV_SECRET_6: "secret_name is not a secret"
   secret_name = "MODERNISATION_PLATFORM_ENVIRONMENTS"
   repository  = each.key

--- a/terraform/modernisation-platform-account/iam.tf
+++ b/terraform/modernisation-platform-account/iam.tf
@@ -372,7 +372,7 @@ module "github-oidc" {
   source                      = "github.com/ministryofjustice/modernisation-platform-github-oidc-provider?ref=v2.0.0"
   additional_permissions      = data.aws_iam_policy_document.oidc-deny-specific-actions.json
   additional_managed_policies = ["arn:aws:iam::aws:policy/AdministratorAccess"]
-  github_repositories         = ["ministryofjustice/modernisation-platform:*", "modernisation-platform-ami-builds:*"]
+  github_repositories         = ["ministryofjustice/modernisation-platform:*", "ministryofjustice/modernisation-platform-ami-builds:*"]
   tags_common                 = { "Name" = format("%s-oidc", terraform.workspace) }
   tags_prefix                 = ""
 }


### PR DESCRIPTION
To use OIDC provider in authentication, the workflow needs to know the full arn of the role it's assuming post-authentication before terraform can run. Therefore, the environments-management secret, which contains all the member account numbers is loaded as a GHA secret instead.

Additionally, fixing a bug introduced in the previous OIDC PR: passing the ami repo name with the organisation name prefix.

ETA: It looks like one of the certs in the certificate chain for the github oidc host have been updated, as one of the thumbprints has changed. I verified the one starts with 69* is still valid.
