### PR TITLE
Resolve Checkov issues with firewalls

### DIFF
--- a/terraform/environments/core-network-services/data.tf
+++ b/terraform/environments/core-network-services/data.tf
@@ -17,3 +17,7 @@ data "aws_route" "live_data" {
   route_table_id         = each.value
   destination_cidr_block = "0.0.0.0/0"
 }
+
+data "aws_kms_key" "general_shared" {
+  key_id = "arn:aws:kms:eu-west-2:${local.environment_management.account_ids["core-shared-services-production"]}:alias/general-${var.networking[0].business-unit}"
+}

--- a/terraform/environments/core-network-services/firewall.tf
+++ b/terraform/environments/core-network-services/firewall.tf
@@ -162,6 +162,7 @@ resource "aws_route_table_association" "external_inspection_out" {
 module "firewall_policy" {
   source                 = "../../modules/firewall-policy"
   fw_rulegroup_capacity  = "10000"
+  fw_kms_arn             = data.aws_kms_key.general_shared.arn
   fw_policy_name         = format("%s-fw-policy", local.application_name)
   fw_rulegroup_name      = format("%s-fw-rulegroup", local.application_name)
   fw_fqdn_rulegroup_name = format("%s-fw-fqdn-rulegroup", local.application_name)
@@ -183,6 +184,11 @@ resource "aws_networkfirewall_firewall" "external_inspection" {
   name                = "external-inspection"
   firewall_policy_arn = module.firewall_policy.fw_policy_arn
   vpc_id              = aws_vpc.external_inspection.id
+  delete_protection   = true
+  encryption_configuration {
+    type = "CUSTOMER_KMS"
+    key_id = data.aws_kms_key.general_shared.arn
+  }
   subnet_mapping { subnet_id = aws_subnet.external_inspection_out["eu-west-2a"].id }
   subnet_mapping { subnet_id = aws_subnet.external_inspection_out["eu-west-2b"].id }
   subnet_mapping { subnet_id = aws_subnet.external_inspection_out["eu-west-2c"].id }

--- a/terraform/environments/core-network-services/networking.auto.tfvars.json
+++ b/terraform/environments/core-network-services/networking.auto.tfvars.json
@@ -1,7 +1,7 @@
 {
   "networking": [
     {
-      "business-unit": "",
+      "business-unit": "platforms",
       "set": "",
       "application": "core-network-services"
     }

--- a/terraform/environments/core-network-services/vpc.tf
+++ b/terraform/environments/core-network-services/vpc.tf
@@ -12,6 +12,7 @@ module "vpc_inspection" {
   application_name      = local.application_name
   fw_allowed_domains    = local.fqdn_firewall_rules.fw_allowed_domains
   fw_home_net_ips       = local.fqdn_firewall_rules.fw_home_net_ips
+  fw_kms_arn            = data.aws_kms_key.general_shared.arn
   fw_rules              = local.inline_firewall_rules
   vpc_cidr              = each.value
   vpc_flow_log_iam_role = data.aws_iam_role.vpc-flow-log.arn

--- a/terraform/modules/firewall-policy/main.tf
+++ b/terraform/modules/firewall-policy/main.tf
@@ -4,6 +4,10 @@ resource "random_id" "policy_id" {
 
 resource "aws_networkfirewall_firewall_policy" "main" {
   name = replace(format("%s-%s", var.fw_policy_name, random_id.policy_id.id), "/-|_/", "")
+  encryption_configuration {
+    type = "CUSTOMER_KMS"
+    key_id = var.fw_kms_arn
+  }
   firewall_policy {
     stateful_engine_options {
       rule_order = "DEFAULT_ACTION_ORDER"

--- a/terraform/modules/firewall-policy/main.tf
+++ b/terraform/modules/firewall-policy/main.tf
@@ -31,6 +31,10 @@ resource "aws_networkfirewall_firewall_policy" "main" {
 
 resource "aws_networkfirewall_rule_group" "stateful" {
   capacity = var.fw_rulegroup_capacity
+  encryption_configuration {
+    type = "CUSTOMER_KMS"
+    key_id = var.fw_kms_arn
+  }
   name     = replace(format("%s-%s", var.fw_rulegroup_name, random_id.policy_id.id), "/-|_/", "")
   type     = "STATEFUL"
 
@@ -66,6 +70,10 @@ resource "aws_networkfirewall_rule_group" "stateful" {
 
 resource "aws_networkfirewall_rule_group" "fqdn-stateful" {
   capacity = var.fw_fqdn_rulegroup_capacity
+  encryption_configuration {
+    type = "CUSTOMER_KMS"
+    key_id = var.fw_kms_arn
+  }
   name     = replace(format("%s-%s", var.fw_fqdn_rulegroup_name, random_id.policy_id.id), "/-|_/", "")
   type     = "STATEFUL"
   rule_group {

--- a/terraform/modules/firewall-policy/variables.tf
+++ b/terraform/modules/firewall-policy/variables.tf
@@ -18,6 +18,11 @@ variable "fw_fqdn_rulegroup_name" {
   type = string
 }
 
+variable "fw_kms_arn" {
+  description = "ARN of KMS key used for encryption at rest"
+  type        = string
+}
+
 variable "fw_policy_name" {
   type = string
 }

--- a/terraform/modules/vpc-inspection/firewall.tf
+++ b/terraform/modules/vpc-inspection/firewall.tf
@@ -2,6 +2,11 @@ resource "aws_networkfirewall_firewall" "inline_inspection" {
   name                = replace(format("%s-inline-inspection", var.tags_prefix), "/_/", "-")
   firewall_policy_arn = module.inline_inspection_policy.fw_policy_arn
   vpc_id              = aws_vpc.main.id
+  delete_protection   = var.fw_delete_protection
+  encryption_configuration {
+    type = "CUSTOMER_KMS"
+    key_id = var.fw_kms_arn
+  }
   dynamic "subnet_mapping" {
     for_each = aws_subnet.inspection
     content {
@@ -17,6 +22,7 @@ resource "aws_networkfirewall_firewall" "inline_inspection" {
 module "inline_inspection_policy" {
   source                 = "../../modules/firewall-policy"
   fw_rulegroup_capacity  = "10000"
+  fw_kms_arn             = var.fw_kms_arn
   fw_policy_name         = format("%s-inline-fw-policy", var.tags_prefix)
   fw_rulegroup_name      = format("%s-inline-fw-rulegroup", var.tags_prefix)
   fw_fqdn_rulegroup_name = format("%s-inlinefw-fqdn-rulegroup", var.tags_prefix)

--- a/terraform/modules/vpc-inspection/main.tf
+++ b/terraform/modules/vpc-inspection/main.tf
@@ -148,6 +148,10 @@ resource "aws_network_acl" "transit-gateway" {
 
 #tfsec:ignore:aws-vpc-no-public-ingress-acl
 resource "aws_network_acl_rule" "transit-gateway" {
+  #checkov:skip=CKV_AWS_229:NACL rules open as firewall applies controls
+  #checkov:skip=CKV_AWS_230:NACL rules open as firewall applies controls
+  #checkov:skip=CKV_AWS_231:NACL rules open as firewall applies controls
+  #checkov:skip=CKV_AWS_232:NACL rules open as firewall applies controls
   for_each = local.nacl_rules
 
   network_acl_id = aws_network_acl.transit-gateway.id
@@ -229,6 +233,10 @@ resource "aws_network_acl" "inspection" {
 
 #tfsec:ignore:aws-vpc-no-public-ingress-acl
 resource "aws_network_acl_rule" "inspection" {
+  #checkov:skip=CKV_AWS_229:NACL rules open as firewall applies controls
+  #checkov:skip=CKV_AWS_230:NACL rules open as firewall applies controls
+  #checkov:skip=CKV_AWS_231:NACL rules open as firewall applies controls
+  #checkov:skip=CKV_AWS_232:NACL rules open as firewall applies controls
   for_each = local.nacl_rules
 
   network_acl_id = aws_network_acl.inspection.id
@@ -313,6 +321,10 @@ resource "aws_network_acl" "public" {
 
 #tfsec:ignore:aws-vpc-no-public-ingress-acl
 resource "aws_network_acl_rule" "public" {
+  #checkov:skip=CKV_AWS_229:NACL rules open as firewall applies controls
+  #checkov:skip=CKV_AWS_230:NACL rules open as firewall applies controls
+  #checkov:skip=CKV_AWS_231:NACL rules open as firewall applies controls
+  #checkov:skip=CKV_AWS_232:NACL rules open as firewall applies controls
   for_each = local.nacl_rules
 
   network_acl_id = aws_network_acl.public.id

--- a/terraform/modules/vpc-inspection/variables.tf
+++ b/terraform/modules/vpc-inspection/variables.tf
@@ -14,9 +14,19 @@ variable "fw_allowed_domains" {
   type        = list(string)
 }
 
+variable "fw_delete_protection" {
+  description = "Boolean to enable or disable firewall deletion protection"
+  default     = true
+}
+
 variable "fw_home_net_ips" {
   description = "List of strings covering firewall HOME_NET values"
   type        = list(string)
+}
+
+variable "fw_kms_arn" {
+  description = "KMS key ARN used for firewall encryption"
+  type        = string
 }
 
 variable "fw_rules" {


### PR DESCRIPTION
This PR addresses some Checkov issues as follows:
* Skips Checkov checks for network ACLs as these are not relevant in context
* Adds use of `general-platforms` KMS key to encrypt network firewalls, policies, and rule groups at rest
* Adds `delete protection` statements to firewalls to prevent accidental deletion