### PR TITLE
Refactor provisioning script

### DIFF
--- a/scripts/provision-environment-directories.sh
+++ b/scripts/provision-environment-directories.sh
@@ -2,7 +2,7 @@
 
 basedir=terraform/environments
 networkdir=environments-networks
-templates=terraform/templates/*.tf
+templates=terraform/templates/modernisation-platform/*.*
 environments=environments
 
 provision_environment_directories() {
@@ -87,8 +87,6 @@ copy_templates() {
     filename=$(basename "$file")
     account_type=$(jq -r '."account-type"' ${environments}/${application_name}.json)
 
-    if [ ${filename} != "platform_locals.tf" ] && [ ${filename} != "platform_providers.tf" ] && [ ${filename} != "platform_data.tf" ] && [[ "${filename}" !=  "member_"* ]]
-    then
       if [ ${filename} == "subnet_share.tf" ] && ([ ${account_type} == "member-unrestricted" ] ||  [ ${account_type} == "core" ]); then
         echo "Skipping $file for $application_name as it is an unrestricted or a core account."
       else
@@ -105,7 +103,6 @@ copy_templates() {
           fi
         fi
       fi
-    fi
   done
 
   echo "Finished copying templates."

--- a/scripts/provision-member-directories.sh
+++ b/scripts/provision-member-directories.sh
@@ -9,7 +9,7 @@ core_repo_dir=core-repo
 env_repo_dir=modernisation-platform-environments
 basedir=$env_repo_dir/terraform/environments
 networkdir=$core_repo_dir/environments-networks
-templates=$core_repo_dir/terraform/templates/*.tf
+templates=$core_repo_dir/terraform/templates/modernisation-platform-environments/*.*
 environment_json_dir=$core_repo_dir/environments
 codeowners_file=$env_repo_dir/.github/CODEOWNERS
 
@@ -98,40 +98,21 @@ provision_environment_directories() {
 }
 
 copy_templates() {
-
   for file in $templates; do
     filename=$(basename "$file")
-
-    if [ ${filename} != "subnet_share.tf" ] && [ ${filename} != "providers.tf" ] && [ ${filename} != "locals.tf" ] && [ ${filename} != "data.tf" ]
-    then
-      echo "Copying $file to $1, replacing application_name with $application_name"
-      sed "s/\$application_name/${application_name}/g" "$file" > "$1/$filename"
-      if [ ${filename} == "platform_backend.tf" ]
+    echo "Copying $file to $1, replacing application_name with $application_name"
+    sed "s/\$application_name/${application_name}/g" "$file" > "$1/$filename"
+    if [ ${filename} == "platform_backend.tf" ]
       then
         if [ `uname` = "Linux" ]
         then
           sed -i "s/environments\//environments\/members\//g" "$1/$filename"
-          sed -i "/dynamodb_table/d" "$1/$filename"
         else
           # This must be a Mac
           sed -i '' "s/environments\//environments\/members\//g" "$1/$filename"
-          sed -i '' "/dynamodb_table/d" "$1/$filename"
         fi
       fi
-    fi
   done
-
-  # rename member data file to data.tf
-  mv $1/member_data.tf $1/data.tf
-  # rename member locals file to locals.tf
-  mv $1/member_locals.tf $1/locals.tf
-  # rename member secrets file to secrets.tf
-  mv $1/member_secrets.tf $1/secrets.tf
-  # copy application variable file
-  cp $core_repo_dir/terraform/templates/application_variables.json $1
-  # copy service runbook template file and rename it to README.md
-  cp $core_repo_dir/terraform/templates/service_runbook_template.md $1/README.md
-
   echo "Finished copying templates."
 }
 

--- a/terraform/templates/modernisation-platform-environments/README.md
+++ b/terraform/templates/modernisation-platform-environments/README.md
@@ -1,0 +1,76 @@
+# Service Runbook
+
+<!-- This is a template that should be populated by the development team when moving to the modernisation platform, but also reviewed and kept up to date.
+To ensure that people looking at your runbook can get the information they need quickly, your runbook should be short but clear. Throughout, only use acronyms if you’re confident that someone who has just been woken up at 3am would understand them. -->
+
+_If you have any questions surrounding this page please post in the `#team-name` channel._
+
+## Mandatory Information
+
+### **Last review date:**
+
+<!-- Adding the last date this page was reviewed, with any accompanying information -->
+
+### **Description:**
+
+<!-- A short (less than 50 word) description of what your service does, and who it’s for.-->
+
+### **Service URLs:**
+
+<!--  The URL(s) of the service’s production environment, and test environments if possible-->
+
+### **Incident response hours:**
+
+<!-- When your service receives support for urgent issues. This should be written in a clear, unambiguous way. For example: 24/7/365, Office hours, usually 9am-6pm on working days, or 7am-10pm, 365 days a year. -->
+
+### **Incident contact details:**
+
+<!-- How people can raise an urgent issue with your service. This must not be the email address or phone number of an individual on your team, it should be a shared email address, phone number, or website that allows someone with an urgent issue to raise it quickly. -->
+
+### **Service team contact:**
+
+<!-- How people with non-urgent issues or questions can get in touch with your team. As with incident contact details, this must not be the email address or phone number of an individual on the team, it should be a shared email address or a ticket tracking system.-->
+
+### **Hosting environment:**
+
+Modernisation Platform
+
+<!-- If your service is hosted on another MOJ team’s infrastructure, link to their runbook. If your service has another arrangement or runs its own infrastructure, you should list the supplier of that infrastructure (ideally linking to your account’s login page) and describe, simply and briefly, how to raise an issue with them. -->
+
+## Optional
+
+### **Other URLs:**
+
+<!--  If you can, provide links to the service’s monitoring dashboard(s), health checks, documentation (ideally describing how to run/work with the service), and main GitHub repository. -->
+
+### **Expected speed and frequency of releases:**
+
+<!-- How often are you able to release changes to your service, and how long do those changes take? -->
+
+### **Automatic alerts:**
+
+<!-- List, briefly, problems (or types of problem) that will automatically alert your team when they occur. -->
+
+### **Impact of an outage:**
+
+<!-- A short description of the risks if your service is down for an extended period of time. -->
+
+### **Out of hours response types:**
+
+<!-- Describe how incidents that page a person on call are responded to. How long are out-of-hours responders expected to spend trying to resolve issues before they stop working, put the service into maintenance mode, and hand the issue to in-hours support? -->
+
+### **Consumers of this service:**
+
+<!-- List which other services (with links to their runbooks) rely on this service. If your service is considered a platform, these may be too numerous to reasonably list. -->
+
+### **Services consumed by this:**
+
+<!-- List which other services (with links to their runbooks) this service relies on. -->
+
+### **Restrictions on access:**
+
+<!-- Describe any conditions which restrict access to the service, such as if it’s IP-restricted or only accessible from a private network.-->
+
+### **How to resolve specific issues:**
+
+<!-- Describe the steps someone might take to resolve a specific issue or incident, often for use when on call. This may be a large amount of information, so may need to be split out into multiple pages, or link to other documents.-->

--- a/terraform/templates/modernisation-platform-environments/application_variables.json
+++ b/terraform/templates/modernisation-platform-environments/application_variables.json
@@ -1,0 +1,16 @@
+{
+  "accounts": {
+    "development": {
+      "example_var": "dev-data"
+    },
+    "test": {
+      "example_var": "test-data"
+    },
+    "preproduction": {
+      "example_var": "preproduction-data"
+    },
+    "production": {
+      "example_var": "production-data"
+    }
+  }
+}

--- a/terraform/templates/modernisation-platform-environments/data.tf
+++ b/terraform/templates/modernisation-platform-environments/data.tf
@@ -1,0 +1,1 @@
+#### This file can be used to store data specific to the member account ####

--- a/terraform/templates/modernisation-platform-environments/locals.tf
+++ b/terraform/templates/modernisation-platform-environments/locals.tf
@@ -1,0 +1,1 @@
+#### This file can be used to store locals specific to the member account ####

--- a/terraform/templates/modernisation-platform-environments/platform_backend.tf
+++ b/terraform/templates/modernisation-platform-environments/platform_backend.tf
@@ -1,0 +1,13 @@
+# Backend
+terraform {
+  # `backend` blocks do not support variables, so the following are hard-coded here:
+  # - S3 bucket name, which is created in modernisation-platform-account/s3.tf
+  backend "s3" {
+    acl                  = "bucket-owner-full-control"
+    bucket               = "modernisation-platform-terraform-state"
+    encrypt              = true
+    key                  = "terraform.tfstate"
+    region               = "eu-west-2"
+    workspace_key_prefix = "environments/$application_name" # This will store the object as environments/$application_name/${workspace}/terraform.tfstate
+  }
+}

--- a/terraform/templates/modernisation-platform-environments/platform_base_variables.tf
+++ b/terraform/templates/modernisation-platform-environments/platform_base_variables.tf
@@ -1,0 +1,5 @@
+variable "networking" {
+
+  type = list(any)
+
+}

--- a/terraform/templates/modernisation-platform-environments/platform_data.tf
+++ b/terraform/templates/modernisation-platform-environments/platform_data.tf
@@ -1,0 +1,173 @@
+# Current account data
+data "aws_region" "current" {}
+
+data "aws_caller_identity" "current" {}
+
+# VPC and subnet data
+data "aws_vpc" "shared" {
+  tags = {
+    "Name" = "${var.networking[0].business-unit}-${local.environment}"
+  }
+}
+
+data "aws_subnets" "shared-data" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.shared.id]
+  }
+  tags = {
+    Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-data*"
+  }
+}
+
+data "aws_subnets" "private-public" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.shared.id]
+  }
+  tags = {
+    Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-private*"
+  }
+}
+
+data "aws_subnets" "shared-public" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.shared.id]
+  }
+  tags = {
+    Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-public*"
+  }
+}
+
+data "aws_subnet" "data_subnets_a" {
+  vpc_id = data.aws_vpc.shared.id
+  tags = {
+    "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-data-${data.aws_region.current.name}a"
+  }
+}
+
+data "aws_subnet" "data_subnets_b" {
+  vpc_id = data.aws_vpc.shared.id
+  tags = {
+    "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-data-${data.aws_region.current.name}b"
+  }
+}
+
+data "aws_subnet" "data_subnets_c" {
+  vpc_id = data.aws_vpc.shared.id
+  tags = {
+    "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-data-${data.aws_region.current.name}c"
+  }
+}
+
+data "aws_subnet" "private_subnets_a" {
+  vpc_id = data.aws_vpc.shared.id
+  tags = {
+    "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-private-${data.aws_region.current.name}a"
+  }
+}
+
+data "aws_subnet" "private_subnets_b" {
+  vpc_id = data.aws_vpc.shared.id
+  tags = {
+    "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-private-${data.aws_region.current.name}b"
+  }
+}
+
+data "aws_subnet" "private_subnets_c" {
+  vpc_id = data.aws_vpc.shared.id
+  tags = {
+    "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-private-${data.aws_region.current.name}c"
+  }
+}
+
+data "aws_subnet" "public_subnets_a" {
+  vpc_id = data.aws_vpc.shared.id
+  tags = {
+    Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-public-${data.aws_region.current.name}a"
+  }
+}
+
+data "aws_subnet" "public_subnets_b" {
+  vpc_id = data.aws_vpc.shared.id
+  tags = {
+    Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-public-${data.aws_region.current.name}b"
+  }
+}
+
+data "aws_subnet" "public_subnets_c" {
+  vpc_id = data.aws_vpc.shared.id
+  tags = {
+    Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-public-${data.aws_region.current.name}c"
+  }
+}
+
+# Route53 DNS data
+data "aws_route53_zone" "external" {
+  provider = aws.core-vpc
+
+  name         = "${var.networking[0].business-unit}-${local.environment}.modernisation-platform.service.justice.gov.uk."
+  private_zone = false
+}
+
+data "aws_route53_zone" "inner" {
+  provider = aws.core-vpc
+
+  name         = "${var.networking[0].business-unit}-${local.environment}.modernisation-platform.internal."
+  private_zone = true
+}
+
+data "aws_route53_zone" "network-services" {
+  provider = aws.core-network-services
+
+  name         = "modernisation-platform.service.justice.gov.uk."
+  private_zone = false
+}
+
+# Shared KMS keys (per business unit)
+data "aws_kms_key" "general_shared" {
+  key_id = "arn:aws:kms:eu-west-2:${local.environment_management.account_ids["core-shared-services-production"]}:alias/general-${var.networking[0].business-unit}"
+}
+
+data "aws_kms_key" "ebs_shared" {
+  key_id = "arn:aws:kms:eu-west-2:${local.environment_management.account_ids["core-shared-services-production"]}:alias/ebs-${var.networking[0].business-unit}"
+}
+
+data "aws_kms_key" "rds_shared" {
+  key_id = "arn:aws:kms:eu-west-2:${local.environment_management.account_ids["core-shared-services-production"]}:alias/rds-${var.networking[0].business-unit}"
+}
+
+# State for core-network-services resource information
+data "terraform_remote_state" "core_network_services" {
+  backend = "s3"
+  config = {
+    acl     = "bucket-owner-full-control"
+    bucket  = "modernisation-platform-terraform-state"
+    key     = "environments/accounts/core-network-services/core-network-services-production/terraform.tfstate"
+    region  = "eu-west-2"
+    encrypt = "true"
+  }
+}
+
+data "aws_organizations_organization" "root_account" {}
+
+# Retrieve information about the modernisation platform account
+data "aws_caller_identity" "modernisation_platform" {
+  provider = aws.modernisation-platform
+}
+
+# caller account information to instantiate aws.oidc provider
+data "aws_caller_identity" "original_session" {
+  provider = aws.original-session
+}
+
+data "aws_iam_session_context" "whoami" {
+  provider = aws.original-session
+  arn      = data.aws_caller_identity.original_session.arn
+}
+
+# Get the environments file from the main repository
+data "http" "environments_file" {
+  url = "https://raw.githubusercontent.com/ministryofjustice/modernisation-platform/main/environments/${local.application_name}.json"
+}

--- a/terraform/templates/modernisation-platform-environments/platform_locals.tf
+++ b/terraform/templates/modernisation-platform-environments/platform_locals.tf
@@ -1,0 +1,38 @@
+locals {
+
+  application_name = "$application_name"
+
+  environment_management = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
+
+  # Stores modernisation platform account id for setting up the modernisation-platform provider
+  modernisation_platform_account_id = data.aws_ssm_parameter.modernisation_platform_account_id.value
+
+  # This takes the name of the Terraform workspace (e.g. core-vpc-production), strips out the application name (e.g. core-vpc), and checks if
+  # the string leftover is `-production`, if it isn't (e.g. core-vpc-non-production => -non-production) then it sets the var to false.
+  is-production    = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-production"
+  is-preproduction = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-preproduction"
+  is-test          = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-test"
+  is-development   = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-development"
+
+  # Merge tags from the environment json file with additional ones
+  tags = merge(
+    jsondecode(data.http.environments_file.response_body).tags,
+    { "is-production" = local.is-production },
+    { "environment-name" = terraform.workspace },
+    { "source-code" = "https://github.com/ministryofjustice/modernisation-platform-environments" }
+  )
+
+  environment     = trimprefix(terraform.workspace, "${var.networking[0].application}-")
+  vpc_name        = var.networking[0].business-unit
+  subnet_set      = var.networking[0].set
+  vpc_all         = "${local.vpc_name}-${local.environment}"
+  subnet_set_name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}"
+
+  is_live       = [substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-production" || substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-preproduction" ? "live" : "non-live"]
+  provider_name = "core-vpc-${local.environment}"
+
+  # environment specfic variables
+  # example usage:
+  # example_data = local.application_data.accounts[local.environment].example_var
+  application_data = fileexists("./application_variables.json") ? jsondecode(file("./application_variables.json")) : null
+}

--- a/terraform/templates/modernisation-platform-environments/platform_providers.tf
+++ b/terraform/templates/modernisation-platform-environments/platform_providers.tf
@@ -1,0 +1,94 @@
+# ######################### Run Terraform via CICD ##################################
+# AWS provider for the workspace you're working in (every resource will default to using this, unless otherwise specified)
+provider "aws" {
+  alias  = "original-session"
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccess"
+  }
+}
+
+# AWS provider for the Modernisation Platform, to get things from there if required
+provider "aws" {
+  alias  = "modernisation-platform"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${local.modernisation_platform_account_id}:role/modernisation-account-limited-read-member-access"
+  }
+}
+
+# AWS provider for core-vpc-<environment>, to share VPCs into this account
+provider "aws" {
+  alias  = "core-vpc"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-${local.vpc_name}-${local.environment}"
+  }
+}
+
+# AWS provider for network services to enable dns entries for certificate validation to be created
+provider "aws" {
+  alias  = "core-network-services"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/modify-dns-records"
+  }
+}
+
+# AWS provider for the ACM usage in us-east-1
+provider "aws" {
+  alias  = "us-east-1"
+  region = "us-east-1"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
+  }
+}
+
+######################### Run Terraform via CICD ##################################
+
+
+######################### Run Terraform Plan Locally Only ##################################
+# # To run a Terraform Plan locally, uncomment this bottom section of code and comment out the top section
+
+# provider "aws" {
+#   region = "eu-west-2"
+# }
+
+# provider "aws" {
+#   alias  = "original-session"
+#   region = "eu-west-2"
+# }
+
+# # AWS provider for the Modernisation Platform, to get things from there if required
+# provider "aws" {
+#   alias                  = "modernisation-platform"
+#   region                 = "eu-west-2"
+#   assume_role {
+#     role_arn = "arn:aws:iam::${local.modernisation_platform_account_id}:role/modernisation-account-limited-read-member-access"
+#   }
+# }
+
+# # AWS provider for core-vpc-<environment>, to share VPCs into this account
+# provider "aws" {
+#   alias  = "core-vpc"
+#   region = "eu-west-2"
+
+#   assume_role {
+#     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-read-only"
+#   }
+# }
+
+# # AWS provider for network services to enable dns entries for certificate validation to be created
+# provider "aws" {
+#   alias  = "core-network-services"
+#   region = "eu-west-2"
+
+#   assume_role {
+#     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/read-dns-records"
+#   }
+# }
+######################### Run Terraform Plan Locally Only ##################################

--- a/terraform/templates/modernisation-platform-environments/platform_secrets.tf
+++ b/terraform/templates/modernisation-platform-environments/platform_secrets.tf
@@ -1,0 +1,16 @@
+# Get modernisation account id from ssm parameter
+data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  name = "modernisation_platform_account_id"
+}
+
+# Get secret by arn for environment management
+data "aws_secretsmanager_secret" "environment_management" {
+  provider = aws.modernisation-platform
+  name     = "environment_management"
+}
+
+# Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
+data "aws_secretsmanager_secret_version" "environment_management" {
+  provider  = aws.modernisation-platform
+  secret_id = data.aws_secretsmanager_secret.environment_management.id
+}

--- a/terraform/templates/modernisation-platform-environments/platform_versions.tf
+++ b/terraform/templates/modernisation-platform-environments/platform_versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    aws = {
+      version = ">= 4.0.0, < 5.0.0"
+      source  = "hashicorp/aws"
+    }
+    http = {
+      version = "~> 3.0"
+      source  = "hashicorp/http"
+    }
+  }
+  required_version = "~> 1.0"
+}

--- a/terraform/templates/modernisation-platform-environments/secrets.tf
+++ b/terraform/templates/modernisation-platform-environments/secrets.tf
@@ -1,0 +1,1 @@
+#### This file can be used to store secrets specific to the member account ####

--- a/terraform/templates/modernisation-platform/data.tf
+++ b/terraform/templates/modernisation-platform/data.tf
@@ -1,0 +1,4 @@
+# Get the environments file from the main repository
+data "http" "environments_file" {
+  url = "https://raw.githubusercontent.com/ministryofjustice/modernisation-platform/main/environments/${local.application_name}.json"
+}

--- a/terraform/templates/modernisation-platform/locals.tf
+++ b/terraform/templates/modernisation-platform/locals.tf
@@ -1,0 +1,35 @@
+locals {
+
+  application_name = "$application_name"
+
+  environment_management = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
+
+  # This takes the name of the Terraform workspace (e.g. core-vpc-production), strips out the application name (e.g. core-vpc), and checks if
+  # the string leftover is `-production`, if it isn't (e.g. core-vpc-non-production => -non-production) then it sets the var to false.
+  is-production    = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-production"
+  is-preproduction = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-preproduction"
+  is-test          = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-test"
+  is-development   = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-development"
+
+  # Merge tags from the environment json file with additional ones
+  tags = merge(
+    jsondecode(data.http.environments_file.response_body).tags,
+    { "is-production" = local.is-production },
+    { "environment-name" = terraform.workspace },
+    { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
+  )
+
+  environment     = trimprefix(terraform.workspace, "${var.networking[0].application}-")
+  vpc_name        = var.networking[0].business-unit
+  subnet_set      = var.networking[0].set
+  vpc_all         = "${local.vpc_name}-${local.environment}"
+  subnet_set_name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}"
+
+  is_live       = [substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-production" || substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-preproduction" ? "live" : "non-live"]
+  provider_name = "core-vpc-${local.environment}"
+
+  # environment specfic variables
+  # example usage:
+  # example_data = local.application_data.accounts[local.environment].example_var
+  application_data = fileexists("./application_variables.json") ? jsondecode(file("./application_variables.json")) : {}
+}

--- a/terraform/templates/modernisation-platform/platform_backend.tf
+++ b/terraform/templates/modernisation-platform/platform_backend.tf
@@ -1,0 +1,14 @@
+# Backend
+terraform {
+  # `backend` blocks do not support variables, so the following are hard-coded here:
+  # - S3 bucket name, which is created in modernisation-platform-account/s3.tf
+  backend "s3" {
+    acl                  = "bucket-owner-full-control"
+    bucket               = "modernisation-platform-terraform-state"
+    encrypt              = true
+    key                  = "terraform.tfstate"
+    region               = "eu-west-2"
+    workspace_key_prefix = "environments/$application_name" # This will store the object as environments/$application_name/${workspace}/terraform.tfstate
+    dynamodb_table       = "modernisation-platform-terraform-state-lock"
+  }
+}

--- a/terraform/templates/modernisation-platform/platform_base_variables.tf
+++ b/terraform/templates/modernisation-platform/platform_base_variables.tf
@@ -1,0 +1,5 @@
+variable "networking" {
+
+  type = list(any)
+
+}

--- a/terraform/templates/modernisation-platform/platform_secrets.tf
+++ b/terraform/templates/modernisation-platform/platform_secrets.tf
@@ -1,0 +1,16 @@
+# Get modernisation account id from ssm parameter
+data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  name = "modernisation_platform_account_id"
+}
+
+# Get secret by arn for environment management
+data "aws_secretsmanager_secret" "environment_management" {
+  provider = aws.modernisation-platform
+  name     = "environment_management"
+}
+
+# Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
+data "aws_secretsmanager_secret_version" "environment_management" {
+  provider  = aws.modernisation-platform
+  secret_id = data.aws_secretsmanager_secret.environment_management.id
+}

--- a/terraform/templates/modernisation-platform/platform_versions.tf
+++ b/terraform/templates/modernisation-platform/platform_versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    aws = {
+      version = ">= 4.0.0, < 5.0.0"
+      source  = "hashicorp/aws"
+    }
+    http = {
+      version = "~> 3.0"
+      source  = "hashicorp/http"
+    }
+  }
+  required_version = "~> 1.0"
+}

--- a/terraform/templates/modernisation-platform/providers.tf
+++ b/terraform/templates/modernisation-platform/providers.tf
@@ -1,0 +1,33 @@
+# AWS provider for the workspace you're working in (every resource will default to using this, unless otherwise specified)
+provider "aws" {
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
+  }
+}
+
+# AWS provider for the Modernisation Platform, to get things from there if required
+provider "aws" {
+  alias  = "modernisation-platform"
+  region = "eu-west-2"
+}
+
+# AWS provider for core-vpc-<environment>, to share VPCs into this account
+provider "aws" {
+  alias  = "core-vpc"
+  region = "eu-west-2"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/ModernisationPlatformAccess"
+  }
+}
+
+# AWS provider for core-network-services-production, to share VPCs into this account
+provider "aws" {
+  alias  = "core-network-services"
+  region = "eu-west-2"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
+  }
+}

--- a/terraform/templates/modernisation-platform/subnet_share.tf
+++ b/terraform/templates/modernisation-platform/subnet_share.tf
@@ -1,0 +1,41 @@
+######## DO NOT EDIT - THIS FILE WILL BE OVERWRITTEN BY TERRAFORM #########
+
+data "aws_caller_identity" "current" {}
+
+
+module "ram-principal-association" {
+
+  count = (var.networking[0].set == "") ? 0 : 1
+
+  source = "../../modules/ram-principal-association"
+
+  providers = {
+    aws.share-acm    = aws.core-network-services
+    aws.share-host   = aws.core-vpc
+    aws.share-tenant = aws
+  }
+  principal   = data.aws_caller_identity.current.account_id
+  vpc_name    = var.networking[0].business-unit
+  subnet_set  = var.networking[0].set
+  acm_pca     = "acm-pca-${local.is_live[0]}"
+  environment = local.environment
+
+}
+
+#ram-ec2-retagging module 
+module "ram-ec2-retagging" {
+
+  count = (var.networking[0].set == "") ? 0 : 1
+
+
+  source = "../../modules/ram-ec2-retagging"
+  providers = {
+    aws.share-host   = aws.core-vpc
+    aws.share-tenant = aws
+  }
+
+  vpc_name   = "${var.networking[0].business-unit}-${local.environment}"
+  subnet_set = var.networking[0].set
+
+  depends_on = [module.ram-principal-association[0]]
+}


### PR DESCRIPTION
There are too many differences between the terraform files in the modernisation platform repo and the environments repo to keep using the same templates.  This splits the templates into two folders, one for each repo.  The scripts have been updated and simplified to account for this.  Now we can make changes to one set of files without impacting the other.