### PR TITLE
Feature/cloudwatch kms

### DIFF
--- a/terraform/modules/kms/main.tf
+++ b/terraform/modules/kms/main.tf
@@ -105,4 +105,23 @@ data "aws_iam_policy_document" "kms" {
 
     }
   }
+  statement {
+    effect = "Allow"
+    principals {
+    service [
+      "cloudwatch.amazonaws.com"
+    ]
+    },
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey*"
+    ]
+    resources = ["*"]
+
+    # Feed in AWS account IDs
+    principals {
+      type        = "AWS"
+      identifiers = var.business_unit_account_ids
+    }
+  }  
 }

--- a/terraform/modules/kms/main.tf
+++ b/terraform/modules/kms/main.tf
@@ -107,11 +107,6 @@ data "aws_iam_policy_document" "kms" {
   }
   statement {
     effect = "Allow"
-    principals {
-    service [
-      "cloudwatch.amazonaws.com"
-    ]
-    },
     actions = [
       "kms:Decrypt",
       "kms:GenerateDataKey*"
@@ -120,8 +115,11 @@ data "aws_iam_policy_document" "kms" {
 
     # Feed in AWS account IDs
     principals {
+      service [
+      "cloudwatch.amazonaws.com"
+    ]
       type        = "AWS"
       identifiers = var.business_unit_account_ids
     }
-  }  
+  }
 }


### PR DESCRIPTION
Added new kms allow policy for cloudwatch at the request of users following the bellow comment in the ask channel
Afternoon team, would it be possible to give cloudwatch access to the business unit general CMK. so we can have encrypted SNS topics.