### PR TITLE
updated getting-aws-credentials to reflect relevance

### DIFF
--- a/source/user-guide/getting-aws-credentials.html.md.erb
+++ b/source/user-guide/getting-aws-credentials.html.md.erb
@@ -1,11 +1,13 @@
 ---
 owner_slack: "#modernisation-platform"
 title: Getting AWS Credentials
-last_reviewed_on: 2022-08-30
+last_reviewed_on: 2023-01-13
 review_in: 6 months
 ---
 
 # <%= current_page.data.title %>
+
+_NB. This page is relevant to Ministry of Justice employees. External collaborators should review [Working as a Collaborator](./working-as-a-collaborator.html)_
 
 You can obtain temporary AWS credentials to use the AWS CLI or other command line tools.
 


### PR DESCRIPTION
Our user guide doesn't make clear that the AWS SSO landing page is for Ministry of Justice employees, and that external collaborators should review different guidance. Given that we've had a few customers query us about this, it's worth clarifying for them.