### PR TITLE
📌 Downgraded Data Platform Apps and Tools' AWS VPC modules to 4.0.2

### DIFF
--- a/terraform/environments/data-platform-apps-and-tools/vpc-endpoints.tf
+++ b/terraform/environments/data-platform-apps-and-tools/vpc-endpoints.tf
@@ -1,6 +1,6 @@
 module "vpc_endpoints" {
   source  = "terraform-aws-modules/vpc/aws//modules/vpc-endpoints"
-  version = "5.0.0"
+  version = "4.0.2"
 
   vpc_id = module.vpc.vpc_id
 

--- a/terraform/environments/data-platform-apps-and-tools/vpcs.tf
+++ b/terraform/environments/data-platform-apps-and-tools/vpcs.tf
@@ -1,6 +1,6 @@
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "5.0.0"
+  version = "4.0.2"
 
   name            = "${local.application_name}-${local.environment}"
   azs             = slice(data.aws_availability_zones.available.names, 0, 3)


### PR DESCRIPTION
As per the conversation in [#ask-modernisation-platform](https://mojdt.slack.com/archives/C01A7QK5VM1/p1686562058335599), I have downgraded the affected modules to a compatible version.

```bash
$ terraform init -backend=false
Initializing modules...
Downloading registry.terraform.io/terraform-aws-modules/vpc/aws 4.0.2 for vpc...
- vpc in .terraform/modules/vpc
Downloading registry.terraform.io/terraform-aws-modules/vpc/aws 4.0.2 for vpc_endpoints...
- vpc_endpoints in .terraform/modules/vpc_endpoints/modules/vpc-endpoints

Initializing provider plugins...
- Finding hashicorp/aws versions matching ">= 3.29.0, >= 3.47.0, >= 4.0.0, >= 4.35.0, < 5.0.0"...
- Finding hashicorp/http versions matching "~> 3.0"...
- Installing hashicorp/aws v4.67.0...
- Installed hashicorp/aws v4.67.0 (signed by HashiCorp)
- Installing hashicorp/http v3.3.0...
- Installed hashicorp/http v3.3.0 (signed by HashiCorp)

Terraform has created a lock file .terraform.lock.hcl to record the provider
selections it made above. Include this file in your version control repository
so that Terraform can guarantee to make the same selections by default when
you run "terraform init" in the future.

Terraform has been successfully initialized!
``` 