### PR TITLE
Granting athena query and dms replication task permissions on request from DE/DM

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/policies.tf
+++ b/terraform/environments/bootstrap/delegate-access/policies.tf
@@ -113,7 +113,6 @@ data "aws_iam_policy_document" "developer_additional" {
       "codebuild:PersistOAuthToken",
       "dms:CreateReplicationTask",
       "dms:DeleteReplicationTask",
-      "dms:DescribeReplicationTasks",
       "dms:ModifyReplicationTask",
       "dms:MoveReplicationTask",
       "ds:*Tags*",

--- a/terraform/environments/bootstrap/delegate-access/policies.tf
+++ b/terraform/environments/bootstrap/delegate-access/policies.tf
@@ -102,6 +102,8 @@ data "aws_iam_policy_document" "developer_additional" {
     effect = "Allow"
     actions = [
       "acm:ImportCertificate",
+      "athena:StartQueryExecution",
+      "athena:StopQueryExecution",
       "autoscaling:UpdateAutoScalingGroup",
       "aws-marketplace:ViewSubscriptions",
       "cloudwatch:PutDashboard",
@@ -109,6 +111,11 @@ data "aws_iam_policy_document" "developer_additional" {
       "cloudwatch:DeleteDashboards",
       "codebuild:ImportSourceCredentials",
       "codebuild:PersistOAuthToken",
+      "dms:CreateReplicationTask",
+      "dms:DeleteReplicationTask",
+      "dms:DescribeReplicationTasks",
+      "dms:ModifyReplicationTask",
+      "dms:MoveReplicationTask",
       "ds:*Tags*",
       "ds:*Snapshot*",
       "ec2:StartInstances",


### PR DESCRIPTION
* These permission requests are from the Data Engineering and Data Modelling teams who need permissions to run athena queries on an adhoc basis as well as save some named queries. 
* Data Modelling are requesting DMS permissions so they can execute adhoc replication tasks from their target databases.
