### PR TITLE
Move inspection VPC TGW attachment into module

### DIFF
--- a/terraform/environments/core-network-services/transit-gateway.tf
+++ b/terraform/environments/core-network-services/transit-gateway.tf
@@ -55,17 +55,6 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "attachments" {
   }
 }
 
-## Inline-inspection attachments
-resource "aws_ec2_transit_gateway_vpc_attachment" "attachments-inspection" {
-  for_each                                        = local.networking
-  appliance_mode_support                          = "enable"
-  transit_gateway_default_route_table_association = false
-  transit_gateway_default_route_table_propagation = false
-  transit_gateway_id                              = aws_ec2_transit_gateway.transit-gateway.id
-  vpc_id                                          = module.vpc_inspection[each.key].vpc_id
-  subnet_ids                                      = module.vpc_inspection[each.key].tgw_subnet_ids
-}
-
 #########################
 # Route table and routes
 #########################

--- a/terraform/modules/vpc-inspection/outputs.tf
+++ b/terraform/modules/vpc-inspection/outputs.tf
@@ -34,21 +34,17 @@ output "subnet_attributes" {
   value = {
     transit_gateway = {
       for subnet_name, subnet_attrs in aws_subnet.transit-gateway :
-      subnet_name => subnet_attrs.*
+      subnet_name => subnet_attrs[*]
     },
     inspection = {
       for subnet_name, subnet_attrs in aws_subnet.inspection :
-      subnet_name => subnet_attrs.*
+      subnet_name => subnet_attrs[*]
     },
     public = {
       for subnet_name, subnet_attrs in aws_subnet.public :
-      subnet_name => subnet_attrs.*
+      subnet_name => subnet_attrs[*]
     },
   }
-}
-
-output "tgw_subnet_ids" {
-  value = [for subnet in aws_subnet.transit-gateway : subnet.id]
 }
 
 output "vpc_id" {

--- a/terraform/modules/vpc-inspection/transit_gateway.tf
+++ b/terraform/modules/vpc-inspection/transit_gateway.tf
@@ -1,0 +1,18 @@
+resource "aws_ec2_transit_gateway_vpc_attachment" "attachments-inspection" {
+  appliance_mode_support                          = "enable"
+  transit_gateway_default_route_table_association = false
+  transit_gateway_default_route_table_propagation = false
+  transit_gateway_id                              = var.transit_gateway_id
+  vpc_id                                          = aws_vpc.main.id
+  subnet_ids                                      = [for subnet in aws_subnet.transit-gateway : subnet.id]
+
+  tags = merge(
+    var.tags_common,
+    { "Name" = format("%s-attachment", var.tags_prefix),
+      "inline-inspection" = "true"}
+  )
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}

--- a/terraform/modules/vpc-inspection/versions.tf
+++ b/terraform/modules/vpc-inspection/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    aws = {
+      version = "~> 4.0"
+      source  = "hashicorp/aws"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.4"
+    }
+  }
+  required_version = ">= 1.0"
+}


### PR DESCRIPTION
* Move the `aws_ec2_transit_gateway_vpc_attachment` resource into the `vpc-inspection` module
* Update outputs to remove use of legacy splat syntax
* Remove unused output from `vpc-inspection` module
* Added version constraints to align with good practice