### PR TITLE
Update main.tf

### DIFF
--- a/terraform/modules/iam_baseline/main.tf
+++ b/terraform/modules/iam_baseline/main.tf
@@ -24,6 +24,7 @@ resource "aws_iam_policy" "policy" {
           "ecs:DescribeServices",
           "ecs:DescribeTaskDefinition",
           "ecs:ListTasks",
+          "ecs:StopTask",
           "ecr:GetAuthorizationToken",
           "ecr:GetDownloadUrlForLayer",
           "ecr:BatchGetImage",

--- a/terraform/modules/iam_baseline/main.tf
+++ b/terraform/modules/iam_baseline/main.tf
@@ -23,6 +23,7 @@ resource "aws_iam_policy" "policy" {
           "ecs:UpdateService",
           "ecs:DescribeServices",
           "ecs:DescribeTaskDefinition",
+          "ecs:ListTasks",
           "ecr:GetAuthorizationToken",
           "ecr:GetDownloadUrlForLayer",
           "ecr:BatchGetImage",


### PR DESCRIPTION
ecs:ListTasks permissions added to the cicd-member-user.
ecs:StopTask permissions added to the cicd-member-user.
"I was thinking of stopping the ECS tasks as part of the pipeline to let the task respawn themselves, but running into ecs:ListTasks permission required for cicd-member-user. Is this something that can be added in, or is there a better solution you have encountered before?"
