### PR TITLE
Add developer permissions for codebuild and fleet

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/policies.tf
+++ b/terraform/environments/bootstrap/delegate-access/policies.tf
@@ -105,6 +105,8 @@ data "aws_iam_policy_document" "developer_additional" {
       "cloudwatch:PutDashboard",
       "cloudwatch:ListMetrics",
       "cloudwatch:DeleteDashboards",
+      "codebuild:ImportSourceCredentials",
+      "codebuild:PersistOAuthToken",
       "ds:*Tags*",
       "ds:*Snapshot*",
       "ec2:StartInstances",
@@ -123,6 +125,7 @@ data "aws_iam_policy_document" "developer_additional" {
       "ec2:DescribeInstanceTypes",
       "ecs:StartTask",
       "ecs:StopTask",
+      "identitystore:DescribeUser",
       "kms:Decrypt*",
       "kms:Encrypt",
       "kms:ReEncrypt*",
@@ -148,6 +151,7 @@ data "aws_iam_policy_document" "developer_additional" {
       "secretsmanager:RotateSecret",
       "ssm:*",
       "ssm-guiconnect:*",
+      "sso:ListDirectoryAssociations",
       "support:*"
     ]
     resources = ["*"]


### PR DESCRIPTION
Adding the following permissions to allow fleet manager remote desktop SSO sign on
(https://aws.amazon.com/blogs/security/how-to-enable-secure-seamless-single-sign-on-to-amazon-ec2-windows-instances-with-aws-sso/): `identitystore:DescribeUser`
`sso:ListDirectoryAssociations`

Adding the following permissions to allow credentials to be imported for linking a codebuild project to a source GitHub repository: `codebuild:ImportSourceCredentials`
`codebuild:PersistOAuthToken`