### PR TITLE
Giving Security & Audit team read-only permissions in addition to security-audit

### DIFF
--- a/environments/analytical-platform-data-engineering.json
+++ b/environments/analytical-platform-data-engineering.json
@@ -36,6 +36,10 @@
         {
           "github_slug": "data-platform-security-and-auditors",
           "level": "security-audit"
+        },
+        {
+          "github_slug": "data-platform-security-and-auditors",
+          "level": "read-only"
         }
       ]
     }

--- a/environments/analytical-platform-data.json
+++ b/environments/analytical-platform-data.json
@@ -32,6 +32,10 @@
         {
           "github_slug": "data-platform-security-and-auditors",
           "level": "security-audit"
+        },
+        {
+          "github_slug": "data-platform-security-and-auditors",
+          "level": "read-only"
         }
       ]
     }

--- a/environments/analytical-platform-landing.json
+++ b/environments/analytical-platform-landing.json
@@ -15,6 +15,10 @@
         {
           "github_slug": "data-platform-security-and-auditors",
           "level": "security-audit"
+        },
+        {
+          "github_slug": "data-platform-security-and-auditors",
+          "level": "read-only"
         }
       ]
     }

--- a/environments/analytical-platform-management.json
+++ b/environments/analytical-platform-management.json
@@ -15,6 +15,10 @@
         {
           "github_slug": "data-platform-security-and-auditors",
           "level": "security-audit"
+        },
+        {
+          "github_slug": "data-platform-security-and-auditors",
+          "level": "read-only"
         }
       ]
     }

--- a/environments/analytical-platform.json
+++ b/environments/analytical-platform.json
@@ -11,6 +11,14 @@
         {
           "github_slug": "analytics-hq",
           "level": "view-only"
+        },
+        {
+          "github_slug": "data-platform-security-and-auditors",
+          "level": "security-audit"
+        },
+        {
+          "github_slug": "data-platform-security-and-auditors",
+          "level": "read-only"
         }
       ]
     },
@@ -28,6 +36,10 @@
         {
           "github_slug": "data-platform-security-and-auditors",
           "level": "security-audit"
+        },
+        {
+          "github_slug": "data-platform-security-and-auditors",
+          "level": "read-only"
         }
       ]
     }

--- a/environments/data-platform.json
+++ b/environments/data-platform.json
@@ -19,6 +19,10 @@
         {
           "github_slug": "data-platform-security-and-auditors",
           "level": "security-audit"
+        },
+        {
+          "github_slug": "data-platform-security-and-auditors",
+          "level": "read-only"
         }
       ]
     }


### PR DESCRIPTION
https://github.com/ministryofjustice/analytics-platform-infrastructure/issues/1053

This change was requested by the DP security team because they'd like to have a limited-permissions role for viewing things like SecurityHub but will also on occasion need to look at the contents of S3 buckets as part of their work.