### PR TITLE
IAM permission changes for RDS

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/policies.tf
+++ b/terraform/environments/bootstrap/delegate-access/policies.tf
@@ -150,6 +150,7 @@ data "aws_iam_policy_document" "developer_additional" {
       "rds:CopyDBClusterSnapshot",
       "rds:CreateDBSnapshot",
       "rds:CreateDBClusterSnapshot",
+      "rds:RestoreDBInstanceToPointInTime",
       "rds:RebootDB*",
       "rhelkb:GetRhelURL",
       "s3:PutObject",


### PR DESCRIPTION
Request from the laa team as follows:
Hi MP Team, for disaster recovery planning we are looking into point-in-time restoration for the RDS. Can this permission be provided permanently for us to do this ourselves on the AWS Console - specially I think it’s rds:RestoreDBInstanceToPointInTime? To remove this database manually afterwards I suppose we can request this from your team after the recovery is done.

added to the developer role