### PR TITLE
change for flow group creation

### DIFF
--- a/terraform/environments/core-network-services/monitoring.tf
+++ b/terraform/environments/core-network-services/monitoring.tf
@@ -132,7 +132,7 @@ resource "aws_sns_topic" "tgw_monitoring_production" {
 resource "aws_cloudwatch_log_group" "transit_gateway_flowlog_group" {
   name              = "tgw_flowlogs"
   retention_in_days = "400"
-  kms_key_id        = aws_kms_key.environment_logging.key_id
+  kms_key_id        = aws_kms_key.environment_logging.arn
 }
 
 resource "aws_flow_log" "transit_gateway_flowlog" {


### PR DESCRIPTION
Change made to the kms_key_id  as the documentation for the resource is actually looking for the arn of the kms key not the key id

[kms_key_id](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group#kms_key_id) - (Optional) The ARN of the KMS Key to use when encrypting log data. Please note, after the AWS KMS CMK is disassociated from the log group, AWS CloudWatch Logs stops encrypting newly ingested data for the log group. All previously ingested data remains encrypted, and AWS CloudWatch Logs requires permissions for the CMK whenever the encrypted data is requested.