### PR TITLE
PPUD firewall rules

### DIFF
--- a/terraform/environments/core-network-services/preproduction_rules.json
+++ b/terraform/environments/core-network-services/preproduction_rules.json
@@ -6,13 +6,6 @@
     "destination_port": "80",
     "protocol": "TCP"
   },
-  "psn_to_mp_hmpps_preproduction_http": {
-    "action": "PASS",
-    "source_ip": "51.0.0.0/8",
-    "destination_ip": "10.27.0.0/21",
-    "destination_port": "80",
-    "protocol": "TCP"
-  },
   "psn_to_mp_hmpps_preproduction_https": {
     "action": "PASS",
     "source_ip": "51.0.0.0/8",
@@ -20,25 +13,11 @@
     "destination_port": "443",
     "protocol": "TCP"
   },
-  "moj-core-azure-1_to_mp_hmpps_preproduction_http": {
-    "action": "PASS",
-    "source_ip": "10.50.25.0/27",
-    "destination_ip": "10.27.0.0/21",
-    "destination_port": "80",
-    "protocol": "TCP"
-  },
   "moj-core-azure-1_to_mp_hmpps_preproduction_https": {
     "action": "PASS",
     "source_ip": "10.50.25.0/27",
     "destination_ip": "10.27.0.0/21",
     "destination_port": "443",
-    "protocol": "TCP"
-  },
-  "moj-core-azure-2_to_mp_hmpps_preproduction_http": {
-    "action": "PASS",
-    "source_ip": "10.50.26.0/24",
-    "destination_ip": "10.27.0.0/21",
-    "destination_port": "80",
     "protocol": "TCP"
   },
   "moj-core-azure-2_to_mp_hmpps_preproduction_https": {

--- a/terraform/environments/core-network-services/preproduction_rules.json
+++ b/terraform/environments/core-network-services/preproduction_rules.json
@@ -6,6 +6,48 @@
     "destination_port": "80",
     "protocol": "TCP"
   },
+  "psn_to_mp_hmpps_preproduction_http": {
+    "action": "PASS",
+    "source_ip": "51.0.0.0/8",
+    "destination_ip": "10.27.0.0/21",
+    "destination_port": "80",
+    "protocol": "TCP"
+  },
+  "psn_to_mp_hmpps_preproduction_https": {
+    "action": "PASS",
+    "source_ip": "51.0.0.0/8",
+    "destination_ip": "10.27.0.0/21",
+    "destination_port": "443",
+    "protocol": "TCP"
+  },
+  "moj-core-azure-1_to_mp_hmpps_preproduction_http": {
+    "action": "PASS",
+    "source_ip": "10.50.25.0/27",
+    "destination_ip": "10.27.0.0/21",
+    "destination_port": "80",
+    "protocol": "TCP"
+  },
+  "moj-core-azure-1_to_mp_hmpps_preproduction_https": {
+    "action": "PASS",
+    "source_ip": "10.50.25.0/27",
+    "destination_ip": "10.27.0.0/21",
+    "destination_port": "443",
+    "protocol": "TCP"
+  },
+  "moj-core-azure-2_to_mp_hmpps_preproduction_http": {
+    "action": "PASS",
+    "source_ip": "10.50.26.0/24",
+    "destination_ip": "10.27.0.0/21",
+    "destination_port": "80",
+    "protocol": "TCP"
+  },
+  "moj-core-azure-2_to_mp_hmpps_preproduction_https": {
+    "action": "PASS",
+    "source_ip": "10.50.26.0/24",
+    "destination_ip": "10.27.0.0/21",
+    "destination_port": "443",
+    "protocol": "TCP"
+  },
   "default_block_preprod_production_ingress": {
     "action": "DROP",
     "source_ip": "0.0.0.0/0",

--- a/terraform/environments/core-network-services/production_rules.json
+++ b/terraform/environments/core-network-services/production_rules.json
@@ -111,41 +111,18 @@
     "destination_port": "9100",
     "protocol": "TCP"
   },
