### PR TITLE
Add AWS managed policies for migration services

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/collaborators.tf
+++ b/terraform/environments/bootstrap/delegate-access/collaborators.tf
@@ -106,6 +106,8 @@ module "collaborator_migration_role" {
 
   custom_role_policy_arns = [
     "arn:aws:iam::aws:policy/ReadOnlyAccess",
+    "arn:aws:iam::aws:policy/AWSApplicationMigrationFullAccess",
+    "arn:aws:iam::aws:policy/AWSDataSyncFullAccess",
     aws_iam_policy.migration.arn,
   ]
   number_of_custom_role_policy_arns = 2

--- a/terraform/environments/bootstrap/delegate-access/policies.tf
+++ b/terraform/environments/bootstrap/delegate-access/policies.tf
@@ -359,7 +359,6 @@ data "aws_iam_policy_document" "migration_additional" {
     actions = [
       "dms:*",
       "drs:*",
-      "mgn:*",
       "mgh:*"
     ]
     resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097


### PR DESCRIPTION
Some AWS migration services have managed policies, adding these to the role rather than defining them so that if they change we don't need to update them ourselves.