### PR TITLE
Add hosted zone for jitbit migration test

### DIFF
--- a/terraform/environments/core-network-services/route53.tf
+++ b/terraform/environments/core-network-services/route53.tf
@@ -5,6 +5,7 @@ locals {
   application-zones = {
     equip    = "equip.service.justice.gov.uk",
     ccms-ebs = "ccms-ebs.service.justice.gov.uk",
+    jitbit   = "jitbit.dev.cr.probation.service.justice.gov.uk",
     mlra     = "maat-libra-administration-tool.service.justice.gov.uk",
     mojfin   = "laa-finance-data.service.justice.gov.uk",
     tipstaff = "tipstaff.service.justice.gov.uk"


### PR DESCRIPTION
As per [this Slack request](https://mojdt.slack.com/archives/C01A7QK5VM1/p1685458203323369), this PR adds a hosted zone that can be used by the jitbit team to test a DNS cutover to the Modernisation Platform