### PR TITLE
Update infrastructure support tag for environments

### DIFF
--- a/environments/analytical-platform-data-engineering.json
+++ b/environments/analytical-platform-data-engineering.json
@@ -39,6 +39,7 @@
   "tags": {
     "application": "analytical-platform-data-engineering",
     "business-unit": "Platforms",
+    "infrastructure-support": "analytical_platform@digital.justice.gov.uk",
     "owner": "Analytical Platform: analytical_platform@digital.justice.gov.uk"
   }
 }

--- a/environments/analytical-platform-data.json
+++ b/environments/analytical-platform-data.json
@@ -35,6 +35,7 @@
   "tags": {
     "application": "analytical-platform-data",
     "business-unit": "Platforms",
+    "infrastructure-support": "analytical_platform@digital.justice.gov.uk",
     "owner": "Analytical Platform: analytical_platform@digital.justice.gov.uk"
   }
 }

--- a/environments/analytical-platform-landing.json
+++ b/environments/analytical-platform-landing.json
@@ -18,6 +18,7 @@
   "tags": {
     "application": "analytical-platform-landing",
     "business-unit": "Platforms",
+    "infrastructure-support": "analytical_platform@digital.justice.gov.uk",
     "owner": "Analytical Platform: analytical_platform@digital.justice.gov.uk"
   }
 }

--- a/environments/analytical-platform-management.json
+++ b/environments/analytical-platform-management.json
@@ -18,6 +18,7 @@
   "tags": {
     "application": "analytical-platform-management",
     "business-unit": "Platforms",
+    "infrastructure-support": "analytical_platform@digital.justice.gov.uk",
     "owner": "Analytical Platform: analytical_platform@digital.justice.gov.uk"
   }
 }

--- a/environments/analytical-platform.json
+++ b/environments/analytical-platform.json
@@ -31,6 +31,7 @@
   "tags": {
     "application": "analytical-platform",
     "business-unit": "Platforms",
+    "infrastructure-support": "analytical_platform@digital.justice.gov.uk",
     "owner": "Analytical Platform: analytical_platform@digital.justice.gov.uk"
   }
 }

--- a/environments/apex.json
+++ b/environments/apex.json
@@ -14,8 +14,7 @@
   "tags": {
     "application": "apex",
     "business-unit": "LAA",
-    "infrastructure-support": "modernisation-platform@digital.justice.gov.uk",
+    "infrastructure-support": "aws-webops-laa@digital.justice.gov.uk",
     "owner": "aws-webops-laa@digital.justice.gov.uk"
-  },
-  "debug-toggle": "true"
+  }
 }

--- a/environments/bichard7.json
+++ b/environments/bichard7.json
@@ -68,6 +68,7 @@
   "tags": {
     "application": "bichard7",
     "business-unit": "CJSE",
+    "infrastructure-support": "cjse@madetech.com",
     "owner": "cjse@madetech.com"
   }
 }

--- a/environments/cooker.json
+++ b/environments/cooker.json
@@ -1,14 +1,15 @@
 {
-	"account-type": "member",
-	"environments": [
+  "account-type": "member",
+  "environments": [
     {
       "name": "development",
       "access": []
     }
-	],
-	"tags": {
-		"application": "modernisation-platform",
-		"business-unit": "Platforms",
-		"owner": "Modernisation Platform: modernisation-platform@digital.justice.gov.uk"
-	}
+    ],
+  "tags": {
+    "application": "modernisation-platform",
+    "business-unit": "Platforms",
+    "infrastructure-support": "modernisation-platform@digital.justice.gov.uk",
+    "owner": "Modernisation Platform: modernisation-platform@digital.justice.gov.uk"
+  }
 }

--- a/environments/core-logging.json
+++ b/environments/core-logging.json
@@ -9,6 +9,7 @@
   "tags": {
     "application": "modernisation-platform",
     "business-unit": "Platforms",
+    "infrastructure-support": "modernisation-platform@digital.justice.gov.uk",
     "owner": "Modernisation Platform: modernisation-platform@digital.justice.gov.uk"
   }
 }

--- a/environments/core-network-services.json
+++ b/environments/core-network-services.json
@@ -9,6 +9,7 @@
   "tags": {
     "application": "modernisation-platform",
     "business-unit": "Platforms",
+    "infrastructure-support": "modernisation-platform@digital.justice.gov.uk",
     "owner": "Modernisation Platform: modernisation-platform@digital.justice.gov.uk"
   }
 }

