### PR TITLE
Adding OASys keys

### DIFF
--- a/terraform/pagerduty/aws.tf
+++ b/terraform/pagerduty/aws.tf
@@ -28,7 +28,9 @@ resource "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {
     laa_mojfin_prod_alarms       = pagerduty_service_integration.laa_mojfin_prod_cloudwatch.integration_key,
     hmpps_shef_dba_high_priority = pagerduty_service_integration.hmpps_shef_dba_high_priority.integration_key,
     hmpps_shef_dba_low_priority  = pagerduty_service_integration.hmpps_shef_dba_low_priority.integration_key,
-    hmpps_shef_dba_non_prod      = pagerduty_service_integration.hmpps_shef_dba_non_prod.integration_key
+    hmpps_shef_dba_non_prod      = pagerduty_service_integration.hmpps_shef_dba_non_prod.integration_key,
+    oasys_alarms                 = pagerduty_service_integration.oasys_cloudwatch.integration_key,
+    oasys_nonprod_alarms         = pagerduty_service_integration.oasys_nonprod_cloudwatch.integration_key
   })
 }
 


### PR DESCRIPTION
These are required for CloudWatch-Pagerduty integration.