### PR TITLE
Data-Engineer: Permissions to stop job executions from console.

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/policies.tf
+++ b/terraform/environments/bootstrap/delegate-access/policies.tf
@@ -251,11 +251,13 @@ data "aws_iam_policy_document" "data_engineering_additional" {
       "glue:GetJobRun",
       "glue:GetJobRuns",
       "glue:StartJobRun",
+      "glue:StopRun",
       "glue:UpdateJob",
       "glue:ListJobs",
       "glue:BatchGetJobs",
       "glue:GetJobBookmark",
-      "states:StartExecution"
+      "states:StartExecution",
+      "states:StopExecution"
     ]
     resources = ["*"]
   }

--- a/terraform/environments/bootstrap/delegate-access/policies.tf
+++ b/terraform/environments/bootstrap/delegate-access/policies.tf
@@ -251,7 +251,7 @@ data "aws_iam_policy_document" "data_engineering_additional" {
       "glue:GetJobRun",
       "glue:GetJobRuns",
       "glue:StartJobRun",
-      "glue:StopRun",
+      "glue:StopJobRun",
       "glue:UpdateJob",
       "glue:ListJobs",
       "glue:BatchGetJobs",


### PR DESCRIPTION
https://github.com/ministryofjustice/analytics-platform-infrastructure/issues/804

Additional requests for stopping execution of glue jobs and step functions.