### PR TITLE
Add secret rotation docs and move secrets to SM

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -109,6 +109,7 @@ This documentation is for anyone interested in the Modernisation Platform and it
 - [How to create an AWS account for end users](runbooks/creating-accounts-for-end-users.html)
 - [Creating VPCs](runbooks/creating-vpcs.html)
 - [Reviewing Dependabot PRs](runbooks/reviewing-dependabot-prs.html)
+- [How to rotate secrets](runbooks/rotating-secrets.html)
 
 ## Getting help
 - [Ask for help](getting-help)

--- a/source/runbooks/rotating-secrets.html.md.erb
+++ b/source/runbooks/rotating-secrets.html.md.erb
@@ -1,0 +1,23 @@
+---
+owner_slack: "#modernisation-platform"
+title: How to Rotate Secrets 
+last_reviewed_on: 2023-01-25
+review_in: 6 months
+---
+
+# <%= current_page.data.title %>
+
+## Introduction
+
+We don't have many secrets on stored on the Modernisation Platform, but they are rotated regularly.
+
+This guide advises where secrets are stored and how to rotate them.
+
+|Secret|Useage|Location|How to rotate|
+|---|---|---|---|
+|PagerDuty Token|Used by PagerDuty Terraform to manage PagerDuty resources|AWS Secrets Manager|Contact Operations Engineering to issue a new token and update the secret.|
+|Slack Webhook URL | Used to post alarms to Slack | AWS Secrets Manager | Contact Operations Engineeering to issue a new incoming webhook for the `Modernisation Platform Alerts` custom Slack application.  Revoke the old incoming webhook and update the secret.|
+|GitHub MP CI User PAT | Used to create PRs etc in GitHub actions and deploy GitHub resources via Terraform | AWS Secrets Manager | Log in as the Modernisation Platform CI User and generate a new PAT, revoke the old one and update the secret.|
+|GitHub MP CI User Password | Used to log in and set the PAT | AWS Secrets Manager | Log in to GitHub as the user and reset the password, update the secret |
+|ModernisationPlatformOrganisationManagement IAM user in MoJ root account | Used to perform limited activities in the root account. No longer used as replaced by OIDC but user kept for breakglass purposes. | Not stored | No active access keys, if keys or password needed contact Operations Engineering |
+|Modernisation Platform Account Root User Password | Only used during initial platform set up, log in prevented via SCP and no password or keys set | Not stored | Disable or move account to a non SCP protected OU and follow the password reset steps |

--- a/source/runbooks/rotating-secrets.html.md.erb
+++ b/source/runbooks/rotating-secrets.html.md.erb
@@ -1,6 +1,6 @@
 ---
 owner_slack: "#modernisation-platform"
-title: How to Rotate Secrets 
+title: How to Rotate Secrets
 last_reviewed_on: 2023-01-25
 review_in: 6 months
 ---

--- a/terraform/modernisation-platform-account/secrets.tf
+++ b/terraform/modernisation-platform-account/secrets.tf
@@ -21,6 +21,32 @@ resource "aws_secretsmanager_secret" "slack_webhook_url" {
   tags        = local.tags
 }
 
+# Github CI user PAT
+# Not adding a secret version as this url is generated in Github cannot be added programatically
+# Secret should be manually set in the console.
+# Tfsec ignore
+# - AWS095: No requirement currently to encrypt this secret with customer-managed KMS key
+#tfsec:ignore:AWS095
+resource "aws_secretsmanager_secret" "github_ci_user_pat" {
+  # checkov:skip=CKV_AWS_149:No requirement currently to encrypt this secret with customer-managed KMS key
+  name        = "github_ci_user_pat"
+  description = "GitHub CI user PAT used for generated resources in GitHub via Terraform"
+  tags        = local.tags
+}
+
+# Github CI user password
+# Not adding a secret version as this url is generated in Github cannot be added programatically
+# Secret should be manually set in the console.
+# Tfsec ignore
+# - AWS095: No requirement currently to encrypt this secret with customer-managed KMS key
+#tfsec:ignore:AWS095
+resource "aws_secretsmanager_secret" "github_ci_user_password" {
+  # checkov:skip=CKV_AWS_149:No requirement currently to encrypt this secret with customer-managed KMS key
+  name        = "github_ci_user_password"
+  description = "GitHub CI user password"
+  tags        = local.tags
+}
+
 # Account IDs to be excluded from auto-nuke
 # Tfsec ignore
 # - AWS095: No requirement currently to encrypt this secret with customer-managed KMS key


### PR DESCRIPTION
Adding documentation on how to rotate our secrets.

Also creating secrets manager secrets for the MP GitHub CI user secrets which we'll be moving out of password management into GitHub secrets.