### PR TITLE
Fix: Amending the OIDC role name used by the data platform repository.

### DIFF
--- a/terraform/environments/data-platform/data-platform-oidc.tf
+++ b/terraform/environments/data-platform/data-platform-oidc.tf
@@ -1,7 +1,7 @@
 module "github_actions_roles" {
   source              = "github.com/ministryofjustice/modernisation-platform-github-oidc-role?ref=v1.0.0"
   github_repositories = local.oidc_repositories
-  role_name           = "data-platform-labs-github-actions"
+  role_name           = "data-platform-labs-github-role"
   policy_arns         = local.oidc_default_policy_arns
   policy_jsons        = [data.aws_iam_policy.cicd_member_policy.policy]
   tags                = local.tags


### PR DESCRIPTION
Using an OIDC role name with `github-actions` string in it creates issues when running delegate access and secure baseline jobs because the `github-actions` role is used in trust policies in the platform roles, and the code queries the role, it expects only one role so named will be returned. The code as is causes the iam_role datasource to return 2. While applying a fix on the datasource side would probably be more preferable, it's still better to reserve `github-actions` as a string for platform rather than customer OIDC roles.

Therefore, to resolve the issue, the data-platform OIDC role has been renamed to `data-platform-labs-github-role`. We will follow similar naming conventions on DP with OIDC roles we create in MP.