### PR TITLE
add ability to use apigateway to sandbox policy

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/policies.tf
+++ b/terraform/environments/bootstrap/delegate-access/policies.tf
@@ -315,6 +315,7 @@ data "aws_iam_policy_document" "sandbox_additional" {
     actions = [
       "acm-pca:*",
       "acm:*",
+      "apigateway:*",
       "application-autoscaling:*",
       "athena:*",
       "autoscaling:*",


### PR DESCRIPTION
As per [this Slack thread](https://mojdt.slack.com/archives/C01A7QK5VM1/p1685021660706549?thread_ts=1684838327.099879&cid=C01A7QK5VM1), this PR adds the IAM permission statement to the `sandbox_additional` policy, allowing sandbox users to make use of the AWS API Gateway