### PR TITLE
add edge download update url to allow list in mod-platform firewall

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/fqdn_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/fqdn_rules.json
@@ -8,7 +8,8 @@
     "wustat.windows.com",
     "ntservicepack.microsoft.com",
     "stats.microsoft.com",
-    "saas40.kaseya.net"
+    "saas40.kaseya.net",
+    ".dl.delivery.mp.microsoft.com"
   ],
   "fw_home_net_ips": ["10.26.0.0/16", "10.27.0.0/16"]
 }

--- a/terraform/environments/core-network-services/firewall-rules/fqdn_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/fqdn_rules.json
@@ -8,8 +8,7 @@
     "wustat.windows.com",
     "ntservicepack.microsoft.com",
     "stats.microsoft.com",
-    "saas40.kaseya.net",
-    ".dl.delivery.mp.microsoft.com"
+    "saas40.kaseya.net"
   ],
   "fw_home_net_ips": ["10.26.0.0/16", "10.27.0.0/16"]
 }

--- a/terraform/environments/core-network-services/firewall-rules/inline_fqdn_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/inline_fqdn_rules.json
@@ -8,6 +8,7 @@
     "wustat.windows.com",
     "ntservicepack.microsoft.com",
     "stats.microsoft.com",
-    "saas40.kaseya.net"
+    "saas40.kaseya.net",
+    ".dl.delivery.mp.microsoft.com"
   ]
 }


### PR DESCRIPTION
Updated fqdn_rules.json with a http url allow for Edge browser updates. https://learn.microsoft.com/en-us/deployedge/microsoft-edge-security-endpoints

This is because there are very few options available on Windows servers (using Edge) to force the browser to use HTTPS... 

Without this the browser update process initialises and then never completes...