### PR TITLE
Allow migration role to create access keys

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/policies.tf
+++ b/terraform/environments/bootstrap/delegate-access/policies.tf
@@ -364,6 +364,20 @@ data "aws_iam_policy_document" "migration_additional" {
     ]
     resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
   }
+
+  statement {
+    sid    = "iamOnUsersAllow"
+    effect = "Allow"
+    actions = [
+      "iam:CreateAccessKey",
+      "iam:DeleteAccessKey",
+      "iam:GetAccessKeyLastUsed",
+      "iam:GetUser",
+      "iam:ListAccessKeys",
+      "iam:UpdateAccessKey"
+    ]
+    resources = ["*"]
+  }
 }
 
 


### PR DESCRIPTION
Allow the migration role to create access keys for users, we don't know the name of the user being created for the migration activities, and their may be multiple, so leaving this as a *.