### PR TITLE
Add script to pull dates from environment files

### DIFF
--- a/environments/equip.json
+++ b/environments/equip.json
@@ -26,5 +26,5 @@
     "infrastructure-support": "equip.admin@justice.gov.uk",
     "owner": "kathy.anderson@justice.gov.uk"
   },
-  "go-live-date": "2023-05-17"
+  "go-live-date": "2022-06-17"
 }

--- a/environments/nomis.json
+++ b/environments/nomis.json
@@ -45,5 +45,5 @@
     "infrastructure-support": "digital-studio-operations-team@digital.justice.gov.uk",
     "owner": "digital-studio-operations-team@digital.justice.gov.uk"
   },
-  "go-live-date": "2023-05-17"
+  "go-live-date": "2022-08-25"
 }

--- a/environments/performance-hub.json
+++ b/environments/performance-hub.json
@@ -35,5 +35,5 @@
     "infrastructure-support": "performance-hub@digital.justice.gov.uk",
     "owner": "hubusers@justice.gov.uk"
   },
-  "go-live-date": "2023-05-17"
+  "go-live-date": "2021-11-10"
 }

--- a/environments/xhibit-portal.json
+++ b/environments/xhibit-portal.json
@@ -35,5 +35,5 @@
     "infrastructure-support": "xpsupport@digital.justice.gov.uk",
     "owner": "dom.tomkins@digital.justice.gov.uk"
   },
-  "go-live-date": "2023-05-17"
+  "go-live-date": "2022-03-25"
 }

--- a/scripts/internal/get-application-data-summary/main.go
+++ b/scripts/internal/get-application-data-summary/main.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"strings"
+	"time"
+)
+
+type Environment struct {
+	AccountType string `json:"account-type"`
+	GoLiveDate  string `json:"go-live-date"`
+}
+
+func main() {
+	dir := "../../../environments/"
+
+	// Read the files in the directory
+	files, err := ioutil.ReadDir(dir)
+	if err != nil {
+		fmt.Println("Error reading directory:", err)
+		os.Exit(1)
+	}
+
+	// Variables to store the results
+	memberFiles := []string{}
+	futureGoLiveFiles := []string{}
+	pastGoLiveFiles := []string{}
+
+	// Get today's date
+	today := time.Now().Truncate(24 * time.Hour)
+
+	// Process each JSON file
+	for _, file := range files {
+		// Check if the file is a JSON file
+		if !strings.HasSuffix(file.Name(), ".json") {
+			continue
+		}
+
+		// Read the JSON file
+		filePath := fmt.Sprintf("%s%s", dir, file.Name())
+		jsonData, err := ioutil.ReadFile(filePath)
+		if err != nil {
+			log.Println(err)
+			continue
+		}
+
+		// Parse the JSON data into an Environment struct
+		var env Environment
+		err = json.Unmarshal(jsonData, &env)
+		if err != nil {
+			log.Println(err)
+			continue
+		}
+
+		application_name := strings.TrimSuffix(file.Name(), ".json")
+		// check if an mp account
+		mpOwned := false
+		if application_name == "example" || application_name == "sprinkler" || application_name == "cooker" || application_name == "testing" {
+			mpOwned = true
+		}
+
+		// Check the account type
+		if env.AccountType == "member" && mpOwned == false {
+			memberFiles = append(memberFiles, application_name)
+		}
+
+		if env.GoLiveDate != "" {
+			parsedDate, err := time.Parse("2006-01-02", env.GoLiveDate)
+			if err != nil {
+				log.Println(err)
+				continue
+			}
+			// Check the go-live date
+			if parsedDate.After(today) && env.AccountType == "member" {
+				futureGoLiveFiles = append(futureGoLiveFiles, env.GoLiveDate+" "+application_name)
+			} else if parsedDate.Before(today) && env.AccountType == "member" {
+				pastGoLiveFiles = append(pastGoLiveFiles, env.GoLiveDate+" "+application_name)
+			}
+		}
+
+	}
+
+	// Output the results
+	fmt.Printf("Member applications (%d):\n", len(memberFiles))
+	for _, file := range memberFiles {
+		fmt.Println(file)
+	}
+
+	fmt.Printf("\nUpcoming migrations (%d):\n", len(futureGoLiveFiles))
+	for _, file := range futureGoLiveFiles {
+		fmt.Println(file)
+	}
+
+	fmt.Printf("\nLive in production applications (%d):\n", len(pastGoLiveFiles))
+	for _, file := range pastGoLiveFiles {
+		fmt.Println(file)
+	}
+}


### PR DESCRIPTION
Simple go script to get the go-live-dates and number of applications from the environment files.  Also updating the dates with correct dates of go live.

Current output:

```
Member applications (29):
apex
ccms-ebs
data-and-insights-wepi
data-platform
delius-core
delius-iaps
delius-jitbit
digital-prison-reporting
equip
hmpps-intelligence-management
laa-ccms-infra-azure-ad-sso
laa-oem
long-term-storage
maatdb
mlra
mojfin
nomis-combined-reporting
nomis-data-hub
nomis
oas
oasys
performance-hub
portal
ppud
refer-monitor
tariff
tipstaff
tribunals
xhibit-portal

Upcoming migrations (2):
2023-05-26 ccms-ebs
2023-06-10 ppud

Live in production applications (5):
2023-05-15 delius-iaps
2022-06-17 equip
2022-08-25 nomis
2021-11-10 performance-hub
2022-03-25 xhibit-portal
```