### PR TITLE
Use replace function to sanitise name of network firewall

### DIFF
--- a/terraform/modules/vpc-inspection/firewall.tf
+++ b/terraform/modules/vpc-inspection/firewall.tf
@@ -1,5 +1,5 @@
 resource "aws_networkfirewall_firewall" "inline_inspection" {
-  name                = format("%s-inline-inspection", var.tags_prefix)
+  name                = replace(format("%s-inline-inspection", var.tags_prefix), "/_/", "-")
   firewall_policy_arn = module.inline_inspection_policy.fw_policy_arn
   vpc_id              = aws_vpc.main.id
   dynamic "subnet_mapping" {


### PR DESCRIPTION
As detailed [here](https://docs.aws.amazon.com/network-firewall/latest/APIReference/API_CreateFirewall.html#API_CreateFirewall_RequestSyntax:~:text=Required%3A%20No-,FirewallName,-The%20descriptive%20name), underscores are not valid in a firewall name. This PR uses a replace function to pull `_` characters and replace them with `-` characters.