### PR TITLE
🛂 Allow VpcEndpointService

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -100,6 +100,7 @@ data "aws_iam_policy_document" "member-access" {
       "ec2:*PlacementGroup*",
       "ec2:*IdFormat*",
       "ec2:*Spot*",
+      "ec2:*VpcEndpointService*",
       "ecr-public:*",
       "ecr:*",
       "ecs:*",


### PR DESCRIPTION
While trying to configure MWAA, we see this error ([source](https://github.com/ministryofjustice/modernisation-platform-environments/actions/runs/5310025783/jobs/9611489793))

```bash
│ Error: creating MWAA Environment (development): AccessDeniedException: User does not have permissions to manage VPC endpoints.
│ 
│   with aws_mwaa_environment.main,
│   on mwaa-environments.tf line 5, in resource "aws_mwaa_environment" "main":
│    5: resource "aws_mwaa_environment" "main" {
```

Related CloudTrail entry [e804ddd3-b005-4b62-a751-50bd02d8b521](https://eu-west-2.console.aws.amazon.com/cloudtrail/home?region=eu-west-2#/events/e804ddd3-b005-4b62-a751-50bd02d8b521)

Whilst not strictly MWAA, [this](https://docs.aws.amazon.com/apigateway/latest/developerguide/grant-permissions-to-create-vpclink.html) API Gateway document describes the required actions

---

Update: I have created the infrastructure in one of our member-unrestricted account (https://github.com/ministryofjustice/data-platform/pull/626)

It creates one VPC endpoint for the ENIs it deploys for MWAA, there are no VPC endpoints for other AWS managed services