### PR TITLE
Changes to set-output code as shown in link on the call log

### DIFF
--- a/.github/workflows/new-environment.yml
+++ b/.github/workflows/new-environment.yml
@@ -169,7 +169,7 @@ jobs:
       - name: get new account(s)
         id: new_account
         run: |
-          echo "::set-output name=files::$(git diff --no-commit-id --name-only --diff-filter=AM -r @^ | awk '{print $1}' | grep ".json" | grep -a "environments//*"  | uniq | cut -f2-4 -d"/" | sed 's/.\{5\}$//')" >> $GITHUB_OUTPUT
+          echo "files=$(git diff --no-commit-id --name-only --diff-filter=AM -r @^ | awk '{print $1}' | grep ".json" | grep -a "environments//*"  | uniq | cut -f2-4 -d"/" | sed 's/.\{5\}$//')" >> $GITHUB_OUTPUT
       - name: Run delegate access
         run: |
           accounts=(${{ steps.new_account.outputs.files }})
@@ -218,7 +218,7 @@ jobs:
       - name: get new account(s)
         id: new_account
         run: |
-          echo "::set-output name=files::$(git diff --no-commit-id --name-only --diff-filter=AM -r @^ | awk '{print $1}' | grep ".json" | grep -a "environments//*"  | uniq | cut -f2-4 -d"/" | sed 's/.\{5\}$//')" >> $GITHUB_OUTPUT
+          echo "files=$(git diff --no-commit-id --name-only --diff-filter=AM -r @^ | awk '{print $1}' | grep ".json" | grep -a "environments//*"  | uniq | cut -f2-4 -d"/" | sed 's/.\{5\}$//')" >> $GITHUB_OUTPUT
       - name: Run secure baselines
         run: |
           accounts=(${{ steps.new_account.outputs.files }})
@@ -267,7 +267,7 @@ jobs:
       - name: get new account(s)
         id: new_account
         run: |
-          echo "::set-output name=files::$(git diff --no-commit-id --name-only --diff-filter=AM -r @^ | awk '{print $1}' | grep ".json" | grep -a "environments//*"  | uniq | cut -f2-4 -d"/" | sed 's/.\{5\}$//')" >> $GITHUB_OUTPUT
+          echo "files=$(git diff --no-commit-id --name-only --diff-filter=AM -r @^ | awk '{print $1}' | grep ".json" | grep -a "environments//*"  | uniq | cut -f2-4 -d"/" | sed 's/.\{5\}$//')" >> $GITHUB_OUTPUT
       - name: Run single sign on
         run: |
           accounts=(${{ steps.new_account.outputs.files }})
@@ -316,7 +316,7 @@ jobs:
       - name: get new account(s)
         id: new_account
         run: |
-          echo "::tput name=files::$(git diff --no-commit-id --name-only --diff-filter=AM -r @^ | awk '{print $1}' | grep ".json" | grep -a "environments//*"  | uniq | cut -f2-4 -d"/" | sed 's/.\{5\}$//')" >> $GITHUB_OUTPUT
+          echo "files=$(git diff --no-commit-id --name-only --diff-filter=AM -r @^ | awk '{print $1}' | grep ".json" | grep -a "environments//*"  | uniq | cut -f2-4 -d"/" | sed 's/.\{5\}$//')" >> $GITHUB_OUTPUT
       - name: Run secure baselines
         run: |
           accounts=(${{ steps.new_account.outputs.files }})

--- a/.github/workflows/new-environment.yml
+++ b/.github/workflows/new-environment.yml
@@ -169,7 +169,7 @@ jobs:
       - name: get new account(s)
         id: new_account
         run: |
-          echo "::set-output name=files::$(git diff --no-commit-id --name-only --diff-filter=AM -r @^ | awk '{print $1}' | grep ".json" | grep -a "environments//*"  | uniq | cut -f2-4 -d"/" | sed 's/.\{5\}$//')"
+          echo "::set-output name=files::$(git diff --no-commit-id --name-only --diff-filter=AM -r @^ | awk '{print $1}' | grep ".json" | grep -a "environments//*"  | uniq | cut -f2-4 -d"/" | sed 's/.\{5\}$//')" >> $GITHUB_OUTPUT
       - name: Run delegate access
         run: |
           accounts=(${{ steps.new_account.outputs.files }})
@@ -218,7 +218,7 @@ jobs:
       - name: get new account(s)
         id: new_account
         run: |
-          echo "::set-output name=files::$(git diff --no-commit-id --name-only --diff-filter=AM -r @^ | awk '{print $1}' | grep ".json" | grep -a "environments//*"  | uniq | cut -f2-4 -d"/" | sed 's/.\{5\}$//')"
+          echo "::set-output name=files::$(git diff --no-commit-id --name-only --diff-filter=AM -r @^ | awk '{print $1}' | grep ".json" | grep -a "environments//*"  | uniq | cut -f2-4 -d"/" | sed 's/.\{5\}$//')" >> $GITHUB_OUTPUT
       - name: Run secure baselines
         run: |
           accounts=(${{ steps.new_account.outputs.files }})
@@ -267,7 +267,7 @@ jobs:
       - name: get new account(s)
         id: new_account
         run: |
-          echo "::set-output name=files::$(git diff --no-commit-id --name-only --diff-filter=AM -r @^ | awk '{print $1}' | grep ".json" | grep -a "environments//*"  | uniq | cut -f2-4 -d"/" | sed 's/.\{5\}$//')"
+          echo "::set-output name=files::$(git diff --no-commit-id --name-only --diff-filter=AM -r @^ | awk '{print $1}' | grep ".json" | grep -a "environments//*"  | uniq | cut -f2-4 -d"/" | sed 's/.\{5\}$//')" >> $GITHUB_OUTPUT
       - name: Run single sign on
         run: |
           accounts=(${{ steps.new_account.outputs.files }})
@@ -316,7 +316,7 @@ jobs:
       - name: get new account(s)
         id: new_account
         run: |
-          echo "::set-output name=files::$(git diff --no-commit-id --name-only --diff-filter=AM -r @^ | awk '{print $1}' | grep ".json" | grep -a "environments//*"  | uniq | cut -f2-4 -d"/" | sed 's/.\{5\}$//')"
+          echo "::tput name=files::$(git diff --no-commit-id --name-only --diff-filter=AM -r @^ | awk '{print $1}' | grep ".json" | grep -a "environments//*"  | uniq | cut -f2-4 -d"/" | sed 's/.\{5\}$//')" >> $GITHUB_OUTPUT
       - name: Run secure baselines
         run: |
           accounts=(${{ steps.new_account.outputs.files }})


### PR DESCRIPTION
This is the initial code change for the set-output lines on the modernisation-platform repo.

It is based on the code shown in the call log and other research I have done.

It cannot be tested so it will only be "hit" when we create a new environment. Testing will take place when this is run as the code is in new-environment.yml file under the github workflows.

Reference to changes from the call - https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/