### PR TITLE
update golang version used in tests

### DIFF
--- a/.github/workflows/core-logging-deployment.yml
+++ b/.github/workflows/core-logging-deployment.yml
@@ -66,11 +66,11 @@ jobs:
 
           #RUN TERRATEST
           pushd terraform/environments/core-logging/test
-          # Install GOLANG 15.8
+          # Install GOLANG 1.20.3
           if [ `whoami` != "runner" ]
           then
-          wget -q https://dl.google.com/go/go1.15.8.linux-amd64.tar.gz
-          tar -zxvf go1.15.8.linux-amd64.tar.gz
+          wget -q https://dl.google.com/go/go1.20.3.linux-amd64.tar.gz
+          tar -zxvf go1.20.3.linux-amd64.tar.gz
           sudo mv go /usr/local
           echo "--  running newly installed go  --"
           TEST=`/usr/local/go/bin/go test | ${git_dir}/scripts/redact-output.sh | tee /dev/stderr | tail -n 1`

--- a/.github/workflows/core-network-services-deployment.yml
+++ b/.github/workflows/core-network-services-deployment.yml
@@ -70,11 +70,11 @@ jobs:
 
           #RUN TERRATEST
           pushd terraform/environments/core-network-services/test
-          # Install GOLANG 15.8
+          # Install GOLANG 1.20.3
           if [ `whoami` != "runner" ]
           then
-          wget -q https://dl.google.com/go/go1.15.8.linux-amd64.tar.gz
-          tar -zxvf go1.15.8.linux-amd64.tar.gz
+          wget -q https://dl.google.com/go/go1.20.3.linux-amd64.tar.gz
+          tar -zxvf go1.20.3.linux-amd64.tar.gz
           sudo mv go /usr/local
           echo "--  running newly installed go  --"
           TEST=`/usr/local/go/bin/go test | ${git_dir}/scripts/redact-output.sh | tee /dev/stderr | tail -n 1`

--- a/.github/workflows/core-security-deployment.yml
+++ b/.github/workflows/core-security-deployment.yml
@@ -66,11 +66,11 @@ jobs:
 
           #RUN TERRATEST
           pushd terraform/environments/core-security/test
-          # Install GOLANG 15.8
+          # Install GOLANG 1.20.3
           if [ `whoami` != "runner" ]
           then
-          wget -q https://dl.google.com/go/go1.15.8.linux-amd64.tar.gz
-          tar -zxvf go1.15.8.linux-amd64.tar.gz
+          wget -q https://dl.google.com/go/go1.20.3.linux-amd64.tar.gz
+          tar -zxvf go1.20.3.linux-amd64.tar.gz
           sudo mv go /usr/local
           echo "--  running newly installed go  --"
           TEST=`/usr/local/go/bin/go test | ${git_dir}/scripts/redact-output.sh | tee /dev/stderr | tail -n 1`

--- a/.github/workflows/core-shared-services-deployment.yml
+++ b/.github/workflows/core-shared-services-deployment.yml
@@ -71,11 +71,11 @@ jobs:
 
           #RUN TERRATEST
           pushd terraform/environments/core-shared-services/test
-          # Install GOLANG 15.8
+          # Install GOLANG 1.20.3
           if [ `whoami` != "runner" ]
           then
-          wget -q https://dl.google.com/go/go1.15.8.linux-amd64.tar.gz
-          tar -zxvf go1.15.8.linux-amd64.tar.gz
+          wget -q https://dl.google.com/go/go1.20.3.linux-amd64.tar.gz
+          tar -zxvf go1.20.3.linux-amd64.tar.gz
           sudo mv go /usr/local
           echo "--  running newly installed go  --"
           TEST=`/usr/local/go/bin/go test | ${git_dir}/scripts/redact-output.sh | tee /dev/stderr | tail -n 1`


### PR DESCRIPTION
Our core environment tests utilise a hardcoded version of `go` that is incompatible with modern versions of the `testify` library. In order to stay current, this PR will allow us to use more modern versions.

We should consider refactoring these workflows to use a GitHub action that installs `go`, but in the interim this will do.