### PR TITLE
Remove reference to business unit for core-network-services

### DIFF
--- a/terraform/environments/core-network-services/data.tf
+++ b/terraform/environments/core-network-services/data.tf
@@ -19,5 +19,5 @@ data "aws_route" "live_data" {
 }
 
 data "aws_kms_key" "general_shared" {
-  key_id = "arn:aws:kms:eu-west-2:${local.environment_management.account_ids["core-shared-services-production"]}:alias/general-${var.networking[0].business-unit}"
+  key_id = "arn:aws:kms:eu-west-2:${local.environment_management.account_ids["core-shared-services-production"]}:alias/general-platforms"
 }

--- a/terraform/environments/core-network-services/networking.auto.tfvars.json
+++ b/terraform/environments/core-network-services/networking.auto.tfvars.json
@@ -1,7 +1,7 @@
 {
   "networking": [
     {
-      "business-unit": "platforms",
+      "business-unit": "",
       "set": "",
       "application": "core-network-services"
     }


### PR DESCRIPTION
With the reference to `platforms` in the networking.auto.tfvars.json, we find that our new member environment workflow tries to remove this value. If we choose to investigate this, we'll do so as part of a bug ticket that considers the root cause in a wider context.
With the removal of the reference, there's also a slight change to a data call for a KMS key which is taken into account here.