### PR TITLE
Adjust VPN settings to Azure

### DIFF
--- a/terraform/environments/core-network-services/vpn.tf
+++ b/terraform/environments/core-network-services/vpn.tf
@@ -15,8 +15,12 @@ resource "aws_vpn_connection" "this" {
   transit_gateway_id       = aws_ec2_transit_gateway.transit-gateway.id
   customer_gateway_id      = aws_customer_gateway.this[each.key].id
   type                     = "ipsec.1"
+  tunnel1_dpd_timeout_action = try(each.value.tunnel_dpd_timeout_action, null)
+  tunnel1_dpd_timeout_seconds = try(each.value.tunnel_dpd_timeout_seconds, "30")
   tunnel1_inside_cidr      = try(each.value.tunnel1_inside_cidr, null)
   tunnel1_startup_action   = try(each.value.tunnel_startup_action, null)
+  tunnel2_dpd_timeout_action = try(each.value.tunnel_dpd_timeout_action, null)
+  tunnel2_dpd_timeout_seconds = try(each.value.tunnel_dpd_timeout_seconds, "30")
   tunnel2_inside_cidr      = try(each.value.tunnel2_inside_cidr, null)
   tunnel2_startup_action   = try(each.value.tunnel_startup_action, null)
   remote_ipv4_network_cidr = try(each.value.remote_ipv4_network_cidr, local.core-vpcs[each.value.modernisation_platform_vpc].cidr.subnet_sets["general"].cidr)

--- a/terraform/environments/core-network-services/vpn.tf
+++ b/terraform/environments/core-network-services/vpn.tf
@@ -11,19 +11,19 @@ resource "aws_customer_gateway" "this" {
 }
 
 resource "aws_vpn_connection" "this" {
-  for_each                 = local.vpn_attachments
-  transit_gateway_id       = aws_ec2_transit_gateway.transit-gateway.id
-  customer_gateway_id      = aws_customer_gateway.this[each.key].id
-  type                     = "ipsec.1"
-  tunnel1_dpd_timeout_action = try(each.value.tunnel_dpd_timeout_action, null)
+  for_each                    = local.vpn_attachments
+  transit_gateway_id          = aws_ec2_transit_gateway.transit-gateway.id
+  customer_gateway_id         = aws_customer_gateway.this[each.key].id
+  type                        = "ipsec.1"
+  tunnel1_dpd_timeout_action  = try(each.value.tunnel_dpd_timeout_action, null)
   tunnel1_dpd_timeout_seconds = try(each.value.tunnel_dpd_timeout_seconds, "30")
-  tunnel1_inside_cidr      = try(each.value.tunnel1_inside_cidr, null)
-  tunnel1_startup_action   = try(each.value.tunnel_startup_action, null)
-  tunnel2_dpd_timeout_action = try(each.value.tunnel_dpd_timeout_action, null)
+  tunnel1_inside_cidr         = try(each.value.tunnel1_inside_cidr, null)
+  tunnel1_startup_action      = try(each.value.tunnel_startup_action, null)
+  tunnel2_dpd_timeout_action  = try(each.value.tunnel_dpd_timeout_action, null)
   tunnel2_dpd_timeout_seconds = try(each.value.tunnel_dpd_timeout_seconds, "30")
-  tunnel2_inside_cidr      = try(each.value.tunnel2_inside_cidr, null)
-  tunnel2_startup_action   = try(each.value.tunnel_startup_action, null)
-  remote_ipv4_network_cidr = try(each.value.remote_ipv4_network_cidr, local.core-vpcs[each.value.modernisation_platform_vpc].cidr.subnet_sets["general"].cidr)
+  tunnel2_inside_cidr         = try(each.value.tunnel2_inside_cidr, null)
+  tunnel2_startup_action      = try(each.value.tunnel_startup_action, null)
+  remote_ipv4_network_cidr    = try(each.value.remote_ipv4_network_cidr, local.core-vpcs[each.value.modernisation_platform_vpc].cidr.subnet_sets["general"].cidr)
 
   tunnel1_log_options {
     cloudwatch_log_options {

--- a/terraform/environments/core-network-services/vpn_attachments.json
+++ b/terraform/environments/core-network-services/vpn_attachments.json
@@ -39,6 +39,7 @@
     "modernisation_platform_vpc": "hmpps-development",
     "tunnel1_inside_cidr": "169.254.21.0/30",
     "tunnel2_inside_cidr": "169.254.22.0/30",
+    "tunnel_dpd_timeout_action": "restart",
     "tunnel_dpd_timeout_seconds": "45",
     "tunnel_startup_action": "start"
   },
@@ -50,6 +51,7 @@
     "modernisation_platform_vpc": "hmpps-development",
     "tunnel1_inside_cidr": "169.254.21.4/30",
     "tunnel2_inside_cidr": "169.254.22.4/30",
+    "tunnel_dpd_timeout_action": "restart",
     "tunnel_dpd_timeout_seconds": "45",
     "tunnel_startup_action": "start"
   }

--- a/terraform/environments/core-network-services/vpn_attachments.json
+++ b/terraform/environments/core-network-services/vpn_attachments.json
@@ -39,6 +39,7 @@
     "modernisation_platform_vpc": "hmpps-development",
     "tunnel1_inside_cidr": "169.254.21.0/30",
     "tunnel2_inside_cidr": "169.254.22.0/30",
+    "tunnel_dpd_timeout_seconds": "45",
     "tunnel_startup_action": "start"
   },
   "NOMS-Transit-Live-DR-VPN-VNG_2": {
@@ -49,6 +50,7 @@
     "modernisation_platform_vpc": "hmpps-development",
     "tunnel1_inside_cidr": "169.254.21.4/30",
     "tunnel2_inside_cidr": "169.254.22.4/30",
+    "tunnel_dpd_timeout_seconds": "45",
     "tunnel_startup_action": "start"
   }
 }


### PR DESCRIPTION
This PR brings the DPD timeout settings between AWS and Azure into line, and provides the option to change the behaviour of a VPN tunnel should the DPD timeout be breached.

For the tunnels to Azure, as AWS is the initiator, I have set the DPD action to restart the tunnel.