### PR TITLE
updated syntax to consistently set terraform required_version

### DIFF
--- a/terraform/environments/core-shared-services/test/test_terraform/providers.tf
+++ b/terraform/environments/core-shared-services/test/test_terraform/providers.tf
@@ -18,5 +18,5 @@ terraform {
       source  = "hashicorp/aws"
     }
   }
-  required_version = ">= 1.0"
+  required_version = "~> 1.0"
 }

--- a/terraform/modules/app-ecr-repo/versions.tf
+++ b/terraform/modules/app-ecr-repo/versions.tf
@@ -5,5 +5,5 @@ terraform {
       source  = "hashicorp/aws"
     }
   }
-  required_version = ">= 1.0.1"
+  required_version = "~> 1.0"
 }

--- a/terraform/modules/dns-zone-extend/versions.tf
+++ b/terraform/modules/dns-zone-extend/versions.tf
@@ -5,5 +5,5 @@ terraform {
       source  = "hashicorp/aws"
     }
   }
-  required_version = ">= 1.0.1"
+  required_version = "~> 1.0"
 }

--- a/terraform/modules/dns-zone/versions.tf
+++ b/terraform/modules/dns-zone/versions.tf
@@ -6,5 +6,5 @@ terraform {
       configuration_aliases = [aws.core-network-services, aws.aws-us-east-1]
     }
   }
-  required_version = ">= 1.0.1"
+  required_version = "~> 1.0"
 }

--- a/terraform/modules/ec2-tgw-attachment/versions.tf
+++ b/terraform/modules/ec2-tgw-attachment/versions.tf
@@ -10,5 +10,5 @@ terraform {
       source  = "hashicorp/time"
     }
   }
-  required_version = ">= 1.0.1"
+  required_version = "~> 1.0"
 }

--- a/terraform/modules/firewall-policy/versions.tf
+++ b/terraform/modules/firewall-policy/versions.tf
@@ -9,5 +9,5 @@ terraform {
       version = "~> 3.4"
     }
   }
-  required_version = ">= 1.0"
+  required_version = "~> 1.0"
 }

--- a/terraform/modules/iam_baseline/versions.tf
+++ b/terraform/modules/iam_baseline/versions.tf
@@ -5,5 +5,5 @@ terraform {
       source  = "hashicorp/aws"
     }
   }
-  required_version = ">= 1.0.1"
+  required_version = "~> 1.0"
 }

--- a/terraform/modules/r53-resolver-logs/versions.tf
+++ b/terraform/modules/r53-resolver-logs/versions.tf
@@ -5,5 +5,5 @@ terraform {
       source  = "hashicorp/aws"
     }
   }
-  required_version = ">= 1.0.1"
+  required_version = "~> 1.0"
 }

--- a/terraform/modules/ram-ec2-retagging/versions.tf
+++ b/terraform/modules/ram-ec2-retagging/versions.tf
@@ -6,6 +6,6 @@ terraform {
       configuration_aliases = [aws.share-host, aws.share-tenant]
     }
   }
-  required_version = ">= 1.0.1"
+  required_version = "~> 1.0"
 }
 

--- a/terraform/modules/ram-principal-association/versions.tf
+++ b/terraform/modules/ram-principal-association/versions.tf
@@ -6,5 +6,5 @@ terraform {
       configuration_aliases = [aws.share-host, aws.share-tenant, aws.share-acm]
     }
   }
-  required_version = ">= 1.0.1"
+  required_version = "~> 1.0"
 }

--- a/terraform/modules/ram-resource-share/versions.tf
+++ b/terraform/modules/ram-resource-share/versions.tf
@@ -5,5 +5,5 @@ terraform {
       source  = "hashicorp/aws"
     }
   }
-  required_version = ">= 1.0.1"
+  required_version = "~> 1.0"
 }

--- a/terraform/modules/vpc-hub/versions.tf
+++ b/terraform/modules/vpc-hub/versions.tf
@@ -5,5 +5,5 @@ terraform {
       source  = "hashicorp/aws"
     }
   }
-  required_version = ">= 1.0.1"
+  required_version = "~> 1.0"
 }

--- a/terraform/modules/vpc-inspection/versions.tf
+++ b/terraform/modules/vpc-inspection/versions.tf
@@ -9,5 +9,5 @@ terraform {
       version = "~> 3.4"
     }
   }
-  required_version = ">= 1.0"
+  required_version = "~> 1.0"
 }

--- a/terraform/modules/vpc-nacls/versions.tf
+++ b/terraform/modules/vpc-nacls/versions.tf
@@ -5,5 +5,5 @@ terraform {
       source  = "hashicorp/aws"
     }
   }
-  required_version = ">= 1.0.1"
+  required_version = "~> 1.0"
 }

--- a/terraform/pagerduty/versions.tf
+++ b/terraform/pagerduty/versions.tf
@@ -1,5 +1,4 @@
 terraform {
-  required_version = ">= 1.0.1"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
@@ -10,4 +9,5 @@ terraform {
       version = "~> 2.6"
     }
   }
+  required_version = "~> 1.0"
 }


### PR DESCRIPTION
As part of https://github.com/ministryofjustice/modernisation-platform/issues/4315 this PR consistently sets the `required_version` for terraform code across the repository.