### PR TITLE
Revert Change

### DIFF
--- a/environments/digital-prison-reporting.json
+++ b/environments/digital-prison-reporting.json
@@ -7,7 +7,7 @@
         {
           "github_slug": "hmpps-digital-prison-reporting",
           "level": "sandbox",
-          "nuke": "include"
+          "nuke": "exclude"
         }
       ]
     },


### PR DESCRIPTION
This PR reverts the nuke option that was implemented last week so that the environment is now excluded from the weekly nuke