### PR TITLE
Setting up data-engineering-aws team with data-engineer access.

### DIFF
--- a/environments/analytical-platform-data-engineering.json
+++ b/environments/analytical-platform-data-engineering.json
@@ -14,7 +14,7 @@
         },
         {
           "github_slug": "data-engineering-aws",
-          "level": "developer"
+          "level": "data-engineer"
         }
       ]
     },

--- a/environments/analytical-platform-data.json
+++ b/environments/analytical-platform-data.json
@@ -27,7 +27,7 @@
         },
         {
           "github_slug": "data-engineering-aws",
-          "level": "developer"
+          "level": "data-engineer"
         },
         {
           "github_slug": "data-platform-security-and-auditors",


### PR DESCRIPTION
https://github.com/ministryofjustice/analytics-platform-infrastructure/issues/804


Assigning the new `data-engineer` access level to `data-engineering-aws` Github team.