### PR TITLE
Fix ram share not running on network change

### DIFF
--- a/.github/workflows/core-vpc-development-deployment.yml
+++ b/.github/workflows/core-vpc-development-deployment.yml
@@ -166,10 +166,10 @@ jobs:
           role-session-name: githubactionsrolesession
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Get changed files
+      - name: Get list of accounts in changed environments-networking files
         id: new_account
         run: |
-          echo "::set-output name=files::$(git diff --no-commit-id --name-only --diff-filter=AM -r @^ | awk '{print $1}' | grep ".json" |  cut -c 1- | tr -d : | xargs -I {} grep application {} |  awk '{team=$2; print team "-development"}' | tr -d , | tr -d '"'| uniq | xargs -I {} grep -R -o -h {} environments-networks | uniq)"
+          echo "::set-output name=files::$(git diff --no-commit-id --name-only --diff-filter=AM -r @^ | awk '{print $1}' | grep "environments-networks/.*.json" | xargs -I {} cat {} | jq '.cidr.subnet_sets[].accounts[]' -r | uniq)"
 
       - name: Set RAM assocation for member account
         run: |

--- a/.github/workflows/core-vpc-preproduction-deployment.yml
+++ b/.github/workflows/core-vpc-preproduction-deployment.yml
@@ -167,10 +167,10 @@ jobs:
           role-session-name: githubactionsrolesession
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Get changed files
+      - name: Get list of accounts in changed environments-networking files
         id: new_account
         run: |
-          echo "::set-output name=files::$(git diff --no-commit-id --name-only --diff-filter=AM -r @^ | awk '{print $1}' | grep ".json" |  cut -c 1- | tr -d : | xargs -I {} grep application {} |  awk '{team=$2; print team "-preproduction"}' | tr -d , | tr -d '"'| uniq | xargs -I {} grep -R -o -h {} environments-networks | uniq)"
+          echo "::set-output name=files::$(git diff --no-commit-id --name-only --diff-filter=AM -r @^ | awk '{print $1}' | grep "environments-networks/.*.json" | xargs -I {} cat {} | jq '.cidr.subnet_sets[].accounts[]' -r | uniq)"
 
       - name: Set RAM assocation for member account
         run: |

--- a/.github/workflows/core-vpc-production-deployment.yml
+++ b/.github/workflows/core-vpc-production-deployment.yml
@@ -166,10 +166,10 @@ jobs:
           role-session-name: githubactionsrolesession
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: get changed files
+      - name: Get list of accounts in changed environments-networking files
         id: new_account
         run: |
-          echo "::set-output name=files::$(git diff --no-commit-id --name-only --diff-filter=AM -r @^ | awk '{print $1}' | grep ".json" |  cut -c 1- | tr -d : | xargs -I {} grep application {} |  awk '{team=$2; print team "-production"}' | tr -d , | tr -d '"'| uniq | xargs -I {} grep -R -o -h {} environments-networks | uniq)"
+          echo "::set-output name=files::$(git diff --no-commit-id --name-only --diff-filter=AM -r @^ | awk '{print $1}' | grep "environments-networks/.*.json" | xargs -I {} cat {} | jq '.cidr.subnet_sets[].accounts[]' -r | uniq)"
 
       - name: Set RAM assocation for member account
         run: |

--- a/.github/workflows/core-vpc-test-deployment.yml
+++ b/.github/workflows/core-vpc-test-deployment.yml
@@ -166,10 +166,10 @@ jobs:
           role-session-name: githubactionsrolesession
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Get changed files
+      - name: Get list of accounts in changed environments-networking files
         id: new_account
         run: |
-          echo "::set-output name=files::$(git diff --no-commit-id --name-only --diff-filter=AM -r @^ | awk '{print $1}' | grep ".json" |  cut -c 1- | tr -d : | xargs -I {} grep application {} |  awk '{team=$2; print team "-test"}' | tr -d , | tr -d '"'| uniq | xargs -I {} grep -R -o -h {} environments-networks | uniq)"
+          echo "::set-output name=files::$(git diff --no-commit-id --name-only --diff-filter=AM -r @^ | awk '{print $1}' | grep "environments-networks/.*.json" | xargs -I {} cat {} | jq '.cidr.subnet_sets[].accounts[]' -r | uniq)"
 
       - name: Set RAM assocation for member account
         run: |


### PR DESCRIPTION
The old command was working based on if there was an addition of the networking.auto.tfvars.json, but this file doesn't change after it's initially been created.  Now we are looking for change in the environments-networks/*.json files, these change every time there is a new ram share, either by the file being created in the first instance or by and account being added to it.

The only problem is there is no simple way to know which account has been added, it's easy to do if there is only one account added to existing ones but for the first time file creation it's all new.

So this solution will return all of the accounts and the ram share will run for all of the accounts in a VPC, this shouldn't be a problem however as it should just run and show no changes if they haven't been newly added.