### PR TITLE
Remove go tests being required

### DIFF
--- a/terraform/github/repositories.tf
+++ b/terraform/github/repositories.tf
@@ -77,7 +77,6 @@ module "terraform-module-s3-bucket-replication-role" {
     "s3-replication",
     "iam"
   ]
-  required_checks = ["Run Go Unit Tests"]
   secrets         = nonsensitive(local.testing_ci_iam_user_keys)
 }
 
@@ -314,7 +313,6 @@ module "terraform-module-aws-loadbalancer" {
     "loadbalancer",
     "logging"
   ]
-  required_checks = ["Run Go Unit Tests"]
   secrets         = nonsensitive(local.testing_ci_iam_user_keys)
 }
 
@@ -366,7 +364,6 @@ module "modernisation-platform-terraform-pagerduty-integration" {
     "pagerduty",
     "alerting"
   ]
-  required_checks = ["Run Go Unit Tests"]
   secrets         = nonsensitive(local.testing_ci_iam_user_keys)
 }
 


### PR DESCRIPTION
Have the go tests as required is mostly slowing us down being able to bulk merge minor PRs unrelated to the go tests.  We can still make sure as part of the PR review process that these checks pass.