### PR TITLE
Feature/route53 resolver logging

### DIFF
--- a/terraform/environments/core-logging/route53_resolver_logs.tf
+++ b/terraform/environments/core-logging/route53_resolver_logs.tf
@@ -1,6 +1,16 @@
+provider "aws" {
+  alias  = "us-east-1"
+  region = "us-east-1"
+}
+
 resource "aws_cloudwatch_log_group" "modernisation-platform-r53-resolver-logs" {
   name              = "modernisation-platform-r53-resolver-logs"
   retention_in_days = 365
+}
+
+provider "aws" {
+  alias  = "eu-west-2"
+  region = "eu-west-2"
 }
 
 resource "aws_cloudwatch_log_resource_policy" "route53-query-logging-policy" {
@@ -15,10 +25,10 @@ data "aws_iam_policy_document" "route53-query-logging-policy" {
       "logs:PutLogEvents",
     ]
 
-    resources = ["arn:aws:logs:*:*:log-group:/aws/route53/*"]
+    resources = ["arn:aws:logs:*:*:log-group:modernisation-platform-r53-resolver-logs"]
 
     principals {
-      identifiers = ["route53.amazonaws.com"]
+      identifiers = ["route53resolver.amazonaws.com"]
       type        = "Service"
     }
   }

--- a/terraform/environments/core-vpc/providers.tf
+++ b/terraform/environments/core-vpc/providers.tf
@@ -21,6 +21,15 @@ provider "aws" {
   }
 }
 
+# AWS provider for core-logging, where consolidated CloudWatch logs live
+provider "aws" {
+  alias  = "core-logging"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-logging-production"]}:role/ModernisationPlatformAccess"
+  }
+}
+
 provider "aws" {
   alias  = "aws-us-east-1"
   region = "us-east-1"

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -14,6 +14,11 @@ data "aws_route53_zone" "private" {
   private_zone = true
 }
 
+data "aws_cloudwatch_log_group" "route_53_resolver_logs" {
+  provider = aws.core-logging
+  name     = "modernisation-platform-r53-resolver-logs"
+}
+
 
 locals {
 
@@ -110,6 +115,14 @@ module "vpc_nacls" {
   tags             = local.tags
   tags_prefix      = each.key
   vpc_name         = each.key
+}
+
+module "route_53_resolver_logs" {
+  source                  = "../../modules/r53-resolver-logs"
+  for_each                = toset([for key, value in module.vpc : value["vpc_id"]])
+  logging_destination_arn = data.aws_cloudwatch_log_group.route_53_resolver_logs.arn
+  tags_common             = local.tags
+  vpc_id                  = each.value
 }
 
 locals {

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -119,7 +119,7 @@ module "vpc_nacls" {
 
 module "route_53_resolver_logs" {
   source                  = "../../modules/r53-resolver-logs"
-  for_each                = toset([for key, value in module.vpc : value["vpc_id"]])
+  for_each                = { for key, value in module.vpc : key => value["vpc_id"] }
   logging_destination_arn = data.aws_cloudwatch_log_group.route_53_resolver_logs.arn
   tags_common             = local.tags
   vpc_id                  = each.value

--- a/terraform/modules/r53-resolver-logs/main.tf
+++ b/terraform/modules/r53-resolver-logs/main.tf
@@ -7,5 +7,4 @@ resource "aws_route53_resolver_query_log_config" "main" {
 resource "aws_route53_resolver_query_log_config_association" "main" {
   resolver_query_log_config_id = aws_route53_resolver_query_log_config.main.id
   resource_id                  = var.vpc_id
-  tags                         = var.tags_common
 }


### PR DESCRIPTION
After consulting with AWS about the error we had connecting to VPCs it appears that the log file must be built in us-east-1.
This code changes the location (one on eu-west-2 has been removed) and builds it there. Once this is complete I will re-run the code to link to VPCs
