### PR TITLE
Add additional GUI perms for sandbox collaborators

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/collaborators.tf
+++ b/terraform/environments/bootstrap/delegate-access/collaborators.tf
@@ -304,7 +304,11 @@ data "aws_iam_policy_document" "sandbox_additional" {
       "ds:UpdateDirectorySetup",
       "ds:UpdateNumberOfDomainControllers",
       "ds:UpdateRadius",
-      "ds:UpdateSettings"
+      "ds:UpdateSettings",
+      "support:*",
+      "ssm-guiconnect:*",
+      "aws-marketplace:ViewSubscriptions",
+      "rhelkb:GetRhelURL"
     ]
     resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
   }


### PR DESCRIPTION
These permissions are available to the developer role but missing from the collaborator sandbox role.