### PR TITLE
Switch DDOS and TGW alarms to use new services

### DIFF
--- a/terraform/environments/core-network-services/monitoring.tf
+++ b/terraform/environments/core-network-services/monitoring.tf
@@ -26,7 +26,7 @@ module "pagerduty_route53" {
   ]
   source                    = "github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration?ref=v1.0.0"
   sns_topics                = [aws_sns_topic.route53_monitoring.name]
-  pagerduty_integration_key = local.pagerduty_integration_keys["high_priority_alarms"]
+  pagerduty_integration_key = local.pagerduty_integration_keys["ddos_cloudwatch"]
 }
 
 module "pagerduty_transit_gateway_production" {
@@ -35,7 +35,7 @@ module "pagerduty_transit_gateway_production" {
   ]
   source                    = "github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration?ref=v1.0.0"
   sns_topics                = [aws_sns_topic.tgw_monitoring_production.name]
-  pagerduty_integration_key = local.pagerduty_integration_keys["high_priority_alarms"]
+  pagerduty_integration_key = local.pagerduty_integration_keys["tgw_cloudwatch"]
 }
 
 # hosted zone DDoS monitoring

--- a/terraform/environments/core-vpc/monitoring.tf
+++ b/terraform/environments/core-vpc/monitoring.tf
@@ -24,5 +24,5 @@ module "pagerduty_route53" {
   ]
   source                    = "github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration?ref=v1.0.0"
   sns_topics                = [aws_sns_topic.route53_monitoring.name]
-  pagerduty_integration_key = local.is-production ? local.pagerduty_integration_keys["high_priority_alarms"] : local.pagerduty_integration_keys["low_priority_alarms"]
+  pagerduty_integration_key = local.pagerduty_integration_keys["ddos_cloudwatch"]
 }


### PR DESCRIPTION
Moving these alarms over to the newly created service specific services.