### PR TITLE
Bumping environments module version.

### DIFF
--- a/terraform/environments/environments.tf
+++ b/terraform/environments/environments.tf
@@ -1,5 +1,5 @@
 module "environments" {
-  source                             = "github.com/ministryofjustice/modernisation-platform-terraform-environments?ref=v5.0.0"
+  source                             = "github.com/ministryofjustice/modernisation-platform-terraform-environments?ref=v5.0.1"
   environment_directory              = "../../environments"
   environment_parent_organisation_id = local.environment_management.modernisation_platform_organisation_unit_id
   environment_prefix                 = "modernisation-platform"

--- a/terraform/environments/environments.tf
+++ b/terraform/environments/environments.tf
@@ -1,5 +1,5 @@
 module "environments" {
-  source                             = "github.com/ministryofjustice/modernisation-platform-terraform-environments?ref=v5.0.1"
+  source                             = "github.com/ministryofjustice/modernisation-platform-terraform-environments?ref=30f855778a45a5b7446c033c67bcc1347c3cdbdd"
   environment_directory              = "../../environments"
   environment_parent_organisation_id = local.environment_management.modernisation_platform_organisation_unit_id
   environment_prefix                 = "modernisation-platform"

--- a/terraform/environments/environments.tf
+++ b/terraform/environments/environments.tf
@@ -1,5 +1,5 @@
 module "environments" {
-  source                             = "github.com/ministryofjustice/modernisation-platform-terraform-environments?ref=30f855778a45a5b7446c033c67bcc1347c3cdbdd"
+  source                             = "github.com/ministryofjustice/modernisation-platform-terraform-environments?ref=v5.0.2"
   environment_directory              = "../../environments"
   environment_parent_organisation_id = local.environment_management.modernisation_platform_organisation_unit_id
   environment_prefix                 = "modernisation-platform"


### PR DESCRIPTION
This version fixes how nuke-related lists were generated to allow for definition of multiple access blocks per environment, including multiple sandbox blocks and multiple values for nuke:

See PR for more details: https://github.com/ministryofjustice/modernisation-platform-terraform-environments/pull/27

And a fix for a misspelled name of a local: https://github.com/ministryofjustice/modernisation-platform-terraform-environments/pull/28