### PR TITLE
Split out hmpps dev and test firewall rules

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/development_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/development_rules.json
@@ -1,4 +1,11 @@
 {
+  "default_block_development_test_ingress": {
+    "action": "DROP",
+    "source_ip": "0.0.0.0/0",
+    "destination_ip": "${mp-development-test}",
+    "destination_port": "ANY",
+    "protocol": "IP"
+  },
   "gp_to_hmpps_development_http": {
     "action": "PASS",
     "source_ip": "${global-protect}",
@@ -41,13 +48,6 @@
     "destination_port": "1521",
     "protocol": "TCP"
   },
-  "default_block_development_test_ingress": {
-    "action": "DROP",
-    "source_ip": "0.0.0.0/0",
-    "destination_ip": "${mp-development-test}",
-    "destination_port": "ANY",
-    "protocol": "IP"
-  },
   "hmpps_development_to_saas_agent_tcp": {
     "action": "PASS",
     "source_ip": "${hmpps-development}",
@@ -60,6 +60,69 @@
     "source_ip": "${hmpps-development}",
     "destination_ip": "0.0.0.0/0",
     "destination_port": "5721",
+    "protocol": "UDP"
+  },
+  "noms_test_dr_vnet_to_mp_hmpps_development": {
+    "action": "PASS",
+    "source_ip": "${noms-test-dr-vnet}",
+    "destination_ip": "${hmpps-development}",
+    "destination_port": "ANY",
+    "protocol": "TCP"
+  },
+  "noms_test_vnet_to_mp_hmpps_development": {
+    "action": "PASS",
+    "source_ip": "${noms-test-vnet}",
+    "destination_ip": "${hmpps-development}",
+    "destination_port": "ANY",
+    "protocol": "TCP"
+  },
+  "noms_mgmt_vnet_to_mp_hmpps_development": {
+    "action": "PASS",
+    "source_ip": "${noms-mgmt-vnet}",
+    "destination_ip": "${hmpps-development}",
+    "destination_port": "ANY",
+    "protocol": "TCP"
+  },
+  "noms_mgmt_dr_vnet_to_mp_hmpps_developmemnt": {
+    "action": "PASS",
+    "source_ip": "${noms-mgmt-dr-vnet}",
+    "destination_ip": "${hmpps-test}",
+    "destination_port": "ANY",
+    "protocol": "TCP"
+  },
+  "aks_studio_hosting_dev_1_vnet_to_mp_hmpps_development_db": {
+    "action": "PASS",
+    "source_ip": "${aks-studio-hosting-dev-1-vnet}",
+    "destination_ip": "${hmpps-development}",
+    "destination_port": "1521",
+    "protocol": "TCP"
+  },
+  "aks_studio_hosting_dev_1_vnet_to_mp_hmpps_development_https": {
+    "action": "PASS",
+    "source_ip": "${aks-studio-hosting-dev-1-vnet}",
+    "destination_ip": "${hmpps-development}",
+    "destination_port": "443",
+    "protocol": "TCP"
+  },
+  "nomisapi_t2_root_vnet_to_mp_hmpps_development": {
+    "action": "PASS",
+    "source_ip": "${nomisapi-t2-root-vnet}",
+    "destination_ip": "${hmpps-development}",
+    "destination_port": "1521",
+    "protocol": "TCP"
+  },
+  "nomisapi_t3_root_vnet_to_mp_hmpps_development": {
+    "action": "PASS",
+    "source_ip": "${nomisapi-t3-root-vnet}",
+    "destination_ip": "${hmpps-development}",
+    "destination_port": "1521",
+    "protocol": "TCP"
+  },
+  "mp_hmpps_development_to_noms_mgmt_vnet_dns": {
+    "action": "PASS",
+    "source_ip": "${hmpps-development}",
+    "destination_ip": "${noms-mgmt-vnet}",
+    "destination_port": "53",
     "protocol": "UDP"
   }
 }

