### PR TITLE
Updating developer role to include scaling of bastion instances

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/policies.tf
+++ b/terraform/environments/bootstrap/delegate-access/policies.tf
@@ -103,6 +103,7 @@ data "aws_iam_policy_document" "developer_additional" {
     actions = [
       "acm:ImportCertificate",
       "autoscaling:UpdateAutoScalingGroup",
+      "autoscaling:SetDesiredCapacity",
       "aws-marketplace:ViewSubscriptions",
       "cloudwatch:DisableAlarmActions",
       "cloudwatch:EnableAlarmActions",


### PR DESCRIPTION
This is to empower our users to scale bastion instances in the out of hours and hopefully not raise an incident.