### PR TITLE
SCA ignores for open policies

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -109,6 +109,7 @@ data "aws_iam_policy_document" "oidc_assume_role_member" {
   }
 
   # checkov:skip=CKV_AWS_111: "Cannot restrict by KMS alias so leaving open"
+  # checkov:skip=CKV_AWS_356: "Cannot restrict by KMS alias so leaving open"
   statement {
     sid       = "AllowOIDCToDecryptKMS"
     effect    = "Allow"

--- a/terraform/environments/bootstrap/delegate-access/policies.tf
+++ b/terraform/environments/bootstrap/delegate-access/policies.tf
@@ -96,7 +96,7 @@ data "aws_iam_policy_document" "developer_additional" {
   #checkov:skip=CKV_AWS_109
   #checkov:skip=CKV_AWS_111
   #checkov:skip=CKV_AWS_110
-  #checkov:skip=CKV_AWS_356
+  #checkov:skip=CKV_AWS_356: Needs to access multiple resources
   source_policy_documents = [data.aws_iam_policy_document.common_statements.json]
   statement {
     sid    = "developerAllow"
@@ -225,7 +225,7 @@ data "aws_iam_policy_document" "data_engineering_additional" {
   #checkov:skip=CKV_AWS_109
   #checkov:skip=CKV_AWS_111
   #checkov:skip=CKV_AWS_110
-  #checkov:skip=CKV_AWS_356
+  #checkov:skip=CKV_AWS_356: Needs to access multiple resources
   source_policy_documents = [data.aws_iam_policy_document.developer_additional.json] # this is a developer++ policy with additional permissions required for data engineering
 
   statement {
@@ -307,7 +307,7 @@ data "aws_iam_policy_document" "sandbox_additional" {
   #checkov:skip=CKV_AWS_109
   #checkov:skip=CKV_AWS_110
   #checkov:skip=CKV2_AWS_40
-  #checkov:skip=CKV_AWS_356
+  #checkov:skip=CKV_AWS_356: Needs to access multiple resources
   source_policy_documents = [data.aws_iam_policy_document.common_statements.json]
   statement {
     sid    = "sandboxAllow"
@@ -443,7 +443,7 @@ data "aws_iam_policy_document" "migration_additional" {
   #checkov:skip=CKV_AWS_107
   #checkov:skip=CKV_AWS_109
   #checkov:skip=CKV_AWS_110
-  #checkov:skip=CKV_AWS_356
+  #checkov:skip=CKV_AWS_356: Needs to access multiple resources
   source_policy_documents   = [data.aws_iam_policy_document.developer_additional.json]
   override_policy_documents = [data.aws_iam_policy_document.common_statements.json]
   statement {
@@ -489,7 +489,7 @@ data "aws_iam_policy_document" "instance-management-document" {
   #checkov:skip=CKV_AWS_109
   #checkov:skip=CKV_AWS_111
   #checkov:skip=CKV_AWS_110
-  #checkov:skip=CKV_AWS_356
+  #checkov:skip=CKV_AWS_356: Needs to access multiple resources
   source_policy_documents = [data.aws_iam_policy_document.common_statements.json]
   statement {
     sid    = "databaseAllow"

--- a/terraform/environments/bootstrap/delegate-access/policies.tf
+++ b/terraform/environments/bootstrap/delegate-access/policies.tf
@@ -96,6 +96,7 @@ data "aws_iam_policy_document" "developer_additional" {
   #checkov:skip=CKV_AWS_109
   #checkov:skip=CKV_AWS_111
   #checkov:skip=CKV_AWS_110
+  #checkov:skip=CKV_AWS_356
   source_policy_documents = [data.aws_iam_policy_document.common_statements.json]
   statement {
     sid    = "developerAllow"
@@ -224,6 +225,7 @@ data "aws_iam_policy_document" "data_engineering_additional" {
   #checkov:skip=CKV_AWS_109
   #checkov:skip=CKV_AWS_111
   #checkov:skip=CKV_AWS_110
+  #checkov:skip=CKV_AWS_356
   source_policy_documents = [data.aws_iam_policy_document.developer_additional.json] # this is a developer++ policy with additional permissions required for data engineering
 
   statement {
@@ -305,6 +307,7 @@ data "aws_iam_policy_document" "sandbox_additional" {
   #checkov:skip=CKV_AWS_109
   #checkov:skip=CKV_AWS_110
   #checkov:skip=CKV2_AWS_40
+  #checkov:skip=CKV_AWS_356
   source_policy_documents = [data.aws_iam_policy_document.common_statements.json]
   statement {
     sid    = "sandboxAllow"
@@ -440,6 +443,7 @@ data "aws_iam_policy_document" "migration_additional" {
   #checkov:skip=CKV_AWS_107
   #checkov:skip=CKV_AWS_109
   #checkov:skip=CKV_AWS_110
+  #checkov:skip=CKV_AWS_356
   source_policy_documents   = [data.aws_iam_policy_document.developer_additional.json]
   override_policy_documents = [data.aws_iam_policy_document.common_statements.json]
   statement {
@@ -485,6 +489,7 @@ data "aws_iam_policy_document" "instance-management-document" {
   #checkov:skip=CKV_AWS_109
   #checkov:skip=CKV_AWS_111
   #checkov:skip=CKV_AWS_110
+  #checkov:skip=CKV_AWS_356
   source_policy_documents = [data.aws_iam_policy_document.common_statements.json]
   statement {
     sid    = "databaseAllow"

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -22,6 +22,7 @@ data "aws_iam_policy_document" "member-access" {
     #checkov:skip=CKV_AWS_109
     #checkov:skip=CKV_AWS_110
     #checkov:skip=CKV2_AWS_40
+    #checkov:skip=CKV2_AWS_356
     effect = "Allow"
     actions = [
       "acm-pca:*",
@@ -255,6 +256,7 @@ data "aws_iam_policy_document" "member-access-us-east" {
     #checkov:skip=CKV_AWS_109
     #checkov:skip=CKV_AWS_110
     #checkov:skip=CKV2_AWS_40
+    #checkov:skip=CKV2_AWS_356
     effect    = "Allow"
     actions   = ["acm:*"]
     resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -22,7 +22,7 @@ data "aws_iam_policy_document" "member-access" {
     #checkov:skip=CKV_AWS_109
     #checkov:skip=CKV_AWS_110
     #checkov:skip=CKV2_AWS_40
-    #checkov:skip=CKV2_AWS_356
+    #checkov:skip=CKV2_AWS_356: Needs to access multiple resources
     effect = "Allow"
     actions = [
       "acm-pca:*",
@@ -256,7 +256,7 @@ data "aws_iam_policy_document" "member-access-us-east" {
     #checkov:skip=CKV_AWS_109
     #checkov:skip=CKV_AWS_110
     #checkov:skip=CKV2_AWS_40
-    #checkov:skip=CKV2_AWS_356
+    #checkov:skip=CKV2_AWS_356: Needs to access multiple resources
     effect    = "Allow"
     actions   = ["acm:*"]
     resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097

--- a/terraform/environments/ccms-ebs/iam.tf
+++ b/terraform/environments/ccms-ebs/iam.tf
@@ -18,6 +18,7 @@ resource "aws_iam_user_policy" "email_policy" {
   policy = data.aws_iam_policy_document.email.json
 }
 
+# Following AWS recommended policy
 #tfsec:ignore:aws-iam-no-policy-wildcards
 data "aws_iam_policy_document" "email" {
   #checkov:skip=CKV_AWS_111

--- a/terraform/environments/ccms-ebs/iam.tf
+++ b/terraform/environments/ccms-ebs/iam.tf
@@ -18,6 +18,7 @@ resource "aws_iam_user_policy" "email_policy" {
   policy = data.aws_iam_policy_document.email.json
 }
 
+#tfsec:ignore:aws-iam-no-policy-wildcards
 data "aws_iam_policy_document" "email" {
   #checkov:skip=CKV_AWS_111
   #checkov:skip=CKV_AWS_356: Policy follows AWS guidance

--- a/terraform/environments/core-logging/s3_logging.tf
+++ b/terraform/environments/core-logging/s3_logging.tf
@@ -17,6 +17,7 @@ resource "aws_kms_alias" "s3_logging_cloudtrail" {
 data "aws_iam_policy_document" "kms_logging_cloudtrail" {
 
   # checkov:skip=CKV_AWS_111: "policy is directly related to the resource"
+  # checkov:skip=CKV_AWS_356: "policy is directly related to the resource"
   # checkov:skip=CKV_AWS_109: "role is resticted by limited actions in member account"
 
   statement {

--- a/terraform/environments/core-network-services/firewall.tf
+++ b/terraform/environments/core-network-services/firewall.tf
@@ -180,6 +180,7 @@ module "firewall_logging" {
 }
 
 resource "aws_networkfirewall_firewall" "external_inspection" {
+  # checkov:skip=CKV_AWS_63: Firewall logging is defined in module see call above
   depends_on          = [aws_subnet.external_inspection_out]
   name                = "external-inspection"
   firewall_policy_arn = module.firewall_policy.fw_policy_arn

--- a/terraform/environments/core-network-services/iam.tf
+++ b/terraform/environments/core-network-services/iam.tf
@@ -115,6 +115,7 @@ resource "aws_iam_role" "read_dns" {
 
 #tfsec:ignore:aws-iam-no-policy-wildcards
 resource "aws_iam_role_policy" "read_dns" {
+  # checkov:skip=CKV_AWS_355: "the policy is secured with the condition"
   name = "ReadDNSRecords"
   role = aws_iam_role.read_dns.id
 

--- a/terraform/environments/core-shared-services/iam.tf
+++ b/terraform/environments/core-shared-services/iam.tf
@@ -153,6 +153,7 @@ data "aws_iam_policy_document" "instance-scheduler-lambda-function-policy" {
   }
   # checkov:skip=CKV_AWS_111: "Cannot restrict by KMS alias so leaving open"
   # checkov:skip=CKV_AWS_109: "Cannot restrict by KMS alias so leaving open"
+  # checkov:skip=CKV_AWS_356: "Cannot restrict by KMS alias so leaving open"
   statement {
     sid       = "AllowToDecryptKMS"
     effect    = "Allow"

--- a/terraform/environments/core-shared-services/kms.tf
+++ b/terraform/environments/core-shared-services/kms.tf
@@ -13,6 +13,7 @@ data "aws_iam_policy_document" "ebs_encryption_policy_doc" {
 
   # checkov:skip=CKV_AWS_109: "Key policy requires asterisk resource"
   # checkov:skip=CKV_AWS_111: "Key policy requires asterisk resource"
+  # checkov:skip=CKV_AWS_356: "Key policy requires asterisk resource"
 
   # Allow root users full management access to key
   statement {

--- a/terraform/environments/secrets.tf
+++ b/terraform/environments/secrets.tf
@@ -65,6 +65,7 @@ data "aws_iam_policy_document" "kms_environment_management" {
 
   # checkov:skip=CKV_AWS_111: "policy is directly related to the resource"
   # checkov:skip=CKV_AWS_109: "policy is directly related to the resource"
+  # checkov:skip=CKV_AWS_356: "policy is directly related to the resource"
   statement {
     sid    = "Allow management access of the key to the root and modernisation platform account"
     effect = "Allow"

--- a/terraform/modernisation-platform-account/s3.tf
+++ b/terraform/modernisation-platform-account/s3.tf
@@ -14,6 +14,7 @@ resource "aws_kms_alias" "s3_state_bucket" {
 data "aws_iam_policy_document" "kms_state_bucket" {
 
   # checkov:skip=CKV_AWS_111: "policy is directly related to the resource"
+  # checkov:skip=CKV_AWS_356: "policy is directly related to the resource"
   # checkov:skip=CKV_AWS_109: "role is resticted by limited actions in member account"
 
   statement {

--- a/terraform/modules/kms/main.tf
+++ b/terraform/modules/kms/main.tf
@@ -39,6 +39,7 @@ resource "aws_kms_alias" "rds" {
 data "aws_iam_policy_document" "kms" {
   # checkov:skip=CKV_AWS_109
   # checkov:skip=CKV_AWS_111
+  # checkov:skip=CKV_AWS_356: "policy is directly related to the resource"
   # Allow root users full management access to key
   statement {
     effect = "Allow"


### PR DESCRIPTION
These are mostly for policies which are directly attached to the resource or similar and there for resources needs to be *.  They have been ignored for tfsec before but this is a new check with checkov now doing the same thing.  Also a couple of other ignores which have been verified as ok.