### PR TITLE
Giving Security and Auditor team access higher than view-only and less than admin

### DIFF
--- a/environments/analytical-platform-data-engineering.json
+++ b/environments/analytical-platform-data-engineering.json
@@ -32,6 +32,10 @@
         {
           "github_slug": "data-engineering",
           "level": "administrator"
+        },
+        {
+          "github_slug": "data-platform-security-and-auditors",
+          "level": "developer"
         }
       ]
     }

--- a/environments/analytical-platform-data.json
+++ b/environments/analytical-platform-data.json
@@ -28,6 +28,10 @@
         {
           "github_slug": "data-engineering-aws",
           "level": "developer"
+        },
+        {
+          "github_slug": "data-platform-security-and-auditors",
+          "level": "developer"
         }
       ]
     }

--- a/environments/analytical-platform-landing.json
+++ b/environments/analytical-platform-landing.json
@@ -11,6 +11,10 @@
         {
           "github_slug": "analytics-hq",
           "level": "administrator"
+        },
+        {
+          "github_slug": "data-platform-security-and-auditors",
+          "level": "developer"
         }
       ]
     }

--- a/environments/analytical-platform-management.json
+++ b/environments/analytical-platform-management.json
@@ -11,6 +11,10 @@
         {
           "github_slug": "analytics-hq",
           "level": "view-only"
+        },
+        {
+          "github_slug": "data-platform-security-and-auditors",
+          "level": "developer"
         }
       ]
     }

--- a/environments/analytical-platform.json
+++ b/environments/analytical-platform.json
@@ -24,6 +24,10 @@
         {
           "github_slug": "analytics-hq",
           "level": "view-only"
+        },
+        {
+          "github_slug": "data-platform-security-and-auditors",
+          "level": "developer"
         }
       ]
     }

--- a/environments/data-platform.json
+++ b/environments/data-platform.json
@@ -15,6 +15,10 @@
         {
           "github_slug": "data-platform-labs",
           "level": "sandbox"
+        },
+        {
+          "github_slug": "data-platform-security-and-auditors",
+          "level": "sandbox"
         }
       ]
     }


### PR DESCRIPTION
Data Platform/Analytical Platform security team needs access that is above View-Only (as that doesn't include read-only access to IAM, S3 and CloudWatch/Trail) and less permissive than Admin. `developer` and `sandbox` are a good compromise that should unblock the team in assessing the security posture of AP and DP accounts.

One concern is: is `developer` a role that is available in unrestricted accounts? If not, will have to rethink.