### PR TITLE
Turn on resolver logs in each customer VPC

### DIFF
--- a/terraform/environments/core-vpc/providers.tf
+++ b/terraform/environments/core-vpc/providers.tf
@@ -21,6 +21,15 @@ provider "aws" {
   }
 }
 
+# AWS provider for core-logging, where consolidated CloudWatch logs live
+provider "aws" {
+  alias  = "core-logging"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-logging-production"]}:role/ModernisationPlatformAccess"
+  }
+}
+
 provider "aws" {
   alias  = "aws-us-east-1"
   region = "us-east-1"

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -14,6 +14,11 @@ data "aws_route53_zone" "private" {
   private_zone = true
 }
 
+data "aws_cloudwatch_log_group" "route_53_resolver_logs" {
+  provider = aws.core-logging
+  name     = "modernisation-platform-r53-resolver-logs"
+}
+
 
 locals {
 
@@ -110,6 +115,14 @@ module "vpc_nacls" {
   tags             = local.tags
   tags_prefix      = each.key
   vpc_name         = each.key
+}
+
+module "route_53_resolver_logs" {
+  source                  = "../../modules/r53-resolver-logs"
+  for_each                = toset([for key, value in module.vpc : value["vpc_id"]])
+  logging_destination_arn = data.aws_cloudwatch_log_group.route_53_resolver_logs.arn
+  tags_common             = local.tags
+  vpc_id                  = each.value
 }
 
 locals {

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -119,7 +119,7 @@ module "vpc_nacls" {
 
 module "route_53_resolver_logs" {
   source                  = "../../modules/r53-resolver-logs"
-  for_each                = toset([for key, value in module.vpc : value["vpc_id"]])
+  for_each                = { for key, value in module.vpc : key => value["vpc_id"] }
   logging_destination_arn = data.aws_cloudwatch_log_group.route_53_resolver_logs.arn
   tags_common             = local.tags
   vpc_id                  = each.value

--- a/terraform/modules/r53-resolver-logs/main.tf
+++ b/terraform/modules/r53-resolver-logs/main.tf
@@ -7,5 +7,4 @@ resource "aws_route53_resolver_query_log_config" "main" {
 resource "aws_route53_resolver_query_log_config_association" "main" {
   resolver_query_log_config_id = aws_route53_resolver_query_log_config.main.id
   resource_id                  = var.vpc_id
-  tags                         = var.tags_common
 }


### PR DESCRIPTION
* Add a new provider and data call to get ARN of CloudWatch Log Group in `core-logging` account
* Use a `for` expression in a `for_each` to get the VPC IDs in each workspace and apply the `r53-resolver-logs` module
* Remove an unsupported `tags` attribute from the `r53-resolver-logs` module