### PR TITLE
added laa-crime-apps team to mlra access

### DIFF
--- a/environments/mlra.json
+++ b/environments/mlra.json
@@ -7,6 +7,10 @@
         {
           "github_slug": "laa-aws-infrastructure",
           "level": "developer"
+        },
+        {
+          "github_slug": "laa-crime-apps-team",
+          "level": "developer"
         }
       ]
     },
@@ -15,6 +19,10 @@
       "access": [
         {
           "github_slug": "laa-aws-infrastructure",
+          "level": "developer"
+        },
+        {
+          "github_slug": "laa-crime-apps-team",
           "level": "developer"
         }
       ]
@@ -25,6 +33,10 @@
         {
           "github_slug": "laa-aws-infrastructure",
           "level": "developer"
+        },
+        {
+          "github_slug": "laa-crime-apps-team",
+          "level": "developer"
         }
       ]
     },
@@ -33,6 +45,10 @@
       "access": [
         {
           "github_slug": "laa-aws-infrastructure",
+          "level": "developer"
+        },
+        {
+          "github_slug": "laa-crime-apps-team",
           "level": "developer"
         }
       ]


### PR DESCRIPTION
At the request of @mikereiddigital , via [this slack conversation](https://mojdt.slack.com/archives/C01A7QK5VM1/p1681824743606659), I've added the laa-crime-apps-team to the slugs allowed to access the MLRA accounts.