### PR TITLE
added permission to move SES account from sandbox

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/policies.tf
+++ b/terraform/environments/bootstrap/delegate-access/policies.tf
@@ -162,6 +162,7 @@ data "aws_iam_policy_document" "developer_additional" {
       "secretsmanager:UpdateSecret",
       "secretsmanager:RestoreSecret",
       "secretsmanager:RotateSecret",
+      "ses:PutAccountDetails",
       "ssm:*",
       "ssm-guiconnect:*",
       "sso:ListDirectoryAssociations",


### PR DESCRIPTION
In line with [this Slack conversation](https://mojdt.slack.com/archives/C01A7QK5VM1/p1684835060715299), this allows users to move their SES accounts from the AWS sandbox and into production.