### PR TITLE
Add logic to skip later steps if no changes

### DIFF
--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -62,18 +62,19 @@ jobs:
           changes=$(git diff origin/main...$branch_name --name-only)
           if [ -z "$changes" ]; then
             echo "No changes detected."
-            exit 1
           else
             echo "Changes detected."
-            exit 0
+            echo "changes=true" >> $GITHUB_ENV
           fi
 
       - name: Push changes
+        if: env.changes == 'true'
         run: |
           git config --global push.autoSetupRemote true
           git push
 
       - name: Create pull request
+        if: env.changes == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -83,4 +84,3 @@ jobs:
           pr_head="${{ github.repository_owner }}:${branch_name}"
           pr_base="main"
           gh pr create --title "$pr_title" --body "$pr_body" --head "$pr_head" --base "$pr_base" --label "code quality"
-      


### PR DESCRIPTION
Currently the workflow exits with 1 if there are no changes, this was fine, but now that we are measure workflow failures this is affecting metrics. Switching to using conditional steps.

Tested on this PR which has changes and it worked successfully see here https://github.com/ministryofjustice/modernisation-platform/actions/runs/5059188129/jobs/9080363501

Will need to have it run and merge to see if it works and skips when there are no changes