### PR TITLE
fix up global protect rules for hmpps VPCs

### DIFF
--- a/terraform/environments/core-network-services/development_rules.json
+++ b/terraform/environments/core-network-services/development_rules.json
@@ -1,4 +1,18 @@
 {
+  "gp_to_hmpps_development_http": {
+    "action": "PASS",
+    "source_ip": "10.184.0.0/16",
+    "destination_ip": "10.26.24.0/21",
+    "destination_port": "80",
+    "protocol": "TCP"
+  },
+  "gp_to_hmpps_development_https": {
+    "action": "PASS",
+    "source_ip": "10.184.0.0/16",
+    "destination_ip": "10.26.24.0/21",
+    "destination_port": "443",
+    "protocol": "TCP"
+  },
   "laa_development_to_mp_laa_development": {
     "action": "PASS",
     "source_ip": "10.202.0.0/20",

--- a/terraform/environments/core-network-services/preproduction_rules.json
+++ b/terraform/environments/core-network-services/preproduction_rules.json
@@ -6,6 +6,20 @@
     "destination_port": "80",
     "protocol": "TCP"
   },
+  "gp_to_hmpps_preproduction_http": {
+    "action": "PASS",
+    "source_ip": "10.184.0.0/16",
+    "destination_ip": "10.27.0.0/21",
+    "destination_port": "80",
+    "protocol": "TCP"
+  },
+  "gp_to_hmpps_preproduction_https": {
+    "action": "PASS",
+    "source_ip": "10.184.0.0/16",
+    "destination_ip": "10.27.0.0/21",
+    "destination_port": "443",
+    "protocol": "TCP"
+  },
   "psn_to_mp_hmpps_preproduction_https": {
     "action": "PASS",
     "source_ip": "51.0.0.0/8",

--- a/terraform/environments/core-network-services/production_rules.json
+++ b/terraform/environments/core-network-services/production_rules.json
@@ -1,14 +1,14 @@
 {
   "gp_to_mp_nomis_production_http": {
     "action": "PASS",
-    "source_ip": "10.40.0.0/18",
+    "source_ip": "10.184.0.0/16",
     "destination_ip": "10.27.8.0/21",
     "destination_port": "80",
     "protocol": "TCP"
   },
   "gp_to_mp_nomis_production_https": {
     "action": "PASS",
-    "source_ip": "10.40.0.0/18",
+    "source_ip": "10.184.0.0/16",
     "destination_ip": "10.27.8.0/21",
     "destination_port": "443",
     "protocol": "TCP"

--- a/terraform/environments/core-network-services/test_rules.json
+++ b/terraform/environments/core-network-services/test_rules.json
@@ -1,5 +1,5 @@
 {
-  "gp_to_nomis_test_http": {
+  "gp_to_hmpps_test_http": {
     "action": "PASS",
     "source_ip": "10.184.0.0/16",
     "destination_ip": "10.26.8.0/21",


### PR DESCRIPTION
Fixed / aligned global protect firewall rules for hmpps VPCs
- add access to development for testing
- add access to preprod
- fixed the production rules which were typoed.  It is safe to change as the typoed 10.40/18 subnet is already covered by later rules in the same file
- updated the rule name in hmpps-test