### PR TITLE
Update route53.tf laa-finance-data.service.justice.gov.uk

### DIFF
--- a/terraform/environments/core-network-services/route53.tf
+++ b/terraform/environments/core-network-services/route53.tf
@@ -5,7 +5,7 @@ locals {
   application-zones = {
     equip    = "equip.service.justice.gov.uk",
     ccms-ebs = "ccms-ebs.service.justice.gov.uk",
-    mojfin   = "mojfin.service.justice.gov.uk",
+    mojfin   = "laa-finance-data.service.justice.gov.uk",
     mlra     = "mlra.service.justice.gov.uk"
   }
 }


### PR DESCRIPTION
Changes made based on request from ops engineering. Name did not conform to naming standards.