### PR TITLE
IAPS: set up production alerts

### DIFF
--- a/terraform/pagerduty/aws.tf
+++ b/terraform/pagerduty/aws.tf
@@ -29,6 +29,7 @@ resource "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {
     laa_oas_prod_alarms          = pagerduty_service_integration.laa_oas_prod_cloudwatch.integration_key,
     jitbit_nonprod_alarms        = pagerduty_service_integration.jitbit_nonprod_cloudwatch.integration_key,
     iaps_nonprod_alarms          = pagerduty_service_integration.iaps_nonprod_cloudwatch.integration_key,
+    iaps_prod_alarms             = pagerduty_service_integration.iaps_prod_cloudwatch.integration_key,
     laa_mojfin_prod_alarms       = pagerduty_service_integration.laa_mojfin_prod_cloudwatch.integration_key,
     hmpps_shef_dba_high_priority = pagerduty_service_integration.hmpps_shef_dba_high_priority.integration_key,
     hmpps_shef_dba_low_priority  = pagerduty_service_integration.hmpps_shef_dba_low_priority.integration_key,

--- a/terraform/pagerduty/member-services-integrations.tf
+++ b/terraform/pagerduty/member-services-integrations.tf
@@ -182,7 +182,7 @@ resource "pagerduty_service_integration" "jitbit_nonprod_cloudwatch" {
   vendor  = data.pagerduty_vendor.cloudwatch.id
 }
 
-# # Slack channel: # TBC
+# Slack channel: #hmpps-iaps-alerts-non-prod
 
 resource "pagerduty_service" "iaps_nonprod" {
   name                    = "Delius IAPS Non Prod"
@@ -196,6 +196,23 @@ resource "pagerduty_service" "iaps_nonprod" {
 resource "pagerduty_service_integration" "iaps_nonprod_cloudwatch" {
   name    = data.pagerduty_vendor.cloudwatch.name
   service = pagerduty_service.iaps_nonprod.id
+  vendor  = data.pagerduty_vendor.cloudwatch.id
+}
+
+# Slack channel: #hmpps-iaps-alerts-prod
+
+resource "pagerduty_service" "iaps_prod" {
+  name                    = "Delius IAPS Prod"
+  description             = "Delius IAPS Prod Alarms"
+  auto_resolve_timeout    = 345600
+  acknowledgement_timeout = "null"
+  escalation_policy       = pagerduty_escalation_policy.member_policy.id
+  alert_creation          = "create_alerts_and_incidents"
+}
+
+resource "pagerduty_service_integration" "iaps_prod_cloudwatch" {
+  name    = data.pagerduty_vendor.cloudwatch.name
+  service = pagerduty_service.iaps_prod.id
   vendor  = data.pagerduty_vendor.cloudwatch.id
 }
 


### PR DESCRIPTION
We don't have access to PagerDuty. Could you please handle [this step](https://user-guide.modernisation-platform.service.justice.gov.uk/user-guide/integrating-alarms-with-pagerduty-with-slack.html#4-link-the-pagerduty-service-to-your-slack-channel) for us.