### PR TITLE
Removing member-ci secret from environments repo and deleting ci-related data calls.

### DIFF
--- a/terraform/github/aws.tf
+++ b/terraform/github/aws.tf
@@ -8,25 +8,6 @@ data "aws_secretsmanager_secret_version" "environment_management" {
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
 
-
-# This gets the AWS access keys for Core CI/CD from AWS Secrets Manager to set as repository secrets.
-data "aws_secretsmanager_secret" "ci_iam_user_keys" {
-  name = "ci_iam_user_keys"
-}
-
-data "aws_secretsmanager_secret_version" "ci_iam_user_keys" {
-  secret_id = data.aws_secretsmanager_secret.ci_iam_user_keys.id
-}
-
-# This gets the AWS access keys for Member CI/CD from AWS Secrets Manager to set as repository secrets.
-data "aws_secretsmanager_secret" "member_ci_iam_user_keys" {
-  name = "member_ci_iam_user_keys"
-}
-
-data "aws_secretsmanager_secret_version" "member_ci_iam_user_keys" {
-  secret_id = data.aws_secretsmanager_secret.member_ci_iam_user_keys.id
-}
-
 # This gets the AWS access keys for Testing CI/CD from AWS Secrets Manager to set as repository secrets.
 data "aws_secretsmanager_secret" "testing_ci_iam_user_keys" {
   provider = aws.testing-test
@@ -38,8 +19,6 @@ data "aws_secretsmanager_secret_version" "testing_ci_iam_user_keys" {
   secret_id = data.aws_secretsmanager_secret.testing_ci_iam_user_keys.id
 }
 locals {
-  ci_iam_user_keys         = jsondecode(data.aws_secretsmanager_secret_version.ci_iam_user_keys.secret_string)
-  member_ci_iam_user_keys  = jsondecode(data.aws_secretsmanager_secret_version.member_ci_iam_user_keys.secret_string)
   testing_ci_iam_user_keys = jsondecode(data.aws_secretsmanager_secret_version.testing_ci_iam_user_keys.secret_string)
 }
 

--- a/terraform/github/main.tf
+++ b/terraform/github/main.tf
@@ -241,12 +241,12 @@ module "modernisation-platform-environments" {
     "environments"
   ]
   required_checks = ["run-opa-policy-tests"]
-  secrets = nonsensitive(merge(local.member_ci_iam_user_keys, {
+  secrets = merge({
     # Terraform GitHub token for the CI/CD user
     TERRAFORM_GITHUB_TOKEN        = "This needs to be manually set in GitHub.",
     TESTING_AWS_ACCESS_KEY_ID     = local.testing_ci_iam_user_keys.AWS_ACCESS_KEY_ID
     TESTING_AWS_SECRET_ACCESS_KEY = local.testing_ci_iam_user_keys.AWS_SECRET_ACCESS_KEY
-  }))
+  })
 }
 
 module "modernisation-platform-infrastructure-test" {


### PR DESCRIPTION
Relevant Issue: https://github.com/ministryofjustice/modernisation-platform/issues/2041

Member-ci credentials have not been used since Dec 4th. Removing them from the `modernisation-platform-environments` repo secrets.

As `ci` and `member-ci` locals are not used elsewhere, removing the locals and datacalls from `terraform/github`
