### PR TITLE
Fix numbering for ADRs

### DIFF
--- a/architecture-decision-record/0023-backup-strategy.md
+++ b/architecture-decision-record/0023-backup-strategy.md
@@ -1,4 +1,4 @@
-# 22. Backup Strategy
+# 23. Backup Strategy
 
 Date: 2022-11-11
 

--- a/architecture-decision-record/0024-egress-traffic-inspection.md
+++ b/architecture-decision-record/0024-egress-traffic-inspection.md
@@ -1,4 +1,4 @@
-# 23. Egress Traffic Inspection
+# 24. Egress Traffic Inspection
 
 Date: 2023-03-30
 


### PR DESCRIPTION
The backup strategy ADR appeared to share a number with patching strategy, so this fixes the numbering for two ADRs.