### PR TITLE
Only run slack failure when on main

### DIFF
--- a/.github/workflows/terraform-github.yml
+++ b/.github/workflows/terraform-github.yml
@@ -73,7 +73,7 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-        if: ${{ failure() }}
+        if: ${{ failure() }} && github.event.ref == 'refs/heads/main'
 
   create-github-environments:
       runs-on: ubuntu-latest


### PR DESCRIPTION
This was running for PRs as well which we don't need to know about via slack.  Now we will only get alerted if it fails when merging.