### PR TITLE
Ram association fix - one line

### DIFF
--- a/.github/workflows/core-vpc-development-deployment.yml
+++ b/.github/workflows/core-vpc-development-deployment.yml
@@ -169,14 +169,14 @@ jobs:
       - name: Get list of accounts in changed environments-networking files
         id: new_account
         run: |
-          echo "::set-output name=files::$(git diff --no-commit-id --name-only --diff-filter=AM -r @^ | awk '{print $1}' | grep "environments-networks/.*.json" | xargs -I {} cat {} | jq '.cidr.subnet_sets[].accounts[]' -r | grep "\-${TF_ENV}" | uniq)"
+          echo "::set-output name=files::$(git diff --no-commit-id --name-only --diff-filter=AM -r @^ | awk '{print $1}' | grep "environments-networks/.*.json" | xargs -I {} cat {} | jq '.cidr.subnet_sets[].accounts[]' -r | grep "\-${TF_ENV}" | uniq | tr \\n ,)"
 
       - name: Set RAM association for member account
         run: |
           accounts=(${{ steps.new_account.outputs.files }})
-          if [ ! -z ${accounts} ]
+          if [ ! -z "${accounts}" ]
           then
-          for i in "${accounts[@]}"
+          for i in ${accounts}
           do
           echo "[+] Setting up RAM association for ${i}"
           bash scripts/member-account-ram-association.sh ${i} ${TF_ENV}

--- a/.github/workflows/core-vpc-preproduction-deployment.yml
+++ b/.github/workflows/core-vpc-preproduction-deployment.yml
@@ -170,14 +170,14 @@ jobs:
       - name: Get list of accounts in changed environments-networking files
         id: new_account
         run: |
-          echo "::set-output name=files::$(git diff --no-commit-id --name-only --diff-filter=AM -r @^ | awk '{print $1}' | grep "environments-networks/.*.json" | xargs -I {} cat {} | jq '.cidr.subnet_sets[].accounts[]' -r | grep "\-${TF_ENV}" | uniq)"
+          echo "::set-output name=files::$(git diff --no-commit-id --name-only --diff-filter=AM -r @^ | awk '{print $1}' | grep "environments-networks/.*.json" | xargs -I {} cat {} | jq '.cidr.subnet_sets[].accounts[]' -r | grep "\-${TF_ENV}" | uniq | tr \\n ,)"
 
       - name: Set RAM association for member account
         run: |
           accounts=(${{ steps.new_account.outputs.files }})
-          if [ ! -z ${accounts} ]
+          if [ ! -z "${accounts}" ]
           then
-          for i in "${accounts[@]}"
+          for i in ${accounts}
           do
           echo "[+] Setting up RAM association for ${i}"
           bash scripts/member-account-ram-association.sh ${i} ${TF_ENV}

--- a/.github/workflows/core-vpc-production-deployment.yml
+++ b/.github/workflows/core-vpc-production-deployment.yml
@@ -146,7 +146,7 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         if: ${{ failure() }}
 
-  member-account-ram-associaton:
+  member-account-ram-association:
     runs-on: [ ubuntu-latest ]
     if: github.event.ref == 'refs/heads/main'
     needs: [ core-vpc-production-deployment-apply ]
@@ -169,14 +169,14 @@ jobs:
       - name: Get list of accounts in changed environments-networking files
         id: new_account
         run: |
-          echo "::set-output name=files::$(git diff --no-commit-id --name-only --diff-filter=AM -r @^ | awk '{print $1}' | grep "environments-networks/.*.json" | xargs -I {} cat {} | jq '.cidr.subnet_sets[].accounts[]' -r | grep "\-${TF_ENV}" | uniq)"
+          echo "::set-output name=files::$(git diff --no-commit-id --name-only --diff-filter=AM -r @^ | awk '{print $1}' | grep "environments-networks/.*.json" | xargs -I {} cat {} | jq '.cidr.subnet_sets[].accounts[]' -r | grep "\-${TF_ENV}" | uniq | tr \\n ,)"
 
       - name: Set RAM association for member account
         run: |
           accounts=(${{ steps.new_account.outputs.files }})
-          if [ ! -z ${accounts} ]
+          if [ ! -z "${accounts}" ]
           then
-          for i in "${accounts[@]}"
+          for i in ${accounts}
           do
           echo "[+] Setting up RAM association for ${i}"
           bash scripts/member-account-ram-association.sh ${i} ${TF_ENV}

--- a/.github/workflows/core-vpc-test-deployment.yml
+++ b/.github/workflows/core-vpc-test-deployment.yml
@@ -146,7 +146,7 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         if: ${{ failure() }}
 
-  member-account-ram-associaton:
+  member-account-ram-association:
     runs-on: [ ubuntu-latest ]
     if: github.event.ref == 'refs/heads/main'
     needs: [ core-vpc-test-deployment-apply ]
@@ -169,14 +169,14 @@ jobs:
       - name: Get list of accounts in changed environments-networking files
         id: new_account
         run: |
-          echo "::set-output name=files::$(git diff --no-commit-id --name-only --diff-filter=AM -r @^ | awk '{print $1}' | grep "environments-networks/.*.json" | xargs -I {} cat {} | jq '.cidr.subnet_sets[].accounts[]' -r | grep "\-${TF_ENV}" | uniq)"
+          echo "::set-output name=files::$(git diff --no-commit-id --name-only --diff-filter=AM -r @^ | awk '{print $1}' | grep "environments-networks/.*.json" | xargs -I {} cat {} | jq '.cidr.subnet_sets[].accounts[]' -r | grep "\-${TF_ENV}" | uniq | tr \\n ,)"
 
       - name: Set RAM association for member account
         run: |
           accounts=(${{ steps.new_account.outputs.files }})
-          if [ ! -z ${accounts} ]
+          if [ ! -z "${accounts}" ]
           then
-          for i in "${accounts[@]}"
+          for i in ${accounts}
           do
           echo "[+] Setting up RAM association for ${i}"
           bash scripts/member-account-ram-association.sh ${i} ${TF_ENV}


### PR DESCRIPTION
Passing in multiple lines to the github action output doesn't work, it only takes the first line.  This change merges the lines in to one, and then itterates through strings on a single line separated by a space.