### PR TITLE
CloudWatch Logs VPC Endpoint

### DIFF
--- a/terraform/environments/core-shared-services/vpc.tf
+++ b/terraform/environments/core-shared-services/vpc.tf
@@ -5,8 +5,9 @@ locals {
   }
 
   vpc_interface_endpoint_service_names = toset([
-    "com.amazonaws.${data.aws_region.current_region.name}.imagebuilder",
     "com.amazonaws.${data.aws_region.current_region.name}.ec2messages",
+    "com.amazonaws.${data.aws_region.current_region.name}.imagebuilder",
+    "com.amazonaws.${data.aws_region.current_region.name}.logs",
     "com.amazonaws.${data.aws_region.current_region.name}.ssm",
     "com.amazonaws.${data.aws_region.current_region.name}.ssmmessages"
   ])


### PR DESCRIPTION
In light of [this Slack conversation](https://mojdt.slack.com/archives/C01A7QK5VM1/p1683885328284989?thread_ts=1683799211.928769&cid=C01A7QK5VM1), it appears that the AWS ImageBuilder service attempts to write to CloudWatch logs from an EC2 instance.

Instead of find why this traffic is failing to pass through the new inspection VPCs, I think the better approach is to give it a VPC endpoint for CloudWatch, instead of continuing with traffic passing out to the internet.