### PR TITLE
Add ccms-ebs delegated hosted zone

### DIFF
--- a/terraform/environments/core-network-services/route53.tf
+++ b/terraform/environments/core-network-services/route53.tf
@@ -3,7 +3,8 @@ locals {
   modernisation-platform-internal-domain = "modernisation-platform.internal"
 
   application-zones = {
-    equip = "equip.service.justice.gov.uk"
+    equip = "equip.service.justice.gov.uk",
+    ccms-ebs = "ccms-ebs.service.justice.gov.uk"
   }
 }
 


### PR DESCRIPTION
Hosted zone for ccms-ebs domain so that this domain can be delegated to the modernisation platform.