### PR TITLE
Dropping member_ prefix for env default files

### DIFF
--- a/scripts/provision-member-directories.sh
+++ b/scripts/provision-member-directories.sh
@@ -124,9 +124,9 @@ copy_templates() {
   # rename member data file to data.tf
   mv $1/member_data.tf $1/data.tf
   # rename member locals file to locals.tf
-  mv $1/member_data.tf $1/locals.tf
+  mv $1/member_locals.tf $1/locals.tf
   # rename member secrets file to secrets.tf
-  mv $1/member_data.tf $1/secrets.tf
+  mv $1/member_secrets.tf $1/secrets.tf
   # copy application variable file
   cp $core_repo_dir/terraform/templates/application_variables.json $1
   # copy service runbook template file and rename it to README.md


### PR DESCRIPTION
This PR is part of the #2521 .

Fixing another bug, that @davidkelliott pointed out. thanks Dave!

It's fixing renaming of member default files.