### PR TITLE
Enabling security-audit and read-only permission sets

### DIFF
--- a/environments/analytical-platform-data-engineering.json
+++ b/environments/analytical-platform-data-engineering.json
@@ -35,7 +35,7 @@
         },
         {
           "github_slug": "data-platform-security-and-auditors",
-          "level": "security-audit"
+          "level": "developer"
         }
       ]
     }

--- a/environments/analytical-platform-data-engineering.json
+++ b/environments/analytical-platform-data-engineering.json
@@ -35,7 +35,7 @@
         },
         {
           "github_slug": "data-platform-security-and-auditors",
-          "level": "developer"
+          "level": "security-audit"
         }
       ]
     }

--- a/environments/analytical-platform-data.json
+++ b/environments/analytical-platform-data.json
@@ -31,7 +31,7 @@
         },
         {
           "github_slug": "data-platform-security-and-auditors",
-          "level": "security-audit"
+          "level": "developer"
         }
       ]
     }

--- a/environments/analytical-platform-data.json
+++ b/environments/analytical-platform-data.json
@@ -31,7 +31,7 @@
         },
         {
           "github_slug": "data-platform-security-and-auditors",
-          "level": "developer"
+          "level": "security-audit"
         }
       ]
     }

--- a/environments/analytical-platform-landing.json
+++ b/environments/analytical-platform-landing.json
@@ -14,7 +14,7 @@
         },
         {
           "github_slug": "data-platform-security-and-auditors",
-          "level": "security-audit"
+          "level": "developer"
         }
       ]
     }

--- a/environments/analytical-platform-landing.json
+++ b/environments/analytical-platform-landing.json
@@ -14,7 +14,7 @@
         },
         {
           "github_slug": "data-platform-security-and-auditors",
-          "level": "developer"
+          "level": "security-audit"
         }
       ]
     }

--- a/environments/analytical-platform-management.json
+++ b/environments/analytical-platform-management.json
@@ -14,7 +14,7 @@
         },
         {
           "github_slug": "data-platform-security-and-auditors",
-          "level": "security-audit"
+          "level": "developer"
         }
       ]
     }

--- a/environments/analytical-platform-management.json
+++ b/environments/analytical-platform-management.json
@@ -14,7 +14,7 @@
         },
         {
           "github_slug": "data-platform-security-and-auditors",
-          "level": "developer"
+          "level": "security-audit"
         }
       ]
     }

--- a/environments/analytical-platform.json
+++ b/environments/analytical-platform.json
@@ -27,7 +27,7 @@
         },
         {
           "github_slug": "data-platform-security-and-auditors",
-          "level": "developer"
+          "level": "security-audit"
         }
       ]
     }

--- a/environments/analytical-platform.json
+++ b/environments/analytical-platform.json
@@ -27,7 +27,7 @@
         },
         {
           "github_slug": "data-platform-security-and-auditors",
-          "level": "security-audit"
+          "level": "developer"
         }
       ]
     }

--- a/environments/data-platform.json
+++ b/environments/data-platform.json
@@ -18,7 +18,7 @@
         },
         {
           "github_slug": "data-platform-security-and-auditors",
-          "level": "sandbox"
+          "level": "security-audit"
         }
       ]
     }

--- a/environments/data-platform.json
+++ b/environments/data-platform.json
@@ -18,7 +18,7 @@
         },
         {
           "github_slug": "data-platform-security-and-auditors",
-          "level": "security-audit"
+          "level": "sandbox"
         }
       ]
     }

