### PR TITLE
Modify so only trigger on main

### DIFF
--- a/.github/workflows/modernisation-platform-account.yml
+++ b/.github/workflows/modernisation-platform-account.yml
@@ -66,6 +66,7 @@ jobs:
         run: bash scripts/terraform-apply.sh terraform/modernisation-platform-account
 
       - name: Slack failure notification
+        if: ${{ failure() && github.ref == 'refs/heads/main' }}
         uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0
         with:
           payload: |
@@ -73,4 +74,3 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-        if: ${{ failure() }}


### PR DESCRIPTION
Stops us getting slack failure messages to the channel if it's on a PR