### PR TITLE
Revert "Allow shared VPCs to be associated with private zones"

### DIFF
--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -233,7 +233,6 @@ resource "aws_iam_role_policy" "member-delegation" {
       {
         "Effect" : "Allow",
         "Action" : [
-          "route53:AssociateVPCWithHostedZone",
           "route53:List*",
           "route53:Get*",
           "route53resolver:CreateResolverEndpoint",


### PR DESCRIPTION
Reverts ministryofjustice/modernisation-platform#4383

Because the `aws_route53_zone` resource requires a `vpc_id` in order to create a private zone, and since the VPC is only shared with member accounts and thus there are not sufficient permissions to create and associate the zone, this PR is being reverted so that we can approach this in a more considered fashion