### PR TITLE
Change of priority to allow rule group creation

### DIFF
--- a/terraform/modules/firewall-policy/main.tf
+++ b/terraform/modules/firewall-policy/main.tf
@@ -9,7 +9,7 @@ resource "aws_networkfirewall_firewall_policy" "main" {
       rule_order = "DEFAULT_ACTION_ORDER"
     }
     stateful_rule_group_reference {
-      priority     = 1
+      priority     = 2
       resource_arn = aws_networkfirewall_rule_group.stateful.arn
     }
     stateless_default_actions          = ["aws:forward_to_sfe"]


### PR DESCRIPTION
This PR is to see if the change in priority allows for the rule group to be created as currently this is failing with the following error
Error: creating NetworkFirewall Firewall Policy (corenetworkservicesfwpolicymD8): InvalidRequestException: Priority cannot be provided, parameter: [1], context: StatefulRuleGroupReferences[0][Priority=1]

i believe this is because the priority is in use by the current rule group. i plan to do another PR to change the priority back to one if this PR apply completes successfully. 