### PR TITLE
Reintroduce deprecated rules in stateful fashion

### DIFF
--- a/terraform/environments/core-network-services/production_rules.json
+++ b/terraform/environments/core-network-services/production_rules.json
@@ -1,4 +1,39 @@
 {
+  "gp_to_mp_nomis_production_http": {
+    "action": "PASS",
+    "source_ip": "10.40.0.0/18",
+    "destination_ip": "10.27.8.0/21",
+    "destination_port": "80",
+    "protocol": "TCP"
+  },
+  "gp_to_mp_nomis_production_https": {
+    "action": "PASS",
+    "source_ip": "10.40.0.0/18",
+    "destination_ip": "10.27.8.0/21",
+    "destination_port": "443",
+    "protocol": "TCP"
+  },
+  "azure_noms_to_mp_nomis_production_db": {
+    "action": "PASS",
+    "source_ip": "10.40.0.0/16",
+    "destination_ip": "10.27.8.0/21",
+    "destination_port": "1521",
+    "protocol": "TCP"
+  },
+  "cp_to_mp_nomis_production_db": {
+    "action": "PASS",
+    "source_ip": "172.20.0.0/16",
+    "destination_ip": "10.27.8.0/21",
+    "destination_port": "1521",
+    "protocol": "TCP"
+  },
+  "mp_ppud_production_to_psn_ppud": {
+    "action": "PASS",
+    "source_ip": "10.27.8.0/21",
+    "destination_ip": "51.247.2.115/32",
+    "destination_port": "443",
+    "protocol": "TCP"
+  },
   "default_open": {
     "action": "PASS",
     "source_ip": "0.0.0.0/0",

--- a/terraform/environments/core-network-services/production_rules.json
+++ b/terraform/environments/core-network-services/production_rules.json
@@ -35,7 +35,7 @@
     "protocol": "TCP"
   },
   "default_open": {
-    "action": "PASS",
+    "action": "ALERT",
     "source_ip": "0.0.0.0/0",
     "destination_ip": "0.0.0.0/0",
     "destination_port": "ANY",

--- a/terraform/environments/core-network-services/test_rules.json
+++ b/terraform/environments/core-network-services/test_rules.json
@@ -1,0 +1,30 @@
+{
+  "gp_to_nomis_test_http": {
+    "action": "PASS",
+    "source_ip": "10.184.0.0/16",
+    "destination_ip": "10.26.8.0/21",
+    "destination_port": "80",
+    "protocol": "TCP"
+  },
+  "gp_to_nomis_test_https": {
+    "action": "PASS",
+    "source_ip": "10.101.0.0/16",
+    "destination_ip": "10.26.8.0/21",
+    "destination_port": "443",
+    "protocol": "TCP"
+  },
+  "az_noms_test_to_mp_nomis_test_db": {
+    "action": "PASS",
+    "source_ip": "10.101.0.0/16",
+    "destination_ip": "10.26.8.0/21",
+    "destination_port": "1521",
+    "protocol": "TCP"
+  },
+  "cp_to_mp_nomis_test_db": {
+    "action": "PASS",
+    "source_ip": "172.20.0.0/16",
+    "destination_ip": "10.26.8.0/21",
+    "destination_port": "1521",
+    "protocol": "TCP"
+  }
+}


### PR DESCRIPTION
This PR takes the old stateless firewall rules list and reintroduces them in stateful fashion.
In order to prevent disruption of any flows which we don't yet have firewall rules for this also changes the default action to `ALERT` so that we can capture logs of flows that don't yet have rules.