### PR TITLE
addressed checkov failures

### DIFF
--- a/terraform/environments/data-platform-apps-and-tools/iam-policies.tf
+++ b/terraform/environments/data-platform-apps-and-tools/iam-policies.tf
@@ -13,7 +13,7 @@ data "aws_iam_policy_document" "airflow_ses_policy" {
 }
 
 module "airflow_ses_policy" {
-  # checkov:skip=CKV_TF_1:
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
   version = "~> 5.0"
 
@@ -104,6 +104,7 @@ data "aws_iam_policy_document" "airflow_execution_policy" {
 }
 
 module "airflow_execution_policy" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
   version = "~> 5.0"
 

--- a/terraform/environments/data-platform-apps-and-tools/iam-roles.tf
+++ b/terraform/environments/data-platform-apps-and-tools/iam-roles.tf
@@ -1,4 +1,5 @@
 module "airflow_execution_role" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
   version = "~> 5.0"
 

--- a/terraform/modules/vpc-inspection/main.tf
+++ b/terraform/modules/vpc-inspection/main.tf
@@ -351,6 +351,7 @@ resource "aws_internet_gateway" "public" {
 }
 
 resource "aws_eip" "public" {
+  #checkov:skip=CKV2_AWS_19:EIPs are allocated to NAT gateways
   for_each = aws_subnet.public
   domain   = "vpc"
 


### PR DESCRIPTION
* Use of commit hashes is not supported for Terraform Module registry
* See [this terraform issue](https://github.com/hashicorp/terraform/issues/29867) for more detail
* Added skip around `aws_eip` resources as these are used by NAT gateways