### PR TITLE
Remove pipefail option

### DIFF
--- a/scripts/get-applications-and-run-ram.sh
+++ b/scripts/get-applications-and-run-ram.sh
@@ -1,6 +1,6 @@
 #/bin/bash
 
-set -Eeo pipefail
+set -Ee
 
 environment=$1
 


### PR DESCRIPTION
The git diff command is returning a non 0 when there are no accounts to find, this is causing the script to exit with a non zero status.  As we want to exit nicely if this happens, removing the pipefail option.