### PR TITLE
Associate inspection VPCs with TGW route tables

### DIFF
--- a/terraform/environments/core-network-services/transit-gateway.tf
+++ b/terraform/environments/core-network-services/transit-gateway.tf
@@ -84,6 +84,13 @@ resource "aws_ec2_transit_gateway_route_table_association" "association" {
   transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.route-tables[each.key].id
 }
 
+# Associate the Inspection VPC attachments with the relevant Transit Gateway route table
+resource "aws_ec2_transit_gateway_route_table_association" "inspection_association" {
+  for_each                       = local.networking
+  transit_gateway_attachment_id  = module.vpc_inspection[each.key].transit_gateway_attachment_id
+  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.route-tables[each.key].id
+}
+
 #########################
 # Routes for VPC attachments
 #########################

--- a/terraform/modules/vpc-inspection/outputs.tf
+++ b/terraform/modules/vpc-inspection/outputs.tf
@@ -47,6 +47,10 @@ output "subnet_attributes" {
   }
 }
 
+output "transit_gateway_attachment_id" {
+  value = aws_ec2_transit_gateway_vpc_attachment.attachments-inspection.id
+}
+
 output "vpc_id" {
   value = aws_vpc.main.id
 }

--- a/terraform/modules/vpc-inspection/transit_gateway.tf
+++ b/terraform/modules/vpc-inspection/transit_gateway.tf
@@ -9,7 +9,7 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "attachments-inspection" {
   tags = merge(
     var.tags_common,
     { "Name" = format("%s-attachment", var.tags_prefix),
-      "inline-inspection" = "true"}
+    "inline-inspection" = "true" }
   )
 
   lifecycle {


### PR DESCRIPTION
In preparation for migration, the new inspection VPCs need to be associated with the correct TGW route tables.

As the route tables are defined in `core-network-services`, I think this is the most appropriate place to put the route table association; I could feed it into the module (which is probably the better approach) but starts to blur the line on where the associations are done and for the sake of comprehensibility I'm going to leave the association in its current location.

* Add output of TGW attachment ID to `vpc-inspection` module
* Consume output in `core-network-services`