### PR TITLE
Prune code relating to old egress VPCs

### DIFF
--- a/terraform/environments/core-network-services/output.tf
+++ b/terraform/environments/core-network-services/output.tf
@@ -23,36 +23,6 @@ output "transit_gateway_ram_share" {
   value = aws_ram_resource_share.transit-gateway.name
 }
 
-output "non_live_data_private_route_tables" {
-  value = module.vpc_hub["non_live_data"].private_route_tables
-}
-
-output "public_route_tables" {
-  value = {
-    for key, value in local.networking :
-    key => module.vpc_hub[key].public_route_tables.tags["Name"]
-  }
-}
-
-output "live_data_private_route_tables" {
-  value = module.vpc_hub["live_data"].private_route_tables
-}
-
-output "public_igw_route" {
-  value = {
-    for key, value in local.networking :
-    key => module.vpc_hub[key].public_igw_route.destination_cidr_block
-  }
-}
-
-output "non_tgw_subnet_ids" {
-  value = length(module.vpc_hub["non_live_data"].non_tgw_subnet_ids)
-}
-
-output "tgw_subnet_ids" {
-  value = length(module.vpc_hub["non_live_data"].tgw_subnet_ids)
-}
-
 ###
 
 output "inspection_tgw_subnets" {

--- a/terraform/environments/core-network-services/route53.tf
+++ b/terraform/environments/core-network-services/route53.tf
@@ -21,7 +21,7 @@ resource "aws_route53_zone" "modernisation-platform-internal" {
   name = local.modernisation-platform-internal-domain
 
   vpc {
-    vpc_id = module.vpc_hub["live_data"].vpc_id
+    vpc_id = module.vpc_inspection["live_data"].vpc_id
   }
 
   tags = local.tags

--- a/terraform/environments/core-network-services/test/go_test.go
+++ b/terraform/environments/core-network-services/test/go_test.go
@@ -17,52 +17,9 @@ func TestTransitGateway(t *testing.T) {
 	terraform.RunTerraformCommand(t, terraformOptions, "refresh")
 	terraform.Plan(t, terraformOptions)
 
-	//Test private route tables
-	var privateRouteTableData = []string{
-		"private-eu-west-2a",
-		"private-eu-west-2b",
-		"private-eu-west-2c",
-		"data-eu-west-2a",
-		"data-eu-west-2b",
-		"data-eu-west-2c",
-		"transit-gateway-eu-west-2a",
-		"transit-gateway-eu-west-2b",
-		"transit-gateway-eu-west-2c",
-	}
-	//Test for non_live private route tables
-	for _, element := range privateRouteTableData {
-		output := terraform.Output(t, terraformOptions, "non_live_data_private_route_tables")
-		assert.Contains(t, output, element)
-	}
-	//Test for live private route tables
-	for _, element := range privateRouteTableData {
-		output := terraform.Output(t, terraformOptions, "live_data_private_route_tables")
-		assert.Contains(t, output, element)
-	}
-
-	//Test public igw cidr
-	output7 := terraform.Output(t, terraformOptions, "public_route_tables")
-	assert.Equal(t, output7, "map[live_data:live_data-public non_live_data:non_live_data-public]")
-
-	//Test public igw cidr
-	output1 := terraform.Output(t, terraformOptions, "public_igw_route")
-	assert.Equal(t, output1, "map[live_data:0.0.0.0/0 non_live_data:0.0.0.0/0]")
-
 	//Test transit-gateway will not be affected
 	output2 := terraform.Output(t, terraformOptions, "transit_gateway")
 	assert.Equal(t, output2, "64589")
-
-	//Test tgw-subnet count. There should be 3
-	output3 := terraform.Output(t, terraformOptions, "tgw_subnet_ids")
-	assert.Equal(t, output3, "3")
-
-	//Test non-tgw-subnets count. There should be 9
-	output4 := terraform.Output(t, terraformOptions, "non_tgw_subnet_ids")
-	assert.Equal(t, output4, "9")
-
-	//Check the correct CIDR address have been added
-	output5 := terraform.Output(t, terraformOptions, "vpc_cidrs")
-	assert.Equal(t, output5, "map[live_data:10.20.0.0/19 non_live_data:10.20.32.0/19]")
 
 	//Check the transit gateway ram share is created
 	output6 := terraform.Output(t, terraformOptions, "transit_gateway_ram_share")

--- a/terraform/environments/core-network-services/vpc.tf
+++ b/terraform/environments/core-network-services/vpc.tf
@@ -5,31 +5,6 @@ locals {
   }
 }
 
-module "vpc_hub" {
-  for_each = local.networking
-
-  source = "../../modules/vpc-hub"
-
-  # CIDRs
-  vpc_cidr = each.value
-
-  # Private gateway type
-  #   nat = NAT Gateway
-  #   transit = Transit Gateway
-  #   none = No gateway for internal traffic
-  gateway = "nat"
-
-  # VPC Flow Logs
-  vpc_flow_log_iam_role = data.aws_iam_role.vpc-flow-log.arn
-
-  # Transit Gateway ID
-  transit_gateway_id = aws_ec2_transit_gateway.transit-gateway.id
-
-  # Tags
-  tags_common = local.tags
-  tags_prefix = each.key
-}
-
 module "vpc_inspection" {
   for_each = local.networking
 


### PR DESCRIPTION
Following the completion of #3547 , this PR will remove the tests and terraform relevant to the now-unused egress VPCs.