### PR TITLE
NOMS Live routes

### DIFF
--- a/terraform/environments/core-network-services/locals.tf
+++ b/terraform/environments/core-network-services/locals.tf
@@ -38,12 +38,19 @@ locals {
 
   vpn_attachments = fileexists("./vpn_attachments.json") ? jsondecode(file("./vpn_attachments.json")) : {}
 
-  noms_vpn_static_routes = [
+  noms_dr_vpn_static_routes = [
     "10.40.64.0/18",
     "10.40.144.0/20",
     "10.40.176.0/20",
     "10.111.0.0/16",
     "10.112.0.0/16"
+  ]
+  noms_live_vpn_static_routes = [
+    "10.40.0.0/18",
+    "10.40.128.0/20",
+    "10.40.160.0/20",
+    "10.101.0.0/16",
+    "10.102.0.0/16"
   ]
 
   sixdg_dev_vpn_static_routes   = ["10.221.0.0/16"]

--- a/terraform/environments/core-network-services/vpn.tf
+++ b/terraform/environments/core-network-services/vpn.tf
@@ -63,10 +63,17 @@ resource "aws_ec2_transit_gateway_route_table_association" "vpn_attachments" {
   transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.external_inspection_in.id
 }
 
-resource "aws_ec2_transit_gateway_route" "noms_routes" {
-  for_each                       = toset(local.noms_vpn_static_routes)
+resource "aws_ec2_transit_gateway_route" "noms_dr_routes" {
+  for_each                       = toset(local.noms_dr_vpn_static_routes)
   destination_cidr_block         = each.key
   transit_gateway_attachment_id  = aws_vpn_connection.this["NOMS-Transit-Live-DR-VPN-VNG_1"].transit_gateway_attachment_id
+  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.external_inspection_out.id
+}
+
+resource "aws_ec2_transit_gateway_route" "noms_live_routes" {
+  for_each                       = toset(local.noms_live_vpn_static_routes)
+  destination_cidr_block         = each.key
+  transit_gateway_attachment_id  = aws_vpn_connection.this["NOMS-Transit-Live-VPN-VNG_1"].transit_gateway_attachment_id
   transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.external_inspection_out.id
 }
 

--- a/terraform/environments/core-network-services/vpn_attachments.json
+++ b/terraform/environments/core-network-services/vpn_attachments.json
@@ -61,8 +61,8 @@
     "dx_gateway_id": "",
     "dx_gateway_owner_account_id": "",
     "remote_ipv4_network_cidr": "0.0.0.0/0",
-    "tunnel1_inside_cidr": "169.254.41.0/30",
-    "tunnel2_inside_cidr": "169.254.42.0/30",
+    "tunnel1_inside_cidr": "169.254.21.128/30",
+    "tunnel2_inside_cidr": "169.254.22.128/30",
     "tunnel_dpd_timeout_action": "restart",
     "tunnel_dpd_timeout_seconds": "45",
     "tunnel_startup_action": "start"
@@ -73,8 +73,8 @@
     "dx_gateway_id": "",
     "dx_gateway_owner_account_id": "",
     "remote_ipv4_network_cidr": "0.0.0.0/0",
-    "tunnel1_inside_cidr": "169.254.41.4/30",
-    "tunnel2_inside_cidr": "169.254.42.4/30",
+    "tunnel1_inside_cidr": "169.254.21.132/30",
+    "tunnel2_inside_cidr": "169.254.22.132/30",
     "tunnel_dpd_timeout_action": "restart",
     "tunnel_dpd_timeout_seconds": "45",
     "tunnel_startup_action": "start"


### PR DESCRIPTION
Once the VPNs between the MP TGW and Azure FNG have been establish, static routes will be required to correctly make use of these VPNs.

This PR should **not** be completed until the live Azure VPNs are active.

This PR also renames the existing resource for NOMS routes to clarify the distinction between DR and Live.