### PR TITLE
Adding additional permissions to the DE policy.

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/policies.tf
+++ b/terraform/environments/bootstrap/delegate-access/policies.tf
@@ -224,6 +224,10 @@ data "aws_iam_policy_document" "data_engineering_additional" {
     effect = "Allow"
     actions = [
       "athena:DeleteNamedQuery",
+      "athena:StartQueryExecution",
+      "athena:StopQueryExecution",
+      "dms:StartReplicationTask",
+      "dms:StopReplicationTask",
       "glue:BatchCreatePartition",
       "glue:BatchDeletePartition",
       "glue:BatchDeleteTable",
@@ -250,7 +254,8 @@ data "aws_iam_policy_document" "data_engineering_additional" {
       "glue:UpdateJob",
       "glue:ListJobs",
       "glue:BatchGetJobs",
-      "glue:GetJobBookmark"
+      "glue:GetJobBookmark",
+      "states:StartExecution"
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
https://github.com/ministryofjustice/analytics-platform-infrastructure/issues/804

Additional permissions for the data-engineer access level to perform operational tasks in the console. 
* Athena stop/stop query execution
* dms start/stop execution tasks
* states:StartExecution is for triggering step functions.
