### PR TITLE
Renaming testing-test secrets because the names clash with the ci user.

### DIFF
--- a/terraform/github/main.tf
+++ b/terraform/github/main.tf
@@ -242,9 +242,11 @@ module "modernisation-platform-environments" {
     "environments"
   ]
   required_checks = ["run-opa-policy-tests"]
-  secrets = nonsensitive(merge(local.member_ci_iam_user_keys, local.testing_ci_iam_user_keys, {
+  secrets = nonsensitive(merge(local.member_ci_iam_user_keys, {
     # Terraform GitHub token for the CI/CD user
-    TERRAFORM_GITHUB_TOKEN = "This needs to be manually set in GitHub."
+    TERRAFORM_GITHUB_TOKEN        = "This needs to be manually set in GitHub.",
+    TESTING_AWS_ACCESS_KEY_ID     = local.testing_ci_iam_user_keys.AWS_ACCESS_KEY_ID
+    TESTING_AWS_SECRET_ACCESS_KEY = local.testing_ci_iam_user_keys.AWS_SECRET_ACCESS_KEY
   }))
 }
 


### PR DESCRIPTION
Relevant Story: https://github.com/ministryofjustice/modernisation-platform/issues/2400
