### PR TITLE
Grant RHEL-6 ELS license to all member accounts

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/grants.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/grants.tf
@@ -1,0 +1,10 @@
+module "grant-rhel-els" {
+  source = "../../../modules/license-manager"
+  providers = {
+    aws.modernisation-platform-environment = aws
+    aws.modernisation-platform-account     = aws.modernisation-platform
+  }
+  account_to_grant       = local.environment_management.account_ids[terraform.workspace]
+  destination_grant_name = "RHEL-6-ELS"
+  source_license_arn     = "arn:aws:license-manager::294406891311:license:l-d82b05a0dc724e79a1d164704144d38b"
+}

--- a/terraform/environments/core-network-services/monitoring.tf
+++ b/terraform/environments/core-network-services/monitoring.tf
@@ -152,16 +152,16 @@ resource "aws_flow_log" "tgw_flowlog" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "firewall-traffic-drop-alarm" {
-  alarm_name                = "firewall-traffic-dropped"
-  comparison_operator       = "GreaterThanOrEqualToThreshold"
-  metric_name               = "DroppedPackets"
-  namespace                 = "AWS/NetworkFirewall"
-  period                    = 300
-  evaluation_periods        = 10
-  alarm_description         = "Dropped packets alarm"
-  statistic                 = "Sum"
-  treat_missing_data        = "notBreaching"
-  alarm_actions             = [aws_sns_topic.networking_general.arn]
+  alarm_name          = "firewall-traffic-dropped"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  metric_name         = "DroppedPackets"
+  namespace           = "AWS/NetworkFirewall"
+  period              = 300
+  evaluation_periods  = 10
+  alarm_description   = "Dropped packets alarm"
+  statistic           = "Sum"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [aws_sns_topic.networking_general.arn]
   # Will be populated with a sns topic however currently need to either create a new one or use tgw_monitoring_production or route53_monitoring
   insufficient_data_actions = []
   dimensions = {
@@ -172,7 +172,7 @@ resource "aws_cloudwatch_metric_alarm" "firewall-traffic-drop-alarm" {
 
 resource "aws_sns_topic" "networking_general" {
   #checkov:skip=CKV_AWS_26:"encrypted topics do not work with pagerduty subscription"
-  name     = "networking_general"
+  name = "networking_general"
   tags = local.tags
 }
 

--- a/terraform/modules/license-manager/main.tf
+++ b/terraform/modules/license-manager/main.tf
@@ -1,0 +1,20 @@
+data "aws_licensemanager_grants" "main" {
+  provider = aws.modernisation-platform-account
+  filter {
+    name   = "LicenseArn"
+    values = [var.source_license_arn]
+  }
+}
+
+resource "aws_licensemanager_grant" "main" {
+  provider           = aws.modernisation-platform-account
+  name               = format("%s-%d", var.destination_grant_name, var.account_to_grant)
+  allowed_operations = var.destination_grant_allowed_options
+  license_arn        = data.aws_licensemanager_grants.main.arns[0]
+  principal          = format("arn:aws:iam::%d:root", var.account_to_grant)
+}
+
+resource "aws_licensemanager_grant_accepter" "main" {
+  provider  = aws.modernisation-platform-environment
+  grant_arn = aws_licensemanager_grant.main.arn
+}

--- a/terraform/modules/license-manager/variables.tf
+++ b/terraform/modules/license-manager/variables.tf
@@ -1,0 +1,32 @@
+variable "account_to_grant" {
+  description = "Account IDs to grant license to"
+  type        = string
+}
+
+variable "destination_grant_allowed_options" {
+  description = "A list of the allowed operations for the grant."
+  default = [
+    "ListPurchasedLicenses",
+    "CheckInLicense",
+    "CheckoutLicense",
+    "ExtendConsumptionLicense",
+    "CreateGrant",
+    "CreateToken"
+  ]
+  type = list(string)
+}
+
+variable "destination_grant_name" {
+  type = string
+}
+
+variable "source_license_arn" {
+  description = "ARN of source license - eg. \"arn:aws:license-manager::$account-id:license:$license-id\"."
+  type        = string
+}
+
+variable "source_grant_home_region" {
+  description = "Home AWS region of source grant - eg. \"us-east-1\"."
+  default     = "us-east-1"
+  type        = string
+}

--- a/terraform/modules/license-manager/versions.tf
+++ b/terraform/modules/license-manager/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = "~> 1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+      configuration_aliases = [
+        aws.modernisation-platform-account,
+        aws.modernisation-platform-environment
+      ]
+    }
+  }
+}


### PR DESCRIPTION
As part of #3876 , this PR creates a module to both grant & accept an AWS LicenseManager grant based on a supplied `source_license_arn` value.
The goal of this PR is to allow us to accept an AWS Marketplace agreement in our main `modernisation-platform` account by hand, and then grant that to member accounts through code, ensuring that our LicenseManager grants are managed in Terraform and not through ClickOps.