### PR TITLE
LAA shared services firewall rules

### DIFF
--- a/terraform/environments/core-network-services/cidr-ranges.tf
+++ b/terraform/environments/core-network-services/cidr-ranges.tf
@@ -53,7 +53,6 @@ locals {
     laa-lz-production              = "10.205.0.0/20"
     laa-lz-shared-services-nonprod = "10.200.0.0/20"
     laa-lz-shared-services-prod    = "10.200.16.0/20"
-    laa-appstream-subnets          = "10.200.32.0/23"
     laa-appstream-vpc              = "10.200.32.0/19"
     laa-appstream-vpc_additional   = "10.200.68.0/22"
 

--- a/terraform/environments/core-network-services/cidr-ranges.tf
+++ b/terraform/environments/core-network-services/cidr-ranges.tf
@@ -54,6 +54,8 @@ locals {
     laa-lz-shared-services-nonprod = "10.200.0.0/20"
     laa-lz-shared-services-prod    = "10.200.16.0/20"
     laa-appstream-subnets          = "10.200.32.0/23"
+    laa-appstream-vpc              = "10.200.32.0/19"
+    laa-appstream-vpc_additional   = "10.200.68.0/22"
 
   }
 

--- a/terraform/environments/core-network-services/firewall-rules/development_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/development_rules.json
@@ -138,5 +138,19 @@
     "destination_ip": "${noms-mgmt-vnet}",
     "destination_port": "53",
     "protocol": "UDP"
+  },
+  "laa_appstream_to_mp_laa_development": {
+    "action": "PASS",
+    "source_ip": "${laa-appstream-vpc}",
+    "destination_ip": "${laa-development}",
+    "destination_port": "ANY",
+    "protocol": "TCP"
+  },
+  "laa_appstream_additional_to_mp_laa_development": {
+    "action": "PASS",
+    "source_ip": "${laa-appstream-vpc_additional}",
+    "destination_ip": "${laa-development}",
+    "destination_port": "ANY",
+    "protocol": "TCP"
   }
 }

--- a/terraform/environments/core-network-services/firewall-rules/production_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/production_rules.json
@@ -209,9 +209,16 @@
     "destination_port": "443",
     "protocol": "TCP"
   },
-  "laa-appstream_to_mp_laa_production": {
+  "laa_appstream_to_mp_laa_production": {
     "action": "PASS",
-    "source_ip": "${laa-appstream-subnets}",
+    "source_ip": "${laa-appstream-vpc}",
+    "destination_ip": "${laa-production}",
+    "destination_port": "ANY",
+    "protocol": "TCP"
+  },
+  "laa_appstream_additional_to_mp_laa_production": {
+    "action": "PASS",
+    "source_ip": "${laa-appstream-vpc_additional}",
     "destination_ip": "${laa-production}",
     "destination_port": "ANY",
     "protocol": "TCP"


### PR DESCRIPTION
As part of https://github.com/ministryofjustice/modernisation-platform/issues/4211, this introduces rules allowing access from the VPC for LAA Appstream to the LAA development and production VPCs on the Modernisation Platform