### PR TITLE
Fix exit zero on formatter

### DIFF
--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Check for changes
         run: |
           git add .
-          git commit -m "Updates from GitHub Actions Format Code workflow"
+          git commit -m "Updates from GitHub Actions Format Code workflow" || true
           branch_name=$(git branch --show-current)
           changes=$(git diff origin/main...$branch_name --name-only)
           if [ -z "$changes" ]; then


### PR DESCRIPTION
The workflow is still exiting with zero, this is because the git commit command returns a 1 when there is nothing to commit.  Adding or true to return 0 regardless of the result of the command.