### PR TITLE
Add pagerduty service for Nomis

### DIFF
--- a/terraform/pagerduty/aws.tf
+++ b/terraform/pagerduty/aws.tf
@@ -16,7 +16,8 @@ resource "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {
   secret_string = jsonencode({
     core_alerts_cloudwatch = pagerduty_service_integration.core_alerts_cloudwatch.integration_key,
     high_priority_alarms   = pagerduty_service_integration.high_priority_cloudwatch.integration_key,
-    low_priority_alarms    = pagerduty_service_integration.low_priority_cloudwatch.integration_key
+    low_priority_alarms    = pagerduty_service_integration.low_priority_cloudwatch.integration_key,
+    nomis_alarms           = pagerduty_service_integration.nomis_cloudwatch.integration_key
   })
 }
 

--- a/terraform/pagerduty/member-services-integrations.tf
+++ b/terraform/pagerduty/member-services-integrations.tf
@@ -1,0 +1,37 @@
+# Member services for SNS -> Slack integration
+
+# # Copy and uncomment the following code
+# resource "pagerduty_service" "my_application" {
+#   name                    = "My Application Alarms"
+#   description             = "My Application Alarms"
+#   auto_resolve_timeout    = 345600
+#   acknowledgement_timeout = null
+#   escalation_policy       = pagerduty_escalation_policy.member_policy.id
+#   alert_creation          = "create_alerts_and_incidents"
+# }
+
+# resource "pagerduty_service_integration" "my_application_cloudwatch" {
+#   name    = data.pagerduty_vendor.cloudwatch.name
+#   service = pagerduty_service.my_application.id
+#   vendor  = data.pagerduty_vendor.cloudwatch.id
+# }
+
+# # Slack channel: #my-application-alarm-slack-channel
+
+# Nomis
+resource "pagerduty_service" "nomis" {
+  name                    = "Nomis Alarms"
+  description             = "Nomis Alarms"
+  auto_resolve_timeout    = 345600
+  acknowledgement_timeout = null
+  escalation_policy       = pagerduty_escalation_policy.member_policy.id
+  alert_creation          = "create_alerts_and_incidents"
+}
+
+resource "pagerduty_service_integration" "nomis_cloudwatch" {
+  name    = data.pagerduty_vendor.cloudwatch.name
+  service = pagerduty_service.nomis.id
+  vendor  = data.pagerduty_vendor.cloudwatch.id
+}
+
+# Slack channel: #dso_alerts_modernisation_platform

--- a/terraform/pagerduty/policy-schedules.tf
+++ b/terraform/pagerduty/policy-schedules.tf
@@ -32,6 +32,19 @@ resource "pagerduty_escalation_policy" "low_priority" {
   }
 }
 
+resource "pagerduty_escalation_policy" "member_policy" {
+  name  = "Modernisation Platform Member Policy"
+  teams = [pagerduty_team.modernisation_platform.id]
+
+  rule {
+    escalation_delay_in_minutes = 10
+    target {
+      type = "user_reference"
+      id   = pagerduty_user.pager_duty_users["modernisation_platform"].id
+    }
+  }
+}
+
 resource "pagerduty_schedule" "primary" {
   name      = "Modernisation Platform (primary)"
   time_zone = "Europe/London"


### PR DESCRIPTION
Adding a Pagerduty service and integration for Nomis, once created we will manually associate the service with the slack channel (this cannot be coded unfortunately).

This also creates a new dead end escalation policy which goes through to our dead end user.  This saves having to create the required escalation policy, schedule and user for teams which only want to use this for slack integration.