### PR TITLE
Update provider templates for better local plans

### DIFF
--- a/source/user-guide/running-terraform-plan-locally.html.md.erb
+++ b/source/user-guide/running-terraform-plan-locally.html.md.erb
@@ -10,31 +10,6 @@ review_in: 6 months
 Whilst it is possible to see the results of a Terraform plan when you [create a pull request](./deploying-your-infrastructure.html#jobs-on-pull-request), it is also possible to run a Terraform plan locally.
 Some engineers prefer this as it provides a quicker feedback loop to identify any issues with your infrastructure code.
 
-## Running local plans without file modifications
-
-We are currently trialing the ability to run local terraform plans without modifications to `platform_providers.tf`. Please see [here](https://github.com/ministryofjustice/modernisation-platform-environments/blob/main/terraform/environments/example/platform_providers.tf) for an example of `platform_providers.tf` which supports this. If your environment has been converted, you will see
-
-```
-data "aws_iam_session_context" "whoami" {
-  provider = aws.oidc-session
-  arn      = data.aws_caller_identity.oidc_session.arn
-}
-```
-
-in your `locals.tf`. If you would like to take part in the trial, please get in touch in our Slack channel [#ask-modernisation-platform](https://mojdt.slack.com/archives/C01A7QK5VM1) If you are part of the trial, you skip the next step of this guide and proceed to [Enter your AWS SSO credentials](#enter-your-aws-sso-credentials)
-
-## Modify your platform_providers.tf
-
-In the [modernisation-platform-environments repository](https://github.com/ministryofjustice/modernisation-platform-environments), in your application folder there is a file called `platform_providers.tf`
-
-This file details the Terraform AWS providers used and which roles they use when running Terraform.
-
-The top part of the file details the configuration which is needed to run the Terraform on the GitHub Actions CI/CD pipelines. The second section, which is by default commented out, details configuration required if running a plan locally.
-
-To run a plan locally, you need to comment out the top section of `platform_providers.tf`, and uncomment the bottom section of the file.  Comments within the file show which sections.
-
->Note do not check in to GitHub any modifications to the file, as this will cause the pipeline to stop working, these changes are only for running Terraform plans locally.
-
 ## Enter your AWS SSO credentials
 
 Get your AWS SSO credentials as detailed [here](./getting-aws-credentials.html), choose option 1 and paste the credentials into the terminal window you are working from.
@@ -53,4 +28,4 @@ Follow the instructions [here](https://learn.hashicorp.com/tutorials/terraform/i
 1. Select the required workspace - `terraform workspace select my-application-development`
 1. Run a Terraform plan - `terraform plan`
 
->Running a plan locally has read only permissions, you will not be able to run an apply.
+>Running a plan locally has read only permissions, you will not be able to run an apply, destroy or import.

--- a/source/user-guide/working-as-a-collaborator.html.md.erb
+++ b/source/user-guide/working-as-a-collaborator.html.md.erb
@@ -49,35 +49,34 @@ AWS provides credentials which can give you programatic access to your AWS accou
 
 ## Running a Terraform plan locally as a collaborator
 
-To run a Terraform locally as a collaborator, you will need to get your AWS credentials. These can be obtained from here[https://moj.awsapps.com/start#/] and selecting `Command line or programmatic access` and copy and pasting in the `Short-term credentials` to your terminal.
+### Set credentials
 
-Currently, you should follow the standard [running terraform plan locally](../user-guide/running-terraform-plan-locally.html) instructions, ignoring the SSO section, running Terraform using AWS Vault and making one further code change:
+To run a Terraform locally as a collaborator, you will need to get your AWS credentials. See above for creating and obtaining these, you will need use a tool such as [aws-vault](https://github.com/99designs/aws-vault) to handle MFA, or you can generate a session token using the AWS CLI. (Terraform does not support the use of MFA well when assuming roles.)
 
-Under the local plan section of the `providers.tf` file:
+### Set the role you assume
 
-```
-######################### Run Terraform Plan Locally Only ##################################
-# To run a Terraform Plan locally, uncomment this bottom section of code and comment out the top section
+There are different [access levels](https://user-guide.modernisation-platform.service.justice.gov.uk/user-guide/creating-environments.html#access) that map to different roles that you can assume when running Terraform.
 
-provider "aws" {
-  region = "eu-west-2"
-}
-```
+By default if you do nothing the role you assume will be the `developer` role.
 
-Add in an assume role block for the main provider with the account number that local plan is for, for example:
+If you wish to assume another role, eg `migration` or `sandbox` you will need to set an environment variable:
 
-```
-######################### Run Terraform Plan Locally Only ##################################
-# To run a Terraform Plan locally, uncomment this bottom section of code and comment out the top section
+`export TF_VAR_collaborator_access=migration`
 
-provider "aws" {
-  region = "eu-west-2"
-  assume_role {
-    role_arn = "arn:aws:iam::<my-account-number>:role/developer"
-  }
-}
-```
-As with all local plan changes, please do not add these changes to version control or the CI/CD GitHub workflows will stop running.
+### Install Terraform
+
+Follow the instructions [here](https://learn.hashicorp.com/tutorials/terraform/install-cli) to install the latest version of Terraform according to your platform.
+
+### Run Terraform plan
+
+1. Navigate to your application infrastructure code - `cd modernisation-platform-environments/terraform/environments/my-application`
+1. Run a Terraform init - `terraform init`
+1. View the workspaces (you have different workspaces for your different environment accounts) - `terraform workspace list`
+1. Select the required workspace - `terraform workspace select my-application-development`
+1. Run a Terraform plan - `terraform plan`
+
+>Running a plan locally has read only permissions, you will not be able to run an apply, destroy or import.
+
 
 ## Accessing EC2s as a Collaborator
 

--- a/terraform/templates/modernisation-platform-environments/platform_base_variables.tf
+++ b/terraform/templates/modernisation-platform-environments/platform_base_variables.tf
@@ -3,3 +3,9 @@ variable "networking" {
   type = list(any)
 
 }
+
+variable "collaborator_access" {
+  type        = string
+  default     = "developer"
+  description = "Collaborators must specify which access level they are using, eg set an environment variable of export TF_VAR_collaborator_access=migration"
+}

--- a/terraform/templates/modernisation-platform-environments/platform_providers.tf
+++ b/terraform/templates/modernisation-platform-environments/platform_providers.tf
@@ -1,14 +1,14 @@
-# ######################### Run Terraform via CICD ##################################
-# AWS provider for the workspace you're working in (every resource will default to using this, unless otherwise specified)
+# AWS provider for the original session which you connect with
 provider "aws" {
   alias  = "original-session"
   region = "eu-west-2"
 }
 
+# AWS provider for the workspace you're working in (every resource will default to using this, unless otherwise specified)
 provider "aws" {
   region = "eu-west-2"
   assume_role {
-    role_arn = "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccess"
+    role_arn = !can(regex("githubactionsrolesession|AdministratorAccess|user", data.aws_caller_identity.original_session.arn)) ? null : can(regex("user", data.aws_caller_identity.original_session.arn)) ? "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/${var.collaborator_access}" : "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccess"
   }
 }
 
@@ -21,12 +21,12 @@ provider "aws" {
   }
 }
 
-# AWS provider for core-vpc-<environment>, to share VPCs into this account
+# AWS provider for core-vpc-<environment>, to access resources in the core-vpc accounts
 provider "aws" {
   alias  = "core-vpc"
   region = "eu-west-2"
   assume_role {
-    role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-${local.vpc_name}-${local.environment}"
+    role_arn = !can(regex("githubactionsrolesession|AdministratorAccess", data.aws_caller_identity.original_session.arn)) ? "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-read-only" : "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-${local.vpc_name}-${local.environment}"
   }
 }
 
@@ -35,11 +35,11 @@ provider "aws" {
   alias  = "core-network-services"
   region = "eu-west-2"
   assume_role {
-    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/modify-dns-records"
+    role_arn = !can(regex("githubactionsrolesession|AdministratorAccess", data.aws_caller_identity.original_session.arn)) ? "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/read-dns-records" : "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/modify-dns-records"
   }
 }
 
-# AWS provider for the ACM usage in us-east-1
+# Provider for creating resources in us-east-1, eg ACM resources for CloudFront
 provider "aws" {
   alias  = "us-east-1"
   region = "us-east-1"
@@ -47,48 +47,3 @@ provider "aws" {
     role_arn = "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
   }
 }
-
-######################### Run Terraform via CICD ##################################
-
-
-######################### Run Terraform Plan Locally Only ##################################
-# # To run a Terraform Plan locally, uncomment this bottom section of code and comment out the top section
-
-# provider "aws" {
-#   region = "eu-west-2"
-# }
-
-# provider "aws" {
-#   alias  = "original-session"
-#   region = "eu-west-2"
-# }
-
-# # AWS provider for the Modernisation Platform, to get things from there if required
-# provider "aws" {
-#   alias                  = "modernisation-platform"
-#   region                 = "eu-west-2"
-#   assume_role {
-#     role_arn = "arn:aws:iam::${local.modernisation_platform_account_id}:role/modernisation-account-limited-read-member-access"
-#   }
-# }
-
-# # AWS provider for core-vpc-<environment>, to share VPCs into this account
-# provider "aws" {
-#   alias  = "core-vpc"
-#   region = "eu-west-2"
-
-#   assume_role {
-#     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-read-only"
-#   }
-# }
-
-# # AWS provider for network services to enable dns entries for certificate validation to be created
-# provider "aws" {
-#   alias  = "core-network-services"
-#   region = "eu-west-2"
-
-#   assume_role {
-#     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/read-dns-records"
-#   }
-# }
-######################### Run Terraform Plan Locally Only ##################################

--- a/terraform/templates/modernisation-platform-environments/platform_secrets.tf
+++ b/terraform/templates/modernisation-platform-environments/platform_secrets.tf
@@ -1,6 +1,7 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
-  name = "modernisation_platform_account_id"
+  provider = aws.original-session
+  name     = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management


### PR DESCRIPTION
To run plans locally you used to have to comment and uncomment the provider files.  This change updates the templates so that the user you are using is detected and the appropriate provider settings applied.

Also updating documentation around this.

Issue https://github.com/ministryofjustice/modernisation-platform/issues/2943