### PR TITLE
Fix update-permission-sets job

### DIFF
--- a/.github/workflows/scheduled-baseline.yml
+++ b/.github/workflows/scheduled-baseline.yml
@@ -160,7 +160,7 @@ jobs:
           $(echo "export AWS_SECRET_ACCESS_KEY=$(echo $(cat creds) | sed -n 's/.*"SecretAccessKey": "\([^"]*\)".*/\1/p')")
           $(echo "export AWS_SESSION_TOKEN=$(echo $(cat creds) | sed -n 's/.*"SessionToken": "\([^"]*\)".*/\1/p')")
           grep "ModernisationPlatformSSOAdministrator" <<< $(aws sts get-caller-identity) || { echo 'Failed to assume role' ; exit 1; }
-      - run: bash scripts/update-sso-permission-sets.sh
+          bash scripts/update-sso-permission-sets.sh
       - name: Slack failure notification
         uses: 8398a7/action-slack@bdc6f9de222d3b7518e6cf99c4f3410f653cfde3 # v3.15.0
         with:


### PR DESCRIPTION
The job was failing as the script call was in a separate run command. The call needs to be in the same run command in order to have access to the credentials in the environment.