--- a/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
@@ -1,4 +1,11 @@
 {
+  "default_block_preprod_production_ingress": {
+    "action": "DROP",
+    "source_ip": "0.0.0.0/0",
+    "destination_ip": "${mp-preproduction-production}",
+    "destination_port": "ANY",
+    "protocol": "TCP"
+  },
   "laa_stage_to_mp_laa_preproduction_http": {
     "action": "PASS",
     "source_ip": "${laa-lz-staging}",
@@ -39,13 +46,6 @@
     "source_ip": "${moj-core-azure-2}",
     "destination_ip": "${hmpps-preproduction}",
     "destination_port": "443",
-    "protocol": "TCP"
-  },
-  "default_block_preprod_production_ingress": {
-    "action": "DROP",
-    "source_ip": "0.0.0.0/0",
-    "destination_ip": "${mp-preproduction-production}",
-    "destination_port": "ANY",
     "protocol": "TCP"
   },
   "laa_shared_services_to_mp_laa_preproduction": {
@@ -160,14 +160,14 @@
     "destination_port": "443",
     "protocol": "TCP"
   },
-  "hmpps_preproduction_to_saas_agent_tcp": {
+  "mp_hmpps_preproduction_to_saas_agent_tcp": {
     "action": "PASS",
     "source_ip": "${hmpps-preproduction}",
     "destination_ip": "0.0.0.0/0",
     "destination_port": "5721",
     "protocol": "TCP"
   },
-  "hmpps_preproduction_to_saas_agent_udp": {
+  "mp_hmpps_preproduction_to_saas_agent_udp": {
     "action": "PASS",
     "source_ip": "${hmpps-preproduction}",
     "destination_ip": "0.0.0.0/0",

--- a/terraform/environments/core-network-services/firewall-rules/production_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/production_rules.json
@@ -1,4 +1,11 @@
 {
+  "default_open": {
+    "action": "ALERT",
+    "source_ip": "0.0.0.0/0",
+    "destination_ip": "0.0.0.0/0",
+    "destination_port": "ANY",
+    "protocol": "IP"
+  },
   "gp_to_mp_hmpps_production_http": {
     "action": "PASS",
     "source_ip": "${global-protect}",
@@ -33,13 +40,6 @@
     "destination_ip": "${psn-ppud}",
     "destination_port": "443",
     "protocol": "TCP"
-  },
-  "default_open": {
-    "action": "ALERT",
-    "source_ip": "0.0.0.0/0",
-    "destination_ip": "0.0.0.0/0",
-    "destination_port": "ANY",
-    "protocol": "IP"
   },
   "laa_production_to_mp_laa_production_http": {
     "action": "PASS",
@@ -181,14 +181,14 @@
     "destination_port": "443",
     "protocol": "TCP"
   },
-  "hmpps_production_to_saas_agent_tcp": {
+  "mp_hmpps_production_to_saas_agent_tcp": {
     "action": "PASS",
     "source_ip": "${hmpps-production}",
     "destination_ip": "0.0.0.0/0",
     "destination_port": "5721",
     "protocol": "TCP"
   },
-  "hmpps_production_to_saas_agent_udp": {
+  "mp_hmpps_production_to_saas_agent_udp": {
     "action": "PASS",
     "source_ip": "${hmpps-production}",
     "destination_ip": "0.0.0.0/0",

--- a/terraform/environments/core-network-services/firewall-rules/test_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/test_rules.json
@@ -34,72 +34,72 @@
     "destination_port": "80",
     "protocol": "TCP"
   },
-  "noms_test_dr_vnet_to_mp_test": {
+  "noms_test_dr_vnet_to_mp_hmpps_test": {
     "action": "PASS",
     "source_ip": "${noms-test-dr-vnet}",
-    "destination_ip": "${mp-development-test}",
+    "destination_ip": "${hmpps-test}",
     "destination_port": "ANY",
     "protocol": "TCP"
   },
-  "noms_test_vnet_to_mp_test": {
+  "noms_test_vnet_to_mp_hmpps_test": {
     "action": "PASS",
     "source_ip": "${noms-test-vnet}",
-    "destination_ip": "${mp-development-test}",
+    "destination_ip": "${hmpps-test}",
     "destination_port": "ANY",
     "protocol": "TCP"
   },
-  "analytics_platform_to_mp_dev_test": {
+  "analytical_platform_airflow_dev_to_mp_dev_test": {
     "action": "PASS",
     "source_ip": "${analytical-platform-airflow-dev}",
     "destination_ip": "${mp-development-test}",
     "destination_port": "1521",
     "protocol": "TCP"
   },
-  "noms_mgmt_vnet_to_mp_dev_test": {
+  "noms_mgmt_vnet_to_mp_hmpps_test": {
     "action": "PASS",
     "source_ip": "${noms-mgmt-vnet}",
-    "destination_ip": "${mp-development-test}",
+    "destination_ip": "${hmpps-test}",
     "destination_port": "ANY",
     "protocol": "TCP"
   },
-  "noms_mgmt_dr_vnet_to_mp_dev_test": {
+  "noms_mgmt_dr_vnet_to_mp_hmpps_test": {
     "action": "PASS",
     "source_ip": "${noms-mgmt-dr-vnet}",
-    "destination_ip": "${mp-development-test}",
+    "destination_ip": "${hmpps-test}",
     "destination_port": "ANY",
     "protocol": "TCP"
   },
-  "aks_studio_hosting_dev_1_vnet_to_mp_dev_test_db": {
+  "aks_studio_hosting_dev_1_vnet_to_mp_hmpps_test_db": {
     "action": "PASS",
     "source_ip": "${aks-studio-hosting-dev-1-vnet}",
-    "destination_ip": "${mp-development-test}",
+    "destination_ip": "${hmpps-test}",
     "destination_port": "1521",
     "protocol": "TCP"
   },
-  "aks_studio_hosting_dev_1_vnet_to_mp_dev_test_https": {
+  "aks_studio_hosting_dev_1_vnet_to_mp_hmpps_test_https": {
     "action": "PASS",
     "source_ip": "${aks-studio-hosting-dev-1-vnet}",
-    "destination_ip": "${mp-development-test}",
+    "destination_ip": "${hmpps-test}",
     "destination_port": "443",
     "protocol": "TCP"
   },
-  "nomisapi_t2_root_vnet_to_mp_dev_test": {
+  "nomisapi_t2_root_vnet_to_mp_hmpps_test": {
     "action": "PASS",
     "source_ip": "${nomisapi-t2-root-vnet}",
-    "destination_ip": "${mp-development-test}",
+    "destination_ip": "${hmpps-test}",
     "destination_port": "1521",
     "protocol": "TCP"
   },
-  "nomisapi_t3_root_vnet_to_mp_dev_test": {
+  "nomisapi_t3_root_vnet_to_mp_hmpps_test": {
     "action": "PASS",
     "source_ip": "${nomisapi-t3-root-vnet}",
-    "destination_ip": "${mp-development-test}",
+    "destination_ip": "${hmpps-test}",
     "destination_port": "1521",
     "protocol": "TCP"
   },
-  "mp_dev_test_to_noms_mgmt_vnet_dns": {
+  "mp_hmpps_test_to_noms_mgmt_vnet_dns": {
     "action": "PASS",
-    "source_ip": "${mp-development-test}",
+    "source_ip": "${hmpps-test}",
     "destination_ip": "${noms-mgmt-vnet}",
     "destination_port": "53",
     "protocol": "UDP"


### PR DESCRIPTION
The hmpps firewall rules for hmpps dev and test were combined, giving the azure estate access to the entire mp dev-test range.  This change splits them out in to dev and test and restricts to hmpps vpcs only.

Also moving the defaults blocks to the top, and renaming a few things for clarity.