### PR TITLE
Add new service integrations to secret

### DIFF
--- a/terraform/pagerduty/aws.tf
+++ b/terraform/pagerduty/aws.tf
@@ -17,6 +17,8 @@ resource "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {
     core_alerts_cloudwatch  = pagerduty_service_integration.core_alerts_cloudwatch.integration_key,
     high_priority_alarms    = pagerduty_service_integration.high_priority_cloudwatch.integration_key,
     low_priority_alarms     = pagerduty_service_integration.low_priority_cloudwatch.integration_key,
+    ddos_alarms             = pagerduty_service_integration.ddos_cloudwatch.integration_key,
+    tgw_alarms              = pagerduty_service_integration.tgw_cloudwatch.integration_key,
     nomis_alarms            = pagerduty_service_integration.nomis_cloudwatch.integration_key,
     nomis_nonprod_alarms    = pagerduty_service_integration.nomis_nonprod_cloudwatch.integration_key,
     laa_mlra_nonprod_alarms = pagerduty_service_integration.laa_mlra_nonprod_cloudwatch.integration_key,

--- a/terraform/pagerduty/services.tf
+++ b/terraform/pagerduty/services.tf
@@ -40,7 +40,7 @@ resource "pagerduty_service_integration" "low_priority_cloudwatch" {
   vendor  = data.pagerduty_vendor.cloudwatch.id
 }
 
-### Low priority core alerts
+### Core platform security hub, config and cloudtrail alerts
 resource "pagerduty_service" "core_alerts" {
   name                    = "Core Alerts - Modernisation Platform"
   description             = "Core Infrastructure Alerts"
@@ -137,7 +137,7 @@ resource "pagerduty_service" "tgw" {
   }
 }
 
-resource "pagerduty_service_integration" "tgw" {
+resource "pagerduty_service_integration" "tgw_cloudwatch" {
   name    = data.pagerduty_vendor.cloudwatch.name
   service = pagerduty_service.tgw.id
   vendor  = data.pagerduty_vendor.cloudwatch.id


### PR DESCRIPTION
In order to start using the new services we need to store the integration tokens in the shared secret.