### PR TITLE
Add Xray VPC endpoint

### DIFF
--- a/environments-networks/laa-development.json
+++ b/environments-networks/laa-development.json
@@ -10,7 +10,7 @@
   "options": {
     "bastion_linux": true,
     "additional_cidrs": [],
-    "additional_endpoints": [],
+    "additional_endpoints": ["com.amazonaws.eu-west-2.xray"],
     "additional_vpcs": [],
     "dns_zone_extend": []
   }

--- a/environments-networks/laa-preproduction.json
+++ b/environments-networks/laa-preproduction.json
@@ -10,7 +10,7 @@
   "options": {
     "bastion_linux": false,
     "additional_cidrs": [],
-    "additional_endpoints": [],
+    "additional_endpoints": ["com.amazonaws.eu-west-2.xray"],
     "additional_vpcs": [],
     "dns_zone_extend": []
   }

--- a/environments-networks/laa-production.json
+++ b/environments-networks/laa-production.json
@@ -10,7 +10,7 @@
   "options": {
     "bastion_linux": false,
     "additional_cidrs": [],
-    "additional_endpoints": [],
+    "additional_endpoints": ["com.amazonaws.eu-west-2.xray"],
     "additional_vpcs": [],
     "dns_zone_extend": []
   }

--- a/environments-networks/laa-test.json
+++ b/environments-networks/laa-test.json
@@ -10,7 +10,7 @@
   "options": {
     "bastion_linux": true,
     "additional_cidrs": [],
-    "additional_endpoints": [],
+    "additional_endpoints": ["com.amazonaws.eu-west-2.xray"],
     "additional_vpcs": [],
     "dns_zone_extend": []
   }


### PR DESCRIPTION
Query via ask channel:

The MLRA application that we're moving across from the LAA Landingzone uses AWS X-RAY to collect telemetry data. Our testing of the initial deployment of the stack in mlra-development has thrown up some errors being caught by x-ray when it's launching. Specifically: [Error] Get instance id metadata failed: EC2MetadataError: failed to make EC2Metadata request status code: 401, request id: We have gone over the IAM policies that the EC2 uses and we've content there are no differences that would causes this. However what we have discovered is that the x-ray service endpoint doesn't seem to be available in the core VPC - as covered here - https://docs.aws.amazon.com/xray/latest/devguide/xray-security-vpc-endpoint.html.