### PR TITLE
Adding the OIDC role in the environments directory.

### DIFF
--- a/terraform/environments/data-platform/data-platform-oidc.tf
+++ b/terraform/environments/data-platform/data-platform-oidc.tf
@@ -1,0 +1,8 @@
+module "github_actions_roles" {
+  source              = "github.com/ministryofjustice/modernisation-platform-github-oidc-role?ref=v1.0.0"
+  github_repositories = local.oidc_repositories
+  role_name           = "data-platform-labs-github-actions"
+  policy_arns         = local.oidc_default_policy_arns
+  policy_jsons        = [data.aws_iam_policy.cicd_member_policy.policy]
+  tags                = local.tags
+}

--- a/terraform/environments/data-platform/data.tf
+++ b/terraform/environments/data-platform/data.tf
@@ -2,3 +2,7 @@
 data "http" "environments_file" {
   url = "https://raw.githubusercontent.com/ministryofjustice/modernisation-platform/main/environments/${local.application_name}.json"
 }
+
+data "aws_iam_policy" "cicd_member_policy" {
+  name = "cicd-member-policy"
+}

--- a/terraform/environments/data-platform/locals.tf
+++ b/terraform/environments/data-platform/locals.tf
@@ -32,4 +32,8 @@ locals {
   # example usage:
   # example_data = local.application_data.accounts[local.environment].example_var
   application_data = fileexists("./application_variables.json") ? jsondecode(file("./application_variables.json")) : {}
+
+  oidc_repositories        = ["ministryofjustice/data-platform-products:*"]
+  oidc_default_policy_arns = ["arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess"]
+
 }


### PR DESCRIPTION
Using the modernisation platform oidc role module to create a web-identity-assumable role to be used in external data platform repositories.

List of repositories managed via a local.
Permissions are duplicates of cicd-member-user
