### PR TITLE
Bump secure baselines version to fix default ctrl

### DIFF
--- a/terraform/environments/bootstrap/secure-baselines/main.tf
+++ b/terraform/environments/bootstrap/secure-baselines/main.tf
@@ -5,7 +5,7 @@ data "aws_kms_key" "cloudtrail_key" {
 }
 
 module "baselines" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=v4.3.1"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=v4.3.2"
 
   providers = {
     # Default and replication regions

--- a/terraform/modernisation-platform-account/baselines.tf
+++ b/terraform/modernisation-platform-account/baselines.tf
@@ -16,7 +16,7 @@ locals {
 
 # Secure baselines (GuardDuty, Config, SecurityHub, etc)
 module "baselines-modernisation-platform" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=v4.3.1"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=v4.3.2"
   providers = {
     # Default and replication regions
     aws                    = aws.modernisation-platform-eu-west-2


### PR DESCRIPTION
In the tfprovider-aws4.64.0 update the default for control_finding_generator is set to `SECURITY_CONTROL`.

This is different to what we have set at the org level, so we are now getting errors on applies -

```
  # module.baselines-modernisation-platform.module.securityhub-eu-central-1["enabled"].aws_securityhub_account.default will be updated in-place
  ~ resource "aws_securityhub_account" "default" {
      ~ control_finding_generator = "STANDARD_CONTROL" -> "SECURITY_CONTROL"
        id                        = "***"
        # (3 unchanged attributes hidden)
    }
```

Because this setting is controlled at the org level we do not have permissions to make this change.

Setting the default as `STANDARD_CONTROL` to fix.