### PR TITLE
Change code-formatter task to use PAT

### DIFF
--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         with:
             persist-credentials: false
+            token: ${{ secrets.TERRAFORM_GITHUB_TOKEN }}
       - uses: ministryofjustice/github-actions/code-formatter@15729e214b8e626847cf4b4596c7635ddb6b1b0a # v10
         with:
             ignore-files: "README.md"

--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -15,4 +15,5 @@ jobs:
       - uses: ministryofjustice/github-actions/code-formatter@15729e214b8e626847cf4b4596c7635ddb6b1b0a # v10
         with:
             ignore-files: "README.md"
-            github_token: ${{ secrets.TERRAFORM_GITHUB_TOKEN }}
+        env:
+            GITHUB_TOKEN: ${{ secrets.TERRAFORM_GITHUB_TOKEN }}

--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -16,4 +16,4 @@ jobs:
         with:
             ignore-files: "README.md"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TERRAFORM_GITHUB_TOKEN }}

--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -15,5 +15,4 @@ jobs:
       - uses: ministryofjustice/github-actions/code-formatter@15729e214b8e626847cf4b4596c7635ddb6b1b0a # v10
         with:
             ignore-files: "README.md"
-        env:
-          GITHUB_TOKEN: ${{ secrets.TERRAFORM_GITHUB_TOKEN }}
+            github_token: ${{ secrets.TERRAFORM_GITHUB_TOKEN }}

--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        with:
+            persist-credentials: false
       - uses: ministryofjustice/github-actions/code-formatter@15729e214b8e626847cf4b4596c7635ddb6b1b0a # v10
         with:
             ignore-files: "README.md"

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -105,8 +105,8 @@ module "vpc" {
 module "vpc_nacls" {
   source           = "../../modules/vpc-nacls"
   for_each         = local.vpcs[terraform.workspace]
-  additional_cidrs     = each.value.options.additional_cidrs
-  additional_vpcs       = each.value.options.additional_vpcs
+  additional_cidrs = each.value.options.additional_cidrs
+  additional_vpcs  = each.value.options.additional_vpcs
   tags             = local.tags
   tags_prefix      = each.key
   vpc_name         = each.key

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -105,8 +105,8 @@ module "vpc" {
 module "vpc_nacls" {
   source           = "../../modules/vpc-nacls"
   for_each         = local.vpcs[terraform.workspace]
-  additional_cidrs      = each.value.options.additional_cidrs
-  additional_vpcs       = each.value.options.additional_vpcs
+  additional_cidrs = each.value.options.additional_cidrs
+  additional_vpcs  = each.value.options.additional_vpcs
   tags             = local.tags
   tags_prefix      = each.key
   vpc_name         = each.key

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -105,7 +105,7 @@ module "vpc" {
 module "vpc_nacls" {
   source           = "../../modules/vpc-nacls"
   for_each         = local.vpcs[terraform.workspace]
-  additional_cidrs      = each.value.options.additional_cidrs
+  additional_cidrs     = each.value.options.additional_cidrs
   additional_vpcs       = each.value.options.additional_vpcs
   tags             = local.tags
   tags_prefix      = each.key

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -105,8 +105,8 @@ module "vpc" {
 module "vpc_nacls" {
   source           = "../../modules/vpc-nacls"
   for_each         = local.vpcs[terraform.workspace]
-  additional_cidrs = each.value.options.additional_cidrs
-  additional_vpcs  = each.value.options.additional_vpcs
+  additional_cidrs      = each.value.options.additional_cidrs
+  additional_vpcs       = each.value.options.additional_vpcs
   tags             = local.tags
   tags_prefix      = each.key
   vpc_name         = each.key


### PR DESCRIPTION
* Change to use CI User PAT instead of github token
* This is because the GitHub token can't be used to kick off a workflow following a push
* [Triggering a workflow](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#:~:text=For%20example%2C%20if%20a%20workflow%20run%20pushes%20code%20using%20the%20repository%27s%20GITHUB_TOKEN%2C%20a%20new%20workflow%20will%20not%20run%20even%20when%20the%20repository%20contains%20a%20workflow%20configured%20to%20run%20when%20push%20events%20occur.)