### PR TITLE
remove r53resolver cloudwatch resource policies

### DIFF
--- a/terraform/modules/r53-resolver-logs/main.tf
+++ b/terraform/modules/r53-resolver-logs/main.tf
@@ -13,24 +13,3 @@ resource "aws_cloudwatch_log_group" "main" {
   name              = format("%s-r53-resolver-logs", var.vpc_name)
   retention_in_days = 365
 }
-
-resource "aws_cloudwatch_log_resource_policy" "route53-query-logging-policy" {
-  policy_document = data.aws_iam_policy_document.route53-query-logging-policy.json
-  policy_name     = format("%s-r53-query-logging-policy", var.vpc_name)
-}
-
-data "aws_iam_policy_document" "route53-query-logging-policy" {
-  statement {
-    actions = [
-      "logs:CreateLogStream",
-      "logs:PutLogEvents",
-    ]
-
-    resources = [aws_cloudwatch_log_group.main.arn]
-
-    principals {
-      identifiers = ["route53resolver.amazonaws.com"]
-      type        = "Service"
-    }
-  }
-}


### PR DESCRIPTION
Following on from the support case raised around r53 resolver logging issues, it seems prudent to remove these cloudwatch resource policies. They don't seem to add any necessary, extra, security to our logging, they're not visible through the AWS Console, and we're limited to 10 policies per account - this PR frees up 8 of them.