### PR TITLE
Move route53 log to Virginia

### DIFF
--- a/terraform/environments/core-logging/providers.tf
+++ b/terraform/environments/core-logging/providers.tf
@@ -28,3 +28,8 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
 }
+
+provider "aws" {
+  alias  = "us-east-1"
+  region = "us-east-1"
+}

--- a/terraform/environments/core-logging/route53_resolver_logs.tf
+++ b/terraform/environments/core-logging/route53_resolver_logs.tf
@@ -1,5 +1,5 @@
 resource "aws_cloudwatch_log_group" "modernisation-platform-r53-resolver-logs" {
-  provider = aws.us-east-1
+  provider          = aws.us-east-1
   name              = "modernisation-platform-r53-resolver-logs"
   retention_in_days = 365
 }

--- a/terraform/environments/core-logging/route53_resolver_logs.tf
+++ b/terraform/environments/core-logging/route53_resolver_logs.tf
@@ -1,9 +1,5 @@
-provider "aws" {
-  alias  = "us-east-1"
-  region = "us-east-1"
-}
-
 resource "aws_cloudwatch_log_group" "modernisation-platform-r53-resolver-logs" {
+  provider = aws.us-east-1
   name              = "modernisation-platform-r53-resolver-logs"
   retention_in_days = 365
 }

--- a/terraform/environments/core-logging/route53_resolver_logs.tf
+++ b/terraform/environments/core-logging/route53_resolver_logs.tf
@@ -1,3 +1,8 @@
+provider "aws" {
+  alias  = "us-east-1"
+  region = "us-east-1"
+}
+
 resource "aws_cloudwatch_log_group" "modernisation-platform-r53-resolver-logs" {
   name              = "modernisation-platform-r53-resolver-logs"
   retention_in_days = 365


### PR DESCRIPTION
Move the route 53 log to us-east-1 (North Virginia) as suggested in the AWS documentation and suggested by AWS following a call