### PR TITLE
new fqdn rule for equip

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/fqdn_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/fqdn_rules.json
@@ -7,7 +7,8 @@
     ".download.windowsupdate.com",
     "wustat.windows.com",
     "ntservicepack.microsoft.com",
-    "stats.microsoft.com"
+    "stats.microsoft.com",
+    "saas40.kaseya.net"
   ],
   "fw_home_net_ips": ["10.26.0.0/16", "10.27.0.0/16"]
 }


### PR DESCRIPTION
As part of the request for issue [#3339](https://github.com/ministryofjustice/modernisation-platform/issues/3339)
we need to add in the sass dns name to the allowed list before the nacl ticket is complete to allow the traffic to flow out to the site from the environments