### PR TITLE
allowing kms encryption

### DIFF
--- a/terraform/modules/kms/main.tf
+++ b/terraform/modules/kms/main.tf
@@ -115,6 +115,7 @@ data "aws_iam_policy_document" "kms-general" {
     effect = "Allow"
     actions = [
       "kms:Decrypt",
+      "kms:Encrypt",
       "kms:GenerateDataKey*"
     ]
     resources = ["*"]


### PR DESCRIPTION
User request to allow the use if kms keys to encrypt cloudwatch logs