### PR TITLE
allow dso-monitoring blackbox to monitor the new T1 endpoint in mp

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
@@ -111,11 +111,18 @@
     "destination_port": "ANY",
     "protocol": "TCP"
   },
-  "aks_studio_hosting_live_1_to_mp_hmpps_preproduction": {
+  "aks_studio_hosting_live_1_to_mp_hmpps_preproduction_db": {
     "action": "PASS",
     "source_ip": "${aks-studio-hosting-live-1-vnet}",
     "destination_ip": "${hmpps-preproduction}",
     "destination_port": "1521",
+    "protocol": "TCP"
+  },
+  "aks_studio_hosting_live_1_to_mp_hmpps_preproduction_https": {
+    "action": "PASS",
+    "source_ip": "${aks-studio-hosting-live-1-vnet}",
+    "destination_ip": "${hmpps-preproduction}",
+    "destination_port": "443",
     "protocol": "TCP"
   },
   "nomisapi_prod_root_to_mp_hmpps_preproduction": {

--- a/terraform/environments/core-network-services/firewall-rules/production_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/production_rules.json
@@ -76,11 +76,18 @@
     "destination_port": "ANY",
     "protocol": "TCP"
   },
-  "aks_studio_hosting_live_1_to_mp_hmpps_production": {
+  "aks_studio_hosting_live_1_to_mp_hmpps_production_db": {
     "action": "PASS",
     "source_ip": "${aks-studio-hosting-live-1-vnet}",
     "destination_ip": "${hmpps-production}",
     "destination_port": "1521",
+    "protocol": "TCP"
+  },
+  "aks_studio_hosting_live_1_to_mp_hmpps_production_https": {
+    "action": "PASS",
+    "source_ip": "${aks-studio-hosting-live-1-vnet}",
+    "destination_ip": "${hmpps-production}",
+    "destination_port": "443",
     "protocol": "TCP"
   },
   "nomisapi_preprod_root_to_mp_hmpps_production": {
@@ -110,7 +117,7 @@
     "destination_ip": "${hmpps-production}",
     "destination_port": "9100",
     "protocol": "TCP"
-  },
+  },  
   "psn_to_mp_hmpps_preproduction_https": {
     "action": "PASS",
     "source_ip": "${psn}",

--- a/terraform/environments/core-network-services/firewall-rules/test_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/test_rules.json
@@ -69,11 +69,18 @@
     "destination_port": "ANY",
     "protocol": "TCP"
   },
-  "aks_studio_hosting_dev_1_vnet_to_mp_dev_test": {
+  "aks_studio_hosting_dev_1_vnet_to_mp_dev_test_db": {
     "action": "PASS",
     "source_ip": "${aks-studio-hosting-dev-1-vnet}",
     "destination_ip": "${mp-development-test}",
     "destination_port": "1521",
+    "protocol": "TCP"
+  },
+  "aks_studio_hosting_dev_1_vnet_to_mp_dev_test_https": {
+    "action": "PASS",
+    "source_ip": "${aks-studio-hosting-dev-1-vnet}",
+    "destination_ip": "${mp-development-test}",
+    "destination_port": "443",
     "protocol": "TCP"
   },
   "nomisapi_t2_root_vnet_to_mp_dev_test": {


### PR DESCRIPTION
[Jira item](https://dsdmoj.atlassian.net/browse/DSOS-1887)

- allow https traffic from our prometheus based monitoring to check the T1 endpoint in mod-platform
- added _db to the proceeding rule name to differentiate from the _https one

The target url in [this commit](https://github.com/ministryofjustice/dso-monitoring/commit/392cb03d9d433c5ee0b24354fba6cd079a2551aa#diff-0083453b77e01a34ba6176d233562fe7ca86abe6c271f8b67b59de2f0ec9a15dR111) will be enabled after https traffic has been allowed