### PR TITLE
Unwind inspection changes

### DIFF
--- a/terraform/environments/core-network-services/test/go_test.go
+++ b/terraform/environments/core-network-services/test/go_test.go
@@ -56,7 +56,7 @@ func TestTransitGateway(t *testing.T) {
 
 	//Test non-tgw-subnets count. There should be 9
 	output4 := terraform.Output(t, terraformOptions, "non_tgw_subnet_ids")
-	assert.Equal(t, output4, "12")
+	assert.Equal(t, output4, "9")
 
 	//Check the correct CIDR address have been added
 	output5 := terraform.Output(t, terraformOptions, "vpc_cidrs")

--- a/terraform/environments/core-network-services/vpc.tf
+++ b/terraform/environments/core-network-services/vpc.tf
@@ -33,9 +33,6 @@ module "vpc_hub" {
   # Transit Gateway ID
   transit_gateway_id = aws_ec2_transit_gateway.transit-gateway.id
 
-  # Create inline firewall inspection endpoints
-  inline_inspection = true
-
   # Tags
   tags_common = local.tags
   tags_prefix = each.key

--- a/terraform/modules/vpc-hub/main.tf
+++ b/terraform/modules/vpc-hub/main.tf
@@ -59,14 +59,6 @@ locals {
     }
   }
 
-  inspection_subnets = var.inline_inspection ? {
-    for index, cidr in local.inspection_cidrs :
-    "inspection-${local.az[index]}" => {
-      az   = local.az[index]
-      cidr = cidr
-    }
-  } : {}
-
   # NACLs
   nacl_rules = [
     { egress = false, action = "allow", protocol = -1, from_port = 0, to_port = 0, rule_num = 910, cidr = "0.0.0.0/0" },
@@ -588,99 +580,6 @@ resource "aws_route_table_association" "transit-gateway" {
 
   subnet_id      = each.value.id
   route_table_id = aws_route_table.transit-gateway[each.key].id
-}
-
-######################
-# Inspection subnets #
-######################
-resource "aws_subnet" "inspection" {
-  for_each = var.inline_inspection ? tomap(local.inspection_subnets) : {}
-
-  vpc_id = aws_vpc.default.id
-
-  cidr_block        = each.value.cidr
-  availability_zone = each.value.az
-
-  tags = merge(
-    var.tags_common,
-    {
-      Name = "${var.tags_prefix}-${each.key}"
-    }
-  )
-}
-
-# Inspection NACLs
-resource "aws_network_acl" "inspection" {
-  count  = var.inline_inspection ? 1 : 0
-  vpc_id = aws_vpc.default.id
-  subnet_ids = [
-    for subnet in aws_subnet.inspection : subnet.id
-  ]
-
-  tags = merge(
-    var.tags_common,
-    {
-      Name = "${var.tags_prefix}-inspection"
-    }
-  )
-}
-
-# Inspection NACLs rules
-resource "aws_network_acl_rule" "inspection" {
-  for_each = var.inline_inspection ? local.nacl_rules_expanded : {}
-
-  network_acl_id = aws_network_acl.inspection[0].id
-  rule_number    = each.value.rule_num
-  egress         = each.value.egress
-  protocol       = each.value.protocol
-  rule_action    = each.value.action
-  cidr_block     = each.value.cidr
-  from_port      = each.value.from_port
-  to_port        = each.value.to_port
-}
-
-#tfsec:ignore:aws-vpc-no-excessive-port-access
-resource "aws_network_acl_rule" "inspection-local-ingress" {
-  count          = var.inline_inspection ? 1 : 0
-  network_acl_id = aws_network_acl.inspection[0].id
-  rule_number    = 210
-  egress         = false
-  protocol       = "-1"
-  rule_action    = "allow"
-  cidr_block     = var.vpc_cidr
-}
-
-#tfsec:ignore:aws-vpc-no-excessive-port-access
-resource "aws_network_acl_rule" "inspection-local-egress" {
-  count          = var.inline_inspection ? 1 : 0
-  network_acl_id = aws_network_acl.inspection[0].id
-  rule_number    = 210
-  egress         = true
-  protocol       = "-1"
-  rule_action    = "allow"
-  cidr_block     = var.vpc_cidr
-}
-
-# Inspection route table
-resource "aws_route_table" "inspection" {
-  for_each = aws_subnet.inspection
-
-  vpc_id = aws_vpc.default.id
-
-  tags = merge(
-    var.tags_common,
-    {
-      Name = "${var.tags_prefix}-${each.key}"
-    }
-  )
-}
-
-# Transit Gateway route table assocation with transit-gateway subnets
-resource "aws_route_table_association" "inspection" {
-  for_each = aws_subnet.inspection
-
-  subnet_id      = each.value.id
-  route_table_id = aws_route_table.inspection[each.key].id
 }
 
 ###############

--- a/terraform/modules/vpc-hub/outputs.tf
+++ b/terraform/modules/vpc-hub/outputs.tf
@@ -24,9 +24,6 @@ output "non_tgw_subnet_ids" {
     ], [
     for subnet in aws_subnet.data :
     subnet.id
-    ], [
-    for subnet in aws_subnet.inspection :
-    subnet.id
   ])
 }
 

--- a/terraform/modules/vpc-hub/outputs.tf
+++ b/terraform/modules/vpc-hub/outputs.tf
@@ -36,7 +36,6 @@ output "non_tgw_subnet_ids_map" {
     "public"     = [for subnet in aws_subnet.public : subnet.id]
     "private"    = [for subnet in aws_subnet.private : subnet.id]
     "data"       = [for subnet in aws_subnet.data : subnet.id]
-    "inspection" = var.inline_inspection ? [for subnet in aws_subnet.inspection : subnet.id] : []
   }
 }
 

--- a/terraform/modules/vpc-hub/variables.tf
+++ b/terraform/modules/vpc-hub/variables.tf
@@ -13,12 +13,6 @@ variable "gateway" {
   }
 }
 
-variable "inline_inspection" {
-  description = "Boolean value to allow the creation of inspection subnets for firewall endpoints"
-  type        = bool
-  default     = false
-}
-
 variable "tags_common" {
   description = "Ministry of Justice required tags"
   type        = map(any)


### PR DESCRIPTION
After some internal discussion we've decided that the creation of egress VPCs with inline inspection is better handled in a separate module. The current approach adds extra complexity and spreads resources around in a number of locations which isn't ideal for user comprehension or code maintenance.

This PR unwinds the changes that have already been made.