### PR TITLE
Remove exit 0 from RAM account script

### DIFF
--- a/scripts/get-applications-and-run-ram.sh
+++ b/scripts/get-applications-and-run-ram.sh
@@ -1,7 +1,5 @@
 #/bin/bash
 
-set -Ee
-
 environment=$1
 
 # Check for changes in environments-networks
@@ -23,10 +21,8 @@ if [ ! -z "${accounts}" ]; then
       echo "[+] ${networking_file} does not exist, skipping RAM share."
     fi
   done
-  exit 0
 else
   echo "[+] There were no member accounts to process"
-  exit 0
 fi
 
 # check for changes to networking.auto.tfvars.json files
@@ -44,8 +40,8 @@ if [ ! -z "${changed_networking_files}" ]; then
     echo "[+] Starting up RAM association for application ${application}"
     bash scripts/member-account-ram-association.sh ${application} ${environment}
   done
-  exit 0
 else
   echo "[+] There were no networking.auto.tfvars.json changed files"
-  exit 0
 fi
+
+exit 0


### PR DESCRIPTION
After the first if statement was successful, the script was exiting with 0 status without running the 2nd if statement which is required if there
  are changes with the networking vars.

The exit 0 statements were put in there to try to fix an error where the script was running successfully but returning a non zero code and the workflow was failing.

Removing the set e to try to resolve this.  We will have to see how the next new account run looks to see if this has resolved it.