### PR TITLE
Add CloudWatch log group and Route53 resolver logs module

### DIFF
--- a/terraform/environments/core-logging/route53_resolver_logs.tf
+++ b/terraform/environments/core-logging/route53_resolver_logs.tf
@@ -1,0 +1,25 @@
+resource "aws_cloudwatch_log_group" "modernisation-platform-r53-resolver-logs" {
+  name              = "modernisation-platform-r53-resolver-logs"
+  retention_in_days = 365
+}
+
+resource "aws_cloudwatch_log_resource_policy" "route53-query-logging-policy" {
+  policy_document = data.aws_iam_policy_document.route53-query-logging-policy.json
+  policy_name     = "route53-query-logging-policy"
+}
+
+data "aws_iam_policy_document" "route53-query-logging-policy" {
+  statement {
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
+
+    resources = ["arn:aws:logs:*:*:log-group:/aws/route53/*"]
+
+    principals {
+      identifiers = ["route53.amazonaws.com"]
+      type        = "Service"
+    }
+  }
+}

--- a/terraform/modules/r53-resolver-logs/main.tf
+++ b/terraform/modules/r53-resolver-logs/main.tf
@@ -1,11 +1,11 @@
 resource "aws_route53_resolver_query_log_config" "main" {
   name            = "dns_logs"
   destination_arn = var.logging_destination_arn
-  tags = var.tags_common
+  tags            = var.tags_common
 }
 
 resource "aws_route53_resolver_query_log_config_association" "main" {
   resolver_query_log_config_id = aws_route53_resolver_query_log_config.main.id
   resource_id                  = var.vpc_id
-  tags = var.tags_common
+  tags                         = var.tags_common
 }

--- a/terraform/modules/r53-resolver-logs/main.tf
+++ b/terraform/modules/r53-resolver-logs/main.tf
@@ -1,0 +1,11 @@
+resource "aws_route53_resolver_query_log_config" "main" {
+  name            = "dns_logs"
+  destination_arn = var.logging_destination_arn
+  tags = var.tags_common
+}
+
+resource "aws_route53_resolver_query_log_config_association" "main" {
+  resolver_query_log_config_id = aws_route53_resolver_query_log_config.main.id
+  resource_id                  = var.vpc_id
+  tags = var.tags_common
+}

--- a/terraform/modules/r53-resolver-logs/variables.tf
+++ b/terraform/modules/r53-resolver-logs/variables.tf
@@ -1,0 +1,14 @@
+variable "logging_destination_arn" {
+  type        = string
+  description = "ARN for destination of Route53 resolver logs. EG, a CloudWatch log group"
+}
+
+variable "vpc_id" {
+  type        = string
+  description = "VPC ID to turn on resolver logs"
+}
+
+variable "tags_common" {
+  description = "Map of tags"
+  type        = map(string)
+}

--- a/terraform/modules/r53-resolver-logs/versions.tf
+++ b/terraform/modules/r53-resolver-logs/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    aws = {
+      version = ">= 4.0.0, < 5.0.0"
+      source  = "hashicorp/aws"
+    }
+  }
+  required_version = ">= 1.0.1"
+}


### PR DESCRIPTION
* Add new cloudwatch group to take Route53 resolver logs
* Add module to turn on resolver logging

Essentially a rollup of @SteveLinden 's prior branches