### PR TITLE
Adding org account id as GH secret.

### DIFF
--- a/terraform/github/aws.tf
+++ b/terraform/github/aws.tf
@@ -60,3 +60,5 @@ data "aws_secretsmanager_secret" "pagerduty_token" {
 data "aws_secretsmanager_secret_version" "pagerduty_token" {
   secret_id = data.aws_secretsmanager_secret.pagerduty_token.id
 }
+# Organizations root acct
+data "aws_organizations_organization" "root_account" {}

--- a/terraform/github/main.tf
+++ b/terraform/github/main.tf
@@ -19,6 +19,8 @@ module "core" {
     SLACK_WEBHOOK_URL = data.aws_secretsmanager_secret_version.slack_webhook_url.secret_string
     # Pagerduty api token
     PAGERDUTY_TOKEN = data.aws_secretsmanager_secret_version.pagerduty_token.secret_string
+    # Org Account Id
+    AWS_ORG_MASTER_ACCOUNT_ID = data.aws_organizations_organization.root_account.master_account_id
   }))
 }
 


### PR DESCRIPTION
Relevant Issue: https://github.com/ministryofjustice/modernisation-platform/issues/2593

A small prerequisitve to converting org-related workflows to OIDC.

In order to assume a role in the Org account, GHA will need the full arn, including the account id before the terraform can run and fetch it. 
Therefore, need to add the account id as a Github secret.
