### PR TITLE
Amend LAA rule to ANY port rather than 80

### DIFF
--- a/terraform/environments/core-network-services/production_rules.json
+++ b/terraform/environments/core-network-services/production_rules.json
@@ -45,7 +45,7 @@
     "action": "PASS",
     "source_ip": "10.205.0.0/20",
     "destination_ip": "10.27.64.0/21",
-    "destination_port": "80",
+    "destination_port": "ANY",
     "protocol": "TCP"
   },
   "noms_live_vnet_to_mp_prod_preprod": {


### PR DESCRIPTION
The port 80 was too restrictive on one of the laa firewall settings so it has been amended to ANY.