### PR TITLE
Fix broken KMS policy

### DIFF
--- a/terraform/modules/kms/main.tf
+++ b/terraform/modules/kms/main.tf
@@ -115,7 +115,7 @@ data "aws_iam_policy_document" "kms" {
 
     # Feed in AWS account IDs
     principals {
-      service [
+      service = [
       "cloudwatch.amazonaws.com"
     ]
       type        = "AWS"

--- a/terraform/modules/kms/main.tf
+++ b/terraform/modules/kms/main.tf
@@ -115,11 +115,8 @@ data "aws_iam_policy_document" "kms" {
 
     # Feed in AWS account IDs
     principals {
-      service = [
-      "cloudwatch.amazonaws.com"
-    ]
-      type        = "AWS"
-      identifiers = var.business_unit_account_ids
+      type        = "Service"
+      identifiers = ["cloudwatch.amazonaws.com"]
     }
   }
 }


### PR DESCRIPTION
I missed an `=` sign when reviewing a prior PR; this branch introduces the missing operator