### PR TITLE
Disable auto-nuke on delius-jitbit dev environment

### DIFF
--- a/environments/delius-jitbit.json
+++ b/environments/delius-jitbit.json
@@ -6,7 +6,8 @@
       "access": [
         {
           "github_slug": "hmpps-migration",
-          "level": "sandbox"
+          "level": "sandbox",
+          "nuke": "exclude"
         }
       ]
     },


### PR DESCRIPTION
Disable the auto-nuke feature in the jitbit dev environment.
This is likely to be temporary until we have the app pipeline built which we're currently working on. At which point, we should remove this from being a sandbox account.