### PR TITLE
Allowing cicd member pull permissions on the mlra ecr repo

### DIFF
--- a/terraform/environments/core-shared-services/ecr_repos.tf
+++ b/terraform/environments/core-shared-services/ecr_repos.tf
@@ -31,6 +31,7 @@ module "mlra_ecr_repo" {
   ]
 
   pull_principals = [
+    "arn:aws:iam::${local.environment_management.account_ids["mlra-development"]}:user/cicd-member-user",
     local.environment_management.account_ids["mlra-development"],
     local.environment_management.account_ids["apex-development"]
   ]


### PR DESCRIPTION
The mlra codebuild pipeline gets triggered by cicd-member user, currently it fails on pull and the cicd-member is not listed in the ECR repo pull permissions.

This change hopefully fixes it.