### PR TITLE
Update deprecated value in vpc-inspection module

### DIFF
--- a/terraform/modules/vpc-inspection/main.tf
+++ b/terraform/modules/vpc-inspection/main.tf
@@ -352,7 +352,7 @@ resource "aws_internet_gateway" "public" {
 
 resource "aws_eip" "public" {
   for_each = aws_subnet.public
-  vpc      = true
+  domain   = "vpc"
 
   tags = merge(
     var.tags_common,


### PR DESCRIPTION
Switch to use new attribute for `aws_eip` in vpc-inspection module.