### PR TITLE
Allow push access for modernisation platform repositories

### DIFF
--- a/terraform/github/README.md
+++ b/terraform/github/README.md
@@ -6,7 +6,7 @@ This directory creates and maintains the following GitHub items for the Modernis
   - team membership
   - team access to repositories
 
-The state is stored in S3, as defined in [main.tf](main.tf).
+The state is stored in S3, as defined in [backend.tf](backend.tf).
 
 ## How to create a new repository for a terraform module
 

--- a/terraform/github/data.tf
+++ b/terraform/github/data.tf
@@ -1,0 +1,4 @@
+data "github_repositories" "modernisation-platform-repositories" {
+  query = "org:ministryofjustice modernisation-platform"
+  sort  = "stars"
+}

--- a/terraform/github/locals.tf
+++ b/terraform/github/locals.tf
@@ -64,4 +64,9 @@ locals {
     "hmpps-migration",
     "laa-ccms-migration-team"
   ]
+
+  # Create a list of repositories that we want our customers to be able to contribute to
+  modernisation_platform_repositories = [
+    for s in data.github_repositories.modernisation-platform-repositories.names : s if startswith(s, "modernisation-platform-")
+  ]
 }

--- a/terraform/github/main.tf
+++ b/terraform/github/main.tf
@@ -392,34 +392,9 @@ module "aws-team" {
   parent_team_id = module.core-team.team_id
 }
 
-# Give write access to teams on the AMI builds repo (access to merge to main is restricted by codeowners file)
-resource "github_team_repository" "modernisation-platform-ami-builds-access" {
-  for_each   = { for team in local.application_teams : team => team }
-  team_id    = each.value
-  repository = module.modernisation-platform-ami-builds.repository.id
-  permission = "push"
-}
-
-# Give write access to teams on the environments repo (access to merge to main is restricted by codeowners file)
-resource "github_team_repository" "modernisation-platform-environments-access" {
-  for_each   = { for team in local.application_teams : team => team }
-  team_id    = each.value
-  repository = module.modernisation-platform-environments.repository.id
-  permission = "push"
-}
-
-# Give write access to teams on the configuration management repo (access to merge to main is restricted by codeowners file)
-resource "github_team_repository" "modernisation-platform-configuration-management-access" {
-  for_each   = { for team in local.application_teams : team => team }
-  team_id    = each.value
-  repository = module.modernisation-platform-configuration-management.repository.id
-  permission = "push"
-}
-
-# Give write access to teams on the loadbalancer module repo (access to merge to main is restricted by codeowners file)
-resource "github_team_repository" "modernisation-platform-terraform-loadbalancer-access" {
-  for_each   = { for team in local.application_teams : team => team }
-  team_id    = each.value
-  repository = module.terraform-module-aws-loadbalancer.repository.id
-  permission = "push"
+module "contributor-access" {
+  for_each          = toset(local.modernisation_platform_repositories)
+  source            = "./modules/contributor"
+  application_teams = local.application_teams
+  repository_id     = each.key
 }

--- a/terraform/github/modules/contributor/main.tf
+++ b/terraform/github/modules/contributor/main.tf
@@ -1,4 +1,4 @@
-resource "github_team_repository" "modernisation-platform-ami-builds-access" {
+resource "github_team_repository" "main" {
   for_each   = { for team in var.application_teams : team => team }
   team_id    = each.value
   repository = var.repository_id

--- a/terraform/github/modules/contributor/main.tf
+++ b/terraform/github/modules/contributor/main.tf
@@ -1,0 +1,6 @@
+resource "github_team_repository" "modernisation-platform-ami-builds-access" {
+  for_each   = { for team in var.application_teams : team => team }
+  team_id    = each.value
+  repository = var.repository_id
+  permission = "push"
+}

--- a/terraform/github/modules/contributor/variables.tf
+++ b/terraform/github/modules/contributor/variables.tf
@@ -1,0 +1,2 @@
+variable "application_teams" {}
+variable "repository_id" {}

--- a/terraform/github/modules/contributor/versions.tf
+++ b/terraform/github/modules/contributor/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = "~> 1.0"
+  required_providers {
+    github = {
+      version = "~> 5.2"
+      source  = "integrations/github"
+    }
+  }
+}


### PR DESCRIPTION
As detailed in https://github.com/ministryofjustice/modernisation-platform/issues/2549 this PR does the following:
* Moves the `github_team_repository` code into a child module
* Adds a data call for `github_repositories` and a local value to create a list of repositories
* Uses the module in conjunction with the local value to supply each module with a list of teams to be given `push` access

The goal of this PR is to reduce the amount of manual intervention involved in allowing Modernisation Platform customers the ability to contribute to our code.