### PR TITLE
Switch to quiet and add workflow dispatch for SCA

### DIFF
--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -2,6 +2,7 @@ name: Secure Code Analysis
 on:
   schedule:
     - cron: '35 1 * * *'
+  workflow_dispatch:
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 permissions:
@@ -84,6 +85,7 @@ jobs:
           framework: terraform
           output_file_path: ./checkov.sarif
           output_format: sarif
+          quiet: true
           skip_check: CKV_GIT_1,CKV_AWS_126,CKV2_AWS_38,CKV2_AWS_39
       - name: Upload SARIF file
         if: success() || failure()


### PR DESCRIPTION
Currently to find the errors you need to scroll through all the successful checks, switching to quiet mode will only show the failed checks.

Also adding a workflow dispatch trigger so that this workflow can be manually be run following corrections.