### PR TITLE
Remove 6DG vpns

### DIFF
--- a/terraform/environments/core-network-services/vpn.tf
+++ b/terraform/environments/core-network-services/vpn.tf
@@ -94,34 +94,6 @@ resource "aws_ec2_transit_gateway_route" "noms_live_routes" {
   transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.external_inspection_out.id
 }
 
-resource "aws_ec2_transit_gateway_route" "sixdg_dev_routes" {
-  for_each                       = toset(local.sixdg_dev_vpn_static_routes)
-  destination_cidr_block         = each.key
-  transit_gateway_attachment_id  = aws_vpn_connection.this["sixdegrees_development"].transit_gateway_attachment_id
-  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.external_inspection_out.id
-}
-
-resource "aws_ec2_transit_gateway_route" "sixdg_uat_routes" {
-  for_each                       = toset(local.sixdg_uat_vpn_static_routes)
-  destination_cidr_block         = each.key
-  transit_gateway_attachment_id  = aws_vpn_connection.this["sixdegrees_uat"].transit_gateway_attachment_id
-  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.external_inspection_out.id
-}
-
-resource "aws_ec2_transit_gateway_route" "sixdg_stage_routes" {
-  for_each                       = toset(local.sixdg_stage_vpn_static_routes)
-  destination_cidr_block         = each.key
-  transit_gateway_attachment_id  = aws_vpn_connection.this["sixdegrees_stage"].transit_gateway_attachment_id
-  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.external_inspection_out.id
-}
-
-resource "aws_ec2_transit_gateway_route" "sixdg_prod_routes" {
-  for_each                       = toset(local.sixdg_prod_vpn_static_routes)
-  destination_cidr_block         = each.key
-  transit_gateway_attachment_id  = aws_vpn_connection.this["sixdegrees_prod"].transit_gateway_attachment_id
-  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.external_inspection_out.id
-}
-
 resource "aws_ec2_transit_gateway_route" "parole_board_routes" {
   for_each                       = toset(local.parole_board_vpn_static_routes)
   destination_cidr_block         = each.key

--- a/terraform/environments/core-network-services/vpn_attachments.json
+++ b/terraform/environments/core-network-services/vpn_attachments.json
@@ -1,40 +1,4 @@
 {
-  "sixdegrees_development": {
-    "customer_gateway_ip": "31.210.246.15",
-    "bgp_asn": "31220",
-    "modernisation_platform_vpc": "laa-development",
-    "dx_gateway_id": "",
-    "dx_gateway_owner_account_id": "",
-    "static_routes_only": true,
-    "tunnel_startup_action": "start"
-  },
-  "sixdegrees_uat": {
-    "customer_gateway_ip": "80.79.133.20",
-    "bgp_asn": "6908",
-    "modernisation_platform_vpc": "laa-test",
-    "dx_gateway_id": "",
-    "dx_gateway_owner_account_id": "",
-    "static_routes_only": true,
-    "tunnel_startup_action": "start"
-  },
-  "sixdegrees_stage": {
-    "customer_gateway_ip": "82.147.30.124",
-    "bgp_asn": "6908",
-    "modernisation_platform_vpc": "laa-preproduction",
-    "dx_gateway_id": "",
-    "dx_gateway_owner_account_id": "",
-    "static_routes_only": true,
-    "tunnel_startup_action": "start"
-  },
-  "sixdegrees_prod": {
-    "customer_gateway_ip": "82.147.39.116",
-    "bgp_asn": "6908",
-    "modernisation_platform_vpc": "laa-production",
-    "dx_gateway_id": "",
-    "dx_gateway_owner_account_id": "",
-    "static_routes_only": true,
-    "tunnel_startup_action": "start"
-  },
   "NOMS-Transit-Live-DR-VPN-VNG_1": {
     "bgp_asn": "64532",
     "customer_gateway_ip": "51.11.165.198",


### PR DESCRIPTION
Following the migration of CCMS-EBS to the Modernisation Platform, our VPN connections to Six Degrees are no longer required and can be removed. We've confirmed this with the migration team [here](https://mojdt.slack.com/archives/C04EZ78B6US/p1686063147217849).