--- a/environments/core-sandbox.json
+++ b/environments/core-sandbox.json
@@ -9,6 +9,7 @@
   "tags": {
     "application": "core-sandbox",
     "business-unit": "Platforms",
+    "infrastructure-support": "modernisation-platform@digital.justice.gov.uk",
     "owner": "Modernisation Platform: modernisation-platform@digital.justice.gov.uk"
   }
 }

--- a/environments/core-security.json
+++ b/environments/core-security.json
@@ -9,6 +9,7 @@
   "tags": {
     "application": "modernisation-platform",
     "business-unit": "Platforms",
+    "infrastructure-support": "modernisation-platform@digital.justice.gov.uk",
     "owner": "Modernisation Platform: modernisation-platform@digital.justice.gov.uk"
   }
 }

--- a/environments/core-shared-services.json
+++ b/environments/core-shared-services.json
@@ -9,6 +9,7 @@
   "tags": {
     "application": "modernisation-platform",
     "business-unit": "Platforms",
+    "infrastructure-support": "modernisation-platform@digital.justice.gov.uk",
     "owner": "Modernisation Platform: modernisation-platform@digital.justice.gov.uk"
   }
 }

--- a/environments/core-vpc.json
+++ b/environments/core-vpc.json
@@ -25,6 +25,7 @@
   "tags": {
     "application": "modernisation-platform",
     "business-unit": "Platforms",
+    "infrastructure-support": "modernisation-platform@digital.justice.gov.uk",
     "owner": "Modernisation Platform: modernisation-platform@digital.justice.gov.uk"
   }
 }

--- a/environments/data-and-insights-wepi.json
+++ b/environments/data-and-insights-wepi.json
@@ -33,6 +33,7 @@
   "tags": {
     "application": "data-and-insights-wepi",
     "business-unit": "HQ",
+    "infrastructure-support": "Philip.cooke@justice.gov.uk",
     "owner": "Philip.cooke@justice.gov.uk"
   }
 }

--- a/environments/delius-iaps.json
+++ b/environments/delius-iaps.json
@@ -33,7 +33,7 @@
   "tags": {
     "application": "delius-iaps",
     "business-unit": "HMPPS",
-    "infrastructure-support": "modernisation-platform@digital.justice.gov.uk",
+    "infrastructure-support": "probation-webops@digital.justice.gov.uk",
     "owner": "probation-webops@digital.justice.gov.uk"
   }
 }

--- a/environments/delius-jitbit.json
+++ b/environments/delius-jitbit.json
@@ -33,6 +33,7 @@
   "tags": {
     "application": "delius-jitbit",
     "business-unit": "HMPPS",
+    "infrastructure-support": "probation-webops@digital.justice.gov.uk",
     "owner": "Probation WebOps: probation-webops@digital.justice.gov.uk"
   }
 }

--- a/environments/digital-prison-reporting.json
+++ b/environments/digital-prison-reporting.json
@@ -15,6 +15,7 @@
   "tags": {
     "application": "digital-prison-reporting",
     "business-unit": "HMPPS",
+    "infrastructure-support": "digitalprisonreporting@digital.justice.gov.uk",
     "owner": "digitalprisonreporting@digital.justice.gov.uk"
   }
 }

--- a/environments/example.json
+++ b/environments/example.json
@@ -14,6 +14,7 @@
   "tags": {
     "application": "example",
     "business-unit": "Platforms",
+    "infrastructure-support": "modernisation-platform@digital.justice.gov.uk",
     "owner": "Modernisation Platform: modernisation-platform@digital.justice.gov.uk"
   }
 }

--- a/environments/maatdb.json
+++ b/environments/maatdb.json
@@ -14,7 +14,7 @@
   "tags": {
     "application": "maatdb",
     "business-unit": "LAA",
-    "infrastructure-support": "modernisation-platform@digital.justice.gov.uk",
+    "infrastructure-support": "aws-webops-laa@digital.justice.gov.uk",
     "owner": "laa-crime-apps@digital.justice.gov.uk"
   }
 }

--- a/environments/mi-platform.json
+++ b/environments/mi-platform.json
@@ -14,6 +14,7 @@
   "tags": {
     "application": "mi-platform",
     "business-unit": "Platforms",
+    "infrastructure-support": "analytical_platform@digital.justice.gov.uk",
     "owner": "Analytical Platform: analytical_platform@digital.justice.gov.uk"
   }
 }

--- a/environments/mlra.json
+++ b/environments/mlra.json
@@ -41,7 +41,7 @@
   "tags": {
     "application": "mlra",
     "business-unit": "LAA",
-    "infrastructure-support": "modernisation-platform@digital.justice.gov.uk",
+    "infrastructure-support": "aws-webops-laa@digital.justice.gov.uk",
     "owner": "laa-crime-apps@digital.justice.gov.uk"
   }
 }

