### PR TITLE
updated number of custom policies for migration role

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/collaborators.tf
+++ b/terraform/environments/bootstrap/delegate-access/collaborators.tf
@@ -110,7 +110,7 @@ module "collaborator_migration_role" {
     "arn:aws:iam::aws:policy/AWSDataSyncFullAccess",
     aws_iam_policy.migration.arn,
   ]
-  number_of_custom_role_policy_arns = 2
+  number_of_custom_role_policy_arns = 4
 }
 
 module "collaborator_database_mgmt_role" {


### PR DESCRIPTION
Number of custom policies was set to `2`, causing only the first two roles alphabetically to be attached to the migration role