### PR TITLE
Tests for new inspection VPCs

### DIFF
--- a/terraform/environments/core-network-services/data.tf
+++ b/terraform/environments/core-network-services/data.tf
@@ -1,4 +1,4 @@
-data "aws_route" "non_live" {
+data "aws_route" "non_live_data" {
   for_each               = merge(
     module.vpc_inspection["non_live_data"].route_table_ids.transit_gateway,
     module.vpc_inspection["non_live_data"].route_table_ids.inspection,
@@ -8,7 +8,7 @@ data "aws_route" "non_live" {
   destination_cidr_block = "0.0.0.0/0"
 }
 
-data "aws_route" "live" {
+data "aws_route" "live_data" {
   for_each               = merge(
     module.vpc_inspection["live_data"].route_table_ids.transit_gateway,
     module.vpc_inspection["live_data"].route_table_ids.inspection,

--- a/terraform/environments/core-network-services/data.tf
+++ b/terraform/environments/core-network-services/data.tf
@@ -1,0 +1,19 @@
+data "aws_route" "non_live" {
+  for_each               = merge(
+    module.vpc_inspection["non_live_data"].route_table_ids.transit_gateway,
+    module.vpc_inspection["non_live_data"].route_table_ids.inspection,
+    module.vpc_inspection["non_live_data"].route_table_ids.public
+  )
+  route_table_id         = each.value
+  destination_cidr_block = "0.0.0.0/0"
+}
+
+data "aws_route" "live" {
+  for_each               = merge(
+    module.vpc_inspection["live_data"].route_table_ids.transit_gateway,
+    module.vpc_inspection["live_data"].route_table_ids.inspection,
+    module.vpc_inspection["live_data"].route_table_ids.public
+  )
+  route_table_id         = each.value
+  destination_cidr_block = "0.0.0.0/0"
+}

--- a/terraform/environments/core-network-services/output.tf
+++ b/terraform/environments/core-network-services/output.tf
@@ -53,3 +53,40 @@ output "tgw_subnet_ids" {
   value = length(module.vpc_hub["non_live_data"].tgw_subnet_ids)
 }
 
+###
+
+output "inspection_tgw_subnets" {
+  value = {
+    for vpc_key, vpc_value in local.networking : vpc_key => [
+      for subnet_key, subnet_value in module.vpc_inspection[vpc_key].subnet_attributes.transit_gateway : subnet_value[0].id
+    ]
+  }
+}
+
+output "inspection_inspection_subnets" {
+  value = {
+    for vpc_key, vpc_value in local.networking : vpc_key => [
+      for subnet_key, subnet_value in module.vpc_inspection[vpc_key].subnet_attributes.inspection : subnet_value[0].id
+    ]
+  }
+}
+
+output "inspection_public_subnets" {
+  value = {
+    for vpc_key, vpc_value in local.networking : vpc_key => [
+      for subnet_key, subnet_value in module.vpc_inspection[vpc_key].subnet_attributes.public : subnet_value[0].id
+    ]
+  }
+}
+
+output "firewall_arn" {
+  value = {
+    for vpc_key, vpc_value in local.networking : vpc_key => module.vpc_inspection[vpc_key].firewall.arn
+  }
+}
+
+output "inspection_vpc_ids" {
+  value = {
+    for vpc_key, vpc_value in local.networking : vpc_key => module.vpc_inspection[vpc_key].vpc_id
+  }
+}

--- a/terraform/environments/core-network-services/output.tf
+++ b/terraform/environments/core-network-services/output.tf
@@ -90,3 +90,16 @@ output "inspection_vpc_ids" {
     for vpc_key, vpc_value in local.networking : vpc_key => module.vpc_inspection[vpc_key].vpc_id
   }
 }
+
+output "inspection_igw_id" {
+  value = {
+    for vpc_key, vpc_value in local.networking : vpc_key => module.vpc_inspection[vpc_key].internet_gateway.id
+  }
+}
+
+output "inspection_natgw_ids" {
+  value = {
+    for vpc_key, vpc_value in local.networking : vpc_key => length([
+      for key in module.vpc_inspection[vpc_key].nat_gateway : key.id])
+  }
+}

--- a/terraform/environments/core-network-services/output.tf
+++ b/terraform/environments/core-network-services/output.tf
@@ -103,3 +103,10 @@ output "inspection_natgw_ids" {
       for key in module.vpc_inspection[vpc_key].nat_gateway : key.id])
   }
 }
+
+output "inspection_default_routes" {
+  value = {
+    live_data = { for key, value in data.aws_route.live_data : key => value.destination_cidr_block }
+    non_live_data = { for key, value in data.aws_route.non_live_data : key => value.destination_cidr_block }
+  }
+}

--- a/terraform/environments/core-network-services/output.tf
+++ b/terraform/environments/core-network-services/output.tf
@@ -57,25 +57,25 @@ output "tgw_subnet_ids" {
 
 output "inspection_tgw_subnets" {
   value = {
-    for vpc_key, vpc_value in local.networking : vpc_key => [
+    for vpc_key, vpc_value in local.networking : vpc_key => length([
       for subnet_key, subnet_value in module.vpc_inspection[vpc_key].subnet_attributes.transit_gateway : subnet_value[0].id
-    ]
+    ])
   }
 }
 
 output "inspection_inspection_subnets" {
   value = {
-    for vpc_key, vpc_value in local.networking : vpc_key => [
+    for vpc_key, vpc_value in local.networking : vpc_key => length([
       for subnet_key, subnet_value in module.vpc_inspection[vpc_key].subnet_attributes.inspection : subnet_value[0].id
-    ]
+    ])
   }
 }
 
 output "inspection_public_subnets" {
   value = {
-    for vpc_key, vpc_value in local.networking : vpc_key => [
+    for vpc_key, vpc_value in local.networking : vpc_key => length([
       for subnet_key, subnet_value in module.vpc_inspection[vpc_key].subnet_attributes.public : subnet_value[0].id
-    ]
+    ])
   }
 }
 

--- a/terraform/environments/core-network-services/test/go_test.go
+++ b/terraform/environments/core-network-services/test/go_test.go
@@ -102,11 +102,19 @@ func TestInspectionVPCs(t *testing.T) {
 	assert.Equal(t, inspectionInspectionSubnets["live_data"], "3")
 	assert.Equal(t, inspectionPublicSubnets["live_data"], "3")
 
-	//Retrieve firewall ARNs as a map
+	// Retrieve firewall ARNs as a map
 	inspectionFirewalls := terraform.OutputMap(t, terraformOptions, "firewall_arn")
 	// Define a regular expression pattern to match the VPC IDs
     firewallARNPattern := regexp.MustCompile(`^arn:aws:network-firewall:eu-west-2:[0-9]{12}:firewall/(live-data|non-live-data)-inline-inspection$`)
     // Assert that the firewall_arn values in the map match the regular expression pattern
 	assert.Regexp(t, firewallARNPattern, inspectionFirewalls["non_live_data"], "non_live_data firewall_arn does not match the expected pattern")
 	assert.Regexp(t, firewallARNPattern, inspectionFirewalls["live_data"], "live_data firewall_arn does not match the expected pattern")
+
+	// Retrieve Internet Gateway IDs
+	inspectionIGWs := terraform.OutputMap(t, terraformOptions, "inspection_igw_id")
+	// Define a regular expression pattern to match the VPC IDs
+    igwIDPattern := regexp.MustCompile(`^igw-[0-9a-f]{17}$`)
+	// Assert that both live_data and non_live_data have an IGW matching the regext
+	assert.Regexp(t, igwIDPattern, inspectionIGWs["non_live_data"], "non_live_data igw_id does not match the expected pattern")
+	assert.Regexp(t, igwIDPattern, inspectionIGWs["live_data"], "live_data igw_id does not match the expected pattern")
 }

--- a/terraform/environments/core-network-services/test/go_test.go
+++ b/terraform/environments/core-network-services/test/go_test.go
@@ -80,7 +80,7 @@ func TestInspectionVPCs(t *testing.T) {
 	// Retrieve the VPC output as a map
     inspectionVPCs := terraform.OutputMap(t, terraformOptions, "inspection_vpc_ids")
 
-	// Define the regular expression pattern
+	// Define a regular expression pattern to match the VPC IDs
     vpcIDPattern := regexp.MustCompile(`^vpc-[0-9a-f]{17}$`)
 
 	// Assert that the vpc_id values in the map match the regular expression pattern
@@ -101,4 +101,12 @@ func TestInspectionVPCs(t *testing.T) {
 	assert.Equal(t, inspectionTgwSubnets["live_data"], "3")
 	assert.Equal(t, inspectionInspectionSubnets["live_data"], "3")
 	assert.Equal(t, inspectionPublicSubnets["live_data"], "3")
+
+	//Retrieve firewall ARNs as a map
+	inspectionFirewalls := terraform.OutputMap(t, terraformOptions, "firewall_arn")
+	// Define a regular expression pattern to match the VPC IDs
+    firewallARNPattern := regexp.MustCompile(`^arn:aws:network-firewall:eu-west-2:[0-9]{12}:firewall/(live-data|non-live-data)-inline-inspection$`)
+    // Assert that the firewall_arn values in the map match the regular expression pattern
+	assert.Regexp(t, firewallARNPattern, inspectionFirewalls["non_live_data"], "non_live_data firewall_arn does not match the expected pattern")
+	assert.Regexp(t, firewallARNPattern, inspectionFirewalls["live_data"], "live_data firewall_arn does not match the expected pattern")
 }

--- a/terraform/environments/core-network-services/test/go_test.go
+++ b/terraform/environments/core-network-services/test/go_test.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"testing"
+	"regexp"
 
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/stretchr/testify/assert"
@@ -66,4 +67,24 @@ func TestTransitGateway(t *testing.T) {
 	output6 := terraform.Output(t, terraformOptions, "transit_gateway_ram_share")
 	assert.Equal(t, output6, "transit-gateway")
 
+}
+
+func TestInspectionVPCs(t *testing.T) {
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		TerraformDir: "../",
+	})
+
+	terraform.RunTerraformCommand(t, terraformOptions, "refresh")
+	terraform.Plan(t, terraformOptions)
+
+	// Retrieve the output values as a map
+    inspectionVPCs := terraform.OutputMap(t, terraformOptions, "inspection_vpc_ids")
+
+	// Define the regular expression pattern
+    vpcIDPattern := regexp.MustCompile(`^vpc-[0-9a-f]{17}$`)
+
+	// Assert that the vpc_id values match the regular expression pattern
+	// Assert that the vpc_id values in the map match the regular expression pattern
+	assert.Regexp(t, vpcIDPattern, inspectionVPCs["non_live_data"], "non_live_data vpc_id does not match the expected pattern")
+	assert.Regexp(t, vpcIDPattern, inspectionVPCs["live_data"], "live_data vpc_id does not match the expected pattern")
 }

--- a/terraform/environments/core-network-services/test/go_test.go
+++ b/terraform/environments/core-network-services/test/go_test.go
@@ -117,4 +117,11 @@ func TestInspectionVPCs(t *testing.T) {
 	// Assert that both live_data and non_live_data have an IGW matching the regext
 	assert.Regexp(t, igwIDPattern, inspectionIGWs["non_live_data"], "non_live_data igw_id does not match the expected pattern")
 	assert.Regexp(t, igwIDPattern, inspectionIGWs["live_data"], "live_data igw_id does not match the expected pattern")
+
+	// Retrieve a map of NAT Gateway outputs
+	inspectionNATGWs := terraform.OutputMap(t, terraformOptions, "inspection_natgw_ids")
+
+    // Assert that each VPC has all of its NAT Gateways
+	assert.Equal(t, inspectionNATGWs["non_live_data"], "3")
+	assert.Equal(t, inspectionNATGWs["non_live_data"], "3")
 }

--- a/terraform/environments/core-network-services/test/go_test.go
+++ b/terraform/environments/core-network-services/test/go_test.go
@@ -79,66 +79,66 @@ func TestInspectionVPCs(t *testing.T) {
 	terraform.Plan(t, terraformOptions)
 
 	// Retrieve the VPC output as a map
-    inspectionVPCs := terraform.OutputMap(t, terraformOptions, "inspection_vpc_ids")
+	vpcIDs := terraform.OutputMap(t, terraformOptions, "inspection_vpc_ids")
 
 	// Define a regular expression pattern to match the VPC IDs
-    vpcIDPattern := regexp.MustCompile(`^vpc-[0-9a-f]{17}$`)
+	vpcIDPattern := regexp.MustCompile(`^vpc-[0-9a-f]{17}$`)
 
 	// Assert that the vpc_id values in the map match the regular expression pattern
-	assert.Regexp(t, vpcIDPattern, inspectionVPCs["non_live_data"], "non_live_data vpc_id does not match the expected pattern")
-	assert.Regexp(t, vpcIDPattern, inspectionVPCs["live_data"], "live_data vpc_id does not match the expected pattern")
+	assert.Regexp(t, vpcIDPattern, vpcIDs["non_live_data"], "non_live_data vpc_id does not match the expected pattern")
+	assert.Regexp(t, vpcIDPattern, vpcIDs["live_data"], "live_data vpc_id does not match the expected pattern")
 
 	// Retrieve the subnet outputs
-	inspectionTgwSubnets := terraform.OutputMap(t, terraformOptions, "inspection_tgw_subnets")
-	inspectionInspectionSubnets := terraform.OutputMap(t, terraformOptions, "inspection_inspection_subnets")
-	inspectionPublicSubnets := terraform.OutputMap(t, terraformOptions, "inspection_public_subnets")
+	tgwSubnets := terraform.OutputMap(t, terraformOptions, "inspection_tgw_subnets")
+	inspectionSubnets := terraform.OutputMap(t, terraformOptions, "inspection_inspection_subnets")
+	publicSubnets := terraform.OutputMap(t, terraformOptions, "inspection_public_subnets")
 
-    // Assert that non_live_data has all of its subnets
-	assert.Equal(t, inspectionTgwSubnets["non_live_data"], "3")
-	assert.Equal(t, inspectionInspectionSubnets["non_live_data"], "3")
-	assert.Equal(t, inspectionPublicSubnets["non_live_data"], "3")
+	// Assert that non_live_data has all of its subnets
+	assert.Equal(t, tgwSubnets["non_live_data"], "3")
+	assert.Equal(t, inspectionSubnets["non_live_data"], "3")
+	assert.Equal(t, publicSubnets["non_live_data"], "3")
 
-    // Assert that live_data has all of its subnets
-	assert.Equal(t, inspectionTgwSubnets["live_data"], "3")
-	assert.Equal(t, inspectionInspectionSubnets["live_data"], "3")
-	assert.Equal(t, inspectionPublicSubnets["live_data"], "3")
+	// Assert that live_data has all of its subnets
+	assert.Equal(t, tgwSubnets["live_data"], "3")
+	assert.Equal(t, inspectionSubnets["live_data"], "3")
+	assert.Equal(t, publicSubnets["live_data"], "3")
 
 	// Retrieve firewall ARNs as a map
-	inspectionFirewalls := terraform.OutputMap(t, terraformOptions, "firewall_arn")
+	firewallARNs := terraform.OutputMap(t, terraformOptions, "firewall_arn")
 	// Define a regular expression pattern to match the VPC IDs
-    firewallARNPattern := regexp.MustCompile(`^arn:aws:network-firewall:eu-west-2:[0-9]{12}:firewall/(live-data|non-live-data)-inline-inspection$`)
-    // Assert that the firewall_arn values in the map match the regular expression pattern
-	assert.Regexp(t, firewallARNPattern, inspectionFirewalls["non_live_data"], "non_live_data firewall_arn does not match the expected pattern")
-	assert.Regexp(t, firewallARNPattern, inspectionFirewalls["live_data"], "live_data firewall_arn does not match the expected pattern")
+	firewallARNPattern := regexp.MustCompile(`^arn:aws:network-firewall:eu-west-2:[0-9]{12}:firewall/(live-data|non-live-data)-inline-inspection$`)
+	// Assert that the firewall_arn values in the map match the regular expression pattern
+	assert.Regexp(t, firewallARNPattern, firewallARNs["non_live_data"], "non_live_data firewall_arn does not match the expected pattern")
+	assert.Regexp(t, firewallARNPattern, firewallARNs["live_data"], "live_data firewall_arn does not match the expected pattern")
 
 	// Retrieve Internet Gateway IDs
-	inspectionIGWs := terraform.OutputMap(t, terraformOptions, "inspection_igw_id")
+	igwIDs := terraform.OutputMap(t, terraformOptions, "inspection_igw_id")
 	// Define a regular expression pattern to match the VPC IDs
-    igwIDPattern := regexp.MustCompile(`^igw-[0-9a-f]{17}$`)
-	// Assert that both live_data and non_live_data have an IGW matching the regext
-	assert.Regexp(t, igwIDPattern, inspectionIGWs["non_live_data"], "non_live_data igw_id does not match the expected pattern")
-	assert.Regexp(t, igwIDPattern, inspectionIGWs["live_data"], "live_data igw_id does not match the expected pattern")
+	igwIDPattern := regexp.MustCompile(`^igw-[0-9a-f]{17}$`)
+	// Assert that both live_data and non_live_data have an IGW matching the regex
+	assert.Regexp(t, igwIDPattern, igwIDs["non_live_data"], "non_live_data igw_id does not match the expected pattern")
+	assert.Regexp(t, igwIDPattern, igwIDs["live_data"], "live_data igw_id does not match the expected pattern")
 
 	// Retrieve a map of NAT Gateway outputs
-	inspectionNATGWs := terraform.OutputMap(t, terraformOptions, "inspection_natgw_ids")
+	natGWs := terraform.OutputMap(t, terraformOptions, "inspection_natgw_ids")
 
-    // Assert that each VPC has all of its NAT Gateways
-	assert.Equal(t, inspectionNATGWs["non_live_data"], "3")
-	assert.Equal(t, inspectionNATGWs["non_live_data"], "3")
+	// Assert that each VPC has all of its NAT Gateways
+	assert.Equal(t, natGWs["non_live_data"], "3")
+	assert.Equal(t, natGWs["non_live_data"], "3")
 
 	// Run `terraform output` to get the value of the output variable as a string
 	terraformOutput := terraform.OutputJson(t, terraformOptions, "inspection_default_routes")
 
 	// Parse the string value as JSON to obtain the map structure
-	var inspectionDefaultRoutes map[string]interface{}
-	err := json.Unmarshal([]byte(terraformOutput), &inspectionDefaultRoutes)
+	var defaultRoutes map[string]interface{}
+	err := json.Unmarshal([]byte(terraformOutput), &defaultRoutes)
 	if err != nil {
 		t.Fatalf("Failed to parse inspection_default_routes output as JSON: %s", err)
 	}
 
 	// Check the number of keys in `inspection_default_routes`
-	liveDataRoutes, _ := inspectionDefaultRoutes["live_data"].(map[string]interface{})
-	nonLiveDataRoutes, _ := inspectionDefaultRoutes["non_live_data"].(map[string]interface{})
+	liveDataRoutes, _ := defaultRoutes["live_data"].(map[string]interface{})
+	nonLiveDataRoutes, _ := defaultRoutes["non_live_data"].(map[string]interface{})
 
 	assert.Len(t, liveDataRoutes, 9)
 	assert.Len(t, nonLiveDataRoutes, 9)

--- a/terraform/environments/core-network-services/test/go_test.go
+++ b/terraform/environments/core-network-services/test/go_test.go
@@ -77,14 +77,28 @@ func TestInspectionVPCs(t *testing.T) {
 	terraform.RunTerraformCommand(t, terraformOptions, "refresh")
 	terraform.Plan(t, terraformOptions)
 
-	// Retrieve the output values as a map
+	// Retrieve the VPC output as a map
     inspectionVPCs := terraform.OutputMap(t, terraformOptions, "inspection_vpc_ids")
 
 	// Define the regular expression pattern
     vpcIDPattern := regexp.MustCompile(`^vpc-[0-9a-f]{17}$`)
 
-	// Assert that the vpc_id values match the regular expression pattern
 	// Assert that the vpc_id values in the map match the regular expression pattern
 	assert.Regexp(t, vpcIDPattern, inspectionVPCs["non_live_data"], "non_live_data vpc_id does not match the expected pattern")
 	assert.Regexp(t, vpcIDPattern, inspectionVPCs["live_data"], "live_data vpc_id does not match the expected pattern")
+
+	// Retrieve the subnet outputs
+	inspectionTgwSubnets := terraform.OutputMap(t, terraformOptions, "inspection_tgw_subnets")
+	inspectionInspectionSubnets := terraform.OutputMap(t, terraformOptions, "inspection_inspection_subnets")
+	inspectionPublicSubnets := terraform.OutputMap(t, terraformOptions, "inspection_public_subnets")
+
+    // Assert that non_live_data has all of its subnets
+	assert.Equal(t, inspectionTgwSubnets["non_live_data"], "3")
+	assert.Equal(t, inspectionInspectionSubnets["non_live_data"], "3")
+	assert.Equal(t, inspectionPublicSubnets["non_live_data"], "3")
+
+    // Assert that live_data has all of its subnets
+	assert.Equal(t, inspectionTgwSubnets["live_data"], "3")
+	assert.Equal(t, inspectionInspectionSubnets["live_data"], "3")
+	assert.Equal(t, inspectionPublicSubnets["live_data"], "3")
 }


### PR DESCRIPTION
This PR recreates the existing tests for the old egress VPCs and rewrites them for the new inline-inspection egress VPCs.