### PR TITLE
Change to the checkov ignore

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -21,7 +21,7 @@ data "aws_iam_policy_document" "member-access" {
     #checkov:skip=CKV_AWS_107
     #checkov:skip=CKV_AWS_109
     #checkov:skip=CKV_AWS_110
-    #checkov:skip=CKV_AWS_40
+    #checkov:skip=CKV2_AWS_40
     effect = "Allow"
     actions = [
       "acm-pca:*",


### PR DESCRIPTION
Checkov ignore was incorrect in the check it was set to CKV_AWS_40 but the actual check is as bellow with a CKV2

Check: CKV2_AWS_40: "Ensure AWS IAM policy does not allow full IAM privileges
	FAILED for resource: aws_iam_policy_document.member-access
	File: /iam.tf:17-190

this should fix this checkov error now