--- a/policies/environments/environment-definitions.rego
+++ b/policies/environments/environment-definitions.rego
@@ -17,7 +17,9 @@ allowed_access := [
   "sandbox",
   "administrator",
   "migration",
-  "instance-management"
+  "instance-management",
+  "read-only",
+  "security-audit"
 ]
 
 allowed_nuke := [

--- a/policies/environments/environment-definitions_test.rego
+++ b/policies/environments/environment-definitions_test.rego
@@ -41,7 +41,7 @@ test_business_units_character{
 }
 
 test_unexpected_access {
-  deny["`example.json` uses an unexpected access level: got `incorrect-access`, expected one of: view-only, developer, sandbox, administrator, migration, instance-management"] with input as { "filename": "example.json", "environments": [{"access": [{"level": "incorrect-access"}]}]}
+  deny["`example.json` uses an unexpected access level: got `incorrect-access`, expected one of: view-only, developer, sandbox, administrator, migration, instance-management, read-only, security-audit"] with input as { "filename": "example.json", "environments": [{"access": [{"level": "incorrect-access"}]}]}
 }
 
 test_unexpected_nuke {

--- a/source/user-guide/creating-environments.html.md.erb
+++ b/source/user-guide/creating-environments.html.md.erb
@@ -39,6 +39,12 @@ This is the level of access for the GitHub team to the Modernisation Platform. T
  - Log into the console
  - See resources and basic metadata. You cannot see the content of resources such as logs or S3 buckets.
 
+#### read-only
+
+- Log into the console
+- Comprehensive read-only visibility of the AWS environment. As this role provides access to contents of S3 and others, it is designed for users for whom view-only is insufficient.
+- Role makes use of AWS ReadOnly managed policy and is not at present configurable beyond that.
+
 #### developer
 
  - Log into the console
@@ -85,6 +91,12 @@ The instance-management role is a role given to assist database administrators.
 - The role contains mainly RDS and EC2 permissions.
 
 This is a new role created in Feb 2023, and if more permissions are required for database admins, we're happy to adjust the policy.
+
+#### security-audit
+
+- Log into the console
+- See resources and metadata useful to security operations teams and security audit teams.
+- Makes use of AWS managed SecurityAudit policy and is not generally configurable beyond that.
 
 #### administrator
 

--- a/source/user-guide/working-as-a-collaborator.html.md.erb
+++ b/source/user-guide/working-as-a-collaborator.html.md.erb
@@ -36,8 +36,7 @@ Once you have been [set up as a collaborator](../runbooks/adding-collaborators.h
 |sandbox|Admin role to perform most AWS actions via the console| Used by engineers to make development easier in some situations, only allowed in the development account
 |migration|Role with developer and AWS migration services permissions| Used by engineers to migrate applications, will be removed before application goes into production
 |instance-management|Role for use by instance management with permissions for EC2 and RDS instances | Used by database or EC2 administrators  to migrate services and perform tasks.
-|security-audit|Role with AWS managed SecurityAudit policy | Used mebers of security and audit teams.
-|read-only|Comprehensive Read-Only role which uses AWS managed ReadOnly policy, covers almost all services including S3 and IAM | Used operational users, security users, and customers who need to get information from AWS accounts with no need for write access.
+|security-audit|Role with AWS managed SecurityAudit policy | Used by members of security and audit teams.
 
 You can see the accounts and roles assigned to you [here](https://github.com/ministryofjustice/modernisation-platform/blob/main/collaborators.json)
 

--- a/source/user-guide/working-as-a-collaborator.html.md.erb
+++ b/source/user-guide/working-as-a-collaborator.html.md.erb
@@ -36,6 +36,8 @@ Once you have been [set up as a collaborator](../runbooks/adding-collaborators.h
 |sandbox|Admin role to perform most AWS actions via the console| Used by engineers to make development easier in some situations, only allowed in the development account
 |migration|Role with developer and AWS migration services permissions| Used by engineers to migrate applications, will be removed before application goes into production
 |instance-management|Role for use by instance management with permissions for EC2 and RDS instances | Used by database or EC2 administrators  to migrate services and perform tasks.
+|security-audit|Role with AWS managed SecurityAudit policy | Used mebers of security and audit teams.
+|read-only|Comprehensive Read-Only role which uses AWS managed ReadOnly policy, covers almost all services including S3 and IAM | Used operational users, security users, and customers who need to get information from AWS accounts with no need for write access.
 
 You can see the accounts and roles assigned to you [here](https://github.com/ministryofjustice/modernisation-platform/blob/main/collaborators.json)
 

--- a/terraform/environments/bootstrap/single-sign-on/main.tf
+++ b/terraform/environments/bootstrap/single-sign-on/main.tf
@@ -264,7 +264,7 @@ resource "aws_ssoadmin_account_assignment" "instance-management" {
   provider = aws.sso-management
 
   instance_arn       = local.sso_instance_arn
-  permission_set_arn = data.aws_ssoadmin_permission_set.migration.arn
+  permission_set_arn = data.aws_ssoadmin_permission_set.instance-management.arn
 
   principal_id   = data.aws_identitystore_group.member[each.value.github_slug].group_id
   principal_type = "GROUP"


### PR DESCRIPTION
- Adding security-audit and read-only permission options, updating rego.
- Switching permission_set_arn for instance-management.
- Documentation update

SecurityAudit and ReadOnly permission sets are already defined in the root account, so this is code to enable these permissions for MP and MP users.

