### PR TITLE
Adding testing account information and tags, workflow scheduling and updating docs.

### DIFF
--- a/.github/workflows/terraform-github.yml
+++ b/.github/workflows/terraform-github.yml
@@ -16,6 +16,10 @@ on:
     branches:
       - main
     types: [opened, edited, reopened, synchronize]
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    # trigger every Saturday at 12:00am
+    - cron: '0 12 * * 6'
   workflow_dispatch:
 
 defaults:
@@ -25,7 +29,7 @@ defaults:
 permissions:
   id-token: write # This is required for requesting the JWT
   contents: read # This is required for actions/checkout
- 
+
 jobs:
   github-plan-and-apply:
     runs-on: ubuntu-latest
@@ -53,7 +57,7 @@ jobs:
         with:
           terraform_version: "~1"
           terraform_wrapper: false
-         
+
       - name: terraform init
         run: bash scripts/terraform-init.sh terraform/github
       - name: terraform plan

--- a/source/concepts/sdlc/testing-strategy.html.md.erb
+++ b/source/concepts/sdlc/testing-strategy.html.md.erb
@@ -30,6 +30,8 @@ Run tests locally using the testing-test account Admin SSO credentials.
 
 Tests running in GitHub actions use the `testing-ci` user.
 
+To minimise securty risks around using static credentials, aws keys for `testing-ci` user are automatically rotated every 7 days.
+
 ## Testing areas
 
 |Area to test | Type of test | Testing tool | Testing environment | Comments |

--- a/terraform/github/README.md
+++ b/terraform/github/README.md
@@ -5,6 +5,7 @@ This directory creates and maintains the following GitHub items for the Modernis
   - repositories
   - team membership
   - team access to repositories
+  - rotation of `testing-ci` AWS keys and updates to corresponding [Github secrets](testing-ci.tf) 
 
 The state is stored in S3, as defined in [backend.tf](backend.tf).
 

--- a/terraform/github/locals.tf
+++ b/terraform/github/locals.tf
@@ -1,4 +1,11 @@
+# Adding information tags about resources created in the testing-test account but managed in this terraform project.
+
+data "http" "environments_file" {
+  url = "https://raw.githubusercontent.com/ministryofjustice/modernisation-platform/main/environments/${local.testing_application_name}.json"
+}
 locals {
+  testing_application_name = "testing"
+
   environment_management = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
 
   # GitHub usernames for the Modernisation Platform team maintainers
@@ -70,5 +77,7 @@ locals {
   ]
 
 
-  tags = { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
+  testing_tags = merge(
+    jsondecode(data.http.environments_file.response_body).tags,
+  { "source-code" = "https://github.com/ministryofjustice/modernisation-platform/tree/main/terraform/github" })
 }

--- a/terraform/github/testing-ci.tf
+++ b/terraform/github/testing-ci.tf
@@ -4,7 +4,7 @@
 resource "aws_iam_user" "testing_ci" {
   provider = aws.testing-test
   name     = "testing-ci"
-  tags     = local.tags
+  tags     = local.testing_tags
 }
 
 # Add policy directly to the testing user
@@ -81,6 +81,7 @@ resource "aws_iam_policy" "testing_ci_policy" {
   name        = "TestingCiActions"
   description = "Allowed actions for the testing_ci user"
   policy      = data.aws_iam_policy_document.testing_ci_policy.json
+  tags        = local.testing_tags
 }
 
 resource "aws_iam_user_policy_attachment" "testing_ci_attach" {
@@ -133,7 +134,7 @@ resource "aws_secretsmanager_secret" "testing_ci_iam_user_keys" {
   policy      = data.aws_iam_policy_document.testing_ci_iam_user_secrets_manager_policy.json
   kms_key_id  = aws_kms_key.testing_ci_iam_user_kms_key.id
   description = "Access keys for the testing CI user, this secret is used by GitHub to set the correct repository secrets."
-  tags        = local.tags
+  tags        = local.testing_tags
 }
 
 resource "aws_secretsmanager_secret_version" "testing_ci_iam_user_keys" {
@@ -152,6 +153,7 @@ resource "aws_kms_key" "testing_ci_iam_user_kms_key" {
   policy                  = data.aws_iam_policy_document.testing_ci_iam_user_kms_key_policy.json
   enable_key_rotation     = true
   deletion_window_in_days = 30
+  tags                    = local.testing_tags
 }
 
 resource "aws_kms_alias" "testing_ci_iam_user_kms_key" {

--- a/terraform/github/versions.tf
+++ b/terraform/github/versions.tf
@@ -13,5 +13,9 @@ terraform {
       version = "~> 0.9"
       source  = "hashicorp/time"
     }
+    http = {
+      version = "~> 3.0"
+      source  = "hashicorp/http"
+    }
   }
 }


### PR DESCRIPTION
Closes https://github.com/ministryofjustice/modernisation-platform/issues/2576
- Adding tags to make it more obvious which `testing-test` resources are managed in the github project.
- Updating testing docs
- Updating README
- Adding schedule to github workflow to run every Saturday at midnight.