### PR TITLE
Changed Github Slug for laa-ccms

### DIFF
--- a/environments/laa-ccms-infra-azure-ad-sso.json
+++ b/environments/laa-ccms-infra-azure-ad-sso.json
@@ -5,7 +5,7 @@
       "name": "development",
       "access": [
         {
-          "github_slug": "laa-ccms-devs",
+          "github_slug": "laa-ccms-webops",
           "level": "sandbox",
           "nuke": "exclude"
         },


### PR DESCRIPTION
Changed slug based on this request - https://mojdt.slack.com/archives/C01A7QK5VM1/p1683022120483349

Seems possible thanks to the documentation here - https://user-guide.modernisation-platform.service.justice.gov.uk/runbooks/changing-environment-details.html#change-the-github-slug-for-an-environment-takaway