### PR TITLE
Add generic services to raise incidents manually

### DIFF
--- a/terraform/pagerduty/business-services.tf
+++ b/terraform/pagerduty/business-services.tf
@@ -118,3 +118,42 @@ resource "pagerduty_service_dependency" "modernisation_platform_tgw" {
     }
   }
 }
+
+resource "pagerduty_service_dependency" "modernisation_platform_networking_general" {
+  dependency {
+    dependent_service {
+      id   = pagerduty_business_service.modernisation_platform_networking.id
+      type = "business_service"
+    }
+    supporting_service {
+      id   = pagerduty_service.networking.id
+      type = "service"
+    }
+  }
+}
+
+resource "pagerduty_service_dependency" "modernisation_platform_operations_general" {
+  dependency {
+    dependent_service {
+      id   = pagerduty_business_service.modernisation_platform_operations.id
+      type = "business_service"
+    }
+    supporting_service {
+      id   = pagerduty_service.operations.id
+      type = "service"
+    }
+  }
+}
+
+resource "pagerduty_service_dependency" "modernisation_platform_security_general" {
+  dependency {
+    dependent_service {
+      id   = pagerduty_business_service.modernisation_platform_security.id
+      type = "business_service"
+    }
+    supporting_service {
+      id   = pagerduty_service.security.id
+      type = "service"
+    }
+  }
+}

--- a/terraform/pagerduty/services.tf
+++ b/terraform/pagerduty/services.tf
@@ -103,3 +103,42 @@ resource "pagerduty_service_integration" "tgw_cloudwatch" {
   service = pagerduty_service.tgw.id
   vendor  = data.pagerduty_vendor.cloudwatch.id
 }
+
+resource "pagerduty_service" "networking" {
+  name                    = "Networking - Modernisation Platform"
+  description             = "Generic service to raise networking issues against"
+  auto_resolve_timeout    = 345600
+  acknowledgement_timeout = "null"
+  escalation_policy       = pagerduty_escalation_policy.on_call.id
+  alert_creation          = "create_alerts_and_incidents"
+  incident_urgency_rule {
+    type    = "constant"
+    urgency = "high"
+  }
+}
+
+resource "pagerduty_service" "operations" {
+  name                    = "Operations - Modernisation Platform"
+  description             = "Generic service to raise operations issues against"
+  auto_resolve_timeout    = 345600
+  acknowledgement_timeout = "null"
+  escalation_policy       = pagerduty_escalation_policy.on_call.id
+  alert_creation          = "create_alerts_and_incidents"
+  incident_urgency_rule {
+    type    = "constant"
+    urgency = "high"
+  }
+}
+
+resource "pagerduty_service" "security" {
+  name                    = "Security - Modernisation Platform"
+  description             = "Generic service to raise security issues against"
+  auto_resolve_timeout    = 345600
+  acknowledgement_timeout = "null"
+  escalation_policy       = pagerduty_escalation_policy.on_call.id
+  alert_creation          = "create_alerts_and_incidents"
+  incident_urgency_rule {
+    type    = "constant"
+    urgency = "high"
+  }
+}


### PR DESCRIPTION
Specific areas such as TGW or DDOS have their own services, but if there is a generic issue which isn't covered by one of the other services we need to be able to raise it somewhere.

Following the incident meeting we decided we preferred to keep networking, operations and security as business services as it's makes it clear to users where the problem is, but add additional general services which feed in to these business services.