### PR TITLE
Skip certain files in replace script

### DIFF
--- a/scripts/replace-platform-files-with-templates.sh
+++ b/scripts/replace-platform-files-with-templates.sh
@@ -8,15 +8,26 @@ for subfolder in "$environments_folder"/*/
 do
   if [ -d "$subfolder" ]; then
     application_name=$(basename "$subfolder")
-    echo "Copying files for $application_name"
-    for file in "$template_folder"/platform_*
-      do
-        if [ -f "$file" ]; then
-          filename=$(basename "$file")
-          echo "    $filename"
-          cp "$file" "$subfolder/$filename"
-          sed -i '' "s/$token/$application_name/g" "$subfolder/$filename"
-        fi
-    done
+    if [ "$application_name" == "sprinkler" ] || [ "$application_name" == "cooker" ]; then
+      echo "Skipping sprinkler and cooker, update these manually"
+    else
+      echo "Copying files for $application_name"
+      for file in "$template_folder"/platform_*
+        do
+          if [ -f "$file" ]; then
+            filename=$(basename "$file")
+            echo "    $filename"
+            if [ "$filename" == "platform_versions.tf" ]; then
+              echo "Skipping $filename"
+            else
+              cp "$file" "$subfolder/$filename"
+              sed -i '' "s/$token/$application_name/g" "$subfolder/$filename"
+            fi
+          fi
+      done
+    fi
   fi
 done
+
+echo
+echo "NOTE: This script skips sprinkler and cooker, and all platform_versions.tf files"


### PR DESCRIPTION
Skipping sprinkler and cooker as changes are already made in those first, plus they have slightly different files as they are sandbox vpc accounts.

Also skipping platform_versions.tf as we said we would allow changes for these files for users to add different provider versions as they needed.