### PR TITLE
Allow push principal to describe ECR images

### DIFF
--- a/terraform/environments/core-shared-services/ecr_repos.tf
+++ b/terraform/environments/core-shared-services/ecr_repos.tf
@@ -147,7 +147,7 @@ module "data_platform_code_ecr_repo" {
 
   push_principals = [
     "arn:aws:iam::${local.environment_management.account_ids["data-platform-development"]}:user/cicd-member-user",
-    "arn:aws:iam::${local.environment_management.account_ids["data-platform-development"]}:role/data-platform-github-actions",
+    "arn:aws:iam::${local.environment_management.account_ids["data-platform-development"]}:role/data-platform-gha",
     local.environment_management.account_ids["data-platform-development"]
   ]
 
@@ -167,7 +167,7 @@ module "data_platform_data_ecr_repo" {
 
   push_principals = [
     "arn:aws:iam::${local.environment_management.account_ids["data-platform-development"]}:user/cicd-member-user",
-    "arn:aws:iam::${local.environment_management.account_ids["data-platform-development"]}:role/data-platform-github-actions",
+    "arn:aws:iam::${local.environment_management.account_ids["data-platform-development"]}:role/data-platform-gha",
     local.environment_management.account_ids["data-platform-development"]
   ]
 
@@ -187,7 +187,7 @@ module "data_platform_athena_load_ecr_repo" {
 
   push_principals = [
     "arn:aws:iam::${local.environment_management.account_ids["data-platform-development"]}:user/cicd-member-user",
-    "arn:aws:iam::${local.environment_management.account_ids["data-platform-development"]}:role/data-platform-github-actions",
+    "arn:aws:iam::${local.environment_management.account_ids["data-platform-development"]}:role/data-platform-gha",
     local.environment_management.account_ids["data-platform-development"]
   ]
 

--- a/terraform/modules/app-ecr-repo/main.tf
+++ b/terraform/modules/app-ecr-repo/main.tf
@@ -33,7 +33,8 @@ data "aws_iam_policy_document" "ecr_repo_policy" {
       "ecr:BatchCheckLayerAvailability",
       "ecr:PutImage",
       "ecr:InitiateLayerUpload",
-      "ecr:UploadLayerPart"
+      "ecr:UploadLayerPart",
+      "ecr:DescribeImages"
     ]
     principals {
       type        = "AWS"


### PR DESCRIPTION
Part of our workflow checks for the existence of the tag in ECR

```bash
imageTag=$(aws ecr describe-images \
    --registry-id "XXXXXXX" \
    --repository-name "XXXXXXX" \
    | jq -r --arg imageTag "" '.imageDetails[] | select(.imageTags[] == $imageTag) | .imageTags[]')
  export imageTag
  
  if [[ -z "${imageTag}" ]]; then
    echo "tag_exists=false" >>"${GITHUB_ENV}"
  else
    echo "tag_exists=true" >>"${GITHUB_ENV}"
  fi
```

However this returns

```bash
An error occurred (AccessDeniedException) when calling the DescribeImages operation: User: arn:aws:sts::***:assumed-role/data-platform-github-actions/GitHubActions is not authorized to perform: ecr:DescribeImages on resource: arn:aws:ecr:eu-west-2:XXXXXXX:repository/XXXXXXX because no resource-based policy allows the ecr:DescribeImages action
```
---
Also, fix OIDC role name https://github.com/ministryofjustice/modernisation-platform-environments/pull/2696