### PR TITLE
Give members of data-engineering-aws team developer access in analytical-platfrom-data-prod

### DIFF
--- a/environments/analytical-platform-data.json
+++ b/environments/analytical-platform-data.json
@@ -24,6 +24,10 @@
         {
           "github_slug": "analytics-hq",
           "level": "view-only"
+        },
+        {
+          "github_slug": "data-engineering-aws",
+          "level": "developer"
         }
       ]
     }


### PR DESCRIPTION
This is Data Engineering's main working account. Giving them limited access in it.
