### PR TITLE
added codedeploy to permissions

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -34,6 +34,7 @@ data "aws_iam_policy_document" "member-access" {
       "cloudfront:*",
       "cloudwatch:*",
       "codebuild:*",
+      "codedeploy:*",
       "codepipeline:*",
       "dbqms:*",
       "dlm:*",


### PR DESCRIPTION
Added permissions for AWS CodeDeploy following request [here](https://mojdt.slack.com/archives/C01A7QK5VM1/p1678810798208709), this expands the permissions for the MemberInfrastructureAccess role to include them.