### PR TITLE
Trim reviewers for new environments

### DIFF
--- a/scripts/git-create-environments.sh
+++ b/scripts/git-create-environments.sh
@@ -52,9 +52,9 @@ create_environment() {
   # echo "Teams for payload: ${github_teams}"
   if [ "${env}" == "preproduction" ] || [ "${env}" == "production" ]
   then
-    payload="{\"deployment_branch_policy\":{\"protected_branches\":true,\"custom_branch_policies\":false},\"reviewers\": [{\"type\":\"Team\",\"id\":${modernisation_platform_id}},${github_teams}]}"
+    payload="{\"deployment_branch_policy\":{\"protected_branches\":true,\"custom_branch_policies\":false},\"reviewers\": [{\"type\":\"Team\",\"id\":${github_teams}]}"
   else
-    payload="{\"reviewers\": [{\"type\":\"Team\",\"id\":${modernisation_platform_id}},${github_teams}]}"
+    payload="{\"reviewers\": [{\"type\":\"Team\",\"id\":${github_teams}]}"
   fi
   # echo "Payload: $payload"
   echo "${payload}" | curl -s \
@@ -78,11 +78,6 @@ create_reviewers_json() {
   reviewers_json=`echo ${reviewers_json} | sed 's/,*$//g'`
   # echo "Reviewers json: ${reviewers_json}"
 }
-
-# get modernisation platform github ID
-team_ids=""
-get_github_team_id modernisation-platform
-modernisation_platform_id=$team_ids
 
 main() {
   #load existing github environments


### PR DESCRIPTION
In response to #3476 this PR removes sections of the `git-create-environments` script that add in the modernisation platform team as a secondary approver for environment deployments, and trims the part of the script that populates the `modernisation_platform_id` variable.