### PR TITLE
Reduce scope of formatter

### DIFF
--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -66,7 +66,7 @@ jobs:
         run: |
           git add .
           git commit -m "Updates from GitHub Actions Format Code workflow"
-          git push -u origin $branch_name
+          git push --set-upstream origin $branch_name
 
       - name: Create pull request
         run: |

--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -64,9 +64,10 @@ jobs:
 
       - name: Commit and push changes
         run: |
+          git config --global push.autoSetupRemote true
           git add .
           git commit -m "Updates from GitHub Actions Format Code workflow"
-          git push --set-upstream origin $branch_name
+          git push
 
       - name: Create pull request
         run: |

--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -36,8 +36,8 @@ jobs:
 
       - name: Create new branch
         run: |
-          date=$(date +%Y-%m-%d)
-          branch_name="date-$date"
+          date=$(date +%Y_%m_%d)
+          branch_name="date_$date"
           git checkout -b $branch_name
 
       - name: Run linter
@@ -56,7 +56,7 @@ jobs:
 
       - name: Check for changes
         run: |
-          changes=$(git diff main...$branch_name --name-only)
+          changes=$(git diff origin/main...$branch_name --name-only)
            if [ -z "$changes" ]; then
              echo "No changes detected."
              exit 0

--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -49,6 +49,7 @@ jobs:
           # All available variables are described in documentation
           # https://megalinter.io/configuration/#shared-variables
           # ADD YOUR CUSTOM ENV VARIABLES HERE OR DEFINE THEM IN A FILE .mega-linter.yml AT THE ROOT OF YOUR REPOSITORY
+          DISABLE_LINTERS: KICS
           VALIDATE_ALL_CODEBASE: true
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
           EMAIL_REPORTER: false

--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -49,7 +49,7 @@ jobs:
           # All available variables are described in documentation
           # https://megalinter.io/configuration/#shared-variables
           # ADD YOUR CUSTOM ENV VARIABLES HERE OR DEFINE THEM IN A FILE .mega-linter.yml AT THE ROOT OF YOUR REPOSITORY
-          DISABLE_LINTERS: KICS
+          ENABLE_LINTERS: JSON_PRETTIER, YAML_PRETTIER, TERRAFORM_TERRAFORM_FMT
           VALIDATE_ALL_CODEBASE: true
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
           EMAIL_REPORTER: false


### PR DESCRIPTION
In order to complete bcode formatter runs in a timely fashion, this PR reduces the scope to just three:
* [JSON_PRETTIER](https://megalinter.io/6.19.0/descriptors/json_prettier/)
* [YAML_PRETTIER](https://megalinter.io/latest/descriptors/yaml_prettier/)
* [TERRAFORM_TERRAFORM_FMT](https://megalinter.io/latest/descriptors/terraform_terraform_fmt/)

The step to create a pull request isn't quite right, but I will resolve that in a following PR.