### PR TITLE
Create two inline_inspection VPCs

### DIFF
--- a/terraform/environments/core-network-services/transit-gateway.tf
+++ b/terraform/environments/core-network-services/transit-gateway.tf
@@ -63,7 +63,7 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "attachments-inspection" {
   transit_gateway_default_route_table_propagation = false
   transit_gateway_id                              = aws_ec2_transit_gateway.transit-gateway.id
   vpc_id                                          = module.vpc_inspection[each.key].vpc_id
-  subnet_ids                                      = module.vpc_inspection[each.key].subnet_attributes.transit-gateway.*.id
+  subnet_ids                                      = module.vpc_inspection[each.key].tgw_subnet_ids
 }
 
 #########################

--- a/terraform/environments/core-network-services/transit-gateway.tf
+++ b/terraform/environments/core-network-services/transit-gateway.tf
@@ -63,7 +63,7 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "attachments-inspection" {
   transit_gateway_default_route_table_propagation = false
   transit_gateway_id                              = aws_ec2_transit_gateway.transit-gateway.id
   vpc_id                                          = module.vpc_inspection[each.key].vpc_id
-  subnet_ids                                      = module.vpc-inspection[each.key].subnet_attributes.transit-gateway.*.id
+  subnet_ids                                      = module.vpc_inspection[each.key].subnet_attributes.transit-gateway.*.id
 }
 
 #########################

--- a/terraform/environments/core-network-services/transit-gateway.tf
+++ b/terraform/environments/core-network-services/transit-gateway.tf
@@ -55,6 +55,19 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "attachments" {
   }
 }
 
+## Inline-inspection attachments
+resource "aws_ec2_transit_gateway_vpc_attachment" "attachments-inspection" {
+  for_each = local.networking
+  appliance_mode_support = "enable"
+  transit_gateway_default_route_table_association = false
+  transit_gateway_default_route_table_propagation = false
+  transit_gateway_id = aws_ec2_transit_gateway.transit-gateway.id
+  vpc_id             = module.vpc_inspection[each.key].vpc_id
+  subnet_ids {
+    module.vpc-inspection[each.key].subnet_attributes.transit-gateway.*.id
+  }
+}
+
 #########################
 # Route table and routes
 #########################

