### PR TITLE
Change from static to dynamic github app teams

### DIFF
--- a/.github/workflows/terraform-github.yml
+++ b/.github/workflows/terraform-github.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - 'terraform/github/**'
       - '.github/workflows/terraform-github.yml'
+      - 'environments/**.json'
     branches:
       - main
   pull_request:
     paths:
       - 'terraform/github/**'
       - '.github/workflows/terraform-github.yml'
+      - 'environments/**.json'
     branches:
       - main
     types: [opened, edited, reopened, synchronize]

--- a/source/runbooks/creating-accounts-for-end-users.html.md.erb
+++ b/source/runbooks/creating-accounts-for-end-users.html.md.erb
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#modernisation-platform"
 title: Creating AWS Accounts for Teams
-last_reviewed_on: 2022-08-18
+last_reviewed_on: 2022-12-14
 review_in: 6 months
 ---
 
@@ -18,7 +18,7 @@ Customers will fill out the new-environment template via our public repository [
 ### Application name
 The name must be in lowercase and a maximum of 30 characters. For our example we have `data-and-insights-wepi`
 ### GitHub team slug
-This is the name of your GitHub team that will be accessing the environment. Environments are accessed via single sign on (SSO), so to give people permissions to access your environment you just have to add them to your GitHub team. The file containing them can be found [here](https://github.com/ministryofjustice/modernisation-platform/blob/main/terraform/github/locals.tf)
+This is the name of your GitHub team that will be accessing the environment. Environments are accessed via single sign on (SSO), so to give people permissions to access your environment you just have to add them to your GitHub team. 
 ### Access
 For our example, sandbox access has been requested. To read more about access levels, click [here](https://user-guide.modernisation-platform.service.justice.gov.uk/user-guide/creating-environments.html#application-name)
 ### Environment name

--- a/source/runbooks/creating-accounts-for-end-users.html.md.erb
+++ b/source/runbooks/creating-accounts-for-end-users.html.md.erb
@@ -18,7 +18,7 @@ Customers will fill out the new-environment template via our public repository [
 ### Application name
 The name must be in lowercase and a maximum of 30 characters. For our example we have `data-and-insights-wepi`
 ### GitHub team slug
-This is the name of your GitHub team that will be accessing the environment. Environments are accessed via single sign on (SSO), so to give people permissions to access your environment you just have to add them to your GitHub team. 
+This is the name of your GitHub team that will be accessing the environment. Environments are accessed via single sign on (SSO), so to give people permissions to access your environment you just have to add them to your GitHub team.
 ### Access
 For our example, sandbox access has been requested. To read more about access levels, click [here](https://user-guide.modernisation-platform.service.justice.gov.uk/user-guide/creating-environments.html#application-name)
 ### Environment name

--- a/terraform/github/main.tf
+++ b/terraform/github/main.tf
@@ -394,6 +394,6 @@ module "aws-team" {
 module "contributor-access" {
   for_each          = toset(local.modernisation_platform_repositories)
   source            = "./modules/contributor"
-  application_teams = local.application_teams
+  application_teams = local.application_github_slugs
   repository_id     = each.key
 }


### PR DESCRIPTION
- dynamically generate a list of the application teams to be added to our repo from the json files, rather than using a static list that needs to be updated on new account creation.
- modify the workflow to run on json file changes
- update documentation