### PR TITLE
Remove SMTP Submission changes

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/inline_fqdn_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/inline_fqdn_rules.json
@@ -8,7 +8,6 @@
     "wustat.windows.com",
     "ntservicepack.microsoft.com",
     "stats.microsoft.com",
-    "saas40.kaseya.net",
-    ".cjsm.net"
+    "saas40.kaseya.net"
   ]
 }

--- a/terraform/environments/core-network-services/firewall-rules/inline_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/inline_rules.json
@@ -6,13 +6,6 @@
     "destination_port": "443",
     "protocol": "TCP"
   },
-  "mp_dev_test_to_internet_http": {
-    "action": "PASS",
-    "source_ip": "${mp-development-test}",
-    "destination_ip": "0.0.0.0/0",
-    "destination_port": "80",
-    "protocol": "TCP"
-  },
   "mp_dev_test_to_internet_https": {
     "action": "PASS",
     "source_ip": "${mp-development-test}",
@@ -20,11 +13,11 @@
     "destination_port": "443",
     "protocol": "TCP"
   },
-  "mp_dev_test_to_internet_smtp_submission": {
+  "mp_dev_test_to_internet_http": {
     "action": "PASS",
     "source_ip": "${mp-development-test}",
     "destination_ip": "0.0.0.0/0",
-    "destination_port": "587",
+    "destination_port": "80",
     "protocol": "TCP"
   },
   "mp_preprod_prod_to_internet_http": {
@@ -34,32 +27,11 @@
     "destination_port": "80",
     "protocol": "TCP"
   },
-  "hmpps_preprod_to_internet_monitoring": {
-    "action": "PASS",
-    "source_ip": "${hmpps-preproduction}",
-    "destination_ip": "0.0.0.0/0",
-    "destination_port": "5721",
-    "protocol": "TCP"
-  },
-  "hmpps_prod_to_internet_monitoring": {
-    "action": "PASS",
-    "source_ip": "${hmpps-production}",
-    "destination_ip": "0.0.0.0/0",
-    "destination_port": "5721",
-    "protocol": "TCP"
-  },
   "mp_preprod_prod_to_internet_https": {
     "action": "PASS",
     "source_ip": "${mp-preproduction-production}",
     "destination_ip": "0.0.0.0/0",
     "destination_port": "443",
-    "protocol": "TCP"
-  },
-  "mp_preprod_prod_to_internet_smtp_submission": {
-    "action": "PASS",
-    "source_ip": "${mp-preproduction-production}",
-    "destination_ip": "0.0.0.0/0",
-    "destination_port": "587",
     "protocol": "TCP"
   },
   "hmpps_development_to_internet_monitoring": {
@@ -72,6 +44,20 @@
   "hmpps_test_to_internet_monitoring": {
     "action": "PASS",
     "source_ip": "${hmpps-test}",
+    "destination_ip": "0.0.0.0/0",
+    "destination_port": "5721",
+    "protocol": "TCP"
+  },
+  "hmpps_preprod_to_internet_monitoring": {
+    "action": "PASS",
+    "source_ip": "${hmpps-preproduction}",
+    "destination_ip": "0.0.0.0/0",
+    "destination_port": "5721",
+    "protocol": "TCP"
+  },
+  "hmpps_prod_to_internet_monitoring": {
+    "action": "PASS",
+    "source_ip": "${hmpps-production}",
     "destination_ip": "0.0.0.0/0",
     "destination_port": "5721",
     "protocol": "TCP"

--- a/terraform/environments/core-network-services/firewall-rules/inline_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/inline_rules.json
@@ -6,18 +6,18 @@
     "destination_port": "443",
     "protocol": "TCP"
   },
-  "mp_dev_test_to_internet_https": {
-    "action": "PASS",
-    "source_ip": "${mp-development-test}",
-    "destination_ip": "0.0.0.0/0",
-    "destination_port": "443",
-    "protocol": "TCP"
-  },
   "mp_dev_test_to_internet_http": {
     "action": "PASS",
     "source_ip": "${mp-development-test}",
     "destination_ip": "0.0.0.0/0",
     "destination_port": "80",
+    "protocol": "TCP"
+  },
+  "mp_dev_test_to_internet_https": {
+    "action": "PASS",
+    "source_ip": "${mp-development-test}",
+    "destination_ip": "0.0.0.0/0",
+    "destination_port": "443",
     "protocol": "TCP"
   },
   "mp_preprod_prod_to_internet_http": {

--- a/terraform/modules/vpc-nacls/data.tf
+++ b/terraform/modules/vpc-nacls/data.tf
@@ -158,22 +158,13 @@ locals {
       rule_number = 5100
       to_port     = 80
     },
-    allow_0-0-0-0_smtp_submission_out = {
-      cidr_block  = "0.0.0.0/0"
-      egress      = true
-      from_port   = 587
-      protocol    = "tcp"
-      rule_action = "allow"
-      rule_number = 5200
-      to_port     = 587
-    },
     allow_0-0-0-0_agent_tcp_out = {
       cidr_block  = "0.0.0.0/0"
       egress      = true
       from_port   = 5721
       protocol    = "tcp"
       rule_action = "allow"
-      rule_number = 5300
+      rule_number = 5200
       to_port     = 5721
     },
     allow_0-0-0-0_dynamic_tcp_in = {
@@ -182,7 +173,7 @@ locals {
       from_port   = 1024
       protocol    = "tcp"
       rule_action = "allow"
-      rule_number = 5400
+      rule_number = 5300
       to_port     = 65535
     }
   }


### PR DESCRIPTION
After further discussion with the PPUD migration team the changes to allow hosts in private subnets to send SMTP Submission traffic out to the internet is no longer needed. This PR removes those changes, and re-orders the firewall rules for readability.