### PR TITLE
Set BucketOwnerEnforced for core-shared-services image-artefact bucket

### DIFF
--- a/terraform/environments/core-shared-services/s3.tf
+++ b/terraform/environments/core-shared-services/s3.tf
@@ -9,6 +9,7 @@ module "s3-bucket" {
   replication_enabled = false
   versioning_enabled  = true
   force_destroy       = false
+  ownership_controls  = "BucketOwnerEnforced" # Disable all S3 bucket ACL to ensure that objects owner it the bucket with bucket policy IAM governing permissions
   lifecycle_rule = [
     {
       id      = "main"


### PR DESCRIPTION
The image artefact bucket is a shared bucket containing software artefacts used during AMI/Docker image building.
To ensure that IAM policy only governs access (and that objects PUT to the bucket from different accounts are still owned by the bucket, and not the source account), this change is required.