### PR TITLE
Remove some collaborators

### DIFF
--- a/collaborators.json
+++ b/collaborators.json
@@ -75,34 +75,6 @@
       ]
     },
     {
-      "username": "michael.bullen",
-      "github-username": "MMBRoc",
-      "accounts": [
-        {
-          "account-name": "equip-development",
-          "access": "developer"
-        },
-        {
-          "account-name": "equip-production",
-          "access": "developer"
-        }
-      ]
-    },
-    {
-      "username": "mitul.dattani",
-      "github-username": "md-roc",
-      "accounts": [
-        {
-          "account-name": "equip-development",
-          "access": "developer"
-        },
-        {
-          "account-name": "equip-production",
-          "access": "developer"
-        }
-      ]
-    },
-    {
       "username": "nigel.freeman",
       "github-username": "nigelf-roc",
       "accounts": [
@@ -217,20 +189,6 @@
     {
       "username": "helen.vickers",
       "github-username": "helenvickers-roc",
-      "accounts": [
-        {
-          "account-name": "equip-development",
-          "access": "developer"
-        },
-        {
-          "account-name": "equip-production",
-          "access": "developer"
-        }
-      ]
-    },
-    {
-      "username": "tom.whiteley",
-      "github-username": "tom-whi",
       "accounts": [
         {
           "account-name": "equip-development",


### PR DESCRIPTION
According to Operations Engineering, the following collaborators have not accepted their invitations despite having been outstanding for almost 12 months:
* mmbroc
* tom-whi
* md-roc

That being the case, I can only presume that these user neither want nor need access. Should this change, we can re-add them on request.