### PR TITLE
Route traffic back to MP core ranges

### DIFF
--- a/terraform/environments/core-network-services/cidr-ranges.tf
+++ b/terraform/environments/core-network-services/cidr-ranges.tf
@@ -1,5 +1,6 @@
 locals {
   mp_core_cidr_ranges = {
+    mp-core                     = "10.20.0.0/16"
     mp-development-test         = "10.26.0.0/16"
     mp-preproduction-production = "10.27.0.0/16"
   }

--- a/terraform/environments/core-network-services/firewall-rules/inline_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/inline_rules.json
@@ -1,4 +1,11 @@
 {
+  "mp_core_to_internet_https": {
+    "action": "PASS",
+    "source_ip": "${mp-core}",
+    "destination_ip": "0.0.0.0/0",
+    "destination_port": "443",
+    "protocol": "TCP"
+  },
   "mp_dev_test_to_internet_http": {
     "action": "PASS",
     "source_ip": "${mp-development-test}",

--- a/terraform/modules/vpc-inspection/main.tf
+++ b/terraform/modules/vpc-inspection/main.tf
@@ -115,6 +115,13 @@ resource "aws_route" "transit-gateway-0-0-0-0" {
   vpc_endpoint_id        = local.firewall_endpoint_map[aws_subnet.transit-gateway[each.key].availability_zone]
 }
 
+resource "aws_route" "transit-gateway-10-20-0-0" {
+  for_each               = aws_route_table.transit-gateway
+  destination_cidr_block = "10.20.0.0/16"
+  route_table_id         = each.value.id
+  transit_gateway_id     = var.transit_gateway_id
+}
+
 resource "aws_route" "transit-gateway-10-26-0-0" {
   for_each               = aws_route_table.transit-gateway
   destination_cidr_block = "10.26.0.0/16"
@@ -189,6 +196,13 @@ resource "aws_route" "inspection-0-0-0-0" {
   nat_gateway_id         = aws_nat_gateway.public[replace(each.key, "inspection", "public")].id
 }
 
+resource "aws_route" "inspection-10-20-0-0" {
+  for_each               = aws_route_table.inspection
+  destination_cidr_block = "10.20.0.0/16"
+  route_table_id         = each.value.id
+  transit_gateway_id     = var.transit_gateway_id
+}
+
 resource "aws_route" "inspection-10-26-0-0" {
   for_each               = aws_route_table.inspection
   destination_cidr_block = "10.26.0.0/16"
@@ -261,6 +275,14 @@ resource "aws_route" "public-0-0-0-0" {
   destination_cidr_block = "0.0.0.0/0"
   route_table_id         = each.value.id
   gateway_id             = aws_internet_gateway.public.id
+}
+
+resource "aws_route" "public-10-20-0-0" {
+  depends_on             = [aws_networkfirewall_firewall.inline_inspection]
+  for_each               = aws_route_table.public
+  destination_cidr_block = "10.20.0.0/16"
+  route_table_id         = each.value.id
+  vpc_endpoint_id        = local.firewall_endpoint_map[aws_subnet.public[each.key].availability_zone]
 }
 
 resource "aws_route" "public-10-26-0-0" {


### PR DESCRIPTION
During the implementation of inline-inspection, our expectation was that traffic in the Modernisation Platform core environments would not need to pass out to the internet. However, on further inspection we've found that some services such as our image builder pipelines *do* need internet access. This PR does the following:

* Add routes to the MP core ranges to the `vpc-inspection` module that builds our inline inspection VPCs.
* Add a name for the MP core ranges
* Use the new name in the inline rules to allow outbound HTTPS access