### PR TITLE
Create initial resources for inline inspection

### DIFF
--- a/terraform/environments/core-network-services/vpc.tf
+++ b/terraform/environments/core-network-services/vpc.tf
@@ -33,6 +33,9 @@ module "vpc_hub" {
   # Transit Gateway ID
   transit_gateway_id = aws_ec2_transit_gateway.transit-gateway.id
 
+  # Create inline firewall inspection endpoints
+  inline_inspection = true
+
   # Tags
   tags_common = local.tags
   tags_prefix = each.key

--- a/terraform/modules/vpc-hub/main.tf
+++ b/terraform/modules/vpc-hub/main.tf
@@ -629,7 +629,7 @@ resource "aws_network_acl" "inspection" {
 resource "aws_network_acl_rule" "inspection" {
   for_each = var.inline_inspection ? local.nacl_rules_expanded : {}
 
-  network_acl_id = aws_network_acl.transit-gateway.id
+  network_acl_id = aws_network_acl.inspection.id
   rule_number    = each.value.rule_num
   egress         = each.value.egress
   protocol       = each.value.protocol

--- a/terraform/modules/vpc-hub/main.tf
+++ b/terraform/modules/vpc-hub/main.tf
@@ -629,7 +629,7 @@ resource "aws_network_acl" "inspection" {
 resource "aws_network_acl_rule" "inspection" {
   for_each = var.inline_inspection ? local.nacl_rules_expanded : {}
 
-  network_acl_id = aws_network_acl.inspection.id
+  network_acl_id = aws_network_acl.inspection[0].id
   rule_number    = each.value.rule_num
   egress         = each.value.egress
   protocol       = each.value.protocol

--- a/terraform/modules/vpc-hub/main.tf
+++ b/terraform/modules/vpc-hub/main.tf
@@ -13,8 +13,11 @@ data "aws_availability_zones" "available" {
 
 locals {
   az    = sort(data.aws_availability_zones.available.names)
-  cidrs = cidrsubnets(var.vpc_cidr, 9, 9, 9, 4, 4, 4, 4, 4, 4, 4, 4, 4)
-  types = ["transit-gateway", "data", "private", "public"]
+  cidrs = flatten([
+    cidrsubnets(var.vpc_cidr, 9, 9, 9, 4, 4, 4, 4, 4, 4, 4, 4, 4),
+    var.inline_inspection ? slice(cidrsubnets(var.vpc_cidr, 9, 9, 9, 9, 9, 9), 3, 6) : []
+  ])
+  types = ["transit-gateway", "data", "private", "public", var.inline_inspection ? "inspection" : ""]
 
   # SAMPLE OUTPUT OF: types_and_az_and_cidrs
 

--- a/terraform/modules/vpc-hub/main.tf
+++ b/terraform/modules/vpc-hub/main.tf
@@ -14,7 +14,7 @@ data "aws_availability_zones" "available" {
 locals {
   az               = sort(data.aws_availability_zones.available.names)
   cidrs            = cidrsubnets(var.vpc_cidr, 9, 9, 9, 4, 4, 4, 4, 4, 4, 4, 4, 4)
-  inspection_cidrs = var.inline_inspection ? slice(cidrsubnets(var.vpc_cidr, 9, 9, 9, 9, 9, 9), 3, 6) : []
+  inspection_cidrs = slice(cidrsubnets(var.vpc_cidr, 9, 9, 9, 9, 9, 9), 3, 6)
   types            = ["transit-gateway", "data", "private", "public"]
 
   # SAMPLE OUTPUT OF: types_and_az_and_cidrs
@@ -594,7 +594,7 @@ resource "aws_route_table_association" "transit-gateway" {
 # Inspection subnets #
 ######################
 resource "aws_subnet" "inspection" {
-  for_each = tomap(local.inspection_subnets)
+  for_each = var.inline_inspection ? tomap(local.inspection_subnets) : {}
 
   vpc_id = aws_vpc.default.id
 

--- a/terraform/modules/vpc-hub/main.tf
+++ b/terraform/modules/vpc-hub/main.tf
@@ -59,7 +59,7 @@ locals {
     }
   }
 
-  inspection = var.inline_inspection ? {
+  inspection_subnets = var.inline_inspection ? {
     for index, cidr in local.inspection_cidrs :
     "inspection-${local.az[index]}" => {
       az   = local.az[index]
@@ -588,6 +588,99 @@ resource "aws_route_table_association" "transit-gateway" {
 
   subnet_id      = each.value.id
   route_table_id = aws_route_table.transit-gateway[each.key].id
+}
+
+######################
+# Inspection subnets #
+######################
+resource "aws_subnet" "inspection" {
+  for_each = tomap(local.inspection_subnets)
+
+  vpc_id = aws_vpc.default.id
+
+  cidr_block        = each.value.cidr
+  availability_zone = each.value.az
+
+  tags = merge(
+    var.tags_common,
+    {
+      Name = "${var.tags_prefix}-${each.key}"
+    }
+  )
+}
+
+# Inspection NACLs
+resource "aws_network_acl" "inspection" {
+  count  = var.inline_inspection ? 1 : 0
+  vpc_id = aws_vpc.default.id
+  subnet_ids = [
+    for subnet in aws_subnet.inspection : subnet.id
+  ]
+
+  tags = merge(
+    var.tags_common,
+    {
+      Name = "${var.tags_prefix}-inspection"
+    }
+  )
+}
+
+# Inspection NACLs rules
+resource "aws_network_acl_rule" "inspection" {
+  for_each = var.inline_inspection ? local.nacl_rules_expanded : {}
+
+  network_acl_id = aws_network_acl.transit-gateway.id
+  rule_number    = each.value.rule_num
+  egress         = each.value.egress
+  protocol       = each.value.protocol
+  rule_action    = each.value.action
+  cidr_block     = each.value.cidr
+  from_port      = each.value.from_port
+  to_port        = each.value.to_port
+}
+
+#tfsec:ignore:aws-vpc-no-excessive-port-access
+resource "aws_network_acl_rule" "inspection-local-ingress" {
+  count          = var.inline_inspection ? 1 : 0
+  network_acl_id = aws_network_acl.inspection[0].id
+  rule_number    = 210
+  egress         = false
+  protocol       = "-1"
+  rule_action    = "allow"
+  cidr_block     = var.vpc_cidr
+}
+
+#tfsec:ignore:aws-vpc-no-excessive-port-access
+resource "aws_network_acl_rule" "inspection-local-egress" {
+  count          = var.inline_inspection ? 1 : 0
+  network_acl_id = aws_network_acl.inspection[0].id
+  rule_number    = 210
+  egress         = true
+  protocol       = "-1"
+  rule_action    = "allow"
+  cidr_block     = var.vpc_cidr
+}
+
+# Inspection route table
+resource "aws_route_table" "inspection" {
+  for_each = aws_subnet.inspection
+
+  vpc_id = aws_vpc.default.id
+
+  tags = merge(
+    var.tags_common,
+    {
+      Name = "${var.tags_prefix}-${each.key}"
+    }
+  )
+}
+
+# Transit Gateway route table assocation with transit-gateway subnets
+resource "aws_route_table_association" "inspection" {
+  for_each = aws_subnet.inspection
+
+  subnet_id      = each.value.id
+  route_table_id = aws_route_table.inspection[each.key].id
 }
 
 ###############

--- a/terraform/modules/vpc-hub/outputs.tf
+++ b/terraform/modules/vpc-hub/outputs.tf
@@ -74,7 +74,3 @@ output "public_igw_route" {
   description = "Public Internet Gateway route"
   value       = aws_route.public-internet-gateway
 }
-
-output "types" {
-  value = local.types_and_azs_and_cidrs
-}

--- a/terraform/modules/vpc-hub/outputs.tf
+++ b/terraform/modules/vpc-hub/outputs.tf
@@ -75,3 +75,6 @@ output "public_igw_route" {
   value       = aws_route.public-internet-gateway
 }
 
+output "types" {
+  value = local.types_and_azs_and_cidrs
+}

--- a/terraform/modules/vpc-hub/variables.tf
+++ b/terraform/modules/vpc-hub/variables.tf
@@ -13,9 +13,10 @@ variable "gateway" {
   }
 }
 
-variable "vpc_flow_log_iam_role" {
-  description = "VPC Flow Log IAM role ARN for VPC Flow Logs to CloudWatch"
-  type        = string
+variable "inline_inspection" {
+  description = "Boolean value to allow the creation of inspection subnets for firewall endpoints"
+  type = bool
+  default = false
 }
 
 variable "tags_common" {
@@ -31,4 +32,9 @@ variable "tags_prefix" {
 variable "transit_gateway_id" {
   default = ""
   type    = string
+}
+
+variable "vpc_flow_log_iam_role" {
+  description = "VPC Flow Log IAM role ARN for VPC Flow Logs to CloudWatch"
+  type        = string
 }

--- a/terraform/modules/vpc-hub/variables.tf
+++ b/terraform/modules/vpc-hub/variables.tf
@@ -15,8 +15,8 @@ variable "gateway" {
 
 variable "inline_inspection" {
   description = "Boolean value to allow the creation of inspection subnets for firewall endpoints"
-  type = bool
-  default = false
+  type        = bool
+  default     = false
 }
 
 variable "tags_common" {


### PR DESCRIPTION
As part of #3547 this PR adds code to the `vpc-hub` module to conditionally create the following:
* Inspection subnets to hold firewall endpoints
* Inspection NACLs
* Inspection route tables

Later PRs will address further parts of #3547 such as creating the firewalls, policies, and endpoints, and eventually adjusting the routing to make egress traffic flow bidirectionally through the new firewalls, but this PR changes no existing functionality.

This PR also alphabetises the variables in the `vpc-hub` module.