### PR TITLE
Remove superfluous local value from vpc-hub

### DIFF
--- a/terraform/modules/vpc-hub/main.tf
+++ b/terraform/modules/vpc-hub/main.tf
@@ -14,7 +14,6 @@ data "aws_availability_zones" "available" {
 locals {
   az               = sort(data.aws_availability_zones.available.names)
   cidrs            = cidrsubnets(var.vpc_cidr, 9, 9, 9, 4, 4, 4, 4, 4, 4, 4, 4, 4)
-  inspection_cidrs = slice(cidrsubnets(var.vpc_cidr, 9, 9, 9, 9, 9, 9), 3, 6)
   types            = ["transit-gateway", "data", "private", "public"]
 
   # SAMPLE OUTPUT OF: types_and_az_and_cidrs


### PR DESCRIPTION
Removed an unneeded local that provided subnet values for inspection subnets.