### PR TITLE
Update to modules and core-* accounts to v5.

### DIFF
--- a/terraform/environments/analytical-platform-data/versions.tf
+++ b/terraform/environments/analytical-platform-data/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = ">= 4.0.0, < 5.0.0"
+      version = "~> 5.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/analytical-platform-management/versions.tf
+++ b/terraform/environments/analytical-platform-management/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = ">= 4.0.0, < 5.0.0"
+      version = "~> 5.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -10,7 +10,7 @@ resource "aws_iam_account_alias" "alias" {
 }
 
 module "cross-account-access" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access?ref=v2.3.0"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access?ref=v3.0.0"
   providers = {
     aws = aws.workspace
   }
@@ -78,7 +78,7 @@ module "shield_response_team_role" {
 # Github OIDC provider
 module "github-oidc" {
   count  = (local.account_data.account-type == "member" && terraform.workspace != "testing-test") ? 1 : 0
-  source = "github.com/ministryofjustice/modernisation-platform-github-oidc-provider?ref=v2.1.0"
+  source = "github.com/ministryofjustice/modernisation-platform-github-oidc-provider?ref=v3.0.0"
   providers = {
     aws = aws.workspace
   }

--- a/terraform/environments/bootstrap/delegate-access/versions.tf
+++ b/terraform/environments/bootstrap/delegate-access/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = ">= 4.0.0, < 5.0.0"
+      version = "~> 5.0"
       source  = "hashicorp/aws"
     }
     tls = {

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -5,7 +5,7 @@ locals {
 
 module "member-access" {
   count                  = local.account_data.account-type == "member" && terraform.workspace != "testing-test" ? 1 : 0
-  source                 = "github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access?ref=v2.3.0"
+  source                 = "github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access?ref=v3.0.0"
   account_id             = local.modernisation_platform_account.id
   additional_trust_roles = [one(data.aws_iam_roles.github_actions_role.arns), one(data.aws_iam_roles.member-sso-admin-access.arns)]
   policy_arn             = aws_iam_policy.member-access[0].id
@@ -244,7 +244,7 @@ resource "aws_iam_role_policy_attachment" "testing_member_infrastructure_access_
 # MemberInfrastructureAccessUSEast
 module "member-access-us-east" {
   count                  = local.account_data.account-type == "member" && terraform.workspace != "testing-test" ? 1 : 0
-  source                 = "github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access?ref=v2.3.0"
+  source                 = "github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access?ref=v3.0.0"
   account_id             = local.modernisation_platform_account.id
   additional_trust_roles = [one(data.aws_iam_roles.github_actions_role.arns), one(data.aws_iam_roles.member-sso-admin-access.arns)]
   policy_arn             = aws_iam_policy.member-access-us-east[0].id

--- a/terraform/environments/bootstrap/member-bootstrap/instance-scheduler.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/instance-scheduler.tf
@@ -2,7 +2,7 @@
 
 module "instance-scheduler-access" {
   count                  = local.account_data.account-type == "member" && terraform.workspace != "testing-test" ? 1 : 0
-  source                 = "github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access?ref=v2.3.0"
+  source                 = "github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access?ref=v3.0.0"
   account_id             = local.environment_management.account_ids["core-shared-services-production"]
   additional_trust_roles = [format("arn:aws:iam::%s:role/InstanceSchedulerLambdaFunctionPolicy", local.environment_management.account_ids["core-shared-services-production"])]
   policy_arn             = aws_iam_policy.instance-scheduler-access[0].id
@@ -60,7 +60,7 @@ resource "aws_iam_policy" "instance-scheduler-access" {
 
 module "testing_instance-scheduler-access" {
   count                  = terraform.workspace == "testing-test" ? 1 : 0
-  source                 = "github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access?ref=v2.3.0"
+  source                 = "github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access?ref=v3.0.0"
   account_id             = local.environment_management.account_ids["core-shared-services-production"]
   additional_trust_roles = [format("arn:aws:iam::%s:role/InstanceSchedulerLambdaFunctionPolicy", local.environment_management.account_ids["core-shared-services-production"]), format("arn:aws:iam::%s:root", local.environment_management.account_ids["testing-test"])]
   policy_arn             = aws_iam_policy.instance-scheduler-access[0].id

--- a/terraform/environments/bootstrap/member-bootstrap/ssm.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/ssm.tf
@@ -1,7 +1,7 @@
 # resources for patching via SSM
 
 module "ssm-cross-account-access" {
-  source                      = "github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access?ref=v2.3.0"
+  source                      = "github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access?ref=v3.0.0"
   account_id                  = local.environment_management.account_ids["core-shared-services-production"]
   policy_arn                  = aws_iam_policy.execution-combined-policy.arn
   role_name                   = "AWS-SSM-AutomationExecutionRole"

--- a/terraform/environments/bootstrap/member-bootstrap/versions.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = ">= 4.0.0, < 5.0.0"
+      version = "~> 5.0"
       source  = "hashicorp/aws"
     }
     tls = {

--- a/terraform/environments/bootstrap/secure-baselines/main.tf
+++ b/terraform/environments/bootstrap/secure-baselines/main.tf
@@ -5,7 +5,7 @@ data "aws_kms_key" "cloudtrail_key" {
 }
 
 module "baselines" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=v4.3.6"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=v5.0.0"
 
   providers = {
     # Default and replication regions

--- a/terraform/environments/bootstrap/secure-baselines/versions.tf
+++ b/terraform/environments/bootstrap/secure-baselines/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = ">= 4.0.0, < 5.0.0"
+      version = "~> 5.0"
       source  = "hashicorp/aws"
     }
   }

--- a/terraform/environments/bootstrap/single-sign-on/versions.tf
+++ b/terraform/environments/bootstrap/single-sign-on/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = ">= 4.0.0, < 5.0.0"
+      version = "~> 5.0"
       source  = "hashicorp/aws"
     }
   }

--- a/terraform/environments/ccms-ebs/versions.tf
+++ b/terraform/environments/ccms-ebs/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = ">= 4.0.0, < 5.0.0"
+      version = "~> 5.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/cooker/versions.tf
+++ b/terraform/environments/cooker/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = ">= 4.0.0, < 5.0.0"
+      version = "~> 5.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/core-logging/athena.tf
+++ b/terraform/environments/core-logging/athena.tf
@@ -10,7 +10,7 @@ data "aws_kms_alias" "environment_management" {
 #S3 Bucket for Athena temp SQL queries 
 
 module "s3-bucket-athena" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=v6.4.0"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=v7.0.0"
   providers = {
     aws.bucket-replication = aws.modernisation-platform-eu-west-1
   }

--- a/terraform/environments/core-logging/s3_logging.tf
+++ b/terraform/environments/core-logging/s3_logging.tf
@@ -164,7 +164,7 @@ module "cloudtrail-s3-replication-role" {
 }
 
 module "s3-bucket-cloudtrail" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=v6.4.0"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=v7.0.0"
   providers = {
     aws.bucket-replication = aws.modernisation-platform-eu-west-1
   }
@@ -297,7 +297,7 @@ module "cloudtrail-s3-logging-replication-role" {
 }
 
 module "s3-bucket-cloudtrail-logging" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=v6.4.0"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=v7.0.0"
   providers = {
     aws.bucket-replication = aws.modernisation-platform-eu-west-1
   }

--- a/terraform/environments/core-logging/versions.tf
+++ b/terraform/environments/core-logging/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = ">= 4.0.0, < 5.0.0"
+      version = "~> 5.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/core-network-services/monitoring.tf
+++ b/terraform/environments/core-network-services/monitoring.tf
@@ -24,7 +24,7 @@ module "pagerduty_route53" {
   depends_on = [
     aws_sns_topic.route53_monitoring
   ]
-  source                    = "github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration?ref=v1.0.0"
+  source                    = "github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration?ref=v2.0.0"
   sns_topics                = [aws_sns_topic.route53_monitoring.name]
   pagerduty_integration_key = local.pagerduty_integration_keys["ddos_cloudwatch"]
 }
@@ -33,7 +33,7 @@ module "pagerduty_transit_gateway_production" {
   depends_on = [
     aws_sns_topic.tgw_monitoring_production
   ]
-  source                    = "github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration?ref=v1.0.0"
+  source                    = "github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration?ref=v2.0.0"
   sns_topics                = [aws_sns_topic.tgw_monitoring_production.name]
   pagerduty_integration_key = local.pagerduty_integration_keys["tgw_cloudwatch"]
 }
@@ -182,7 +182,7 @@ module "pagerduty_networking_general" {
   depends_on = [
     aws_sns_topic.networking_general
   ]
-  source                    = "github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration?ref=v1.0.0"
+  source                    = "github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration?ref=v2.0.0"
   sns_topics                = [aws_sns_topic.networking_general.name]
   pagerduty_integration_key = local.pagerduty_integration_keys["networking_cloudwatch"]
 }

--- a/terraform/environments/core-network-services/versions.tf
+++ b/terraform/environments/core-network-services/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = ">= 4.0.0, < 5.0.0"
+      version = "~> 5.0"
       source  = "hashicorp/aws"
     }
   }

--- a/terraform/environments/core-sandbox/playground.tf
+++ b/terraform/environments/core-sandbox/playground.tf
@@ -21,7 +21,7 @@ module "ram-principal-association" {
 
 data "aws_ami_ids" "example" {
   owners     = ["self"]
-  name_regex = "(?!oracle-linux-5.11)*"
+  name_regex = "^(?!oracle-linux-5.11)*"
   # filter {
   #   name   = "name"
   #   values = ["oracle-linux-5.11*"]

--- a/terraform/environments/core-sandbox/versions.tf
+++ b/terraform/environments/core-sandbox/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = ">= 4.0.0, < 5.0.0"
+      version = "~> 5.0"
       source  = "hashicorp/aws"
     }
   }

--- a/terraform/environments/core-security/versions.tf
+++ b/terraform/environments/core-security/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = ">= 4.0.0, < 5.0.0"
+      version = "~> 5.0"
       source  = "hashicorp/aws"
     }
   }

--- a/terraform/environments/core-shared-services/bucket.tf
+++ b/terraform/environments/core-shared-services/bucket.tf
@@ -1,6 +1,6 @@
 # tfsec:ignore:aws-s3-enable-versioning tfsec:ignore:aws-s3-encryption-customer-key
 module "imagebuilder_log_bucket" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=v6.4.0"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=v7.0.0"
 
   providers = {
     aws.bucket-replication = aws.bucket-replication

--- a/terraform/environments/core-shared-services/iam.tf
+++ b/terraform/environments/core-shared-services/iam.tf
@@ -167,7 +167,7 @@ data "aws_iam_policy_document" "instance-scheduler-lambda-function-policy" {
 
 # OIDC Confiuration for core-shared-services
 module "github-oidc" {
-  source                 = "github.com/ministryofjustice/modernisation-platform-github-oidc-provider?ref=v2.1.0"
+  source                 = "github.com/ministryofjustice/modernisation-platform-github-oidc-provider?ref=v3.0.0"
   additional_permissions = data.aws_iam_policy_document.oidc_assume_role_core.json
   github_repositories    = ["ministryofjustice/modernisation-platform-instance-scheduler:*"]
   tags_common            = { "Name" = format("%s-oidc", terraform.workspace) }
@@ -243,7 +243,7 @@ resource "aws_iam_policy" "ssm-cross-account-admin-policy" {
 
 
 module "ssm-cross-account-access-admin" {
-  source                      = "github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access?ref=v2.3.0"
+  source                      = "github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access?ref=v3.0.0"
   account_id                  = local.environment_management.account_ids["core-shared-services-production"]
   policy_arn                  = aws_iam_policy.ssm-cross-account-admin-policy.arn
   role_name                   = "AWS-SSM-AutomationAdministrationRole"

--- a/terraform/environments/core-shared-services/instance-scheduler-lambda-function.tf
+++ b/terraform/environments/core-shared-services/instance-scheduler-lambda-function.tf
@@ -3,7 +3,7 @@ module "instance_scheduler" {
   #checkov:skip=CKV_AWS_117
   #checkov:skip=CKV_AWS_272 "Code signing not required"
   #checkov:skip=CKV_AWS_173 "These lambda envvars aren't sensitive and don't need a cmk. Default AWS KMS key is sufficient"
-  source                         = "github.com/ministryofjustice/modernisation-platform-terraform-lambda-function?ref=v1.0.0"
+  source                         = "github.com/ministryofjustice/modernisation-platform-terraform-lambda-function?ref=v2.0.0"
   application_name               = local.application_name
   tags                           = local.tags
   description                    = "Lambda to automatically start and stop instances on member accounts"

--- a/terraform/environments/core-shared-services/s3.tf
+++ b/terraform/environments/core-shared-services/s3.tf
@@ -1,5 +1,5 @@
 module "s3-bucket" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=v6.4.0"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=v7.0.0"
 
   providers = {
     aws.bucket-replication = aws.bucket-replication
@@ -82,7 +82,7 @@ data "aws_iam_policy_document" "bucket_policy" {
 }
 
 module "s3-software-bucket" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=v6.4.0"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=v7.0.0"
 
   providers = {
     aws.bucket-replication = aws.bucket-replication

--- a/terraform/environments/core-shared-services/test/test_terraform/providers.tf
+++ b/terraform/environments/core-shared-services/test/test_terraform/providers.tf
@@ -14,7 +14,7 @@ provider "aws" {
 terraform {
   required_providers {
     aws = {
-      version = ">= 4.0.0, < 5.0.0"
+      version = "~> 5.0"
       source  = "hashicorp/aws"
     }
   }

--- a/terraform/environments/core-shared-services/versions.tf
+++ b/terraform/environments/core-shared-services/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = ">= 4.0.0, < 5.0.0"
+      version = "~> 5.0"
       source  = "hashicorp/aws"
     }
   }

--- a/terraform/environments/core-vpc/monitoring.tf
+++ b/terraform/environments/core-vpc/monitoring.tf
@@ -22,7 +22,7 @@ module "pagerduty_route53" {
   depends_on = [
     aws_sns_topic.route53_monitoring
   ]
-  source                    = "github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration?ref=v1.0.0"
+  source                    = "github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration?ref=v2.0.0"
   sns_topics                = [aws_sns_topic.route53_monitoring.name]
   pagerduty_integration_key = local.pagerduty_integration_keys["ddos_cloudwatch"]
 }

--- a/terraform/environments/core-vpc/versions.tf
+++ b/terraform/environments/core-vpc/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = ">= 4.0.0, < 5.0.0"
+      version = "~> 5.0"
       source  = "hashicorp/aws"
     }
   }

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -85,7 +85,7 @@ locals {
 module "vpc" {
   for_each = local.vpcs[terraform.workspace]
 
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-member-vpc?ref=v1.3.0"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-member-vpc?ref=v2.0.0"
 
   subnet_sets = { for key, subnet in each.value.cidr.subnet_sets : key => subnet.cidr }
 

--- a/terraform/environments/data-platform-apps-and-tools/versions.tf
+++ b/terraform/environments/data-platform-apps-and-tools/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = ">= 4.0.0, < 5.0.0"
+      version = "~> 5.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/data-platform/versions.tf
+++ b/terraform/environments/data-platform/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = ">= 4.0.0, < 5.0.0"
+      version = "~> 5.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/versions.tf
+++ b/terraform/environments/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = ">= 4.0.0, < 5.0.0"
+      version = "~> 5.0"
       source  = "hashicorp/aws"
     }
     github = {

--- a/terraform/modules/app-ecr-repo/versions.tf
+++ b/terraform/modules/app-ecr-repo/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = ">= 4.0.0, < 5.0.0"
+      version = "~> 5.0"
       source  = "hashicorp/aws"
     }
   }

--- a/terraform/modules/collaborators/versions.tf
+++ b/terraform/modules/collaborators/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
     time = {
       source  = "hashicorp/time"

--- a/terraform/modules/core-monitoring/main.tf
+++ b/terraform/modules/core-monitoring/main.tf
@@ -1,5 +1,5 @@
 module "pagerduty_core_alerts" {
-  source                    = "github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration?ref=v1.0.0"
+  source                    = "github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration?ref=v2.0.0"
   sns_topics                = ["config", "securityhub-alarms", "cloudtrail"]
   pagerduty_integration_key = var.pagerduty_integration_keys["core_alerts_cloudwatch"]
 }

--- a/terraform/modules/core-monitoring/versions.tf
+++ b/terraform/modules/core-monitoring/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/terraform/modules/dns-zone-extend/versions.tf
+++ b/terraform/modules/dns-zone-extend/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = ">= 4.0.0, < 5.0.0"
+      version = "~> 5.0"
       source  = "hashicorp/aws"
     }
   }

--- a/terraform/modules/dns-zone/versions.tf
+++ b/terraform/modules/dns-zone/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version               = ">= 3.47.0"
+      version = "~> 5.0"
       source                = "hashicorp/aws"
       configuration_aliases = [aws.core-network-services, aws.aws-us-east-1]
     }

--- a/terraform/modules/ec2-tgw-attachment/versions.tf
+++ b/terraform/modules/ec2-tgw-attachment/versions.tf
@@ -1,12 +1,12 @@
 terraform {
   required_providers {
     aws = {
-      version               = ">= 3.47.0"
+      version               = "~> 5.0"
       source                = "hashicorp/aws"
       configuration_aliases = [aws.transit-gateway-host, aws.transit-gateway-tenant]
     }
     time = {
-      version = ">= 0.6.0"
+      version = ">= 0.9.1"
       source  = "hashicorp/time"
     }
   }

--- a/terraform/modules/firewall-logging/versions.tf
+++ b/terraform/modules/firewall-logging/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 4.0"
+      version = "~> 5.0"
       source  = "hashicorp/aws"
     }
     random = {

--- a/terraform/modules/firewall-policy/versions.tf
+++ b/terraform/modules/firewall-policy/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 4.0"
+      version = "~> 5.0"
       source  = "hashicorp/aws"
     }
     random = {

--- a/terraform/modules/iam_baseline/versions.tf
+++ b/terraform/modules/iam_baseline/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = ">= 4.0.0, < 5.0.0"
+      version = "~> 5.0"
       source  = "hashicorp/aws"
     }
   }

--- a/terraform/modules/kms/versions.tf
+++ b/terraform/modules/kms/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/terraform/modules/r53-resolver-logs/versions.tf
+++ b/terraform/modules/r53-resolver-logs/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = ">= 4.0.0, < 5.0.0"
+      version = "~> 5.0"
       source  = "hashicorp/aws"
     }
   }

--- a/terraform/modules/ram-resource-share/versions.tf
+++ b/terraform/modules/ram-resource-share/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = ">= 4.0.0, < 5.0.0"
+      version = "~> 5.0"
       source  = "hashicorp/aws"
     }
   }

--- a/terraform/modules/vpc-hub/versions.tf
+++ b/terraform/modules/vpc-hub/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = ">= 3.47.0"
+      version = "~> 5.0"
       source  = "hashicorp/aws"
     }
   }

--- a/terraform/modules/vpc-inspection/versions.tf
+++ b/terraform/modules/vpc-inspection/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 4.0"
+      version = "~> 5.0"
       source  = "hashicorp/aws"
     }
     random = {

--- a/terraform/modules/vpc-nacls/versions.tf
+++ b/terraform/modules/vpc-nacls/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = ">= 4.0.0, < 5.0.0"
+      version = "~> 5.0"
       source  = "hashicorp/aws"
     }
   }


### PR DESCRIPTION
Required for ticket - https://github.com/ministryofjustice/modernisation-platform/issues/3970 

Myself and @ASTRobinson have run a terraform plan before the upgrade, and then after, making sure no resources are to be changed. We have upgraded any module usage to use the new tagged version running on v5. 

Only changes to the code have been non-related to the upgrade, where terraform would not apply even before upgrading from v4 to v5. 