### PR TITLE
Test replacement of slack action

### DIFF
--- a/.github/workflows/terraform-static-analysis.yml
+++ b/.github/workflows/terraform-static-analysis.yml
@@ -76,12 +76,7 @@ jobs:
         tfsec_exclude: aws-ssm-secret-use-customer-key,github-repositories-private,aws-vpc-no-excessive-port-access,github-repositories-require-signed-commits
         checkov_exclude: CKV_GIT_1,CKV_AWS_126,CKV2_AWS_38,CKV2_AWS_39
         tflint_exclude: terraform_unused_declarations
-    - uses: 8398a7/action-slack@bdc6f9de222d3b7518e6cf99c4f3410f653cfde3 # v3.15.0
-      name: Slack failure notification
-      with:
-        job_name: Terraform Static Analysis - scheduled scan of all directories
-        status: ${{ job.status }}
-        fields: workflow,job,repo,commit,message
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - name: Slack failure notification
+      run: | 
+          curl -d '{"blocks":[{"type": "section","text": {"type": "mrkdwn","text": ":no_entry: Failed GitHub Action:"}},{"type": "section","fields":[{"type": "mrkdwn","text": "*Workflow:*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>"},{"type": "mrkdwn","text": "*Job:*\n${{ github.job }}"},{"type": "mrkdwn","text": "*Repo:*\n${{ github.repository }}"}]}]}' -H "Content-Type: application/json" -X POST ${{ secrets.SLACK_WEBHOOK_URL }}
       if: ${{ failure() }}


### PR DESCRIPTION
Currently we use a 3rd party action to post to slack, testing swapping this out and replacing with a direct curl call to the slack webhook to increase security.  Note, I have not put the PR title in as without sanitation this could be used for an injection attack.

This action is currently failing overnight so we should see if this works tomorrow.