### PR TITLE
Disconnect old egress VPCs

### DIFF
--- a/terraform/environments/core-network-services/vpc.tf
+++ b/terraform/environments/core-network-services/vpc.tf
@@ -3,14 +3,6 @@ locals {
     live_data     = "10.20.0.0/19"
     non_live_data = "10.20.32.0/19"
   }
-
-  useful_vpc_ids = {
-    for key in keys(local.networking) :
-    key => {
-      vpc_id                 = module.vpc_hub[key].vpc_id
-      private_tgw_subnet_ids = module.vpc_hub[key].tgw_subnet_ids
-    }
-  }
 }
 
 module "vpc_hub" {
@@ -42,6 +34,7 @@ module "vpc_inspection" {
   for_each = local.networking
 
   source                = "../../modules/vpc-inspection"
+  application_name      = local.application_name
   fw_allowed_domains    = local.fqdn_firewall_rules.fw_allowed_domains
   fw_home_net_ips       = local.fqdn_firewall_rules.fw_home_net_ips
   fw_rules              = local.inline_firewall_rules

--- a/terraform/modules/vpc-inspection/transit_gateway.tf
+++ b/terraform/modules/vpc-inspection/transit_gateway.tf
@@ -8,7 +8,7 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "attachments-inspection" {
 
   tags = merge(
     var.tags_common,
-    { "Name" = format("%s-attachment", var.tags_prefix),
+    { "Name" = format("%s-%s-attachment", var.application_name, var.tags_prefix),
     "inline-inspection" = "true" }
   )
 

--- a/terraform/modules/vpc-inspection/variables.tf
+++ b/terraform/modules/vpc-inspection/variables.tf
@@ -1,3 +1,8 @@
+variable "application_name" {
+  description = "Application name, eg `core-shared-services` or `core-network-services"
+  type        = string
+}
+
 variable "fw_allowed_domains" {
   description = "List of strings containing allowed domains"
   type        = list(string)


### PR DESCRIPTION
As the old egress VPCs are no longer required, the first step in removing them is disconnecting them from the Modernisation Platform transit gateway.

This PR also updates the `Name` tags of the attachments to the new egress VPCs so that they match the previous syntax, and are monitored by our CloudWatch alarms.