### PR TITLE
Update mojfin pagerduty chanel ID

### DIFF
--- a/terraform/pagerduty/member-services-integrations.tf
+++ b/terraform/pagerduty/member-services-integrations.tf
@@ -575,7 +575,7 @@ resource "pagerduty_slack_connection" "laa_mojfin_prod_connection" {
   source_id         = pagerduty_service.laa_mojfin_prod.id
   source_type       = "service_reference"
   workspace_id      = local.slack_workspace_id
-  channel_id        = "C048QNJRWP3"
+  channel_id        = "C01JGH46Z97"
   notification_type = "responder"
   lifecycle {
     ignore_changes = [

--- a/terraform/pagerduty/member-services-integrations.tf
+++ b/terraform/pagerduty/member-services-integrations.tf
@@ -575,7 +575,7 @@ resource "pagerduty_slack_connection" "laa_mojfin_prod_connection" {
   source_id         = pagerduty_service.laa_mojfin_prod.id
   source_type       = "service_reference"
   workspace_id      = local.slack_workspace_id
-  channel_id        = "C01JGH46Z97"
+  channel_id        = "C05DXKG5SQ2"
   notification_type = "responder"
   lifecycle {
     ignore_changes = [
@@ -605,7 +605,7 @@ resource "pagerduty_slack_connection" "laa_mojfin_prod_connection" {
   }
 }
 
-# # Slack channel: #laa-alerts-mojfin-prod
+# # Slack channel: #mp-laa-alerts-mojfin-prod
 
 # NOTE: Update escalation_policy once alarms have been tested
 resource "pagerduty_service" "hmpps_shef_dba_high_priority" {


### PR DESCRIPTION
Terraform runs for PagerDuty are failing with a message like...
```
Error: PUT API call to https://app.pagerduty.com/integration-slack/workspaces/T02DYEB3A/connections/P5YNAW3 failed 400 Bad Request. Code: 0, Errors: <nil>, Message: You don't have Slack permission to that channel or we couldn't find it. Please connect another channel or contact your Slack admin to try again.
```
From what I can see the channel ID is incorrect, so this should adjust the code to match the correct channel ID