### PR TITLE
Turn off strict checking

### DIFF
--- a/terraform/github/modules/repository/main.tf
+++ b/terraform/github/modules/repository/main.tf
@@ -47,7 +47,7 @@ resource "github_branch_protection" "default" {
   require_signed_commits = false
 
   required_status_checks {
-    strict   = true
+    strict   = false
     contexts = var.required_checks
   }
 


### PR DESCRIPTION
This means branches don't have to be updated against main prior to merging.  This is off by default and only comes on when you have status checks, but it is very annoying and doesn't add much value as merge conflict will still prevent bad merges and the opa tests are rarely updated and protected by codeowners.