### PR TITLE
Fix ram sharing running when it shouldn't

### DIFF
--- a/.github/workflows/core-vpc-development-deployment.yml
+++ b/.github/workflows/core-vpc-development-deployment.yml
@@ -146,7 +146,7 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         if: ${{ failure() }}
 
-  member-account-ram-associaton:
+  member-account-ram-association:
     runs-on: [ ubuntu-latest ]
     if: github.event.ref == 'refs/heads/main'
     needs: [ core-vpc-development-deployment-apply ]
@@ -169,16 +169,16 @@ jobs:
       - name: Get list of accounts in changed environments-networking files
         id: new_account
         run: |
-          echo "::set-output name=files::$(git diff --no-commit-id --name-only --diff-filter=AM -r @^ | awk '{print $1}' | grep "environments-networks/.*.json" | xargs -I {} cat {} | jq '.cidr.subnet_sets[].accounts[]' -r | uniq)"
+          echo "::set-output name=files::$(git diff --no-commit-id --name-only --diff-filter=AM -r @^ | awk '{print $1}' | grep "environments-networks/.*.json" | xargs -I {} cat {} | jq '.cidr.subnet_sets[].accounts[]' -r | grep "\-${TF_ENV}" | uniq)"
 
-      - name: Set RAM assocation for member account
+      - name: Set RAM association for member account
         run: |
           accounts=(${{ steps.new_account.outputs.files }})
           if [ ! -z ${accounts} ]
           then
           for i in "${accounts[@]}"
           do
-          echo "[+] Setting up RAM asocation for ${i}"
+          echo "[+] Setting up RAM association for ${i}"
           bash scripts/member-account-ram-association.sh ${i} ${TF_ENV}
           done
           else

--- a/.github/workflows/core-vpc-preproduction-deployment.yml
+++ b/.github/workflows/core-vpc-preproduction-deployment.yml
@@ -147,7 +147,7 @@ jobs:
         if: ${{ failure() }}
 
 
-  member-account-ram-associaton:
+  member-account-ram-association:
     runs-on: [ ubuntu-latest ]
     if: github.event.ref == 'refs/heads/main'
     needs: [ core-vpc-preproduction-deployment-apply ]
@@ -170,16 +170,16 @@ jobs:
       - name: Get list of accounts in changed environments-networking files
         id: new_account
         run: |
-          echo "::set-output name=files::$(git diff --no-commit-id --name-only --diff-filter=AM -r @^ | awk '{print $1}' | grep "environments-networks/.*.json" | xargs -I {} cat {} | jq '.cidr.subnet_sets[].accounts[]' -r | uniq)"
+          echo "::set-output name=files::$(git diff --no-commit-id --name-only --diff-filter=AM -r @^ | awk '{print $1}' | grep "environments-networks/.*.json" | xargs -I {} cat {} | jq '.cidr.subnet_sets[].accounts[]' -r | grep "\-${TF_ENV}" | uniq)"
 
-      - name: Set RAM assocation for member account
+      - name: Set RAM association for member account
         run: |
           accounts=(${{ steps.new_account.outputs.files }})
           if [ ! -z ${accounts} ]
           then
           for i in "${accounts[@]}"
           do
-          echo "[+] Setting up RAM asocation for ${i}"
+          echo "[+] Setting up RAM association for ${i}"
           bash scripts/member-account-ram-association.sh ${i} ${TF_ENV}
           done
           else

--- a/.github/workflows/core-vpc-production-deployment.yml
+++ b/.github/workflows/core-vpc-production-deployment.yml
@@ -169,16 +169,16 @@ jobs:
       - name: Get list of accounts in changed environments-networking files
         id: new_account
         run: |
-          echo "::set-output name=files::$(git diff --no-commit-id --name-only --diff-filter=AM -r @^ | awk '{print $1}' | grep "environments-networks/.*.json" | xargs -I {} cat {} | jq '.cidr.subnet_sets[].accounts[]' -r | uniq)"
+          echo "::set-output name=files::$(git diff --no-commit-id --name-only --diff-filter=AM -r @^ | awk '{print $1}' | grep "environments-networks/.*.json" | xargs -I {} cat {} | jq '.cidr.subnet_sets[].accounts[]' -r | grep "\-${TF_ENV}" | uniq)"
 
-      - name: Set RAM assocation for member account
+      - name: Set RAM association for member account
         run: |
           accounts=(${{ steps.new_account.outputs.files }})
           if [ ! -z ${accounts} ]
           then
           for i in "${accounts[@]}"
           do
-          echo "[+] Setting up RAM asocation for ${i}"
+          echo "[+] Setting up RAM association for ${i}"
           bash scripts/member-account-ram-association.sh ${i} ${TF_ENV}
           done
           else

--- a/.github/workflows/core-vpc-test-deployment.yml
+++ b/.github/workflows/core-vpc-test-deployment.yml
@@ -169,16 +169,16 @@ jobs:
       - name: Get list of accounts in changed environments-networking files
         id: new_account
         run: |
-          echo "::set-output name=files::$(git diff --no-commit-id --name-only --diff-filter=AM -r @^ | awk '{print $1}' | grep "environments-networks/.*.json" | xargs -I {} cat {} | jq '.cidr.subnet_sets[].accounts[]' -r | uniq)"
+          echo "::set-output name=files::$(git diff --no-commit-id --name-only --diff-filter=AM -r @^ | awk '{print $1}' | grep "environments-networks/.*.json" | xargs -I {} cat {} | jq '.cidr.subnet_sets[].accounts[]' -r | grep "\-${TF_ENV}" | uniq)"
 
-      - name: Set RAM assocation for member account
+      - name: Set RAM association for member account
         run: |
           accounts=(${{ steps.new_account.outputs.files }})
           if [ ! -z ${accounts} ]
           then
           for i in "${accounts[@]}"
           do
-          echo "[+] Setting up RAM asocation for ${i}"
+          echo "[+] Setting up RAM association for ${i}"
           bash scripts/member-account-ram-association.sh ${i} ${TF_ENV}
           done
           else


### PR DESCRIPTION
```
Environment: production
Account: mlra-preproduction
Running terraform across workspace mlra-preproduction-production Terraform init
Error handling -chdir option: chdir terraform/environments/mlra-preproduction: no such file or directory Error: Process completed with exit code 1.
```

RAM sharing was running for accounts it shouldn't, eg above it's running in production for a preproduction account.  This is because the list of changed accounts isn't being filter.  The new grep checks and filters out any accounts which don't match the environment.

Also fixing spelling errors.