-  "psn_to_mp_hmpps_preproduction_http": {
-    "action": "PASS",
-    "source_ip": "51.0.0.0/8",
-    "destination_ip": "10.27.8.0/21",
-    "destination_port": "80",
-    "protocol": "TCP"
-  },
   "psn_to_mp_hmpps_preproduction_https": {
     "action": "PASS",
     "source_ip": "51.0.0.0/8",
     "destination_ip": "10.27.8.0/21",
     "destination_port": "443",
     "protocol": "TCP"
-  },
-  "moj-core-azure-1_to_mp_hmpps_preproduction_http": {
-    "action": "PASS",
-    "source_ip": "10.50.25.0/27",
-    "destination_ip": "10.27.8.0/21",
-    "destination_port": "80",
-    "protocol": "TCP"
-  },
   "moj-core-azure-1_to_mp_hmpps_preproduction_https": {
     "action": "PASS",
     "source_ip": "10.50.25.0/27",
     "destination_ip": "10.27.8.0/21",
     "destination_port": "443",
     "protocol": "TCP"
-  },
-  "moj-core-azure-2_to_mp_hmpps_preproduction_http": {
-    "action": "PASS",
-    "source_ip": "10.50.26.0/24",
-    "destination_ip": "10.27.8.0/21",
-    "destination_port": "80",
-    "protocol": "TCP"
-  },
   "moj-core-azure-2_to_mp_hmpps_preproduction_https": {
     "action": "PASS",
     "source_ip": "10.50.26.0/24",

--- a/terraform/environments/core-network-services/production_rules.json
+++ b/terraform/environments/core-network-services/production_rules.json
@@ -110,5 +110,47 @@
     "destination_ip": "10.27.8.0/21",
     "destination_port": "9100",
     "protocol": "TCP"
+  },
+  "psn_to_mp_hmpps_preproduction_http": {
+    "action": "PASS",
+    "source_ip": "51.0.0.0/8",
+    "destination_ip": "10.27.8.0/21",
+    "destination_port": "80",
+    "protocol": "TCP"
+  },
+  "psn_to_mp_hmpps_preproduction_https": {
+    "action": "PASS",
+    "source_ip": "51.0.0.0/8",
+    "destination_ip": "10.27.8.0/21",
+    "destination_port": "443",
+    "protocol": "TCP"
+  },
+  "moj-core-azure-1_to_mp_hmpps_preproduction_http": {
+    "action": "PASS",
+    "source_ip": "10.50.25.0/27",
+    "destination_ip": "10.27.8.0/21",
+    "destination_port": "80",
+    "protocol": "TCP"
+  },
+  "moj-core-azure-1_to_mp_hmpps_preproduction_https": {
+    "action": "PASS",
+    "source_ip": "10.50.25.0/27",
+    "destination_ip": "10.27.8.0/21",
+    "destination_port": "443",
+    "protocol": "TCP"
+  },
+  "moj-core-azure-2_to_mp_hmpps_preproduction_http": {
+    "action": "PASS",
+    "source_ip": "10.50.26.0/24",
+    "destination_ip": "10.27.8.0/21",
+    "destination_port": "80",
+    "protocol": "TCP"
+  },
+  "moj-core-azure-2_to_mp_hmpps_preproduction_https": {
+    "action": "PASS",
+    "source_ip": "10.50.26.0/24",
+    "destination_ip": "10.27.8.0/21",
+    "destination_port": "443",
+    "protocol": "TCP"
   }
 }

--- a/terraform/environments/core-network-services/production_rules.json
+++ b/terraform/environments/core-network-services/production_rules.json
@@ -117,12 +117,14 @@
     "destination_ip": "10.27.8.0/21",
     "destination_port": "443",
     "protocol": "TCP"
+  },
   "moj-core-azure-1_to_mp_hmpps_preproduction_https": {
     "action": "PASS",
     "source_ip": "10.50.25.0/27",
     "destination_ip": "10.27.8.0/21",
     "destination_port": "443",
     "protocol": "TCP"
+  },
   "moj-core-azure-2_to_mp_hmpps_preproduction_https": {
     "action": "PASS",
     "source_ip": "10.50.26.0/24",


### PR DESCRIPTION
To allow internal MOJ administrators access to the PPUD systems being replatformed onto the Modernisation Platform, some firewall rules need to be added.