### PR TITLE
Remove jitbit migration test zone

### DIFF
--- a/terraform/environments/core-network-services/route53.tf
+++ b/terraform/environments/core-network-services/route53.tf
@@ -5,7 +5,6 @@ locals {
   application-zones = {
     equip    = "equip.service.justice.gov.uk",
     ccms-ebs = "ccms-ebs.service.justice.gov.uk",
-    jitbit   = "jitbit.dev.cr.probation.service.justice.gov.uk",
     mlra     = "maat-libra-administration-tool.service.justice.gov.uk",
     mojfin   = "laa-finance-data.service.justice.gov.uk",
     tipstaff = "tipstaff.service.justice.gov.uk"


### PR DESCRIPTION
In line with [this request](https://mojdt.slack.com/archives/C01A7QK5VM1/p1686580443588189?thread_ts=1685458203.323369&cid=C01A7QK5VM1), this PR removes the now unneeded `jitbit.dev.cr.probation.service.justice.gov.uk` hosted zone.