### PR TITLE
Add SMTP endpoint to LAA VPCs

### DIFF
--- a/environments-networks/laa-development.json
+++ b/environments-networks/laa-development.json
@@ -22,7 +22,8 @@
     "additional_cidrs": [],
     "additional_endpoints": [
       "com.amazonaws.eu-west-2.xray",
-      "com.amazonaws.eu-west-2.secretsmanager"
+      "com.amazonaws.eu-west-2.secretsmanager",
+      "com.amazonaws.eu-west-2.email-smtp"
     ],
     "additional_vpcs": [],
     "dns_zone_extend": []

--- a/environments-networks/laa-preproduction.json
+++ b/environments-networks/laa-preproduction.json
@@ -18,7 +18,8 @@
     "additional_cidrs": [],
     "additional_endpoints": [
       "com.amazonaws.eu-west-2.xray",
-      "com.amazonaws.eu-west-2.secretsmanager"
+      "com.amazonaws.eu-west-2.secretsmanager",
+      "com.amazonaws.eu-west-2.email-smtp"
     ],
     "additional_vpcs": [],
     "dns_zone_extend": []

--- a/environments-networks/laa-production.json
+++ b/environments-networks/laa-production.json
@@ -19,7 +19,8 @@
     "additional_cidrs": [],
     "additional_endpoints": [
       "com.amazonaws.eu-west-2.xray",
-      "com.amazonaws.eu-west-2.secretsmanager"
+      "com.amazonaws.eu-west-2.secretsmanager",
+      "com.amazonaws.eu-west-2.email-smtp"
     ],
     "additional_vpcs": [],
     "dns_zone_extend": []

--- a/environments-networks/laa-test.json
+++ b/environments-networks/laa-test.json
@@ -19,7 +19,8 @@
     "additional_cidrs": [],
     "additional_endpoints": [
       "com.amazonaws.eu-west-2.xray",
-      "com.amazonaws.eu-west-2.secretsmanager"
+      "com.amazonaws.eu-west-2.secretsmanager",
+      "com.amazonaws.eu-west-2.email-smtp"
     ],
     "additional_vpcs": [],
     "dns_zone_extend": []


### PR DESCRIPTION
Following [this request](https://mojdt.slack.com/archives/C01A7QK5VM1/p1684164890037909), this PR adds an extra endpoint to the `LAA` VPCs: `com.amazonaws.eu-west-2.email-smtp`