### PR TITLE
Add dashboard team to refer-monitor environment

### DIFF
--- a/environments/refer-monitor.json
+++ b/environments/refer-monitor.json
@@ -7,6 +7,10 @@
         {
           "github_slug": "hmpps-interventions-dev",
           "level": "sandbox"
+        },
+        {
+          "github_slug": "hmpps-interventions-dashboard-access",
+          "level": "sandbox"
         }
       ]
     }


### PR DESCRIPTION
[IPB-44](https://dsdmoj.atlassian.net/browse/IPB-44): Add the @ministryofjustice/hmpps-interventions-dashboard-access team to the `refer-monitor` environment to allow access to QuickSight and Athena for non-developer people with GitHub accounts.

If there's a better way to achieve the above, I am happy to change this.

`hmpps-interventions-dev` is tied to other operational resources, making extending unsafe.



[IPB-44]: https://dsdmoj.atlassian.net/browse/IPB-44?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