### PR TITLE
Inline-Inspection VPC secure code analysis mitigations

### DIFF
--- a/terraform/environments/core-network-services/acm-pca.tf
+++ b/terraform/environments/core-network-services/acm-pca.tf
@@ -13,11 +13,9 @@ provider "aws" {
 #tfsec:ignore:AWS098 tfsec:ignore:AWS002 tfsec:ignore:aws-s3-block-public-acls tfsec:ignore:aws-s3-enable-bucket-encryption tfsec:ignore:aws-s3-enable-bucket-encryption tfsec:ignore:aws-s3-enable-versioning tfsec:ignore:aws-s3-encryption-customer-key
 resource "aws_s3_bucket" "acm-pca" {
   #checkov:skip=CKV_AWS_18:Ignore warnings regarding lack of s3 bucket server access logging - considered overkill given bucket purpose and restricted access to bucket
-  #checkov:skip=CKV_AWS_19:Moved to new resource in 4.0 provider
-  #checkov:skip=CKV_AWS_21:Moved to new resource in 4.0 provider
   #checkov:skip=CKV_AWS_144:Ignore lack of cross-regional replication - not required here - represents an overkill
-  #checkov:skip=CKV_AWS_145:Moved to new resource in 4.0 provider
   #checkov:skip=CKV2_AWS_41:As noted above, logging considered overkill given bucket purpose
+  #checkov:skip=CKV2_AWS_62:As noted above, event notifications not required
   bucket_prefix = "acm"
 
   lifecycle {
@@ -36,6 +34,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "acm-pca" {
   bucket = aws_s3_bucket.acm-pca.bucket
 
   rule {
+    abort_incomplete_multipart_upload = "3"
     id     = "default"
     status = "Enabled"
 

--- a/terraform/environments/core-network-services/transit-gateway.tf
+++ b/terraform/environments/core-network-services/transit-gateway.tf
@@ -2,6 +2,7 @@
 # Create Transit Gateway
 #########################
 resource "aws_ec2_transit_gateway" "transit-gateway" {
+  #checkov:skip=CKV_AWS_331
   description = "Managed by Terraform"
 
   amazon_side_asn                 = "64589"

--- a/terraform/modules/vpc-inspection/main.tf
+++ b/terraform/modules/vpc-inspection/main.tf
@@ -57,6 +57,7 @@ resource "random_string" "main" {
 
 resource "aws_cloudwatch_log_group" "main" {
   #checkov:skip=CKV_AWS_158:Temporarily skip KMS encryption check while logging solution is being updated
+  kms_key_id        = var.cloudwatch_kms_key_id > 1 ? var.cloudwatch_kms_key_id : null
   name              = format("%s-vpc-flow-logs-%s", var.tags_prefix, random_string.main.result)
   retention_in_days = 365
 

--- a/terraform/modules/vpc-inspection/main.tf
+++ b/terraform/modules/vpc-inspection/main.tf
@@ -44,6 +44,10 @@ resource "aws_vpc" "main" {
   )
 }
 
+resource "aws_default_security_group" "default" {
+  vpc_id = aws_vpc.main.id
+}
+
 ### VPC Flow Logs ###
 resource "random_string" "main" {
   length  = 8

--- a/terraform/modules/vpc-inspection/variables.tf
+++ b/terraform/modules/vpc-inspection/variables.tf
@@ -3,6 +3,11 @@ variable "application_name" {
   type        = string
 }
 
+variable "cloudwatch_kms_key_id" {
+  description = "Optional KMS key ID to use in encrypting VPC flow logs CloudWatch group."
+  type        = string
+}
+
 variable "fw_allowed_domains" {
   description = "List of strings containing allowed domains"
   type        = list(string)


### PR DESCRIPTION
This PR addresses findings from `checkov` and `tfsec` introduced by the new `vpc-inspection` module, as well as tidying up some checks that are no longer relevant.

This PR also introduces an optional `cloudwatch_kms_key_id` variable to allow for the encryption of VPC flow logs in the inspection VPCs.