### PR TITLE
Firewall Alarm Dropped Packets

### DIFF
--- a/terraform/environments/core-network-services/monitoring.tf
+++ b/terraform/environments/core-network-services/monitoring.tf
@@ -150,3 +150,22 @@ resource "aws_flow_log" "tgw_flowlog" {
   transit_gateway_attachment_id = each.value["id"]
   tags                          = local.tags
 }
+
+resource "aws_cloudwatch_metric_alarm" "firewall-traffic-drop-alarm" {
+  alarm_name                = "firewall-traffic-dropped"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  metric_name               = "DroppedPackets"
+  namespace                 = "AWS/NetworkFirewall"
+  period                    = 300
+  evaluation_periods        = 10
+  alarm_description         = "Dropped packets alarm"
+  statistic                 = "Sum"
+  treat_missing_data        = "notBreaching"
+  alarm_actions             = []
+  # Will be populated with a sns topic however currently need to either create a new one or use tgw_monitoring_production or route53_monitoring
+  insufficient_data_actions = []
+  dimensions                = {
+    AvailabilityZone = "eu-west-2"
+    FirewallName     = aws_networkfirewall_firewall.external_inspection.name
+  }
+}


### PR DESCRIPTION
Added firewall cloudwatch alarm with no sns topic attached. Already applied, and works.

Related to this card. https://github.com/ministryofjustice/modernisation-platform/issues/3290