### PR TITLE
Fixing creation/update of environments settings

### DIFF
--- a/environments/cooker.json
+++ b/environments/cooker.json
@@ -3,7 +3,12 @@
   "environments": [
     {
       "name": "development",
-      "access": []
+      "access": [
+        {
+          "github_slug": "modernisation-platform",
+          "level": "developer"
+        }
+      ]
     }
   ],
   "tags": {


### PR DESCRIPTION
Recently our newly created accounts do not have workflow protection, which means that apply gets deployed automatically if the plan passes OK. This can cause a lot of problems, e.g. unwanted destruction of resources in a test environment if a dev environment passes.

This PR is to fix the problem. It's been already tested and applied on `cooker` and on the `hmpps-intelligence-management`.