### PR TITLE
Create VPN to Parole Board

### DIFF
--- a/terraform/environments/core-network-services/vpn_attachments.json
+++ b/terraform/environments/core-network-services/vpn_attachments.json
@@ -82,5 +82,16 @@
     "tunnel_dpd_timeout_action": "restart",
     "tunnel_dpd_timeout_seconds": "45",
     "tunnel_startup_action": "start"
+  },
+  "Parole-Board-VPN": {
+    "bgp_asn": "65535",
+    "customer_gateway_ip": "51.140.46.165",
+    "remote_ipv4_network_cidr": "0.0.0.0/0",
+    "static_routes_only": true,
+    "tunnel1_inside_cidr": "169.254.6.0/30",
+    "tunnel2_inside_cidr": "169.254.6.4/30",
+    "tunnel_dpd_timeout_action": "restart",
+    "tunnel_dpd_timeout_seconds": "45",
+    "tunnel_startup_action": "start"
   }
 }


### PR DESCRIPTION
* create customer gateway to parole board
* set placeholder BGP ASN (customer is not using BGP, but this is a required field)
* create site-to-site vpns to parole board
* attach VPN to MP Transit Gateway
* associate attachment with `external` Transit Gateway route table