### PR TITLE
Remove start option for 6dg VPN tunnel startup

### DIFF
--- a/terraform/environments/core-network-services/vpn_attachments.json
+++ b/terraform/environments/core-network-services/vpn_attachments.json
@@ -5,8 +5,7 @@
     "modernisation_platform_vpc": "laa-development",
     "dx_gateway_id": "",
     "dx_gateway_owner_account_id": "",
-    "static_routes_only": true,
-    "tunnel_startup_action": "start"
+    "static_routes_only": true
   },
   "sixdegrees_uat": {
     "customer_gateway_ip": "80.79.133.20",
@@ -14,8 +13,7 @@
     "modernisation_platform_vpc": "laa-test",
     "dx_gateway_id": "",
     "dx_gateway_owner_account_id": "",
-    "static_routes_only": true,
-    "tunnel_startup_action": "start"
+    "static_routes_only": true
   },
   "sixdegrees_stage": {
     "customer_gateway_ip": "82.147.30.124",
@@ -23,8 +21,7 @@
     "modernisation_platform_vpc": "laa-preproduction",
     "dx_gateway_id": "",
     "dx_gateway_owner_account_id": "",
-    "static_routes_only": true,
-    "tunnel_startup_action": "start"
+    "static_routes_only": true
   },
   "sixdegrees_prod": {
     "customer_gateway_ip": "82.147.39.116",
@@ -32,8 +29,7 @@
     "modernisation_platform_vpc": "laa-production",
     "dx_gateway_id": "",
     "dx_gateway_owner_account_id": "",
-    "static_routes_only": true,
-    "tunnel_startup_action": "start"
+    "static_routes_only": true
   },
   "NOMS-Transit-Live-DR-VPN-VNG_1": {
     "bgp_asn": "64532",


### PR DESCRIPTION
Based on the advice of AWS Support, I've removed the optional field that causes AWS to initiate tunnel establishment. From their investigation of the logs, the 6DG CGW is initiating connections.

From discussion with AWS Support they stated the following:
> Start: AWS initiates the IKE negotiation to bring the tunnel up. Only supported if your customer gateway is configured with an IP address. Supported if using IKEv2.

However, I'm pretty sure that we're using IKEv1 in other VPNs (eg, Nomis) so I don't know how trustworthy that statement is.