### PR TITLE
Prevent VPN resource thrashing

### DIFF
--- a/terraform/environments/core-network-services/vpn.tf
+++ b/terraform/environments/core-network-services/vpn.tf
@@ -46,6 +46,15 @@ resource "aws_vpn_connection" "this" {
     { "Name" = replace(each.key, "_", "-") },
   )
 
+  lifecycle {
+    ignore_changes = [
+      tunnel1_ike_versions, tunnel1_phase1_dh_group_numbers, tunnel1_phase1_encryption_algorithms, tunnel1_phase1_integrity_algorithms,
+      tunnel1_phase2_dh_group_numbers, tunnel1_phase2_encryption_algorithms, tunnel1_phase2_integrity_algorithms,
+      tunnel2_ike_versions, tunnel2_phase1_dh_group_numbers, tunnel2_phase1_encryption_algorithms, tunnel2_phase1_integrity_algorithms,
+      tunnel2_phase2_dh_group_numbers, tunnel2_phase2_encryption_algorithms, tunnel2_phase2_integrity_algorithms,
+    ]
+  }
+
 }
 
 resource "aws_ec2_transit_gateway_route_table_association" "vpn_attachments" {


### PR DESCRIPTION
Our VPN code relies on terraform default values for attribute such as `tunnel1_ike_versions`. This means that AWS then fills in the blanks by writing in the default values. However, on re-running terraform the `aws_vpn_connection` resource sees those defaults but does not expect them and attempts to remove them, leading to the AWS API to recreate them.

In order to prevent this thrashing, I've added a lifecycle `ignore_changes` statement to cover the relevant attributes.