### PR TITLE
LAA appstream rules

### DIFF
--- a/terraform/environments/core-network-services/cidr-ranges.tf
+++ b/terraform/environments/core-network-services/cidr-ranges.tf
@@ -53,6 +53,7 @@ locals {
     laa-lz-production              = "10.205.0.0/20"
     laa-lz-shared-services-nonprod = "10.200.0.0/20"
     laa-lz-shared-services-prod    = "10.200.16.0/20"
+    laa-appstream-subnets          = "10.200.32.0/23"
 
   }
 

--- a/terraform/environments/core-network-services/firewall-rules/production_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/production_rules.json
@@ -125,7 +125,7 @@
     "destination_port": "9100",
     "protocol": "TCP"
   },
-  "psn_to_mp_hmpps_preproduction_https": {
+  "psn_to_mp_hmpps_production_https": {
     "action": "PASS",
     "source_ip": "${psn}",
     "destination_ip": "${hmpps-production}",
@@ -209,14 +209,7 @@
     "destination_port": "443",
     "protocol": "TCP"
   },
-  "cp_to_hmpps_preproduction_https": {
-    "action": "PASS",
-    "source_ip": "${cloud-platform}",
-    "destination_ip": "${hmpps-preproduction}",
-    "destination_port": "443",
-    "protocol": "TCP"
-  },
-  "laa-appstream_to_laa_production": {
+  "laa-appstream_to_mp_laa_production": {
     "action": "PASS",
     "source_ip": "${laa-appstream-subnets}",
     "destination_ip": "${laa-production}",

--- a/terraform/environments/core-network-services/firewall-rules/production_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/production_rules.json
@@ -215,5 +215,12 @@
     "destination_ip": "${hmpps-preproduction}",
     "destination_port": "443",
     "protocol": "TCP"
+  },
+  "laa-appstream_to_laa_production": {
+    "action": "PASS",
+    "source_ip": "${laa-appstream-subnets}",
+    "destination_ip": "${laa-production}",
+    "destination_port": "ANY",
+    "protocol": "TCP"
   }
 }


### PR DESCRIPTION
In response to [this request](https://mojdt.slack.com/archives/C01A7QK5VM1/p1686649139459569), this adds a firewall rule allowing traffic from LAA AppStream subnets into the LAA Production VPC.

This also removes a rule from `production.json` that refers to preproduction, that also appears in the preproduction rules and also cleans up an incorrect name.