### PR TITLE
Temp rule for access to ppud-production

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/production_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/production_rules.json
@@ -257,5 +257,12 @@
     "destination_ip": "${cloud-platform}",
     "destination_port": "5432",
     "protocol": "TCP"
+  },
+  "fitzwan_to_ppud_production_https": {
+    "action": "PASS",
+    "source_ip": "10.0.0.0/8",
+    "destination_ip": "${hmpps-production}",
+    "destination_port": "443",
+    "protocol": "TCP"
   }
 }


### PR DESCRIPTION
In lieu of a full list of PPUD customers, this rule will allow access to PPUD via the PTTP Transit Gateway for on-premise customers.