--- a/environments/nomis.json
+++ b/environments/nomis.json
@@ -42,7 +42,7 @@
   "tags": {
     "application": "nomis",
     "business-unit": "HMPPS",
-    "infrastructure-support": "modernisation-platform@digital.justice.gov.uk",
+    "infrastructure-support": "digital-studio-operations-team@digital.justice.gov.uk",
     "owner": "digital-studio-operations-team@digital.justice.gov.uk"
   }
 }

--- a/environments/oas.json
+++ b/environments/oas.json
@@ -14,7 +14,7 @@
   "tags": {
     "application": "oas",
     "business-unit": "LAA",
-    "infrastructure-support": "modernisation-platform@digital.justice.gov.uk",
+    "infrastructure-support": "aws-webops-laa@digital.justice.gov.uk",
     "owner": "get-acccess-service-improvement@digital.justice.gov.uk"
   }
 }

--- a/environments/oasys.json
+++ b/environments/oasys.json
@@ -42,7 +42,7 @@
   "tags": {
     "application": "oasys",
     "business-unit": "HMPPS",
-    "infrastructure-support": "modernisation-platform@digital.justice.gov.uk",
+    "infrastructure-support": "digital-studio-operations-team@digital.justice.gov.uk",
     "owner": "digital-studio-operations-team@digital.justice.gov.uk"
   }
 }

--- a/environments/performance-hub.json
+++ b/environments/performance-hub.json
@@ -32,8 +32,7 @@
   "tags": {
     "application": "performance-hub",
     "business-unit": "HMPPS",
-    "infrastructure-support": "modernisation-platform@digital.justice.gov.uk",
+    "infrastructure-support": "jeremy.collins@digital.justice.gov.uk",
     "owner": "hubusers@justice.gov.uk"
   }
-  
 }

--- a/environments/refer-monitor.json
+++ b/environments/refer-monitor.json
@@ -18,6 +18,7 @@
   "tags": {
     "application": "refer-monitor",
     "business-unit": "HMPPS",
+    "infrastructure-support": "interventions-devs@digital.justice.gov.uk",
     "owner": "interventions-devs@digital.justice.gov.uk"
   }
 }

--- a/environments/remote-supervision.json
+++ b/environments/remote-supervision.json
@@ -23,6 +23,7 @@
   "tags": {
     "application": "remote-supervision",
     "business-unit": "HMPPS",
+    "infrastructure-support": "remote.supervision+hosting@digital.justice.gov.uk",
     "owner": "Remote Supervision: remote.supervision+hosting@digital.justice.gov.uk"
   }
 }

--- a/environments/sprinkler.json
+++ b/environments/sprinkler.json
@@ -15,6 +15,7 @@
   "tags": {
     "application": "modernisation-platform",
     "business-unit": "Platforms",
+    "infrastructure-support": "modernisation-platform@digital.justice.gov.uk",
     "owner": "Modernisation Platform: modernisation-platform@digital.justice.gov.uk"
   }
 }

--- a/environments/testing.json
+++ b/environments/testing.json
@@ -1,6 +1,6 @@
 {
-	"account-type": "member",
-	"environments": [
+  "account-type": "member",
+  "environments": [
     {
       "name": "test",
       "access": [
@@ -10,10 +10,11 @@
         }
       ]
     }
-	],
-	"tags": {
-		"application": "testing",
-		"business-unit": "Platforms",
-		"owner": "Modernisation Platform: modernisation-platform@digital.justice.gov.uk"
-	}
+  ],
+  "tags": {
+    "application": "testing",
+    "business-unit": "Platforms",
+    "infrastructure-support": "modernisation-platform@digital.justice.gov.uk",
+    "owner": "Modernisation Platform: modernisation-platform@digital.justice.gov.uk"
+  }
 }

--- a/environments/xhibit-portal.json
+++ b/environments/xhibit-portal.json
@@ -32,8 +32,7 @@
   "tags": {
     "application": "xhibit-portal",
     "business-unit": "HMCTS",
-    "infrastructure-support": "modernisation-platform@digital.justice.gov.uk",
-    "owner": "george.cairns@digital.justice.gov.uk"
+    "infrastructure-support": "xpsupport@digital.justice.gov.uk",
+    "owner": "dom.tomkins@digital.justice.gov.uk"
   }
 }
-


### PR DESCRIPTION
We want to start sending AWS health messages directly to the infrastructure support email addresses, rather than the current manual process of forwarding these on. Ensuring all accounts have these and they are up-to-date.