### PR TITLE
Add modules folder to codeowners generation

### DIFF
--- a/scripts/provision-member-directories.sh
+++ b/scripts/provision-member-directories.sh
@@ -155,6 +155,7 @@ EOL
 **/backend.tf @ministryofjustice/modernisation-platform
 **/subnet_share.tf @ministryofjustice/modernisation-platform
 **/networking.auto.tfvars.json @ministryofjustice/modernisation-platform
+/terraform/modules
 EOL
 
 }


### PR DESCRIPTION
This allows any repository users to be able to approve changes to the terraform/modules directory.