### PR TITLE
Static routes for 6DG

### DIFF
--- a/terraform/environments/core-network-services/locals.tf
+++ b/terraform/environments/core-network-services/locals.tf
@@ -37,6 +37,7 @@ locals {
   firewall_rules      = merge(local.development_rules, local.test_rules, local.preproduction_rules, local.production_rules)
 
   vpn_attachments = fileexists("./vpn_attachments.json") ? jsondecode(file("./vpn_attachments.json")) : {}
+
   noms_vpn_static_routes = [
     "10.40.64.0/18",
     "10.40.144.0/20",
@@ -44,6 +45,12 @@ locals {
     "10.111.0.0/16",
     "10.112.0.0/16"
   ]
+
+  sixdg_dev_vpn_static_routes   = ["10.221.0.0/16"]
+  sixdg_test_vpn_static_routes  = ["10.224.0.0/16"]
+  sixdg_stage_vpn_static_routes = ["10.223.0.0/16"]
+  sixdg_uat_vpn_static_routes   = ["10.222.0.0/16"]
+  sixdg_prod_vpn_static_routes  = ["10.225.0.0/16"]
 
   core-vpcs = {
     for file in fileset("../../../environments-networks", "*.json") :

--- a/terraform/environments/core-network-services/vpn.tf
+++ b/terraform/environments/core-network-services/vpn.tf
@@ -70,6 +70,34 @@ resource "aws_ec2_transit_gateway_route" "noms_routes" {
   transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.external_inspection_out.id
 }
 
+resource "aws_ec2_transit_gateway_route" "sixdg_dev_routes" {
+  for_each                       = toset(local.sixdg_dev_vpn_static_routes)
+  destination_cidr_block         = each.key
+  transit_gateway_attachment_id  = aws_vpn_connection.this["sixdegrees_development"].transit_gateway_attachment_id
+  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.external_inspection_out.id
+}
+
+resource "aws_ec2_transit_gateway_route" "sixdg_uat_routes" {
+  for_each                       = toset(local.sixdg_uat_vpn_static_routes)
+  destination_cidr_block         = each.key
+  transit_gateway_attachment_id  = aws_vpn_connection.this["sixdegrees_uat"].transit_gateway_attachment_id
+  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.external_inspection_out.id
+}
+
+resource "aws_ec2_transit_gateway_route" "sixdg_stage_routes" {
+  for_each                       = toset(local.sixdg_stage_vpn_static_routes)
+  destination_cidr_block         = each.key
+  transit_gateway_attachment_id  = aws_vpn_connection.this["sixdegrees_stage"].transit_gateway_attachment_id
+  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.external_inspection_out.id
+}
+
+resource "aws_ec2_transit_gateway_route" "sixdg_prod_routes" {
+  for_each                       = toset(local.sixdg_prod_vpn_static_routes)
+  destination_cidr_block         = each.key
+  transit_gateway_attachment_id  = aws_vpn_connection.this["sixdegrees_prod"].transit_gateway_attachment_id
+  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.external_inspection_out.id
+}
+
 resource "aws_cloudwatch_log_group" "vpn_attachments" {
   # checkov:skip=CKV_AWS_158: "logs will not be shared so standard encryption fine"
   for_each          = local.vpn_attachments


### PR DESCRIPTION
This PR repeats a pattern used for the NOMS non-live static routes, creating statically-typed locals that are fed into single-purpose resource declarations to create routes on the Modernisation Platform Transit Gateway in the `inspection` route table.

This will allow traffic to leave the Modernisation Platform and be routed through the correct VPN to 6Degrees.