### PR TITLE
Update route53.tf for mlra

### DIFF
--- a/terraform/environments/core-network-services/route53.tf
+++ b/terraform/environments/core-network-services/route53.tf
@@ -6,7 +6,7 @@ locals {
     equip    = "equip.service.justice.gov.uk",
     ccms-ebs = "ccms-ebs.service.justice.gov.uk",
     mojfin   = "laa-finance-data.service.justice.gov.uk",
-    mlra     = "mlra.service.justice.gov.uk"
+    mlra     = "maat-libra-administration-tool.service.justice.gov.uk"
   }
 }
 


### PR DESCRIPTION
maat-libra-administration-tool.service.justice.gov.uk to replace mlra.service.justice.gov.uk

Request from Mike.

https://mojdt.slack.com/archives/C01A7QK5VM1/p1683712424562449