### PR TITLE
test reducing access level of syscon-devs

### DIFF
--- a/environments/nomis.json
+++ b/environments/nomis.json
@@ -20,7 +20,7 @@
         },
         {
           "github_slug": "syscon-devs",
-          "level": "developer"
+          "level": "instance-management"
         }
       ]
     },


### PR DESCRIPTION
- reducing access level of syscon-devs group in nomis-test environment
- assuming this works will do a 2nd pr for the other nomis environments