### PR TITLE
Add Data Platform OIDC role to Data Platform repos

### DIFF
--- a/terraform/environments/core-shared-services/ecr_repos.tf
+++ b/terraform/environments/core-shared-services/ecr_repos.tf
@@ -147,6 +147,7 @@ module "data_platform_code_ecr_repo" {
 
   push_principals = [
     "arn:aws:iam::${local.environment_management.account_ids["data-platform-development"]}:user/cicd-member-user",
+    "arn:aws:iam::${local.environment_management.account_ids["data-platform-development"]}:role/data-platform-github-actions",
     local.environment_management.account_ids["data-platform-development"]
   ]
 
@@ -166,6 +167,7 @@ module "data_platform_data_ecr_repo" {
 
   push_principals = [
     "arn:aws:iam::${local.environment_management.account_ids["data-platform-development"]}:user/cicd-member-user",
+    "arn:aws:iam::${local.environment_management.account_ids["data-platform-development"]}:role/data-platform-github-actions",
     local.environment_management.account_ids["data-platform-development"]
   ]
 
@@ -185,6 +187,7 @@ module "data_platform_athena_load_ecr_repo" {
 
   push_principals = [
     "arn:aws:iam::${local.environment_management.account_ids["data-platform-development"]}:user/cicd-member-user",
+    "arn:aws:iam::${local.environment_management.account_ids["data-platform-development"]}:role/data-platform-github-actions",
     local.environment_management.account_ids["data-platform-development"]
   ]
 


### PR DESCRIPTION
Allows us to push to ECR using our OIDC role

Related: https://github.com/ministryofjustice/modernisation-platform-environments/pull/2691