### PR TITLE
Add script to replace platform files

### DIFF
--- a/scripts/replace-platform-files-with-templates.sh
+++ b/scripts/replace-platform-files-with-templates.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+template_folder="./terraform/templates/modernisation-platform-environments"
+environments_folder="../modernisation-platform-environments/terraform/environments"
+token='$application_name'
+
+for subfolder in "$environments_folder"/*/
+do
+  if [ -d "$subfolder" ]; then
+    application_name=$(basename "$subfolder")
+    echo "Copying files for $application_name"
+    for file in "$template_folder"/platform_*
+      do
+        if [ -f "$file" ]; then
+          filename=$(basename "$file")
+          echo "    $filename"
+          cp "$file" "$subfolder/$filename"
+          sed -i '' "s/$token/$application_name/g" "$subfolder/$filename"
+        fi
+    done
+  fi
+done


### PR DESCRIPTION
This is a helper script to quickly replace all the platform_files in the environments repo to match the environment repo templates.

Note if you keep your environments folder in a different location you will need to update the environments_folder location.