### PR TITLE
Amend routes on TGW external route table

### DIFF
--- a/terraform/environments/core-network-services/transit_gateway_connections.tf
+++ b/terraform/environments/core-network-services/transit_gateway_connections.tf
@@ -64,6 +64,7 @@ locals {
   }
 
   external_static_routes = {
+    "modernisation-platform-core"     = "10.20.0.0/16"
     "modernisation-platform-non-live" = "10.26.0.0/16",
     "modernisation-platform-live"     = "10.27.0.0/16"
   }
@@ -160,12 +161,6 @@ resource "aws_ec2_transit_gateway_route" "tgw_external_egress_routes_for_live_da
   destination_cidr_block         = each.value
   transit_gateway_attachment_id  = aws_ec2_transit_gateway_vpc_attachment.external_inspection_in.id
   transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.route-tables["live_data"].id
-}
-
-resource "aws_ec2_transit_gateway_route" "external_ingress_in_to_inspection_vpc" {
-  destination_cidr_block         = "0.0.0.0/0"
-  transit_gateway_attachment_id  = aws_ec2_transit_gateway_vpc_attachment.external_inspection_in.id
-  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.external_inspection_in.id
 }
 
 resource "aws_ec2_transit_gateway_route" "external_static_routes" {


### PR DESCRIPTION
This PR does the following:
* Removes a default static route from the TGW `external` route table
* Adds a static route for the MP core VPCs to the TGW `external` route table

The rationale for this PR is as follows: there's no need for a `0.0.0.0/0` route on the `external` route table. That route table exists to correctly forward traffic entering the MP from outside, and the only traffic we should expect ought to be for MP destinations. Therefore we only need three routes in line with our [CIDR allocation register](https://github.com/ministryofjustice/modernisation-platform/blob/main/cidr-allocation.md).

Secondarily, by having a `0.0.0.0/0` route on the `external` route table we are at risk of advertising this route to connected parties via BGP. As we only want to receive traffic for an MP destination, advertising a `0.0.0.0/0` route puts us at risk of receiving large volumes of unwanted traffic.