### PR TITLE
Added VPN configuration for NOMS Live VPNs

### DIFF
--- a/terraform/environments/core-network-services/vpn_attachments.json
+++ b/terraform/environments/core-network-services/vpn_attachments.json
@@ -56,7 +56,7 @@
     "tunnel_startup_action": "start"
   },
   "NOMS-Transit-Live-VPN-VNG_1": {
-    "bgp_asn": "64532",
+    "bgp_asn": "64522",
     "customer_gateway_ip": "20.254.177.179",
     "dx_gateway_id": "",
     "dx_gateway_owner_account_id": "",
@@ -68,7 +68,7 @@
     "tunnel_startup_action": "start"
   },
   "NOMS-Transit-Live-VPN-VNG_2": {
-    "bgp_asn": "64532",
+    "bgp_asn": "64522",
     "customer_gateway_ip": "20.254.177.202",
     "dx_gateway_id": "",
     "dx_gateway_owner_account_id": "",

--- a/terraform/environments/core-network-services/vpn_attachments.json
+++ b/terraform/environments/core-network-services/vpn_attachments.json
@@ -54,5 +54,29 @@
     "tunnel_dpd_timeout_action": "restart",
     "tunnel_dpd_timeout_seconds": "45",
     "tunnel_startup_action": "start"
+  },
+  "NOMS-Transit-Live-VPN-VNG_1": {
+    "bgp_asn": "64532",
+    "customer_gateway_ip": "20.254.177.179",
+    "dx_gateway_id": "",
+    "dx_gateway_owner_account_id": "",
+    "remote_ipv4_network_cidr": "0.0.0.0/0",
+    "tunnel1_inside_cidr": "169.254.41.0/30",
+    "tunnel2_inside_cidr": "169.254.42.0/30",
+    "tunnel_dpd_timeout_action": "restart",
+    "tunnel_dpd_timeout_seconds": "45",
+    "tunnel_startup_action": "start"
+  },
+  "NOMS-Transit-Live-VPN-VNG_2": {
+    "bgp_asn": "64532",
+    "customer_gateway_ip": "20.254.177.202",
+    "dx_gateway_id": "",
+    "dx_gateway_owner_account_id": "",
+    "remote_ipv4_network_cidr": "0.0.0.0/0",
+    "tunnel1_inside_cidr": "169.254.41.4/30",
+    "tunnel2_inside_cidr": "169.254.42.4/30",
+    "tunnel_dpd_timeout_action": "restart",
+    "tunnel_dpd_timeout_seconds": "45",
+    "tunnel_startup_action": "start"
   }
 }


### PR DESCRIPTION
This adds the configuration necessary to create a VPN to Azure UK West.
It will need a corresponding change from DSO, as well as some consideration on how to handle routing.
However, without the creation on our side we won't generate PSKs to be passed to DSO.