### PR TITLE
Allow Cloud Platform JDBC calls into HMPPS VPCs

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/development_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/development_rules.json
@@ -48,6 +48,13 @@
     "destination_port": "1521",
     "protocol": "TCP"
   },
+  "cp_to_mp_hmpps_development_jdbc": {
+    "action": "PASS",
+    "source_ip": "${cloud-platform}",
+    "destination_ip": "${hmpps-development}",
+    "destination_port": "5439",
+    "protocol": "TCP"
+  },
   "hmpps_development_to_saas_agent_tcp": {
     "action": "PASS",
     "source_ip": "${hmpps-development}",

--- a/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
@@ -173,5 +173,12 @@
     "destination_ip": "0.0.0.0/0",
     "destination_port": "5721",
     "protocol": "UDP"
+  },
+  "cp_to_mp_hmpps_preproduction_jdbc": {
+    "action": "PASS",
+    "source_ip": "${cloud-platform}",
+    "destination_ip": "${hmpps-preproduction}",
+    "destination_port": "5439",
+    "protocol": "TCP"
   }
 }

--- a/terraform/environments/core-network-services/firewall-rules/production_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/production_rules.json
@@ -34,6 +34,13 @@
     "destination_port": "1521",
     "protocol": "TCP"
   },
+  "cp_to_mp_hmpps_production_jdbc": {
+    "action": "PASS",
+    "source_ip": "${cloud-platform}",
+    "destination_ip": "${hmpps-production}",
+    "destination_port": "5439",
+    "protocol": "TCP"
+  },
   "mp_ppud_production_to_psn_ppud": {
     "action": "PASS",
     "source_ip": "${hmpps-production}",

--- a/terraform/environments/core-network-services/firewall-rules/test_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/test_rules.json
@@ -27,6 +27,13 @@
     "destination_port": "1521",
     "protocol": "TCP"
   },
+  "cp_to_mp_hmpps_test_jdbc": {
+    "action": "PASS",
+    "source_ip": "${cloud-platform}",
+    "destination_ip": "${hmpps-test}",
+    "destination_port": "5439",
+    "protocol": "TCP"
+  },
   "laa_test_to_mp_laa_test_http": {
     "action": "PASS",
     "source_ip": "${laa-lz-test}",


### PR DESCRIPTION
As per [this Slack thread](https://mojdt.slack.com/archives/C01A7QK5VM1/p1685014974773159), this PR adds firewall rules to allow JDBC calls from the MOJ Cloud Platform into the HMPPS VPCs where the Digital Prisons Reporting app is hosted.