### PR TITLE
Adding ECR repo for data platform.

### DIFF
--- a/terraform/environments/core-shared-services/ecr_repos.tf
+++ b/terraform/environments/core-shared-services/ecr_repos.tf
@@ -138,10 +138,29 @@ module "delius_core_openldap_ecr_repo" {
   tags_common = local.tags
 }
 
-module "data_platform_ecr_repo" {
+module "data_platform_code_ecr_repo" {
   source = "../../modules/app-ecr-repo"
 
-  app_name = "data-platform"
+  app_name = "data-platform-code-extractor"
+
+  push_principals = [
+    "arn:aws:iam::${local.environment_management.account_ids["data-platform-development"]}:user/cicd-member-user",
+    local.environment_management.account_ids["data-platform-development"]
+  ]
+
+  pull_principals = [
+    "arn:aws:iam::${local.environment_management.account_ids["data-platform-development"]}:user/cicd-member-user",
+    local.environment_management.account_ids["data-platform-development"],
+  ]
+
+  # Tags
+  tags_common = local.tags
+}
+
+module "data_platform_data_ecr_repo" {
+  source = "../../modules/app-ecr-repo"
+
+  app_name = "data-platform-data-extractor"
 
   push_principals = [
     "arn:aws:iam::${local.environment_management.account_ids["data-platform-development"]}:user/cicd-member-user",

--- a/terraform/environments/core-shared-services/ecr_repos.tf
+++ b/terraform/environments/core-shared-services/ecr_repos.tf
@@ -137,3 +137,22 @@ module "delius_core_openldap_ecr_repo" {
   # Tags
   tags_common = local.tags
 }
+
+module "data_platform_ecr_repo" {
+  source = "../../modules/app-ecr-repo"
+
+  app_name = "data-platform"
+
+  push_principals = [
+    "arn:aws:iam::${local.environment_management.account_ids["data-platform-development"]}:user/cicd-member-user",
+    local.environment_management.account_ids["data-platform-development"]
+  ]
+
+  pull_principals = [
+    "arn:aws:iam::${local.environment_management.account_ids["data-platform-development"]}:user/cicd-member-user",
+    local.environment_management.account_ids["data-platform-development"],
+  ]
+
+  # Tags
+  tags_common = local.tags
+}


### PR DESCRIPTION
Adding two shared ECR repos for data platform. Currently only `data-platform-development` is allowed to push/pull but will be used by all data platform accounts.