### PR TITLE
Fix logging location for route53 log files

### DIFF
--- a/terraform/environments/core-logging/route53_resolver_logs.tf
+++ b/terraform/environments/core-logging/route53_resolver_logs.tf
@@ -15,7 +15,7 @@ data "aws_iam_policy_document" "route53-query-logging-policy" {
       "logs:PutLogEvents",
     ]
 
-    resources = ["arn:aws:logs:*:*:log-group:modernisation-platform-r53-resolver-logs:*"]
+    resources = ["arn:aws:logs:*:*:log-group:modernisation-platform-r53-resolver-logs"]
 
     principals {
       identifiers = ["route53resolver.amazonaws.com"]

--- a/terraform/environments/core-logging/route53_resolver_logs.tf
+++ b/terraform/environments/core-logging/route53_resolver_logs.tf
@@ -15,10 +15,10 @@ data "aws_iam_policy_document" "route53-query-logging-policy" {
       "logs:PutLogEvents",
     ]
 
-    resources = ["arn:aws:logs:*:*:log-group:route53-query-logging-policy"]
+    resources = ["arn:aws:logs:*:*:log-group:modernisation-platform-r53-resolver-logs:*"]
 
     principals {
-      identifiers = ["route53.amazonaws.com"]
+      identifiers = ["route53resolver.amazonaws.com"]
       type        = "Service"
     }
   }

--- a/terraform/environments/core-logging/route53_resolver_logs.tf
+++ b/terraform/environments/core-logging/route53_resolver_logs.tf
@@ -15,7 +15,7 @@ data "aws_iam_policy_document" "route53-query-logging-policy" {
       "logs:PutLogEvents",
     ]
 
-    resources = ["arn:aws:logs:*:*:log-group:/aws/route53/*"]
+    resources = ["arn:aws:logs:*:*:log-group:route53-query-logging-policy"]
 
     principals {
       identifiers = ["route53.amazonaws.com"]


### PR DESCRIPTION
The changes in the core-vpc earlier were not allowed due to log writing issues. This is to correct the name of the location to allow this access.