### PR TITLE
Add Airflow permissions to MemberInfrastructureAccess

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -27,6 +27,7 @@ data "aws_iam_policy_document" "member-access" {
     actions = [
       "acm-pca:*",
       "acm:*",
+      "airflow:*",
       "apigateway:*",
       "application-autoscaling:*",
       "applicationinsights:*",


### PR DESCRIPTION
We're deploying Airflow to our Apps and Tools account in Data Platform, but we get the following error

```bash
╷
│ Error: creating MWAA Environment (development): AccessDeniedException: User: arn:aws:sts::***:assumed-role/MemberInfrastructureAccess/aws-go-sdk-1685711006413181890 is not authorized to perform: airflow:TagResource on resource: arn:aws:airflow:eu-west-2:***:environment/development
│ 
│   with aws_mwaa_environment.main,
│   on mwaa-environments.tf line 5, in resource "aws_mwaa_environment" "main":
│    5: resource "aws_mwaa_environment" "main" {
│ 
╵
```

This pull request adds `airflow:*`

Relates to https://github.com/ministryofjustice/modernisation-platform-environments/pull/2402