### PR TITLE
Ignore rotation warnings

### DIFF
--- a/terraform/environments/delius-jitbit/iam.tf
+++ b/terraform/environments/delius-jitbit/iam.tf
@@ -31,6 +31,7 @@ resource "aws_iam_access_key" "s3_user" {
 
 resource "aws_secretsmanager_secret" "s3_user_access_key" {
   # checkov:skip=CKV_AWS_149: "KMS key not required standard encryption is fine here"
+  # checkov:skip=CKV2_AWS_57:Auto rotation not currently possible
   name                    = "${local.application_name}-s3-user-access-key"
   recovery_window_in_days = 0
   tags = merge(
@@ -48,6 +49,7 @@ resource "aws_secretsmanager_secret_version" "s3_user_access_key" {
 
 resource "aws_secretsmanager_secret" "s3_user_secret_key" {
   # checkov:skip=CKV_AWS_149: "KMS key not required standard encryption is fine here"
+  # checkov:skip=CKV2_AWS_57:Auto rotation not currently possible
   name                    = "${local.application_name}-s3-user-secret-key"
   recovery_window_in_days = 0
   tags = merge(

--- a/terraform/environments/secrets.tf
+++ b/terraform/environments/secrets.tf
@@ -1,5 +1,6 @@
 # Environment Management
 resource "aws_secretsmanager_secret" "environment_management" {
+  # checkov:skip=CKV2_AWS_57:Auto rotation not possible
   provider    = aws.modernisation-platform
   name        = "environment_management"
   description = "IDs for AWS-specific resources for environment management, such as organizational unit IDs"

--- a/terraform/github/testing-ci.tf
+++ b/terraform/github/testing-ci.tf
@@ -130,6 +130,7 @@ resource "time_static" "key_rotate_period" {
 }
 
 resource "aws_secretsmanager_secret" "testing_ci_iam_user_keys" {
+   # checkov:skip=CKV2_AWS_57:Auto rotation done via Terraform
   provider    = aws.testing-test
   name        = "testing_ci_iam_user_keys"
   policy      = data.aws_iam_policy_document.testing_ci_iam_user_secrets_manager_policy.json

--- a/terraform/modernisation-platform-account/secrets.tf
+++ b/terraform/modernisation-platform-account/secrets.tf
@@ -6,6 +6,7 @@
 #tfsec:ignore:AWS095
 resource "aws_secretsmanager_secret" "slack_webhook_url" {
   # checkov:skip=CKV_AWS_149:No requirement currently to encrypt this secret with customer-managed KMS key
+  # checkov:skip=CKV2_AWS_57:Auto rotation not possible
   name        = "slack_webhook_url"
   description = "Slack channel modernisation-platform-notifications webhook url for sending notifications to slack"
   tags        = local.tags
@@ -19,6 +20,7 @@ resource "aws_secretsmanager_secret" "slack_webhook_url" {
 #tfsec:ignore:AWS095
 resource "aws_secretsmanager_secret" "github_ci_user_pat" {
   # checkov:skip=CKV_AWS_149:No requirement currently to encrypt this secret with customer-managed KMS key
+  # checkov:skip=CKV2_AWS_57:Auto rotation not possible
   name        = "github_ci_user_pat"
   description = "GitHub CI user PAT used for generated resources in GitHub via Terraform"
   tags        = local.tags
@@ -32,6 +34,7 @@ resource "aws_secretsmanager_secret" "github_ci_user_pat" {
 #tfsec:ignore:AWS095
 resource "aws_secretsmanager_secret" "github_ci_user_environments_repo_pat" {
   # checkov:skip=CKV_AWS_149:No requirement currently to encrypt this secret with customer-managed KMS key
+  # checkov:skip=CKV2_AWS_57:Auto rotation not possible
   name        = "github_ci_user_environments_repo_pat"
   description = "This PAT token is used in reusable pipelines of the modernisation-platform-environments repository. This is so that the CI user can post comments in PRs, e.g. tf plan/apply output. Expires on Tue, Apr 9 2024."
   tags        = local.tags
@@ -45,6 +48,7 @@ resource "aws_secretsmanager_secret" "github_ci_user_environments_repo_pat" {
 #tfsec:ignore:AWS095
 resource "aws_secretsmanager_secret" "github_ci_user_password" {
   # checkov:skip=CKV_AWS_149:No requirement currently to encrypt this secret with customer-managed KMS key
+  # checkov:skip=CKV2_AWS_57:Auto rotation not possible
   name        = "github_ci_user_password"
   description = "GitHub CI user password"
   tags        = local.tags
@@ -56,6 +60,7 @@ resource "aws_secretsmanager_secret" "github_ci_user_password" {
 #tfsec:ignore:AWS095
 resource "aws_secretsmanager_secret" "nuke_account_blocklist" {
   # checkov:skip=CKV_AWS_149:No requirement currently to encrypt this secret with customer-managed KMS key
+  # checkov:skip=CKV2_AWS_57:Auto rotation not possible
   name        = "nuke_account_blocklist"
   description = "Account IDs to be excluded from auto-nuke. AWS-Nuke (https://github.com/rebuy-de/aws-nuke) requires at least one Account ID to be present in this blocklist, while it is recommended to add every production account to this blocklist."
   tags        = local.tags
@@ -67,6 +72,7 @@ resource "aws_secretsmanager_secret" "nuke_account_blocklist" {
 #tfsec:ignore:AWS095
 resource "aws_secretsmanager_secret" "nuke_account_ids" {
   # checkov:skip=CKV_AWS_149:No requirement currently to encrypt this secret with customer-managed KMS key
+  # checkov:skip=CKV2_AWS_57:Auto rotation not possible
   name        = "nuke_account_ids"
   description = "Account IDs to be auto-nuked on weekly basis. CAUTION: Any account ID you add here will be automatically nuked! This secret is used by GitHub actions job nuke.yml inside the environments repo, to find the Account IDs to be nuked."
   tags        = local.tags

--- a/terraform/pagerduty/aws.tf
+++ b/terraform/pagerduty/aws.tf
@@ -3,6 +3,7 @@
 # to push notifications to pagerduty.  Add any additional integrations to the json secret below
 #tfsec:ignore:aws-ssm-secret-use-customer-key
 resource "aws_secretsmanager_secret" "pagerduty_integration_keys" {
+  # checkov:skip=CKV2_AWS_57:Auto rotation not possible
   # checkov:skip=CKV_AWS_149:No requirement currently to encrypt this secret with customer-managed KMS key
   description = "Pager Duty integration keys"
   kms_key_id  = aws_kms_key.pagerduty.id
@@ -40,6 +41,7 @@ resource "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {
 #tfsec:ignore:aws-ssm-secret-use-customer-key
 resource "aws_secretsmanager_secret" "pagerduty_token" {
   # checkov:skip=CKV_AWS_149:No requirement currently to encrypt this secret with customer-managed KMS key
+  # checkov:skip=CKV2_AWS_57:Auto rotation not possible
   name        = "pagerduty_token"
   description = "PagerDuty api token"
   tags        = local.tags


### PR DESCRIPTION
We either can't, don't want to or currently do rotate these via a different mechanism.