### PR TITLE
Allow traffic from I2N to HMPPS prod and preprod

### DIFF
--- a/terraform/environments/core-network-services/production_rules.json
+++ b/terraform/environments/core-network-services/production_rules.json
@@ -145,5 +145,19 @@
     "destination_ip": "10.27.64.0/21",
     "destination_port": "ANY",
     "protocol": "TCP"
+  },
+  "i2n_to_mp_hmpps_preproduction": {
+    "action": "PASS",
+    "source_ip": "10.110.0.0/16",
+    "destination_ip": "10.27.0.0/21",
+    "destination_port": "ANY",
+    "protocol": "TCP"
+  },
+  "i2n_to_mp_hmpps_production": {
+    "action": "PASS",
+    "source_ip": "10.110.0.0/16",
+    "destination_ip": "10.27.8.0/21",
+    "destination_port": "ANY",
+    "protocol": "TCP"
   }
 }


### PR DESCRIPTION
This is required for delius iaps, see request here - https://mojdt.slack.com/archives/C01A7QK5VM1/p1681394593957699