### PR TITLE
Allowing ICMP from CP to platforms-development in FW

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/development_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/development_rules.json
@@ -153,7 +153,7 @@
     "destination_port": "ANY",
     "protocol": "TCP"
   },
-  "cp_to_platforms_development_https": {
+  "cp_to_platforms_development_icmp": {
     "action": "PASS",
     "source_ip": "${cloud-platform}",
     "destination_ip": "${platforms-development}",

--- a/terraform/environments/core-network-services/firewall-rules/development_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/development_rules.json
@@ -153,7 +153,7 @@
     "destination_port": "ANY",
     "protocol": "TCP"
   },
-  "cp_to_platforms_development_icmp": {
+  "cp_to_mp_platforms_development_icmp": {
     "action": "PASS",
     "source_ip": "${cloud-platform}",
     "destination_ip": "${platforms-development}",

--- a/terraform/environments/core-network-services/firewall-rules/development_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/development_rules.json
@@ -152,5 +152,12 @@
     "destination_ip": "${laa-development}",
     "destination_port": "ANY",
     "protocol": "TCP"
+  },
+  "cp_to_platforms_development_https": {
+    "action": "PASS",
+    "source_ip": "${cloud-platform}",
+    "destination_ip": "${platforms-development}",
+    "destination_port": "ANY",
+    "protocol": "ICMP"
   }
 }

--- a/terraform/environments/core-network-services/firewall-rules/production_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/production_rules.json
@@ -222,5 +222,12 @@
     "destination_ip": "${laa-production}",
     "destination_port": "ANY",
     "protocol": "TCP"
+  },
+  "cp_to_mp_hmpps_production_icmp": {
+    "action": "PASS",
+    "source_ip": "${cloud-platform}",
+    "destination_ip": "${hmpps-production}",
+    "destination_port": "ANY",
+    "protocol": "ICMP"
   }
 }


### PR DESCRIPTION
This PR is part of the https://github.com/ministryofjustice/modernisation-platform/issues/3822 ticket.

This is to allow traffic from CP to platforms-development to allow for latency testing between nettest namespace and example-development EC2. This is a permanent change so that future tests can be performed without a need of changes.


This rule has been tested manually and it worked.
