### PR TITLE
Added mlra accounts to pull principals for mlra ecr repo

### DIFF
--- a/terraform/environments/core-shared-services/ecr_repos.tf
+++ b/terraform/environments/core-shared-services/ecr_repos.tf
@@ -33,6 +33,9 @@ module "mlra_ecr_repo" {
   pull_principals = [
     "arn:aws:iam::${local.environment_management.account_ids["mlra-development"]}:user/cicd-member-user",
     local.environment_management.account_ids["mlra-development"],
+    local.environment_management.account_ids["mlra-test"],
+    local.environment_management.account_ids["mlra-preproduction"],
+    local.environment_management.account_ids["mlra-production"],
     local.environment_management.account_ids["apex-development"]
   ]
 


### PR DESCRIPTION
As per [this customer request](https://mojdt.slack.com/archives/C01A7QK5VM1/p1682323009199579), this PR expands the range of accounts able to pull from the MLRA ECR repository.