### PR TITLE
Securing the NACLs rules

### DIFF
--- a/terraform/modules/vpc-hub/main.tf
+++ b/terraform/modules/vpc-hub/main.tf
@@ -60,8 +60,12 @@ locals {
 
   # NACLs
   nacl_rules = [
-    { egress = false, action = "allow", protocol = -1, from_port = 0, to_port = 0, rule_num = 910, cidr = "0.0.0.0/0" },
-    { egress = true, action = "allow", protocol = -1, from_port = 0, to_port = 0, rule_num = 910, cidr = "0.0.0.0/0" }
+    { egress = false, action = "allow", protocol = -1, from_port = 80, to_port = 80, rule_num = 910, cidr = "0.0.0.0/0" },
+    { egress = false, action = "allow", protocol = -1, from_port = 443, to_port = 443, rule_num = 920, cidr = "0.0.0.0/0" },
+    { egress = false, action = "allow", protocol = -1, from_port = 1024, to_port = 65535, rule_num = 930, cidr = "0.0.0.0/0" },
+    { egress = true, action = "allow", protocol = -1, from_port = 80, to_port = 80, rule_num = 910, cidr = "0.0.0.0/0" },
+    { egress = true, action = "allow", protocol = -1, from_port = 443, to_port = 443, rule_num = 920, cidr = "0.0.0.0/0" },
+    { egress = true, action = "allow", protocol = -1, from_port = 1024, to_port = 65535, rule_num = 930, cidr = "0.0.0.0/0" }
   ]
 
   # NACL rules with keys
@@ -75,8 +79,12 @@ locals {
     { egress = false, action = "allow", protocol = -1, from_port = 0, to_port = 0, rule_num = 520, cidr = "172.16.0.0/12" },
     { egress = false, action = "allow", protocol = -1, from_port = 0, to_port = 0, rule_num = 530, cidr = "192.168.0.0/16" },
     { egress = true, action = "allow", protocol = -1, from_port = 0, to_port = 0, rule_num = 510, cidr = "10.0.0.0/8" },
-    { egress = true, action = "allow", protocol = -1, from_port = 0, to_port = 0, rule_num = 520, cidr = "172.16.0.0/12" },
-    { egress = true, action = "allow", protocol = -1, from_port = 0, to_port = 0, rule_num = 530, cidr = "192.168.0.0/16" },
+    { egress = true, action = "allow", protocol = -1, from_port = 80, to_port = 80, rule_num = 520, cidr = "172.16.0.0/12" },
+    { egress = true, action = "allow", protocol = -1, from_port = 443, to_port = 443, rule_num = 530, cidr = "172.16.0.0/12" },
+    { egress = true, action = "allow", protocol = -1, from_port = 1024, to_port = 65535, rule_num = 540, cidr = "172.16.0.0/12" },
+    { egress = true, action = "allow", protocol = -1, from_port = 80, to_port = 80, rule_num = 550, cidr = "192.168.0.0/16" },
+    { egress = true, action = "allow", protocol = -1, from_port = 443, to_port = 443, rule_num = 560, cidr = "192.168.0.0/16" },
+    { egress = true, action = "allow", protocol = -1, from_port = 1024, to_port = 65535, rule_num = 570, cidr = "192.168.0.0/16" },
     { egress = false, action = "allow", protocol = 6, from_port = 1024, to_port = 65535, rule_num = 910, cidr = "0.0.0.0/0" },
     { egress = true, action = "allow", protocol = 6, from_port = 443, to_port = 443, rule_num = 910, cidr = "0.0.0.0/0" }
   ]


### PR DESCRIPTION
This PR is part of the https://github.com/ministryofjustice/modernisation-platform/issues/3951 ticket.

NACLs have quota of max 20 rules.

There are currently 10 rules in total in NACLs that are used with private/data subnets: 
[L73](https://github.com/ministryofjustice/modernisation-platform/blob/31db3faa5328cb3340480748a4bf46a7bae19e06/terraform/modules/vpc-hub/main.tf#L73), [L349](https://github.com/ministryofjustice/modernisation-platform/blob/31db3faa5328cb3340480748a4bf46a7bae19e06/terraform/modules/vpc-hub/main.tf#L349), [L363](https://github.com/ministryofjustice/modernisation-platform/blob/31db3faa5328cb3340480748a4bf46a7bae19e06/terraform/modules/vpc-hub/main.tf#L363), [L374](https://github.com/ministryofjustice/modernisation-platform/blob/31db3faa5328cb3340480748a4bf46a7bae19e06/terraform/modules/vpc-hub/main.tf#L374) 

and there are 4 rules in total in NACLs that are used with public/transit subnets:
[L62](https://github.com/ministryofjustice/modernisation-platform/blob/31db3faa5328cb3340480748a4bf46a7bae19e06/terraform/modules/vpc-hub/main.tf#L62),
([L230](https://github.com/ministryofjustice/modernisation-platform/blob/31db3faa5328cb3340480748a4bf46a7bae19e06/terraform/modules/vpc-hub/main.tf#L230),
[L245](https://github.com/ministryofjustice/modernisation-platform/blob/31db3faa5328cb3340480748a4bf46a7bae19e06/terraform/modules/vpc-hub/main.tf#L245),
[L256](https://github.com/ministryofjustice/modernisation-platform/blob/31db3faa5328cb3340480748a4bf46a7bae19e06/terraform/modules/vpc-hub/main.tf#L256),



In order to restrict them further, we can break down the current rules that are open to all ports to limit them to 80, 443 and 1024 - 65535. However, because we are limited to a number of 20 rules. It is only possible to refactor some of them.

The question is, is it worth it?

Also, feel free to double check the amount of rules.