### PR TITLE
Moving resources around within template files

### DIFF
--- a/terraform/templates/data.tf
+++ b/terraform/templates/data.tf
@@ -150,12 +150,24 @@ data "terraform_remote_state" "core_network_services" {
   }
 }
 
+data "aws_organizations_organization" "root_account" {}
+
+# Retrieve information about the modernisation platform account
+data "aws_caller_identity" "modernisation_platform" {
+  provider = aws.modernisation-platform
+}
+
 # caller account information to instantiate aws.oidc provider
 data "aws_caller_identity" "oidc_session" {
   provider = aws.oidc-session
 }
 
-# Get modernisation account id from ssm parameter
-data "aws_ssm_parameter" "modernisation_platform_account_id" {
-  name = "modernisation_platform_account_id"
+data "aws_iam_session_context" "whoami" {
+  provider = aws.oidc-session
+  arn      = data.aws_caller_identity.oidc_session.arn
+}
+
+# Get the environments file from the main repository
+data "http" "environments_file" {
+  url = "https://raw.githubusercontent.com/ministryofjustice/modernisation-platform/main/environments/${local.application_name}.json"
 }

--- a/terraform/templates/locals.tf
+++ b/terraform/templates/locals.tf
@@ -1,18 +1,3 @@
-# This data sources allows us to get the Modernisation Platform account information for use elsewhere
-# (when we want to assume a role in the MP, for instance)
-data "aws_organizations_organization" "root_account" {}
-
-# Get the environments file from the main repository
-data "http" "environments_file" {
-  url = "https://raw.githubusercontent.com/ministryofjustice/modernisation-platform/main/environments/${local.application_name}.json"
-}
-
-# Retrieve information about the modernisation platform account
-data "aws_caller_identity" "modernisation_platform" {
-  provider = aws.modernisation-platform
-}
-
-
 locals {
 
   application_name = "$application_name"

--- a/terraform/templates/member-locals.tf
+++ b/terraform/templates/member-locals.tf
@@ -1,18 +1,3 @@
-# This data sources allows us to get the Modernisation Platform account information for use elsewhere
-# (when we want to assume a role in the MP, for instance)
-data "aws_organizations_organization" "root_account" {}
-
-# Get the environments file from the main repository
-data "http" "environments_file" {
-  url = "https://raw.githubusercontent.com/ministryofjustice/modernisation-platform/main/environments/${local.application_name}.json"
-}
-
-# Retrieve information about the modernisation platform account
-data "aws_caller_identity" "modernisation_platform" {
-  provider = aws.modernisation-platform
-}
-
-
 locals {
 
   application_name = "$application_name"

--- a/terraform/templates/platform_secrets.tf
+++ b/terraform/templates/platform_secrets.tf
@@ -1,3 +1,8 @@
+# Get modernisation account id from ssm parameter
+data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  name = "modernisation_platform_account_id"
+}
+
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
   provider = aws.modernisation-platform


### PR DESCRIPTION
Some resources in the template files do not belong to the files that they are in, hence shifting them around. This is needed as part of the https://github.com/ministryofjustice/modernisation-platform/issues/2521 ticket.

Renaming files and generating files in the environments changes will be raised in a separate PR.