### PR TITLE
Fixing a bug introduced when extracting dir names as variables

### DIFF
--- a/scripts/provision-member-directories.sh
+++ b/scripts/provision-member-directories.sh
@@ -38,7 +38,7 @@ provision_environment_directories() {
   #     ]
   #   }...
   # ]
-  networking_definitions=$(jq -n '[ inputs | { subnet_sets: .cidr.subnet_sets | to_entries | map_values(.value + { set: .key, "business-unit": input_filename | ltrimstr("$core_repo_dir/environments-networks/") | rtrimstr(".json") | split("-")[0] } ) } ]' "$networkdir"/*.json)
+  networking_definitions=$(jq -n '[ inputs | { subnet_sets: .cidr.subnet_sets | to_entries | map_values(.value + { set: .key, "business-unit": input_filename | ltrimstr("'$core_repo_dir'/environments-networks/") | rtrimstr(".json") | split("-")[0] } ) } ]' "$networkdir"/*.json)
 
   for file in $environment_json_dir/*.json; do
 


### PR DESCRIPTION
This PR is part of the #2521 .

Tested locally, the network files are populated correctly now.