### PR TITLE
Remove old high low priority alarm infra

### DIFF
--- a/terraform/modules/core-monitoring/main.tf
+++ b/terraform/modules/core-monitoring/main.tf
@@ -1,37 +1,3 @@
-# SNS topics for high and low priority alarms
-# Encryption disabled as it doesn't work with pagerduty
-
-# tfsec:ignore:aws-sns-enable-topic-encryption
-resource "aws_sns_topic" "high_priority_alarms" {
-  #checkov:skip=CKV_AWS_26:"encrypted topics do not work with pagerduty subscription"
-  name = "high_priority_alarms"
-}
-
-# tfsec:ignore:aws-sns-enable-topic-encryption
-resource "aws_sns_topic" "low_priority_alarms" {
-  #checkov:skip=CKV_AWS_26:"encrypted topics do not work with pagerduty subscription"
-  name = "low_priority_alarms"
-}
-
-# subscribe to the sns topics the pagerduty service
-module "pagerduty_high_priority" {
-  depends_on = [
-    aws_sns_topic.high_priority_alarms
-  ]
-  source                    = "github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration?ref=v1.0.0"
-  sns_topics                = [aws_sns_topic.high_priority_alarms.name]
-  pagerduty_integration_key = var.pagerduty_integration_keys["high_priority_alarms"]
-}
-
-module "pagerduty_low_priority" {
-  depends_on = [
-    aws_sns_topic.low_priority_alarms
-  ]
-  source                    = "github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration?ref=v1.0.0"
-  sns_topics                = [aws_sns_topic.low_priority_alarms.name]
-  pagerduty_integration_key = var.pagerduty_integration_keys["low_priority_alarms"]
-}
-
 module "pagerduty_core_alerts" {
   source                    = "github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration?ref=v1.0.0"
   sns_topics                = ["config", "securityhub-alarms", "cloudtrail"]

--- a/terraform/pagerduty/aws.tf
+++ b/terraform/pagerduty/aws.tf
@@ -15,8 +15,6 @@ resource "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {
   secret_id = aws_secretsmanager_secret.pagerduty_integration_keys.id
   secret_string = jsonencode({
     core_alerts_cloudwatch  = pagerduty_service_integration.core_alerts_cloudwatch.integration_key,
-    high_priority_alarms    = pagerduty_service_integration.high_priority_cloudwatch.integration_key,
-    low_priority_alarms     = pagerduty_service_integration.low_priority_cloudwatch.integration_key,
     ddos_cloudwatch         = pagerduty_service_integration.ddos_cloudwatch.integration_key,
     tgw_cloudwatch          = pagerduty_service_integration.tgw_cloudwatch.integration_key,
     nomis_alarms            = pagerduty_service_integration.nomis_cloudwatch.integration_key,

--- a/terraform/pagerduty/services.tf
+++ b/terraform/pagerduty/services.tf
@@ -1,44 +1,5 @@
 
 # Note slack integrations for the service to the relevant channels must be done manually in pagerduty and slack
-### High priority alarms
-resource "pagerduty_service" "high_priority" {
-  name                    = "Modernisation Platform High Priority Alarms"
-  description             = "Modernisation Platform High Priority Alarms"
-  auto_resolve_timeout    = 345600
-  acknowledgement_timeout = "null"
-  escalation_policy       = pagerduty_escalation_policy.on_call.id
-  alert_creation          = "create_alerts_and_incidents"
-  incident_urgency_rule {
-    type    = "constant"
-    urgency = "high"
-  }
-}
-
-resource "pagerduty_service_integration" "high_priority_cloudwatch" {
-  name    = data.pagerduty_vendor.cloudwatch.name
-  service = pagerduty_service.high_priority.id
-  vendor  = data.pagerduty_vendor.cloudwatch.id
-}
-
-### Low priority alarms
-resource "pagerduty_service" "low_priority" {
-  name                    = "Modernisation Platform Low Priority Alarms"
-  description             = "Modernisation Platform Low Priority Alarms"
-  auto_resolve_timeout    = 345600
-  acknowledgement_timeout = "null"
-  escalation_policy       = pagerduty_escalation_policy.low_priority.id
-  alert_creation          = "create_alerts_and_incidents"
-  incident_urgency_rule {
-    type    = "constant"
-    urgency = "low"
-  }
-}
-
-resource "pagerduty_service_integration" "low_priority_cloudwatch" {
-  name    = data.pagerduty_vendor.cloudwatch.name
-  service = pagerduty_service.low_priority.id
-  vendor  = data.pagerduty_vendor.cloudwatch.id
-}
 
 ### Core platform security hub, config and cloudtrail alerts
 resource "pagerduty_service" "core_alerts" {


### PR DESCRIPTION
We weren't really using these topics anyway, the new alerts based on service areas make more sense.