### PR TITLE
Move logging out of firewall policy module

### DIFF
--- a/terraform/modules/firewall-logging/main.tf
+++ b/terraform/modules/firewall-logging/main.tf
@@ -1,3 +1,8 @@
+resource "random_string" "main" {
+  length  = 8
+  special = false
+}
+
 resource "aws_networkfirewall_logging_configuration" "main" {
   firewall_arn = var.fw_arn
   logging_configuration {
@@ -14,7 +19,7 @@ resource "aws_networkfirewall_logging_configuration" "main" {
 #tfsec:ignore:aws-cloudwatch-log-group-customer-key
 resource "aws_cloudwatch_log_group" "main" {
   #checkov:skip=CKV_AWS_158:Temporarily skip KMS encryption check while logging solution is being updated
-  name              = var.cloudwatch_log_group_name
+  name              = format("%s-%s", var.cloudwatch_log_group_name, random_string.main.result)
   retention_in_days = 365 # 0 = never expire
   tags              = var.tags
 }

--- a/terraform/modules/firewall-logging/main.tf
+++ b/terraform/modules/firewall-logging/main.tf
@@ -1,0 +1,20 @@
+resource "aws_networkfirewall_logging_configuration" "main" {
+  firewall_arn = var.fw_arn
+  logging_configuration {
+    log_destination_config {
+      log_destination = {
+        logGroup = aws_cloudwatch_log_group.main.name
+      }
+      log_destination_type = "CloudWatchLogs"
+      log_type             = "ALERT"
+    }
+  }
+}
+
+#tfsec:ignore:aws-cloudwatch-log-group-customer-key
+resource "aws_cloudwatch_log_group" "main" {
+  #checkov:skip=CKV_AWS_158:Temporarily skip KMS encryption check while logging solution is being updated
+  name              = var.cloudwatch_log_group_name
+  retention_in_days = 365 # 0 = never expire
+  tags              = var.tags
+}

--- a/terraform/modules/firewall-logging/variables.tf
+++ b/terraform/modules/firewall-logging/variables.tf
@@ -1,0 +1,14 @@
+variable "cloudwatch_log_group_name" {
+  description = "Name of CloudWatch log group to ship logs to"
+  type        = string
+}
+
+variable "fw_arn" {
+  description = "ARN of firewall for logging configuration"
+  type        = string
+}
+
+variable "tags" {
+  description = "A map of keys and values used to create resource metadata tags"
+  type        = map(any)
+}

--- a/terraform/modules/firewall-policy/main.tf
+++ b/terraform/modules/firewall-policy/main.tf
@@ -83,23 +83,3 @@ resource "aws_networkfirewall_rule_group" "fqdn-stateful" {
   }
 }
 
-resource "aws_networkfirewall_logging_configuration" "main" {
-  firewall_arn = var.fw_arn
-  logging_configuration {
-    log_destination_config {
-      log_destination = {
-        logGroup = aws_cloudwatch_log_group.main.name
-      }
-      log_destination_type = "CloudWatchLogs"
-      log_type             = "ALERT"
-    }
-  }
-}
-
-#tfsec:ignore:aws-cloudwatch-log-group-customer-key
-resource "aws_cloudwatch_log_group" "main" {
-  #checkov:skip=CKV_AWS_158:Temporarily skip KMS encryption check while logging solution is being updated
-  name              = var.cloudwatch_log_group_name
-  retention_in_days = 365 # 0 = never expire
-  tags              = var.tags
-}

--- a/terraform/modules/firewall-policy/variables.tf
+++ b/terraform/modules/firewall-policy/variables.tf
@@ -1,11 +1,21 @@
-variable "cloudwatch_log_group_name" {
-  description = "Name of CloudWatch log group to ship logs to"
+variable "fw_allowed_domains" {
+  description = "A list of domain names that will be added to an allow list rule"
+  type        = list(string)
+}
+
+variable "fw_home_net_ips" {
+  description = "A list of VPC cidr ranges that will be added to the HOME_NET for VPC scanning"
+  type        = list(string)
+}
+
+variable "fw_fqdn_rulegroup_capacity" {
+  description = "rule group capacity for FQDN rule group"
+  default     = "3000"
   type        = string
 }
 
-variable "fw_arn" {
-  description = "ARN of firewall for logging configuration"
-  type        = string
+variable "fw_fqdn_rulegroup_name" {
+  type = string
 }
 
 variable "fw_policy_name" {
@@ -21,31 +31,12 @@ variable "fw_rulegroup_name" {
   type = string
 }
 
-variable "fw_fqdn_rulegroup_name" {
-  type = string
-}
-
 variable "rules" {
   description = "A map of values supplied to create firewall rules"
   type        = map(any)
 }
+
 variable "tags" {
   description = "A map of keys and values used to create resource metadata tags"
   type        = map(any)
-}
-
-variable "fw_allowed_domains" {
-  description = "A list of domain names that will be added to an allow list rule"
-  type        = list(string)
-}
-
-variable "fw_fqdn_rulegroup_capacity" {
-  description = "rule group capacity for FQDN rule group"
-  default     = "3000"
-  type        = string
-}
-
-variable "fw_home_net_ips" {
-  description = "A list of VPC cidr ranges that will be added to the HOME_NET for VPC scanning"
-  type        = list(string)
 }


### PR DESCRIPTION
At present the `firewall-policy` module introduces a cyclic dependency when it's used with a new firewall.
* A new firewall resource requires a policy
* The `firewall-policy` module requires a firewall ARN for its logging configuration

This PR separates out the logging into its own small module, and includes a random prefix to both ensure the new log groups are unique, and to prevent a clash with the existing log groups before they are destroyed.