### PR TITLE
Adjusting AP access

### DIFF
--- a/environments/analytical-platform-data-engineering.json
+++ b/environments/analytical-platform-data-engineering.json
@@ -13,7 +13,7 @@
           "level": "view-only"
         },
         {
-          "github_slug": "data-engineering",
+          "github_slug": "data-engineering-aws",
           "level": "developer"
         }
       ]

--- a/environments/analytical-platform-data.json
+++ b/environments/analytical-platform-data.json
@@ -7,6 +7,10 @@
         {
           "github_slug": "analytical-platform",
           "level": "administrator"
+        },
+        {
+          "github_slug": "analytics-hq",
+          "level": "view-only"
         }
       ]
     }

--- a/environments/analytical-platform.json
+++ b/environments/analytical-platform.json
@@ -11,10 +11,6 @@
         {
           "github_slug": "analytics-hq",
           "level": "view-only"
-        },
-        {
-          "github_slug": "data-engineering",
-          "level": "developer"
         }
       ]
     }


### PR DESCRIPTION
Provided some erroneous access configuration. The PR fixes the errors in access in the AP json files.

* Amending slug name for ap-analytical-platform-data-engineering-production account.
* Giving analytics-hq view-only access in the analytical-platform-data-development account.
* Removing data-engineering access from analytical-platform-development account.
