### PR TITLE
added missing option to tunnel log options

### DIFF
--- a/terraform/environments/core-network-services/vpn.tf
+++ b/terraform/environments/core-network-services/vpn.tf
@@ -23,6 +23,7 @@ resource "aws_vpn_connection" "this" {
     cloudwatch_log_options {
       log_enabled   = true
       log_group_arn = aws_cloudwatch_log_group.vpn_attachments[each.key].arn
+      log_output_format = "json"
     }
   }
 
@@ -30,6 +31,7 @@ resource "aws_vpn_connection" "this" {
     cloudwatch_log_options {
       log_enabled   = true
       log_group_arn = aws_cloudwatch_log_group.vpn_attachments[each.key].arn
+      log_output_format = "json"
     }
   }
 

--- a/terraform/environments/core-network-services/vpn.tf
+++ b/terraform/environments/core-network-services/vpn.tf
@@ -21,16 +21,16 @@ resource "aws_vpn_connection" "this" {
 
   tunnel1_log_options {
     cloudwatch_log_options {
-      log_enabled   = true
-      log_group_arn = aws_cloudwatch_log_group.vpn_attachments[each.key].arn
+      log_enabled       = true
+      log_group_arn     = aws_cloudwatch_log_group.vpn_attachments[each.key].arn
       log_output_format = "json"
     }
   }
 
   tunnel2_log_options {
     cloudwatch_log_options {
-      log_enabled   = true
-      log_group_arn = aws_cloudwatch_log_group.vpn_attachments[each.key].arn
+      log_enabled       = true
+      log_group_arn     = aws_cloudwatch_log_group.vpn_attachments[each.key].arn
       log_output_format = "json"
     }
   }


### PR DESCRIPTION
Without the provision of a `log_output_format` attribute, the AWS API will select `json` by default. However, on seeing this Terraform will attempt to delete this value leading to an unneccesary loop.

This fix PR adds the missing option to prevent this behaviour