### PR TITLE
Add alternative contacts for accounts

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/account.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/account.tf
@@ -7,13 +7,3 @@ resource "aws_account_alternate_contact" "infrastructure_support_operations" {
   email_address = local.application_tags.infrastructure-support
   phone_number  = "+0000000000"
 }
-
-resource "aws_account_alternate_contact" "infrastructure_support_security" {
-
-  alternate_contact_type = "SECURITY"
-
-  name          = "Infrastructure Support"
-  title         = "Infrastructure Support Security"
-  email_address = local.application_tags.infrastructure-support
-  phone_number  = "+0000000000"
-}

--- a/terraform/environments/bootstrap/member-bootstrap/account.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/account.tf
@@ -1,0 +1,19 @@
+resource "aws_account_alternate_contact" "infrastructure_support_operations" {
+
+  alternate_contact_type = "OPERATIONS"
+
+  name          = "Infrastructure Support"
+  title         = "Infrastructure Support Operations"
+  email_address = local.application_tags.infrastructure-support
+  phone_number  = "+0000000000"
+}
+
+resource "aws_account_alternate_contact" "infrastructure_support_security" {
+
+  alternate_contact_type = "SECURITY"
+
+  name          = "Infrastructure Support"
+  title         = "Infrastructure Support Security"
+  email_address = local.application_tags.infrastructure-support
+  phone_number  = "+0000000000"
+}

--- a/terraform/environments/bootstrap/member-bootstrap/locals.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/locals.tf
@@ -28,7 +28,8 @@ locals {
   modernisation_platform_account = data.aws_caller_identity.modernisation-platform
   environment_management         = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
   application_name               = try(regex("^bichard*.|^remote-supervisio*.", terraform.workspace), replace(terraform.workspace, "/-([[:alnum:]]+)$/", ""))
-  business_unit                  = jsondecode(data.http.environments_file.response_body).tags.business-unit
+  application_tags               = jsondecode(data.http.environments_file.response_body).tags
+  business_unit                  = local.application_tags.business-unit
   application_environment        = length(regexall("^bichard*.|^remote-supervisio*.", terraform.workspace)) > 0 ? terraform.workspace : substr(terraform.workspace, length(local.application_name) + 1, -1)
 
   tags = {


### PR DESCRIPTION
This will enable AWS health operations and security emails to go directly to the application support teams rather than to Jake -> MP -> App teams.

https://docs.aws.amazon.com/accounts/latest/reference/manage-acct-update-contact.html

Tested on sprinkler development

Resolves https://github.com/ministryofjustice/modernisation-platform/issues/3069
