### PR TITLE
Adding extra permissions to create logs

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -260,7 +260,7 @@ data "aws_iam_policy_document" "member-access-us-east" {
     #checkov:skip=CKV_AWS_356: Needs to access multiple resources
     effect    = "Allow"
     actions   = ["acm:*",
-      "log:*"
+      "logs:*"
     ]
     resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
   }

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -259,7 +259,9 @@ data "aws_iam_policy_document" "member-access-us-east" {
     #checkov:skip=CKV2_AWS_40
     #checkov:skip=CKV_AWS_356: Needs to access multiple resources
     effect    = "Allow"
-    actions   = ["acm:*"]
+    actions   = ["acm:*",
+      "log:*"
+    ]
     resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
   }
   statement {


### PR DESCRIPTION
As part of [Allow Route53 query logging in cloudwatch#3926](https://github.com/ministryofjustice/modernisation-platform/issues/3926) users needed the ability to create logs for route53 tracking this pr expands on an existing role that has been assigned to the nomis team to include the ability to create logs in the us-east-1 region 