### PR TITLE
Fix non zero exit status

### DIFF
--- a/scripts/get-applications-and-run-ram.sh
+++ b/scripts/get-applications-and-run-ram.sh
@@ -23,6 +23,7 @@ if [ ! -z "${accounts}" ]; then
       echo "[+] ${networking_file} does not exist, skipping RAM share."
     fi
   done
+  exit 0
 else
   echo "[+] There were no member accounts to process"
   exit 0
@@ -43,6 +44,7 @@ if [ ! -z "${changed_networking_files}" ]; then
     echo "[+] Starting up RAM association for application ${application}"
     bash scripts/member-account-ram-association.sh ${application} ${environment}
   done
+  exit 0
 else
   echo "[+] There were no networking.auto.tfvars.json changed files"
   exit 0

--- a/scripts/member-account-ram-association.sh
+++ b/scripts/member-account-ram-association.sh
@@ -26,6 +26,7 @@ setup_ram_share_association() {
       ./scripts/terraform-apply.sh $basedir/$application
     fi
     echo "Finished running ram share association for application: ${application}"
+    exit 0
 }
 
 setup_ram_share_association


### PR DESCRIPTION
```
Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
Finished running ram share association for application: mlra
Error: Process completed with exit code 1.
```

I can't work out what is causing the exit code to be one, explicitly exiting successful functions with zero to see if this helps

Example failing ram share here - 
https://github.com/ministryofjustice/modernisation-platform/actions/runs/3712483609/jobs/6294104349