### PR TITLE
Correct the definition of the testing ci keys local

### DIFF
--- a/terraform/github/aws.tf
+++ b/terraform/github/aws.tf
@@ -9,7 +9,10 @@ data "aws_secretsmanager_secret_version" "environment_management" {
 }
 
 locals {
-  testing_ci_iam_user_keys = jsondecode(aws_secretsmanager_secret_version.testing_ci_iam_user_keys.secret_string)
+  testing_ci_iam_user_keys = sensitive({
+    AWS_ACCESS_KEY_ID     = aws_iam_access_key.testing_ci.id
+    AWS_SECRET_ACCESS_KEY = aws_iam_access_key.testing_ci.secret
+  })
 }
 
 # Get the slack webhook url

--- a/terraform/github/testing-ci.tf
+++ b/terraform/github/testing-ci.tf
@@ -116,7 +116,7 @@ resource "aws_iam_access_key" "testing_ci" {
 # create a rotation period for the access keys
 
 resource "time_rotating" "key_rotate_period" {
-  rotation_minutes = 30
+  rotation_days = 7
 }
 
 # When rotate period of time_rotate expires, it is removed from the state, and terraform treats it as a new resource.


### PR DESCRIPTION
Relevant Issue: https://github.com/ministryofjustice/modernisation-platform/issues/2576


Setting values for the testing_ci_iam_user_keys local from the aws_iam_access_key resource since the value of the aws_secretmanager_secret_version resource is unknown until apply and terraform plan fails when trying to predict changes to dynamic secret resources within the github terraform module..

Additionally:

- Bumping rotation period to 7 days.
