### PR TITLE
Update github to pull secrets from secrets manager

### DIFF
--- a/terraform/github/aws.tf
+++ b/terraform/github/aws.tf
@@ -32,3 +32,12 @@ data "aws_secretsmanager_secret" "pagerduty_token" {
 data "aws_secretsmanager_secret_version" "pagerduty_token" {
   secret_id = data.aws_secretsmanager_secret.pagerduty_token.id
 }
+
+# Get the GitHub CI user PAT
+data "aws_secretsmanager_secret" "github_ci_user_token" {
+  name = "github_ci_user_pat"
+}
+
+data "aws_secretsmanager_secret_version" "github_ci_user_token" {
+  secret_id = data.aws_secretsmanager_secret.github_ci_user_token.id
+}

--- a/terraform/github/main.tf
+++ b/terraform/github/main.tf
@@ -12,7 +12,7 @@ module "core" {
   ]
   secrets = {
     # Terraform GitHub token for the CI/CD user
-    TERRAFORM_GITHUB_TOKEN = "This needs to be manually set in GitHub."
+    TERRAFORM_GITHUB_TOKEN = data.aws_secretsmanager_secret_version.github_ci_user_token.secret_string
     # Slack app webhook url
     SLACK_WEBHOOK_URL = data.aws_secretsmanager_secret_version.slack_webhook_url.secret_string
     # Pagerduty api token
@@ -239,12 +239,12 @@ module "modernisation-platform-environments" {
     "environments"
   ]
   required_checks = ["run-opa-policy-tests"]
-  secrets = merge({
+  secrets = {
     # Terraform GitHub token for the CI/CD user
-    TERRAFORM_GITHUB_TOKEN        = "This needs to be manually set in GitHub.",
+    TERRAFORM_GITHUB_TOKEN        = data.aws_secretsmanager_secret_version.github_ci_user_token.secret_string
     TESTING_AWS_ACCESS_KEY_ID     = local.testing_ci_iam_user_keys.AWS_ACCESS_KEY_ID
     TESTING_AWS_SECRET_ACCESS_KEY = local.testing_ci_iam_user_keys.AWS_SECRET_ACCESS_KEY
-  })
+  }
 }
 
 module "modernisation-platform-infrastructure-test" {


### PR DESCRIPTION
Now that the PAT is stored in secrets manager it can be updated in code rather than manually in the GitHub gui.