### PR TITLE
Inline inspection module

### DIFF
--- a/terraform/modules/vpc-inspection/firewall.tf
+++ b/terraform/modules/vpc-inspection/firewall.tf
@@ -1,6 +1,6 @@
 resource "aws_networkfirewall_firewall" "inline_inspection" {
   name                = format("%s-inline-inspection", var.tags_prefix)
-  firewall_policy_arn = var.fw_policy_arn
+  firewall_policy_arn = module.inline_inspection_policy.fw_policy_arn
   vpc_id              = aws_vpc.main.id
   dynamic "subnet_mapping" {
     for_each = aws_subnet.inspection
@@ -11,6 +11,22 @@ resource "aws_networkfirewall_firewall" "inline_inspection" {
   tags = merge(
     var.tags_common,
     { Name = format("%s-inline-inspection", var.tags_prefix) }
+  )
+}
+
+module "inline_inspection_policy" {
+  source                 = "../../modules/firewall-policy"
+  fw_rulegroup_capacity  = "10000"
+  fw_policy_name         = format("%s-inline-fw-policy", var.tags_prefix)
+  fw_rulegroup_name      = format("%s-inline-fw-rulegroup", var.tags_prefix)
+  fw_fqdn_rulegroup_name = format("%s-inlinefw-fqdn-rulegroup", var.tags_prefix)
+  fw_allowed_domains     = var.fw_allowed_domains
+  fw_home_net_ips        = ["10.26.0.0/16", "10.27.0.0/16"]
+  rules                  = var.fw_rules
+
+  tags = merge(
+    var.tags_common,
+    { Name = format("%s-inline-fw-policy", each.key) }
   )
 }
 

--- a/terraform/modules/vpc-inspection/firewall.tf
+++ b/terraform/modules/vpc-inspection/firewall.tf
@@ -1,0 +1,22 @@
+resource "aws_networkfirewall_firewall" "inline_inspection" {
+  name                = format("%s-inline-inspection", var.tags_prefix)
+  firewall_policy_arn = var.fw_policy_arn
+  vpc_id              = aws_vpc.main.id
+  dynamic "subnet_mapping" {
+    for_each = aws_subnet.inspection
+    content {
+      subnet_id = subnet_mapping.value.id
+    }
+  }
+  tags = merge(
+    var.tags_common,
+    { Name = format("%s-inline-inspection", var.tags_prefix) }
+  )
+}
+
+module "inline_inspection_logging" {
+  source                    = "../firewall-logging"
+  cloudwatch_log_group_name = format("fw-%s-logs", aws_networkfirewall_firewall.inline_inspection.name)
+  fw_arn                    = aws_networkfirewall_firewall.inline_inspection.arn
+  tags                      = var.tags_common
+}

--- a/terraform/modules/vpc-inspection/firewall.tf
+++ b/terraform/modules/vpc-inspection/firewall.tf
@@ -26,7 +26,7 @@ module "inline_inspection_policy" {
 
   tags = merge(
     var.tags_common,
-    { Name = format("%s-inline-fw-policy", each.key) }
+    { Name = format("%s-inline-fw-policy", var.tags_prefix) }
   )
 }
 

--- a/terraform/modules/vpc-inspection/main.tf
+++ b/terraform/modules/vpc-inspection/main.tf
@@ -1,0 +1,253 @@
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+locals {
+  az    = sort(data.aws_availability_zones.available.names)
+  cidrs = cidrsubnets(var.vpc_cidr, 9, 9, 9, 9, 9, 9, 4, 4, 4)
+  types = ["transit-gateway", "inspection", "public"]
+
+  types_and_azs_and_cidrs = {
+    for index, type in local.types :
+    type => {
+      for cidr_index, cidr in slice(local.cidrs, index * 3, index * 3 + 3) :
+      "${type}-${local.az[cidr_index]}" => {
+        cidr = cidr
+        az   = local.az[cidr_index]
+      }
+    }
+  }
+
+  firewall_endpoint_map = {
+    for sync_state in aws_networkfirewall_firewall.inline_inspection.firewall_status[0].sync_states :
+    sync_state.availability_zone => sync_state.attachment[0].endpoint_id
+  }
+
+}
+
+### VPC ###
+resource "aws_vpc" "main" {
+  cidr_block                       = var.vpc_cidr
+  instance_tenancy                 = "default"
+  enable_dns_support               = true
+  enable_dns_hostnames             = true
+  assign_generated_ipv6_cidr_block = false
+
+  tags = merge(
+    var.tags_common,
+    { Name = var.tags_prefix }
+  )
+}
+
+### VPC Flow Logs ###
+resource "random_string" "main" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
+resource "aws_cloudwatch_log_group" "main" {
+  #checkov:skip=CKV_AWS_158:Temporarily skip KMS encryption check while logging solution is being updated
+  name              = format("%s-vpc-flow-logs-%s", var.tags_prefix, random_string.main.result)
+  retention_in_days = 365
+
+  tags = var.tags_common
+}
+
+resource "aws_flow_log" "cloudwatch" {
+  iam_role_arn             = var.vpc_flow_log_iam_role
+  log_destination          = aws_cloudwatch_log_group.main.arn
+  traffic_type             = "ALL"
+  log_destination_type     = "cloud-watch-logs"
+  max_aggregation_interval = "60"
+  vpc_id                   = aws_vpc.main.id
+
+  tags = merge(
+    var.tags_common,
+    { Name = format("%s-vpc-flow-logs", var.tags_prefix) }
+  )
+}
+
+### Transit Gateway Subnets ###
+resource "aws_subnet" "transit-gateway" {
+  for_each          = tomap(local.types_and_azs_and_cidrs.transit-gateway)
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = each.value.cidr
+  availability_zone = each.value.az
+
+  tags = merge(
+    var.tags_common,
+    { Name = format("%s-%s", var.tags_prefix, each.key) }
+  )
+}
+
+resource "aws_route_table" "transit-gateway" {
+  for_each = aws_subnet.transit-gateway
+  vpc_id   = aws_vpc.main.id
+
+  tags = merge(
+    var.tags_common,
+    { Name = format("%s-%s", var.tags_prefix, each.key) }
+  )
+}
+
+resource "aws_route_table_association" "transit-gateway" {
+  for_each       = aws_route_table.transit-gateway
+  vpc_id         = aws_vpc.main.id
+  route_table_id = each.value.id
+}
+
+resource "aws_route" "transit-gateway-0-0-0-0" {
+  depends_on             = [aws_networkfirewall_firewall.inline_inspection]
+  for_each               = aws_route_table.transit-gateway
+  destination_cidr_block = "0.0.0.0/0"
+  route_table_id         = each.value.id
+  vpc_endpoint_id        = local.firewall_endpoint_map[aws_subnet.transit-gateway[each.key].availability_zone]
+}
+
+resource "aws_route" "transit-gateway-10-26-0-0" {
+  for_each               = aws_route_table.transit-gateway
+  destination_cidr_block = "10.26.0.0/16"
+  route_table_id         = each.value.id
+  transit_gateway_id     = var.transit_gateway_id
+}
+
+resource "aws_route" "transit-gateway-10-27-0-0" {
+  for_each               = aws_route_table.transit-gateway
+  destination_cidr_block = "10.27.0.0/16"
+  route_table_id         = each.value.id
+  transit_gateway_id     = var.transit_gateway_id
+}
+
+### Inspection Subnets ###
+resource "aws_subnet" "inspection" {
+  for_each          = tomap(local.types_and_azs_and_cidrs.inspection)
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = each.value.cidr
+  availability_zone = each.value.az
+
+  tags = merge(
+    var.tags_common,
+    { Name = format("%s-%s", var.tags_prefix, each.key) }
+  )
+}
+
+resource "aws_route_table" "inspection" {
+  for_each = aws_subnet.inspection
+  vpc_id   = aws_vpc.main.id
+
+  tags = merge(
+    var.tags_common,
+    { Name = format("%s-%s", var.tags_prefix, each.key) }
+  )
+}
+
+resource "aws_route_table_association" "inspection" {
+  for_each       = aws_route_table.inspection
+  vpc_id         = aws_vpc.main.id
+  route_table_id = each.value.id
+}
+
+resource "aws_route" "inspection-0-0-0-0" {
+  for_each               = aws_route_table.inspection
+  destination_cidr_block = "0.0.0.0/0"
+  route_table_id         = each.value.id
+  nat_gateway_id         = aws_nat_gateway.public[replace(each.key, "inspection", "public")].id
+}
+
+resource "aws_route" "inspection-10-26-0-0" {
+  for_each               = aws_route_table.inspection
+  destination_cidr_block = "10.26.0.0/16"
+  route_table_id         = each.value.id
+  transit_gateway_id     = var.transit_gateway_id
+}
+
+resource "aws_route" "inspection-10-27-0-0" {
+  for_each               = aws_route_table.inspection
+  destination_cidr_block = "10.27.0.0/16"
+  route_table_id         = each.value.id
+  transit_gateway_id     = var.transit_gateway_id
+}
+
+### Public Subnets ###
+resource "aws_subnet" "public" {
+  for_each          = tomap(local.types_and_azs_and_cidrs.public)
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = each.value.cidr
+  availability_zone = each.value.az
+
+  tags = merge(
+    var.tags_common,
+    { Name = format("%s-%s", var.tags_prefix, each.key) }
+  )
+}
+
+resource "aws_route_table" "public" {
+  for_each = aws_subnet.public
+  vpc_id   = aws_vpc.main.id
+
+  tags = merge(
+    var.tags_common,
+    { Name = format("%s-%s", var.tags_prefix, each.key) }
+  )
+}
+
+resource "aws_route_table_association" "public" {
+  for_each       = aws_route_table.public
+  vpc_id         = aws_vpc.main.id
+  route_table_id = each.value.id
+}
+
+resource "aws_route" "public-0-0-0-0" {
+  for_each               = aws_route_table.public
+  destination_cidr_block = "0.0.0.0/0"
+  route_table_id         = each.value.id
+  gateway_id             = aws_internet_gateway.public.id
+}
+
+resource "aws_route" "public-10-26-0-0" {
+  depends_on             = [aws_networkfirewall_firewall.inline_inspection]
+  for_each               = aws_route_table.public
+  destination_cidr_block = "10.26.0.0/16"
+  route_table_id         = each.value.id
+  vpc_endpoint_id        = local.firewall_endpoint_map[aws_subnet.public[each.key].availability_zone]
+}
+
+resource "aws_route" "public-10-27-0-0" {
+  depends_on             = [aws_networkfirewall_firewall.inline_inspection]
+  for_each               = aws_route_table.public
+  destination_cidr_block = "10.27.0.0/16"
+  route_table_id         = each.value.id
+  vpc_endpoint_id        = local.firewall_endpoint_map[aws_subnet.public[each.key].availability_zone]
+}
+
+### AWS Gateways ###
+resource "aws_internet_gateway" "public" {
+  vpc_id = aws_vpc.main.id
+
+  tags = merge(
+    var.tags_common,
+    { Name = format("%s-internet-gateway", var.tags_prefix) }
+  )
+}
+
+resource "aws_eip" "public" {
+  for_each = aws_subnet.public
+  vpc      = true
+
+  tags = merge(
+    var.tags_common,
+    { Name = format("%s-%s-nat", var.tags_prefix, each.key) }
+  )
+}
+
+resource "aws_nat_gateway" "public" {
+  for_each      = aws_subnet.public
+  allocation_id = aws_eip.public[each.key].id
+  subnet_id     = each.value.id
+
+  tags = merge(
+    var.tags_common,
+    { Name = format("%s-%s", var.tags_prefix, each.key) }
+  )
+}

--- a/terraform/modules/vpc-inspection/main.tf
+++ b/terraform/modules/vpc-inspection/main.tf
@@ -23,10 +23,10 @@ locals {
     sync_state.availability_zone => sync_state.attachment[0].endpoint_id
   }
 
-  nacl_rules = [
-    { egress = false, action = "allow", protocol = -1, from_port = 0, to_port = 0, rule_num = 910, cidr = "0.0.0.0/0" },
-    { egress = true, action = "allow", protocol = -1, from_port = 0, to_port = 0, rule_num = 910, cidr = "0.0.0.0/0" }
-  ]
+  nacl_rules = {
+    inbound = { egress = false, action = "allow", protocol = -1, from_port = 0, to_port = 0, rule_num = 910, cidr = "0.0.0.0/0" },
+    outbound = { egress = true, action = "allow", protocol = -1, from_port = 0, to_port = 0, rule_num = 910, cidr = "0.0.0.0/0" }
+  }
 
 }
 
@@ -97,9 +97,9 @@ resource "aws_route_table" "transit-gateway" {
 }
 
 resource "aws_route_table_association" "transit-gateway" {
-  for_each       = aws_route_table.transit-gateway
-  vpc_id         = aws_vpc.main.id
-  route_table_id = each.value.id
+  for_each       = aws_subnet.transit-gateway
+  route_table_id = aws_route_table.transit-gateway[each.key].id
+  subnet_id      = each.value.id
 }
 
 resource "aws_route" "transit-gateway-0-0-0-0" {
@@ -172,9 +172,9 @@ resource "aws_route_table" "inspection" {
 }
 
 resource "aws_route_table_association" "inspection" {
-  for_each       = aws_route_table.inspection
-  vpc_id         = aws_vpc.main.id
-  route_table_id = each.value.id
+  for_each       = aws_subnet.inspection
+  route_table_id = aws_route_table.inspection[each.key].id
+  subnet_id      = each.value.id
 }
 
 resource "aws_route" "inspection-0-0-0-0" {
@@ -246,9 +246,9 @@ resource "aws_route_table" "public" {
 }
 
 resource "aws_route_table_association" "public" {
-  for_each       = aws_route_table.public
-  vpc_id         = aws_vpc.main.id
-  route_table_id = each.value.id
+  for_each       = aws_subnet.public
+  route_table_id = aws_route_table.public[each.key].id
+  subnet_id      = each.value.id
 }
 
 resource "aws_route" "public-0-0-0-0" {

--- a/terraform/modules/vpc-inspection/outputs.tf
+++ b/terraform/modules/vpc-inspection/outputs.tf
@@ -2,6 +2,23 @@ output "firewall" {
   value = aws_networkfirewall_firewall.inline_inspection
 }
 
+output "route_table_ids" {
+  value = {
+    transit_gateway = {
+      for name, table in aws_route_table.transit-gateway :
+      name => table.id
+    },
+    inspection = {
+      for name, table in aws_route_table.inspection :
+      name => table.id
+    },
+    public = {
+      for name, table in aws_route_table.public :
+      name => table.id
+    }
+  }
+}
+
 output "subnet_attributes" {
   value = {
     transit_gateway = {
@@ -16,5 +33,16 @@ output "subnet_attributes" {
       for subnet_name, subnet_attrs in aws_subnet.public :
         subnet_name => subnet_attrs.*
     },
+  }
+}
+
+output "internet_gateway" {
+  value = aws_internet_gateway.public
+}
+
+output "nat_gateway" {
+  value = {
+    for name, gateway in aws_nat_gateway.public :
+    name => gateway
   }
 }

--- a/terraform/modules/vpc-inspection/outputs.tf
+++ b/terraform/modules/vpc-inspection/outputs.tf
@@ -1,13 +1,20 @@
-output "subnet_attributes" {
-  value = {
-    for subnet_type in local.types :
-    subnet_type => {
-      for subnet, attributes in aws_subnet[subnet_type].* :
-      subnet => attributes
-    }
-  }
-}
-
 output "firewall" {
   value = aws_networkfirewall_firewall.inline_inspection
+}
+
+output "subnet_attributes" {
+  value = {
+    transit_gateway = {
+      for subnet_name, subnet_attrs in aws_subnet.transit-gateway :
+        subnet_name => subnet_attrs.*
+    },
+    inspection = {
+      for subnet_name, subnet_attrs in aws_subnet.inspection :
+        subnet_name => subnet_attrs.*
+    },
+    public = {
+      for subnet_name, subnet_attrs in aws_subnet.public :
+        subnet_name => subnet_attrs.*
+    },
+  }
 }

--- a/terraform/modules/vpc-inspection/outputs.tf
+++ b/terraform/modules/vpc-inspection/outputs.tf
@@ -1,0 +1,13 @@
+output "subnet_attributes" {
+  value = {
+    for subnet_type in local.types :
+    subnet_type => {
+      for subnet, attributes in aws_subnet[subnet_type].* :
+      subnet => attributes
+    }
+  }
+}
+
+output "firewall" {
+  value = aws_networkfirewall_firewall.inline_inspection
+}

--- a/terraform/modules/vpc-inspection/variables.tf
+++ b/terraform/modules/vpc-inspection/variables.tf
@@ -1,0 +1,28 @@
+variable "fw_policy_arn" {
+  description = "ARN of policy to be supplied to inline-inspection firewall"
+}
+
+variable "tags_common" {
+  description = "Ministry of Justice required tags"
+  type        = map(any)
+}
+
+variable "tags_prefix" {
+  description = "Prefix for name tags, e.g. \"live_data\""
+  type        = string
+}
+
+variable "transit_gateway_id" {
+  default = ""
+  type    = string
+}
+
+variable "vpc_cidr" {
+  description = "CIDR range for the VPC"
+  type        = string
+}
+
+variable "vpc_flow_log_iam_role" {
+  description = "VPC Flow Log IAM role ARN for VPC Flow Logs to CloudWatch"
+  type        = string
+}

--- a/terraform/modules/vpc-inspection/variables.tf
+++ b/terraform/modules/vpc-inspection/variables.tf
@@ -1,5 +1,9 @@
-variable "fw_policy_arn" {
-  description = "ARN of policy to be supplied to inline-inspection firewall"
+variable "fw_allowed_domains" {
+  description = "JSON map containing a list of allowed domains"
+}
+
+variable "fw_rules" {
+  description = "JSON map of maps containing stateless firewall rules"
 }
 
 variable "tags_common" {


### PR DESCRIPTION
This PR bundles up previous work to create a module which can be used to create an inline inspection VPC.
The VPC contains the following::
* AWS VPC with three types of subnet; `transit-gateway`, `inspection`, and `private`
* AWS Network Firewall with endpoints spread across the `inspection` subnets
* AWS Route tables and routes to flow traffic out through the firewall endpoints and back in via the transit gateway
* AWS NAT gateways with Elastic IP addresses
* AWS Network ACLs
* Outputs to be used in the creation of tests