### PR TITLE
Intial plan for certificates giving all access to developers

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/policies.tf
+++ b/terraform/environments/bootstrap/delegate-access/policies.tf
@@ -103,6 +103,7 @@ data "aws_iam_policy_document" "developer_additional" {
     actions = [
       "acm:ImportCertificate",
       "acm:AddTagsToCertificate",
+      "acm:RemoveTagsFromCertificate",
       "autoscaling:UpdateAutoScalingGroup",
       "autoscaling:SetDesiredCapacity",
       "aws-marketplace:ViewSubscriptions",


### PR DESCRIPTION
This is the initial code to add certificate access to developers. It doesn't currently restrict based on developers area so raised as a draft to look at and confirm it looks correct. Based on json code from AWSCertificateManagerFullAccess. A couple of bits had to be removed as they caused the plan to fail (e.g. Resource": "arn:aws:iam::*:role/aws-service-role/acm.amazonaws.com/AWSServiceRoleForCertificateManager*").

Second iteration was to remove all that code as the acm  "acm:ImportCertificate" was already in place but doesn't allow the addition of tags so  "acm.AddTagsToCertificate" as included.