### PR TITLE
Add dynamic provider for us-east-1

### DIFF
--- a/terraform/templates/modernisation-platform-environments/platform_providers.tf
+++ b/terraform/templates/modernisation-platform-environments/platform_providers.tf
@@ -44,6 +44,6 @@ provider "aws" {
   alias  = "us-east-1"
   region = "us-east-1"
   assume_role {
-    role_arn = "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
+    role_arn = !can(regex("githubactionsrolesession|AdministratorAccess|user", data.aws_caller_identity.original_session.arn)) ? null : can(regex("user", data.aws_caller_identity.original_session.arn)) ? "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/${var.collaborator_access}" : "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
   }
 }


### PR DESCRIPTION
This will allow plans locally for resources created in us-east-1 which were failing previously.