### PR TITLE
Change in rule group name

### DIFF
--- a/terraform/environments/core-network-services/firewall.tf
+++ b/terraform/environments/core-network-services/firewall.tf
@@ -164,8 +164,8 @@ module "firewall_policy" {
   cloudwatch_log_group_name = format("fw-%s-logs", aws_networkfirewall_firewall.external_inspection.name)
   fw_arn                    = aws_networkfirewall_firewall.external_inspection.arn
   fw_rulegroup_capacity     = "10000"
-  fw_policy_name            = format("%s-fw_policy", local.application_name)
-  fw_rulegroup_name         = format("%s-fw_rulegroup", local.application_name)
+  fw_policy_name            = format("%s-fw-policy", local.application_name)
+  fw_rulegroup_name         = format("%s-fw-rulegroup", local.application_name)
   rules                     = local.firewall_rules
   tags                      = local.tags
 }

--- a/terraform/modules/firewall-policy/main.tf
+++ b/terraform/modules/firewall-policy/main.tf
@@ -3,7 +3,7 @@ resource "random_id" "policy_id" {
 }
 
 resource "aws_networkfirewall_firewall_policy" "main" {
-  name = format("%s-%s", var.fw_policy_name, random_id.policy_id.id)
+  name = replace(format("%s-%s", var.fw_policy_name, random_id.policy_id.id),"/-|_/", "")
   firewall_policy {
     stateful_engine_options {
       rule_order = "DEFAULT_ACTION_ORDER"
@@ -25,7 +25,7 @@ resource "aws_networkfirewall_firewall_policy" "main" {
 
 resource "aws_networkfirewall_rule_group" "stateful" {
   capacity = var.fw_rulegroup_capacity
-  name     = format("%s-%s",var.fw_rulegroup_name, random_id.policy_id.id)
+  name     = replace(format("%s-%s",var.fw_rulegroup_name, random_id.policy_id.id),"/-|_/", "")
   type     = "STATEFUL"
 
   rule_group { 


### PR DESCRIPTION
after looking at the issue i have found that for the rule group name underscores are not allowed only the following is aloud

The name must have 1-128 characters. Valid characters: a-z, A-Z, 0-9 and -(hyphen). The name can’t start or end with a hyphen, and it can’t contain two consecutive hyphens.

so i have amended the code and change the two underscores for two dashes