### PR TITLE
Set VPN connections to 6DG to use static addresses only

### DIFF
--- a/terraform/environments/core-network-services/vpn.tf
+++ b/terraform/environments/core-network-services/vpn.tf
@@ -14,6 +14,7 @@ resource "aws_vpn_connection" "this" {
   for_each                    = local.vpn_attachments
   transit_gateway_id          = aws_ec2_transit_gateway.transit-gateway.id
   customer_gateway_id         = aws_customer_gateway.this[each.key].id
+  static_routes_only          = try(each.value.static_routes_only, false)
   type                        = "ipsec.1"
   tunnel1_dpd_timeout_action  = try(each.value.tunnel_dpd_timeout_action, null)
   tunnel1_dpd_timeout_seconds = try(each.value.tunnel_dpd_timeout_seconds, "30")

--- a/terraform/environments/core-network-services/vpn_attachments.json
+++ b/terraform/environments/core-network-services/vpn_attachments.json
@@ -1,6 +1,7 @@
 {
   "sixdegrees_development": {
     "customer_gateway_ip": "31.210.246.15",
+    "bgp_asn": "31220",
     "modernisation_platform_vpc": "laa-development",
     "dx_gateway_id": "",
     "dx_gateway_owner_account_id": "",
@@ -9,6 +10,7 @@
   },
   "sixdegrees_uat": {
     "customer_gateway_ip": "80.79.133.20",
+    "bgp_asn": "6908",
     "modernisation_platform_vpc": "laa-test",
     "dx_gateway_id": "",
     "dx_gateway_owner_account_id": "",
@@ -17,6 +19,7 @@
   },
   "sixdegrees_stage": {
     "customer_gateway_ip": "82.147.30.124",
+    "bgp_asn": "6908",
     "modernisation_platform_vpc": "laa-preproduction",
     "dx_gateway_id": "",
     "dx_gateway_owner_account_id": "",
@@ -25,6 +28,7 @@
   },
   "sixdegrees_prod": {
     "customer_gateway_ip": "82.147.39.116",
+    "bgp_asn": "6908",
     "modernisation_platform_vpc": "laa-production",
     "dx_gateway_id": "",
     "dx_gateway_owner_account_id": "",

--- a/terraform/environments/core-network-services/vpn_attachments.json
+++ b/terraform/environments/core-network-services/vpn_attachments.json
@@ -1,34 +1,34 @@
 {
   "sixdegrees_development": {
     "customer_gateway_ip": "31.210.246.15",
-    "bgp_asn": "31220",
     "modernisation_platform_vpc": "laa-development",
     "dx_gateway_id": "",
     "dx_gateway_owner_account_id": "",
+    "static_routes_only": true,
     "tunnel_startup_action": "start"
   },
   "sixdegrees_uat": {
     "customer_gateway_ip": "80.79.133.20",
-    "bgp_asn": "6908",
     "modernisation_platform_vpc": "laa-test",
     "dx_gateway_id": "",
     "dx_gateway_owner_account_id": "",
+    "static_routes_only": true,
     "tunnel_startup_action": "start"
   },
   "sixdegrees_stage": {
     "customer_gateway_ip": "82.147.30.124",
-    "bgp_asn": "6908",
     "modernisation_platform_vpc": "laa-preproduction",
     "dx_gateway_id": "",
     "dx_gateway_owner_account_id": "",
+    "static_routes_only": true,
     "tunnel_startup_action": "start"
   },
   "sixdegrees_prod": {
     "customer_gateway_ip": "82.147.39.116",
-    "bgp_asn": "6908",
     "modernisation_platform_vpc": "laa-production",
     "dx_gateway_id": "",
     "dx_gateway_owner_account_id": "",
+    "static_routes_only": true,
     "tunnel_startup_action": "start"
   },
   "NOMS-Transit-Live-DR-VPN-VNG_1": {


### PR DESCRIPTION
* Amends `vpn_connection` resource to support `static_routes_only` argument
* Set 6DG VPNs to use `static_routes_only` in the configuration for their `vpn_connections`. The CGWs will still contain BGP configuration as this is a required field