### PR TITLE
Fix License Manager grants

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/grants.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/grants.tf
@@ -6,5 +6,5 @@ module "grant-rhel-els" {
   }
   account_to_grant       = local.environment_management.account_ids[terraform.workspace]
   destination_grant_name = "RHEL-6-ELS"
-  source_license_arn     = "arn:aws:license-manager::294406891311:license:l-d82b05a0dc724e79a1d164704144d38b"
+  source_license_sku     = "02e38931-bf68-46a4-925d-5fdf598c92d2"
 }

--- a/terraform/environments/bootstrap/member-bootstrap/grants.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/grants.tf
@@ -1,8 +1,8 @@
 module "grant-rhel-els" {
   source = "../../../modules/license-manager"
   providers = {
-    aws.modernisation-platform-environment = aws
-    aws.modernisation-platform-account     = aws.modernisation-platform
+    aws.modernisation-platform-environment = aws.modernisation-platform-environments-us-east-1
+    aws.modernisation-platform-account     = aws.modernisation-platform-us-east-1
   }
   account_to_grant       = local.environment_management.account_ids[terraform.workspace]
   destination_grant_name = "RHEL-6-ELS"

--- a/terraform/environments/bootstrap/member-bootstrap/providers.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/providers.tf
@@ -6,8 +6,23 @@ provider "aws" {
   }
 }
 
+# AWS provider for the workspace you're working in but in us-east-1, to do things like accepting License Manager grants
+provider "aws" {
+  region = "us-east-1"
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
+  }
+  alias = "modernisation-platform-environments-us-east-1"
+}
+
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
   alias  = "modernisation-platform"
   region = "eu-west-2"
+}
+
+# AWS provider for the Modernisation Platform for us-east-1, to do things like License Manager grants
+provider "aws" {
+  alias  = "modernisation-platform-us-east-1"
+  region = "us-east-1"
 }

--- a/terraform/modules/license-manager/main.tf
+++ b/terraform/modules/license-manager/main.tf
@@ -1,8 +1,8 @@
-data "aws_licensemanager_grants" "main" {
+data "aws_licensemanager_received_licenses" "main" {
   provider = aws.modernisation-platform-account
   filter {
-    name   = "LicenseArn"
-    values = [var.source_license_arn]
+    name = "ProductSKU"
+    values = [var.source_license_sku]
   }
 }
 
@@ -10,7 +10,7 @@ resource "aws_licensemanager_grant" "main" {
   provider           = aws.modernisation-platform-account
   name               = format("%s-%d", var.destination_grant_name, var.account_to_grant)
   allowed_operations = var.destination_grant_allowed_options
-  license_arn        = data.aws_licensemanager_grants.main.arns[0]
+  license_arn        = data.aws_licensemanager_received_licenses.main.arns[0]
   principal          = format("arn:aws:iam::%d:root", var.account_to_grant)
 }
 

--- a/terraform/modules/license-manager/variables.tf
+++ b/terraform/modules/license-manager/variables.tf
@@ -10,7 +10,6 @@ variable "destination_grant_allowed_options" {
     "CheckInLicense",
     "CheckoutLicense",
     "ExtendConsumptionLicense",
-    "CreateGrant",
     "CreateToken"
   ]
   type = list(string)

--- a/terraform/modules/license-manager/variables.tf
+++ b/terraform/modules/license-manager/variables.tf
@@ -20,13 +20,7 @@ variable "destination_grant_name" {
   type = string
 }
 
-variable "source_license_arn" {
-  description = "ARN of source license - eg. \"arn:aws:license-manager::$account-id:license:$license-id\"."
-  type        = string
-}
-
-variable "source_grant_home_region" {
-  description = "Home AWS region of source grant - eg. \"us-east-1\"."
-  default     = "us-east-1"
+variable "source_license_sku" {
+  description = "SKU of source license visible through CLI tools query"
   type        = string
 }


### PR DESCRIPTION
* Trim default allowed grant operations
* Add new providers for `us-east-1`
* Supply new providers into module
* Update data call to correct from `grant` to `license`