### PR TITLE
Code Changes for equip networking

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/development_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/development_rules.json
@@ -47,5 +47,19 @@
     "destination_ip": "${mp-development-test}",
     "destination_port": "ANY",
     "protocol": "IP"
+  },
+  "hmpps_development_to_saas_agent_tcp": {
+    "action": "PASS",
+    "source_ip": "${hmpps-development}",
+    "destination_ip": "0.0.0.0/0",
+    "destination_port": "5721",
+    "protocol": "TCP"
+  },
+  "hmpps_development_to_saas_agent_udp": {
+    "action": "PASS",
+    "source_ip": "${hmpps-development}",
+    "destination_ip": "0.0.0.0/0",
+    "destination_port": "5721",
+    "protocol": "UDP"
   }
 }

--- a/terraform/environments/core-network-services/firewall-rules/inline_fqdn_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/inline_fqdn_rules.json
@@ -7,6 +7,7 @@
     ".download.windowsupdate.com",
     "wustat.windows.com",
     "ntservicepack.microsoft.com",
-    "stats.microsoft.com"
+    "stats.microsoft.com",
+    "saas40.kaseya.net"
   ]
 }

--- a/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
@@ -152,5 +152,19 @@
     "destination_ip": "${hmpps-preproduction}",
     "destination_port": "443",
     "protocol": "TCP"
+  },
+  "hmpps_preproduction_to_saas_agent_tcp": {
+    "action": "PASS",
+    "source_ip": "${hmpps-preproduction}",
+    "destination_ip": "0.0.0.0/0",
+    "destination_port": "5721",
+    "protocol": "TCP"
+  },
+  "hmpps_preproduction_to_saas_agent_udp": {
+    "action": "PASS",
+    "source_ip": "${hmpps-preproduction}",
+    "destination_ip": "0.0.0.0/0",
+    "destination_port": "5721",
+    "protocol": "UDP"
   }
 }

--- a/terraform/environments/core-network-services/firewall-rules/production_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/production_rules.json
@@ -173,5 +173,19 @@
     "destination_ip": "${hmpps-production}",
     "destination_port": "443",
     "protocol": "TCP"
+  },
+  "hmpps_production_to_saas_agent_tcp": {
+    "action": "PASS",
+    "source_ip": "${hmpps-production}",
+    "destination_ip": "0.0.0.0/0",
+    "destination_port": "5721",
+    "protocol": "TCP"
+  },
+  "hmpps_production_to_saas_agent_udp": {
+    "action": "PASS",
+    "source_ip": "${hmpps-production}",
+    "destination_ip": "0.0.0.0/0",
+    "destination_port": "5721",
+    "protocol": "UDP"
   }
 }

--- a/terraform/environments/core-network-services/firewall-rules/test_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/test_rules.json
@@ -124,5 +124,19 @@
     "destination_ip": "${laa-test}",
     "destination_port": "ANY",
     "protocol": "IP"
+  },
+  "hmpps_test_to_saas_agent_tcp": {
+    "action": "PASS",
+    "source_ip": "${hmpps-test}",
+    "destination_ip": "0.0.0.0/0",
+    "destination_port": "5721",
+    "protocol": "TCP"
+  },
+  "hmpps_test_to_saas_agent_udp": {
+    "action": "PASS",
+    "source_ip": "${hmpps-test}",
+    "destination_ip": "0.0.0.0/0",
+    "destination_port": "5721",
+    "protocol": "UDP"
   }
 }

--- a/terraform/modules/vpc-nacls/data.tf
+++ b/terraform/modules/vpc-nacls/data.tf
@@ -48,6 +48,8 @@ locals {
   # 5000 = https internet access
   # 5100 = http internet access
   # 5200 = tcp internet access on dynamic ports
+  # 5300 = udp saas third party monitor agent
+  # 5400 = tcp saas third party monitor agent
   # 6000 = public address ranges (dynamic)
   # 7000 = access from internet
 
@@ -168,6 +170,24 @@ locals {
       rule_action = "allow"
       rule_number = 5200
       to_port     = 65535
+    },
+    allow_0-0-0-0_agent_udp_out = {
+      cidr_block  = "0.0.0.0/0"
+      egress      = true
+      from_port   = 5721
+      protocol    = "udp"
+      rule_action = "allow"
+      rule_number = 5300
+      to_port     = 5721
+    },
+    allow_0-0-0-0_agent_tcp_out = {
+      cidr_block  = "0.0.0.0/0"
+      egress      = true
+      from_port   = 5721
+      protocol    = "tcp"
+      rule_action = "allow"
+      rule_number = 5400
+      to_port     = 5721
     }
   }
 


### PR DESCRIPTION
This Pr is to cover the work related to [Allow access from Equip to 3rd party monitoring tool#3339](https://github.com/ministryofjustice/modernisation-platform/issues/3339) this adds a NACL Rule as well as updated the network firewall and add the saas dns name to the new inline fqdn inspection rules these are all required to be able to facilitate the saas agent for the equip team 