### PR TITLE
Update rule options generation

### DIFF
--- a/terraform/modules/firewall-policy/main.tf
+++ b/terraform/modules/firewall-policy/main.tf
@@ -48,7 +48,8 @@ resource "aws_networkfirewall_rule_group" "stateful" {
             source           = stateful_rule.value.source_ip
           }
           rule_option {
-            keyword = format("sid:%s", index(keys(var.rules), stateful_rule.key) + 1)
+            keyword = "sid"
+            settings = [format("%s", index(keys(var.rules), stateful_rule.key) + 1)]
           }
         }
       }


### PR DESCRIPTION
When this code was previously written it was compliant with the AWS API. Since then, the way that the firewall rule option and settings are passed in has changed. This means that with our current code, every change has repeating iterations of the following:
```
                  - rule_option {
                      - keyword  = "sid" -> null
                      - settings = [
                          - "1",
                        ] -> null
                    }
                  + rule_option {
                      + keyword  = "sid:1"
                      + settings = []
                    }
```
This change will correct that by ensuring that the `keyword` and `settings` are separated.