### PR TITLE
Expand scope of permissions for Migration role

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/collaborators.tf
+++ b/terraform/environments/bootstrap/delegate-access/collaborators.tf
@@ -108,9 +108,11 @@ module "collaborator_migration_role" {
     "arn:aws:iam::aws:policy/ReadOnlyAccess",
     "arn:aws:iam::aws:policy/AWSApplicationMigrationFullAccess",
     "arn:aws:iam::aws:policy/AWSDataSyncFullAccess",
+    "arn:aws:iam::aws:policy/AmazonEC2FullAccess",
+    "arn:aws:iam::aws:policy/ServerMigrationConnector",
     aws_iam_policy.migration.arn,
   ]
-  number_of_custom_role_policy_arns = 4
+  number_of_custom_role_policy_arns = 6
 }
 
 module "collaborator_database_mgmt_role" {

--- a/terraform/environments/bootstrap/delegate-access/policies.tf
+++ b/terraform/environments/bootstrap/delegate-access/policies.tf
@@ -359,20 +359,6 @@ data "aws_iam_policy_document" "migration_additional" {
     actions = [
       "dms:*",
       "drs:*",
-      "ec2:AuthorizeSecurityGroupEgress",
-      "ec2:AuthorizeSecurityGroupIngress",
-      "ec2:CreateSecurityGroup",
-      "ec2:DeleteSecurityGroup",
-      "ec2:DescribeSecurityGroupReferences",
-      "ec2:DescribeSecurityGroupRules",
-      "ec2:DescribeSecurityGroups",
-      "ec2:DescribeStaleSecurityGroups",
-      "ec2:ModifySecurityGroupRules",
-      "ec2:RunInstances",
-      "ec2:RevokeSecurityGroupEgress",
-      "ec2:RevokeSecurityGroupIngress",
-      "ec2:UpdateSecurityGroupRuleDescriptionsEgress",
-      "ec2:UpdateSecurityGroupRuleDescriptionsIngress",
       "mgh:*"
     ]
     resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097


### PR DESCRIPTION
Following discussion [here](https://mojdt.slack.com/archives/C01A7QK5VM1/p1677234391245069?thread_ts=1676971355.526159&cid=C01A7QK5VM1), I've revisited somewhat how we supply permissions for use with the migration role. I've also asked the customer to give us a full list of what they need in future so we're not stuck in a back-and-forth should this be insufficient.