### PR TITLE
allow Mojo and DOM1 end user compute access to preprod and prod hmpps

### DIFF
--- a/terraform/environments/core-network-services/cidr-ranges.tf
+++ b/terraform/environments/core-network-services/cidr-ranges.tf
@@ -20,6 +20,9 @@ locals {
     moj-core-azure-1                 = "10.50.25.0/27"
     moj-core-azure-2                 = "10.50.26.0/24"
     i2n                              = "10.110.0.0/16"
+    atos_arkc_ras                    = "10.175.0.0/16" # for DOM1 devices connected to Cisco RAS VPN
+    atos_arkf_ras                    = "10.176.0.0/16" # for DOM1 devices connected to Cisco RAS VPN
+    vodafone_wan_nicts_aggregate     = "10.80.0.0/12"  # for devices connected to Prison Networks
 
     # hmpps azure cidr ranges
     noms-live-vnet                 = "10.40.0.0/18"

--- a/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
@@ -131,5 +131,26 @@
     "destination_ip": "${hmpps-preproduction}",
     "destination_port": "1521",
     "protocol": "TCP"
+  },
+  "atos_arkc_ras_to_mp_hmpps_preproduction_https": {
+    "action": "PASS",
+    "source_ip": "${atos_arkc_ras}",
+    "destination_ip": "${hmpps-preproduction}",
+    "destination_port": "443",
+    "protocol": "TCP"
+  },
+  "atos_arkf_ras_to_mp_hmpps_preproduction_https": {
+    "action": "PASS",
+    "source_ip": "${atos_arkf_ras}",
+    "destination_ip": "${hmpps-preproduction}",
+    "destination_port": "443",
+    "protocol": "TCP"
+  },
+  "vodafone_wan_nicts_aggregate_to_mp_hmpps_preproduction_https": {
+    "action": "PASS",
+    "source_ip": "${vodafone_wan_nicts_aggregate}",
+    "destination_ip": "${hmpps-preproduction}",
+    "destination_port": "443",
+    "protocol": "TCP"
   }
 }

--- a/terraform/environments/core-network-services/firewall-rules/production_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/production_rules.json
@@ -152,5 +152,26 @@
     "destination_ip": "${hmpps-production}",
     "destination_port": "ANY",
     "protocol": "TCP"
+  },
+  "atos_arkc_ras_to_mp_hmpps_production_https": {
+    "action": "PASS",
+    "source_ip": "${atos_arkc_ras}",
+    "destination_ip": "${hmpps-production}",
+    "destination_port": "443",
+    "protocol": "TCP"
+  },
+  "atos_arkf_ras_to_mp_hmpps_production_https": {
+    "action": "PASS",
+    "source_ip": "${atos_arkf_ras}",
+    "destination_ip": "${hmpps-production}",
+    "destination_port": "443",
+    "protocol": "TCP"
+  },
+  "vodafone_wan_nicts_aggregate_to_mp_hmpps_production_https": {
+    "action": "PASS",
+    "source_ip": "${vodafone_wan_nicts_aggregate}",
+    "destination_ip": "${hmpps-production}",
+    "destination_port": "443",
+    "protocol": "TCP"
   }
 }


### PR DESCRIPTION
Add additional firewall rules for HMPPS preproduction and production to allow devices connected to Prison networks and DOM1 VPN