### PR TITLE
Change order of new environment workflows

### DIFF
--- a/.github/workflows/new-environment.yml
+++ b/.github/workflows/new-environment.yml
@@ -149,7 +149,7 @@ jobs:
   delegate-access:
     runs-on: ubuntu-latest
     if: github.event.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
-    needs: [single-sign-on]
+    needs: [provision-workspaces]
     steps:
       - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
         with:
@@ -246,7 +246,7 @@ jobs:
   single-sign-on:
     runs-on: ubuntu-latest
     if: github.event.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
-    needs: [provision-workspaces]
+    needs: [provision-workspaces, delegate-access]
     steps:
       - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
         with:


### PR DESCRIPTION
The order of these were changed to fix a bug here - https://github.com/ministryofjustice/modernisation-platform/pull/2855

But this then breaks the SSO as the role doesn't exist yet.  There is no way round this dependancy, so reversing this change and will have to find another way to fix the bug.