### PR TITLE
Fix naming of inline inspection firewalls

### DIFF
--- a/terraform/environments/core-network-services/firewall.tf
+++ b/terraform/environments/core-network-services/firewall.tf
@@ -194,7 +194,7 @@ resource "aws_networkfirewall_firewall" "external_inspection" {
 
 resource "aws_networkfirewall_firewall" "inline_inspection" {
   for_each            = local.networking
-  name                = format("%s-inline-inspection", each.key)
+  name                = replace(format("%s-inline-inspection", each.key), "_", "-")
   firewall_policy_arn = module.inline_inspection_policy[each.key].fw_policy_arn
   vpc_id              = module.vpc_hub[each.key].vpc_id
   dynamic "subnet_mapping" {

--- a/terraform/modules/firewall-logging/main.tf
+++ b/terraform/modules/firewall-logging/main.tf
@@ -1,6 +1,7 @@
 resource "random_string" "main" {
   length  = 8
   special = false
+  upper   = false
 }
 
 resource "aws_networkfirewall_logging_configuration" "main" {


### PR DESCRIPTION
Because the `for_each` keys contain underscores, the inline inspection firewall names fail to pass validation.
Using a terraform `replace()` changes these out to hyphens which are supported in the AWS API reference here: https://docs.aws.amazon.com/network-firewall/latest/APIReference/API_CreateFirewall.html#API_CreateFirewall_RequestSyntax

A small cosmetic fix for the naming of cloudwatch log groups is also included.