### PR TITLE
Allow SMTP Submission traffic to CJSM

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/inline_fqdn_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/inline_fqdn_rules.json
@@ -8,6 +8,7 @@
     "wustat.windows.com",
     "ntservicepack.microsoft.com",
     "stats.microsoft.com",
-    "saas40.kaseya.net"
+    "saas40.kaseya.net",
+    "cjsm.net"
   ]
 }

--- a/terraform/environments/core-network-services/firewall-rules/inline_fqdn_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/inline_fqdn_rules.json
@@ -9,6 +9,6 @@
     "ntservicepack.microsoft.com",
     "stats.microsoft.com",
     "saas40.kaseya.net",
-    "cjsm.net"
+    ".cjsm.net"
   ]
 }

--- a/terraform/environments/core-network-services/firewall-rules/inline_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/inline_rules.json
@@ -34,14 +34,14 @@
     "destination_port": "80",
     "protocol": "TCP"
   },
-  "hmpps_preprod_to_internet_smtp_submission": {
+  "hmpps_preprod_to_internet_monitoring": {
     "action": "PASS",
     "source_ip": "${hmpps-preproduction}",
     "destination_ip": "0.0.0.0/0",
     "destination_port": "5721",
     "protocol": "TCP"
   },
-  "hmpps_prod_to_internet_smtp_submission": {
+  "hmpps_prod_to_internet_monitoring": {
     "action": "PASS",
     "source_ip": "${hmpps-production}",
     "destination_ip": "0.0.0.0/0",
@@ -62,14 +62,14 @@
     "destination_port": "587",
     "protocol": "TCP"
   },
-  "hmpps_development_to_internet_smtp_submission": {
+  "hmpps_development_to_internet_monitoring": {
     "action": "PASS",
     "source_ip": "${hmpps-development}",
     "destination_ip": "0.0.0.0/0",
     "destination_port": "5721",
     "protocol": "TCP"
   },
-  "hmpps_test_to_internet_smtp_submission": {
+  "hmpps_test_to_internet_monitoring": {
     "action": "PASS",
     "source_ip": "${hmpps-test}",
     "destination_ip": "0.0.0.0/0",

--- a/terraform/environments/core-network-services/firewall-rules/inline_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/inline_rules.json
@@ -20,6 +20,13 @@
     "destination_port": "443",
     "protocol": "TCP"
   },
+  "mp_dev_test_to_internet_smtp_submission": {
+    "action": "PASS",
+    "source_ip": "${mp-development-test}",
+    "destination_ip": "0.0.0.0/0",
+    "destination_port": "587",
+    "protocol": "TCP"
+  },
   "mp_preprod_prod_to_internet_http": {
     "action": "PASS",
     "source_ip": "${mp-preproduction-production}",
@@ -27,11 +34,46 @@
     "destination_port": "80",
     "protocol": "TCP"
   },
+  "hmpps_preprod_to_internet_smtp_submission": {
+    "action": "PASS",
+    "source_ip": "${hmpps-preproduction}",
+    "destination_ip": "0.0.0.0/0",
+    "destination_port": "5721",
+    "protocol": "TCP"
+  },
+  "hmpps_prod_to_internet_smtp_submission": {
+    "action": "PASS",
+    "source_ip": "${hmpps-production}",
+    "destination_ip": "0.0.0.0/0",
+    "destination_port": "5721",
+    "protocol": "TCP"
+  },
   "mp_preprod_prod_to_internet_https": {
     "action": "PASS",
     "source_ip": "${mp-preproduction-production}",
     "destination_ip": "0.0.0.0/0",
     "destination_port": "443",
+    "protocol": "TCP"
+  },
+  "mp_preprod_prod_to_internet_smtp_submission": {
+    "action": "PASS",
+    "source_ip": "${mp-preproduction-production}",
+    "destination_ip": "0.0.0.0/0",
+    "destination_port": "587",
+    "protocol": "TCP"
+  },
+  "hmpps_development_to_internet_smtp_submission": {
+    "action": "PASS",
+    "source_ip": "${hmpps-development}",
+    "destination_ip": "0.0.0.0/0",
+    "destination_port": "5721",
+    "protocol": "TCP"
+  },
+  "hmpps_test_to_internet_smtp_submission": {
+    "action": "PASS",
+    "source_ip": "${hmpps-test}",
+    "destination_ip": "0.0.0.0/0",
+    "destination_port": "5721",
     "protocol": "TCP"
   }
 }

--- a/terraform/modules/firewall-policy/main.tf
+++ b/terraform/modules/firewall-policy/main.tf
@@ -88,7 +88,7 @@ resource "aws_networkfirewall_rule_group" "fqdn-stateful" {
     rules_source {
       rules_source_list {
         generated_rules_type = "ALLOWLIST"
-        target_types         = ["HTTP_HOST"]
+        target_types         = ["HTTP_HOST", "TLS_SNI"]
         targets              = var.fw_allowed_domains
       }
     }

--- a/terraform/modules/vpc-nacls/data.tf
+++ b/terraform/modules/vpc-nacls/data.tf
@@ -45,11 +45,7 @@ locals {
   # 2000 = inter-vpc traffic (dynamic rules)
   # 3000 = deny east-west
   # 4000 = private address ranges
-  # 5000 = https internet access
-  # 5100 = http internet access
-  # 5200 = tcp internet access on dynamic ports
-  # 5300 = udp saas third party monitor agent
-  # 5400 = tcp saas third party monitor agent
+  # 5000 = internet access
   # 6000 = public address ranges (dynamic)
   # 7000 = access from internet
 
@@ -162,23 +158,14 @@ locals {
       rule_number = 5100
       to_port     = 80
     },
-    allow_0-0-0-0_dynamic_tcp_in = {
+    allow_0-0-0-0_smtp_submission_out = {
       cidr_block  = "0.0.0.0/0"
-      egress      = false
-      from_port   = 1024
+      egress      = true
+      from_port   = 587
       protocol    = "tcp"
       rule_action = "allow"
       rule_number = 5200
-      to_port     = 65535
-    },
-    allow_0-0-0-0_agent_udp_out = {
-      cidr_block  = "0.0.0.0/0"
-      egress      = true
-      from_port   = 5721
-      protocol    = "udp"
-      rule_action = "allow"
-      rule_number = 5300
-      to_port     = 5721
+      to_port     = 587
     },
     allow_0-0-0-0_agent_tcp_out = {
       cidr_block  = "0.0.0.0/0"
@@ -186,8 +173,17 @@ locals {
       from_port   = 5721
       protocol    = "tcp"
       rule_action = "allow"
-      rule_number = 5400
+      rule_number = 5300
       to_port     = 5721
+    },
+    allow_0-0-0-0_dynamic_tcp_in = {
+      cidr_block  = "0.0.0.0/0"
+      egress      = false
+      from_port   = 1024
+      protocol    = "tcp"
+      rule_action = "allow"
+      rule_number = 5400
+      to_port     = 65535
     }
   }
 


### PR DESCRIPTION
This PR should amend network ACLs, network firewall rules, and allowed inspected destinations to permit SMTP Submission traffic on `tcp/587` to the `cjsm.net` domain