### PR TITLE
SCA fixes for core-network-services

### DIFF
--- a/terraform/environments/core-network-services/secrets.tf
+++ b/terraform/environments/core-network-services/secrets.tf
@@ -26,5 +26,43 @@ resource "aws_kms_key" "environment_logging" {
   description             = "environment-logging"
   enable_key_rotation     = true
   deletion_window_in_days = 30
+  policy                  = data.aws_iam_policy_document.environment_logging.json
 }
 
+resource "aws_kms_alias" "environment_logging" {
+  name          = "alias/environment-logging"
+  target_key_id = aws_kms_key.environment_logging.key_id
+}
+
+data "aws_iam_policy_document" "environment_logging" {
+  statement {
+    sid    = "Enable IAM User Permissions"
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+    actions   = ["kms:*"]
+    resources = ["*"]
+  }
+  statement {
+    sid    = "Allow CloudWatch access"
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["logs.eu-west-2.amazonaws.com"]
+    }
+    actions = [
+      "kms:Encrypt*",
+      "kms:Decrypt*",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:Describe*"
+    ]
+    condition {
+      test     = "ArnLike"
+      values   = ["arn:aws:logs:region:${data.aws_caller_identity.current.account_id}:*"]
+      variable = "kms:EncryptionContext:aws:logs:arn"
+    }
+  }
+}

--- a/terraform/environments/core-network-services/secrets.tf
+++ b/terraform/environments/core-network-services/secrets.tf
@@ -34,7 +34,13 @@ resource "aws_kms_alias" "environment_logging" {
   target_key_id = aws_kms_key.environment_logging.key_id
 }
 
+# Static code analysis ignores:
+# - CKV_AWS_109 and CKV_AWS_111: Ignore warnings regarding resource = ["*"]. See https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html
+#   Specifically: "In a key policy, the value of the Resource element is "*", which means "this KMS key." The asterisk ("*") identifies the KMS key to which the key policy is attached."
 data "aws_iam_policy_document" "environment_logging" {
+  # checkov:skip=CKV_AWS_109: "Key policy requires asterisk resource"
+  # checkov:skip=CKV_AWS_111: "Key policy requires asterisk resource"
+  # checkov:skip=CKV_AWS_356: "Account root user requires full access"
   statement {
     sid    = "Enable IAM User Permissions"
     effect = "Allow"


### PR DESCRIPTION
* Add `aws_kms_alias`
* Add KMS policy document
* Apply KMS policy document

NB. From what I can see in the code, this KMS key isn't actively used for CloudWatch encryption, but could do so in future, and as such this new policy should be appropriate for its intended use.