### PR TITLE
Fix policy name

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/policies.tf
+++ b/terraform/environments/bootstrap/delegate-access/policies.tf
@@ -465,7 +465,7 @@ data "aws_iam_policy_document" "migration_additional" {
 # instance management - member SSO and collaborators
 resource "aws_iam_policy" "instance-management" {
   provider = aws.workspace
-  name     = "database_mgmt_policy"
+  name     = "instance_management_policy"
   path     = "/"
   policy   = data.aws_iam_policy_document.instance-management-document.json
 }


### PR DESCRIPTION
The sso permission set provisioning was failing as the policy name didn't match.  Changing to match the name defined here:

https://github.com/ministryofjustice/aws-root-account/blob/efd728ed376d8ae244c4fb2b1cc99005d3033cc3/management-account/terraform/sso-admin-permission-sets.tf#LL304C13-L304C39