### PR TITLE
added additional endpoint for SMTP/SES to hmpps for ppud preprod

### DIFF
--- a/environments-networks/hmpps-preproduction.json
+++ b/environments-networks/hmpps-preproduction.json
@@ -19,7 +19,7 @@
   "options": {
     "bastion_linux": true,
     "additional_cidrs": [],
-    "additional_endpoints": [],
+    "additional_endpoints": ["com.amazonaws.eu-west-2.email-smtp"],
     "additional_vpcs": [],
     "dns_zone_extend": []
   }


### PR DESCRIPTION
In line with [this request](https://mojdt.slack.com/archives/C01A7QK5VM1/p1678884616231059), this PR adds the SMTP VPC endpoint to HMPPS preproduction so that the PPUD team can use AWS SES