### PR TITLE
Removing org secrets from the MP repo.

### DIFF
--- a/terraform/github/main.tf
+++ b/terraform/github/main.tf
@@ -11,8 +11,6 @@ module "core" {
     "documentation"
   ]
   secrets = {
-    PRIVILEGED_AWS_ACCESS_KEY_ID     = "example"
-    PRIVILEGED_AWS_SECRET_ACCESS_KEY = "example"
     # Terraform GitHub token for the CI/CD user
     TERRAFORM_GITHUB_TOKEN = "This needs to be manually set in GitHub."
     # Slack app webhook url


### PR DESCRIPTION
Relevant Issue: https://github.com/ministryofjustice/modernisation-platform/issues/2041

This PR removes the placeholders for the org-level secrets in the modernisation-platform repo.

The org keys have not been used since November 18th. 

Note: while the user is managed in code in the `aws-root-account` repo, the keys aren't so I've requested that the keys for the user be manually disabled.
