### PR TITLE
add pagerduty service for test alarms

### DIFF
--- a/terraform/pagerduty/aws.tf
+++ b/terraform/pagerduty/aws.tf
@@ -31,6 +31,7 @@ resource "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {
     hmpps_shef_dba_non_prod      = pagerduty_service_integration.hmpps_shef_dba_non_prod.integration_key,
     oasys_alarms                 = pagerduty_service_integration.oasys_cloudwatch.integration_key,
     oasys_nonprod_alarms         = pagerduty_service_integration.oasys_nonprod_cloudwatch.integration_key
+    test_alarms                  = pagerduty_service_integration.test_alarms.integration_key
   })
 }
 

--- a/terraform/pagerduty/member-services-integrations.tf
+++ b/terraform/pagerduty/member-services-integrations.tf
@@ -264,3 +264,19 @@ resource "pagerduty_service_integration" "hmpps_shef_dba_non_prod" {
   vendor  = data.pagerduty_vendor.cloudwatch.id
 }
 # Slack channel: dba_alerts_devtest
+
+ resource "pagerduty_service" "test_alarms" {
+   name                    = "Modernisation Platform Test Alarms"
+   description             = "Pagerduty integration for test alarms"
+   auto_resolve_timeout    = 600
+   acknowledgement_timeout = 300
+   escalation_policy       = pagerduty_escalation_policy.low_priority.id
+   alert_creation          = "create_alerts_and_incidents"
+ }
+
+ resource "pagerduty_service_integration" "test_alarms" {
+   name    = data.pagerduty_vendor.cloudwatch.name
+   service = pagerduty_service.test_alarms.id
+   vendor  = data.pagerduty_vendor.cloudwatch.id
+ }
+# Slack channel: modernisation-platform


### PR DESCRIPTION
Some of our unit tests make use of pagerduty integration keys. This PR introduces a new pagerduty service that can be used by our unit tests.