### PR TITLE
Data Engineering Prod: Giving a new team developer access

### DIFF
--- a/environments/analytical-platform-data-engineering.json
+++ b/environments/analytical-platform-data-engineering.json
@@ -15,6 +15,10 @@
         {
           "github_slug": "data-engineering-aws",
           "level": "data-engineer"
+        },
+        {
+          "github_slug": "data-engineering-aws-developers",
+          "level": "developer"
         }
       ]
     },


### PR DESCRIPTION
Giving developer access to a new team of data engineers as their ask doesn't align well with other access levels.
