### PR TITLE
MP Network Firewall rules

### DIFF
--- a/terraform/environments/core-network-services/development_rules.json
+++ b/terraform/environments/core-network-services/development_rules.json
@@ -1,31 +1,17 @@
 {
-  "laa_development_to_mp_laa_development_http": {
+  "laa_development_to_mp_laa_development": {
     "action": "PASS",
     "source_ip": "10.202.0.0/20",
     "destination_ip": "10.26.56.0/21",
-    "destination_port": "80",
-    "protocol": "TCP"
+    "destination_port": "ANY",
+    "protocol": "IP"
   },
-  "laa_shared_services_to_mp_laa_development_ssh": {
+  "laa_shared_services_to_mp_laa_development": {
     "action": "PASS",
-    "source_ip": "10.200.0.0/20",
+    "source_ip": "10.202.0.0/20",
     "destination_ip": "10.26.56.0/21",
-    "destination_port": "22",
-    "protocol": "TCP"
-  },
-  "laa_shared_services_to_mp_laa_development_http": {
-    "action": "PASS",
-    "source_ip": "10.200.0.0/20",
-    "destination_ip": "10.26.56.0/21",
-    "destination_port": "80",
-    "protocol": "TCP"
-  },
-  "laa_shared_services_to_mp_laa_development_https": {
-    "action": "PASS",
-    "source_ip": "10.200.0.0/20",
-    "destination_ip": "10.26.56.0/21",
-    "destination_port": "443",
-    "protocol": "TCP"
+    "destination_port": "ANY",
+    "protocol": "IP"
   },
   "default_block_development_test_ingress": {
     "action": "DROP",

--- a/terraform/environments/core-network-services/development_rules.json
+++ b/terraform/environments/core-network-services/development_rules.json
@@ -1,14 +1,14 @@
 {
   "laa_development_to_mp_laa_development": {
     "action": "PASS",
-    "source_ip": "10.200.0.0/20",
+    "source_ip": "10.202.0.0/20",
     "destination_ip": "10.26.56.0/21",
     "destination_port": "ANY",
     "protocol": "IP"
   },
   "laa_shared_services_to_mp_laa_development": {
     "action": "PASS",
-    "source_ip": "10.202.0.0/20",
+    "source_ip": "10.200.0.0/20",
     "destination_ip": "10.26.56.0/21",
     "destination_port": "ANY",
     "protocol": "IP"

--- a/terraform/environments/core-network-services/development_rules.json
+++ b/terraform/environments/core-network-services/development_rules.json
@@ -6,11 +6,32 @@
     "destination_port": "80",
     "protocol": "TCP"
   },
+  "laa_shared_services_to_mp_laa_development_ssh": {
+    "action": "PASS",
+    "source_ip": "10.200.0.0/20",
+    "destination_ip": "10.26.56.0/21",
+    "destination_port": "22",
+    "protocol": "TCP"
+  },
+  "laa_shared_services_to_mp_laa_development_http": {
+    "action": "PASS",
+    "source_ip": "10.200.0.0/20",
+    "destination_ip": "10.26.56.0/21",
+    "destination_port": "80",
+    "protocol": "TCP"
+  },
+  "laa_shared_services_to_mp_laa_development_https": {
+    "action": "PASS",
+    "source_ip": "10.200.0.0/20",
+    "destination_ip": "10.26.56.0/21",
+    "destination_port": "443",
+    "protocol": "TCP"
+  },
   "default_block_development_test_ingress": {
     "action": "DROP",
     "source_ip": "0.0.0.0/0",
     "destination_ip": "10.26.0.0/16",
     "destination_port": "ANY",
-    "protocol": "TCP"
+    "protocol": "IP"
   }
 }

--- a/terraform/environments/core-network-services/development_rules.json
+++ b/terraform/environments/core-network-services/development_rules.json
@@ -1,7 +1,7 @@
 {
   "laa_development_to_mp_laa_development": {
     "action": "PASS",
-    "source_ip": "10.202.0.0/20",
+    "source_ip": "10.200.0.0/20",
     "destination_ip": "10.26.56.0/21",
     "destination_port": "ANY",
     "protocol": "IP"


### PR DESCRIPTION
Allow the CCMS-EBS team to use AWS Workspaces to administer hosts in the MP LAA Development VPC in cases where X11 forwarding is required. See https://mojdt.slack.com/archives/C01A7QK5VM1/p1677684248238249 for more discussion