### PR TITLE
Add permissions to sandbox for rdp sso and codebuild

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/policies.tf
+++ b/terraform/environments/bootstrap/delegate-access/policies.tf
@@ -231,6 +231,8 @@ data "aws_iam_policy_document" "sandbox_additional" {
       "autoscaling:*",
       "cloudfront:*",
       "cloudwatch:*",
+      "codebuild:ImportSourceCredentials",
+      "codebuild:PersistOAuthToken",
       "dlm:*",
       "dynamodb:*",
       "dms:*",
@@ -322,7 +324,9 @@ data "aws_iam_policy_document" "sandbox_additional" {
       "support:*",
       "ssm-guiconnect:*",
       "aws-marketplace:ViewSubscriptions",
-      "rhelkb:GetRhelURL"
+      "rhelkb:GetRhelURL",
+      "identitystore:DescribeUser",
+      "sso:ListDirectoryAssociations"
     ]
     resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
   }


### PR DESCRIPTION
Adding the following permissions to allow fleet manager remote desktop SSO sign on (https://aws.amazon.com/blogs/security/how-to-enable-secure-seamless-single-sign-on-to-amazon-ec2-windows-instances-with-aws-sso/): identitystore:DescribeUser sso:ListDirectoryAssociations

Adding the following permissions to allow credentials to be imported for linking a codebuild project to a source GitHub repository: codebuild:ImportSourceCredentials codebuild:PersistOAuthToken