### PR TITLE
Changes to allow one providers file

### DIFF
--- a/terraform/modernisation-platform-account/iam.tf
+++ b/terraform/modernisation-platform-account/iam.tf
@@ -83,7 +83,7 @@ data "aws_iam_policy_document" "collaborator_local_plan" {
       "ssm:GetParameter"
     ]
     resources = [
-     "arn:aws:ssm:eu-west-2:${data.aws_caller_identity.current.id}:parameter/modernisation_platform_account_id"
+      "arn:aws:ssm:eu-west-2:${data.aws_caller_identity.current.id}:parameter/modernisation_platform_account_id"
     ]
     condition {
       test     = "BoolIfExists"

--- a/terraform/modernisation-platform-account/iam.tf
+++ b/terraform/modernisation-platform-account/iam.tf
@@ -47,6 +47,7 @@ data "aws_iam_policy_document" "collaborator_local_plan" {
       "arn:aws:iam::${local.environment_management.account_ids["core-vpc-preproduction"]}:role/member-delegation-read-only",
       "arn:aws:iam::${local.environment_management.account_ids["core-vpc-production"]}:role/member-delegation-read-only",
       "arn:aws:iam::${local.environment_management.account_ids["core-vpc-sandbox"]}:role/member-delegation-read-only",
+      "arn:aws:iam::${data.aws_caller_identity.current.id}:role/modernisation-account-limited-read-member-access"
     ]
     condition {
       test     = "BoolIfExists"
@@ -67,6 +68,22 @@ data "aws_iam_policy_document" "collaborator_local_plan" {
       "arn:aws:s3:::modernisation-platform-terraform-state/environments/members/*",
       "arn:aws:s3:::modernisation-platform-terraform-state/environments/accounts/core-network-services/*",
       "arn:aws:s3:::modernisation-platform-terraform-state"
+    ]
+    condition {
+      test     = "BoolIfExists"
+      variable = "aws:MultiFactorAuthPresent"
+      values   = ["true"]
+    }
+  }
+
+  statement {
+    sid    = "ssmAccess"
+    effect = "Allow"
+    actions = [
+      "ssm:GetParameter"
+    ]
+    resources = [
+     "arn:aws:ssm:eu-west-2:${data.aws_caller_identity.current.id}:parameter/modernisation_platform_account_id"
     ]
     condition {
       test     = "BoolIfExists"

--- a/terraform/modernisation-platform-account/locals.tf
+++ b/terraform/modernisation-platform-account/locals.tf
@@ -4,6 +4,16 @@ data "aws_iam_roles" "sso-admin-access" {
   name_regex  = "AWSReservedSSO_AdministratorAccess_.*"
   path_prefix = "/aws-reserved/sso.amazonaws.com/"
 }
+
+# Reflection of what is in member accounts, needed here as well so that the same code works for collaborators
+resource "aws_ssm_parameter" "modernisation_platform_account_id" {
+  name  = "modernisation_platform_account_id"
+  type  = "SecureString"
+  value = data.aws_caller_identity.current.id
+
+  tags = local.tags
+}
+
 locals {
   root_account                 = data.aws_organizations_organization.root_account
   environment_management       = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)


### PR DESCRIPTION
Adding the ssm parameter allows the data source to function regardless of the user source, SSO or IAM calling it.

Allowing collaborators to assume the read only role in the modernisation platform, again this gives consistency to the providers file.