### PR TITLE
Fix new account order of operations

### DIFF
--- a/.github/workflows/new-environment.yml
+++ b/.github/workflows/new-environment.yml
@@ -147,7 +147,7 @@ jobs:
   delegate-access:
     runs-on: ubuntu-latest
     if: github.event.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
-    needs: [provision-workspaces]
+    needs: [single-sign-on]
     steps:
       - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
         with:


### PR DESCRIPTION
During the new account creation process, the delegate-access step fails with the following error:

```
Error: Null value found in list

  with module.member-access[0].data.aws_iam_policy_document.assume-role-policy,
  on .terraform/modules/member-access/main.tf line 2, in data "aws_iam_policy_document" "assume-role-policy":
   2: data "aws_iam_policy_document" "assume-role-policy" {

Null values are not allowed for this attribute value.
```

On re-running the workflow, the delegate-access step works. This is because the missing resource is created in parallel during the single-sign-on step.

Setting the single-sign-on step to run before delegate-access to resolve.

Closes #2460