--- a/terraform/environments/core-network-services/transit-gateway.tf
+++ b/terraform/environments/core-network-services/transit-gateway.tf
@@ -57,15 +57,13 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "attachments" {
 
 ## Inline-inspection attachments
 resource "aws_ec2_transit_gateway_vpc_attachment" "attachments-inspection" {
-  for_each = local.networking
-  appliance_mode_support = "enable"
+  for_each                                        = local.networking
+  appliance_mode_support                          = "enable"
   transit_gateway_default_route_table_association = false
   transit_gateway_default_route_table_propagation = false
-  transit_gateway_id = aws_ec2_transit_gateway.transit-gateway.id
-  vpc_id             = module.vpc_inspection[each.key].vpc_id
-  subnet_ids {
-    module.vpc-inspection[each.key].subnet_attributes.transit-gateway.*.id
-  }
+  transit_gateway_id                              = aws_ec2_transit_gateway.transit-gateway.id
+  vpc_id                                          = module.vpc_inspection[each.key].vpc_id
+  subnet_ids                                      = module.vpc-inspection[each.key].subnet_attributes.transit-gateway.*.id
 }
 
 #########################

--- a/terraform/environments/core-network-services/vpc.tf
+++ b/terraform/environments/core-network-services/vpc.tf
@@ -52,7 +52,7 @@ module "vpc_inspection" {
   # Tags
   tags_common = merge(
     local.tags,
-    { inline_inspection = "true" }
+    { inline-inspection = "true" }
   )
   tags_prefix = each.key
 }

--- a/terraform/environments/core-network-services/vpc.tf
+++ b/terraform/environments/core-network-services/vpc.tf
@@ -37,3 +37,22 @@ module "vpc_hub" {
   tags_common = local.tags
   tags_prefix = each.key
 }
+
+module "vpc_inspection" {
+  for_each = local.networking
+
+  source                = "../../modules/vpc-inspection"
+  fw_allowed_domains    = local.fqdn_firewall_rules.fw_allowed_domains
+  fw_home_net_ips       = local.fqdn_firewall_rules.fw_home_net_ips
+  fw_rules              = local.inline_firewall_rules
+  vpc_cidr              = each.value
+  vpc_flow_log_iam_role = data.aws_iam_role.vpc-flow-log.arn
+  transit_gateway_id    = aws_ec2_transit_gateway.transit-gateway.id
+
+  # Tags
+  tags_common = merge(
+    local.tags,
+    { inline_inspection = "true" }
+  )
+  tags_prefix = each.key
+}

--- a/terraform/modules/vpc-inspection/firewall.tf
+++ b/terraform/modules/vpc-inspection/firewall.tf
@@ -21,7 +21,7 @@ module "inline_inspection_policy" {
   fw_rulegroup_name      = format("%s-inline-fw-rulegroup", var.tags_prefix)
   fw_fqdn_rulegroup_name = format("%s-inlinefw-fqdn-rulegroup", var.tags_prefix)
   fw_allowed_domains     = var.fw_allowed_domains
-  fw_home_net_ips        = ["10.26.0.0/16", "10.27.0.0/16"]
+  fw_home_net_ips        = var.fw_home_net_ips
   rules                  = var.fw_rules
 
   tags = merge(

--- a/terraform/modules/vpc-inspection/outputs.tf
+++ b/terraform/modules/vpc-inspection/outputs.tf
@@ -47,6 +47,10 @@ output "subnet_attributes" {
   }
 }
 
+output "tgw_subnet_ids" {
+  value = [for subnet in aws_subnet.transit-gateway : subnet.id]
+}
+
 output "vpc_id" {
   value = aws_vpc.main.id
 }

--- a/terraform/modules/vpc-inspection/outputs.tf
+++ b/terraform/modules/vpc-inspection/outputs.tf
@@ -2,6 +2,17 @@ output "firewall" {
   value = aws_networkfirewall_firewall.inline_inspection
 }
 
+output "internet_gateway" {
+  value = aws_internet_gateway.public
+}
+
+output "nat_gateway" {
+  value = {
+    for name, gateway in aws_nat_gateway.public :
+    name => gateway
+  }
+}
+
 output "route_table_ids" {
   value = {
     transit_gateway = {
@@ -36,13 +47,6 @@ output "subnet_attributes" {
   }
 }
 
-output "internet_gateway" {
-  value = aws_internet_gateway.public
-}
-
-output "nat_gateway" {
-  value = {
-    for name, gateway in aws_nat_gateway.public :
-    name => gateway
-  }
+output "vpc_id" {
+  value = aws_vpc.main.id
 }

--- a/terraform/modules/vpc-inspection/variables.tf
+++ b/terraform/modules/vpc-inspection/variables.tf
@@ -1,9 +1,16 @@
 variable "fw_allowed_domains" {
-  description = "JSON map containing a list of allowed domains"
+  description = "List of strings containing allowed domains"
+  type        = list(string)
+}
+
+variable "fw_home_net_ips" {
+  description = "List of strings covering firewall HOME_NET values"
+  type        = list(string)
 }
 
 variable "fw_rules" {
   description = "JSON map of maps containing stateless firewall rules"
+  type        = map(any)
 }
 
 variable "tags_common" {


### PR DESCRIPTION
This PR creates two VPCs from the `vpc-inspection` module, and attaches them to the MP transit gateway.
A future PR will be needed to route traffic through these new VPCs and remove the old VPCs, as well as to introduce tests to ensure that VPCs remain functional.