### PR TITLE
PPUD environment resources changes

### DIFF
--- a/terraform/environments/ppud/iam.tf
+++ b/terraform/environments/ppud/iam.tf
@@ -4,7 +4,6 @@
 #tfsec:ignore:AWS273
 resource "aws_iam_user" "mgn_user" {
   #checkov:skip=CKV_AWS_273: "Skipping as tfsec check is also set to ignore"
-  count = local.is-development == true ? 1 : 0
   name  = "MGN-Test"
   tags  = local.tags
 }
@@ -12,14 +11,14 @@ resource "aws_iam_user" "mgn_user" {
 resource "aws_iam_user_policy_attachment" "mgn_attach_policy" {
   #tfsec:ignore:aws-iam-no-user-attached-policies
   #checkov:skip=CKV_AWS_40: "Skipping as tfsec check is also ignored"
-  count      = local.is-development == true ? 1 : 0
-  user       = aws_iam_user.mgn_user[0].name
+  user       = aws_iam_user.mgn_user.name
   policy_arn = "arn:aws:iam::aws:policy/AWSApplicationMigrationFullAccess"
 }
 
 #tfsec:ignore:aws-iam-no-user-attached-policies
 resource "aws_iam_user" "email" {
   #checkov:skip=CKV_AWS_273: "Skipping as tfsec check is also ignored"
+  count = local.is-production == false ? 1 : 0
   name = format("%s-%s-email_user", local.application_name, local.environment)
   tags = merge(local.tags,
     { Name = format("%s-%s-email_user", local.application_name, local.environment) }
@@ -27,13 +26,15 @@ resource "aws_iam_user" "email" {
 }
 
 resource "aws_iam_access_key" "email" {
-  user = aws_iam_user.email.name
+  count = local.is-production == false ? 1 : 0
+  user = aws_iam_user.email[0].name
 }
 
 #tfsec:ignore:aws-iam-no-policy-wildcards
 resource "aws_iam_user_policy" "email_policy" {
+  count = local.is-production == false ? 1 : 0
   name   = "AmazonSesSendingAccess"
-  user   = aws_iam_user.email.name
+  user   = aws_iam_user.email[0].name
   policy = data.aws_iam_policy_document.email.json
 }
 


### PR DESCRIPTION
Modify conditional statements so the correct resources are created in each environment -

 - MGN user will be needed in all envs for migration
 - SES user will not be needed in production as using CJSM

Applied locally to all environments successfully.