### PR TITLE
Add script to trigger SSO permission set update

### DIFF
--- a/.github/workflows/scheduled-baseline.yml
+++ b/.github/workflows/scheduled-baseline.yml
@@ -10,6 +10,7 @@ on:
       - '.github/workflows/scheduled-baseline.yml'
       - 'terraform/environments/bootstrap/**'
       - 'terraform/modules/iam_baseline/**'
+      - 'scripts/update-sso-permission-sets.sh'
   workflow_dispatch:
 
 env:
@@ -129,6 +130,37 @@ jobs:
       - run: bash scripts/terraform-init.sh terraform/environments/bootstrap/single-sign-on
       - run: bash scripts/loop-through-terraform-workspaces.sh terraform/environments/bootstrap/single-sign-on plan
       - run: bash scripts/loop-through-terraform-workspaces.sh terraform/environments/bootstrap/single-sign-on apply
+      - name: Slack failure notification
+        uses: 8398a7/action-slack@bdc6f9de222d3b7518e6cf99c4f3410f653cfde3 # v3.15.0
+        with:
+          status: ${{ job.status }}
+          fields: workflow,job,repo,commit,message
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: ${{ failure() }}
+  update-permission-sets:
+    runs-on: ubuntu-latest
+    needs: [delegate-access,single-sign-on]
+    steps:
+      - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
+      - name: Set Account Number
+        run: echo "ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+      - name: Set Root Account Number
+        run: echo "ROOT_ACCOUNT_NUMBER=$(jq -r -e '.aws_organizations_root_account_id' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+          role-session-name: githubactionsrolesession
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Update permission sets
+        run: |
+          aws sts assume-role --role-arn "arn:aws:iam::${ROOT_ACCOUNT_NUMBER}:role/ModernisationPlatformSSOAdministrator" --role-session-name ssoadminrolesession > creds
+          $(echo "export AWS_ACCESS_KEY_ID=$(echo $(cat creds) | sed -n 's/.*"AccessKeyId": "\([^"]*\)".*/\1/p')")
+          $(echo "export AWS_SECRET_ACCESS_KEY=$(echo $(cat creds) | sed -n 's/.*"SecretAccessKey": "\([^"]*\)".*/\1/p')")
+          $(echo "export AWS_SESSION_TOKEN=$(echo $(cat creds) | sed -n 's/.*"SessionToken": "\([^"]*\)".*/\1/p')")
+          grep "ModernisationPlatformSSOAdministrator" <<< $(aws sts get-caller-identity) || { echo 'Failed to assume role' ; exit 1; }
+      - run: bash scripts/update-sso-permission-sets.sh
       - name: Slack failure notification
         uses: 8398a7/action-slack@bdc6f9de222d3b7518e6cf99c4f3410f653cfde3 # v3.15.0
         with:

--- a/scripts/update-sso-permission-sets.sh
+++ b/scripts/update-sso-permission-sets.sh
@@ -12,6 +12,9 @@ for permission_set in $permission_sets; do
 	arn=$(echo $description | jq -r '.PermissionSet.PermissionSetArn')
 	if [[ $name == modernisation-platform* ]];then
 		echo "Updating permission set $name"
-		aws sso-admin provision-permission-set --instance-arn $instance_arn --permission-set-arn $arn --target-type ALL_PROVISIONED_ACCOUNTS
+
+		# Capture the aws-cli output as a variable, rather than blocking the next task
+		output=$(aws sso-admin provision-permission-set --instance-arn $instance_arn --permission-set-arn $arn --target-type ALL_PROVISIONED_ACCOUNTS --output json)
+		echo $output
 	fi
 done

--- a/scripts/update-sso-permission-sets.sh
+++ b/scripts/update-sso-permission-sets.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -o pipefail
+set -e
+
+instance_arn=$(aws sso-admin list-instances --query 'Instances[*].InstanceArn' --output text)
+permission_sets=$(aws sso-admin list-permission-sets --instance-arn $instance_arn  --query 'PermissionSets[*]' --output text)
+
+for permission_set in $permission_sets; do
+	description=$(aws sso-admin describe-permission-set --instance-arn $instance_arn --permission-set-arn $permission_set)
+	name=$(echo $description | jq -r '.PermissionSet.Name')
+	arn=$(echo $description | jq -r '.PermissionSet.PermissionSetArn')
+	if [[ $name == modernisation-platform* ]];then
+		echo "Updating permission set $name"
+		aws sso-admin provision-permission-set --instance-arn $instance_arn --permission-set-arn $arn --target-type ALL_PROVISIONED_ACCOUNTS
+	fi
+done


### PR DESCRIPTION
When the policy changes we need to be able to trigger the permission set to update with the new managed policy.

New script created to do this which runs after delegate access,
this is where the policies are set.  Also making sure it runs after
single-sign-on to ensure there are no clashes with this workflow.