### PR TITLE
added firewall rules for traffic from LAA landing zones to mp-laa-test

### DIFF
--- a/terraform/environments/core-network-services/test_rules.json
+++ b/terraform/environments/core-network-services/test_rules.json
@@ -96,5 +96,33 @@
     "destination_ip": "10.102.0.0/16",
     "destination_port": "53",
     "protocol": "UDP"
+  },
+  "laa_staging_to_mp_laa_test": {
+    "action": "PASS",
+    "source_ip": "10.204.0.0/20",
+    "destination_ip": "10.26.96.0/21",
+    "destination_port": "ANY",
+    "protocol": "IP"
+  },
+  "laa_uat_to_mp_laa_test": {
+    "action": "PASS",
+    "source_ip": "10.206.0.0/20",
+    "destination_ip": "10.26.96.0/21",
+    "destination_port": "ANY",
+    "protocol": "IP"
+  },
+  "laa_shared_services_nonprod_to_mp_laa_test": {
+    "action": "PASS",
+    "source_ip": "10.200.0.0/20",
+    "destination_ip": "10.26.96.0/21",
+    "destination_port": "ANY",
+    "protocol": "IP"
+  },
+  "laa_shared_services_prod_to_mp_laa_test": {
+    "action": "PASS",
+    "source_ip": "10.200.16.0/20",
+    "destination_ip": "10.26.96.0/21",
+    "destination_port": "ANY",
+    "protocol": "IP"
   }
 }


### PR DESCRIPTION
Based off of a request through the #ask-modernisation-platform slack channel, we were requested to allow traffic in from the LAA landing-zone AWS accounts: https://mojdt.slack.com/archives/C01A7QK5VM1/p1679308738746229