### PR TITLE
Fix failure notification on PR

### DIFF
--- a/.github/workflows/terraform-pagerduty.yml
+++ b/.github/workflows/terraform-pagerduty.yml
@@ -61,6 +61,7 @@ jobs:
         if: github.event.ref == 'refs/heads/main'
         run: bash scripts/terraform-apply.sh terraform/pagerduty
       - name: Slack failure notification
+        if: ${{ failure() && github.ref == 'refs/heads/main' }}
         uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0
         with:
           payload: |
@@ -68,4 +69,3 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-        if: ${{ failure() }}


### PR DESCRIPTION
Another case of the slack failure notification being send on PR failure rather than a failure on merge.