### PR TITLE
Allow shared VPCs to be associated with private zones

### DIFF
--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -233,6 +233,7 @@ resource "aws_iam_role_policy" "member-delegation" {
       {
         "Effect" : "Allow",
         "Action" : [
+          "route53:AssociateVPCWithHostedZone",
           "route53:List*",
           "route53:Get*",
           "route53resolver:CreateResolverEndpoint",


### PR DESCRIPTION
Where customers have a requirement for application-local AWS Route53 Private zones, we allow them to create those zones but not to associated them with the relevant business-unit VPC that is shared with their account.

This PR will add the ability for the role assumed by the `provider.core-vpc` used by customers to associate a VPC with a private Route53 zone.