### PR TITLE
Add permissions required to diagnose EBS iops issues.

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -429,6 +429,9 @@ data "aws_iam_policy_document" "developer-additional" {
       "ec2:CreateSnapshot",
       "ec2:CreateSnapshots",
       "ec2:CreateTags",
+      "ec2:DescribeVolumes",
+      "ec2:DescribeInstances",
+      "ec2:DescribeInstanceTypes",
       "s3:PutObject",
       "s3:DeleteObject",
       "rds:CopyDBSnapshot",
@@ -437,7 +440,10 @@ data "aws_iam_policy_document" "developer-additional" {
       "rds:CreateDBClusterSnapshot",
       "aws-marketplace:ViewSubscriptions",
       "support:*",
-      "rhelkb:GetRhelURL"
+      "rhelkb:GetRhelURL",
+      "cloudwatch:PutDashboard",
+      "cloudwatch:ListMetrics",
+      "cloudwatch:DeleteDashboards"
     ]
 
     resources = ["*"]


### PR DESCRIPTION
Related conversations:
https://mojdt.slack.com/archives/C01A7QK5VM1/p1669116439379209
https://mojdt.slack.com/archives/C013RM6MFFW/p1669116932521259

The `AWSSupport-CalculateEBSPerformanceMetrics` requires the following permissions:
```
ec2:DescribeVolumes
ec2:DescribeInstances
ec2:DescribeInstanceTypes
cloudwatch:PutDashboard
cloudwatch:ListMetrics
ssm:GetAutomationExecution
```

Adding the ones missing from the developer role as well as `cloudwatch:DeleteDashboards` to allow cleanup.
