### PR TITLE
Glue Permissions and CW Dashboard

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/policies.tf
+++ b/terraform/environments/bootstrap/delegate-access/policies.tf
@@ -668,6 +668,7 @@ data "aws_iam_policy_document" "reporting-operations" {
       "glue:StartJobRun",
       "glue:BatchStopJobRun",
       "glue:ResetJobBookmark",
+      "glue:UpdateJob",
       "logs:DescribeLogStreams",
       "logs:GetLogEvents",
       "dynamodb:BatchGet*",
@@ -684,7 +685,9 @@ data "aws_iam_policy_document" "reporting-operations" {
       "kinesis:DescribeStreamSummary",
       "kinesis:ListStreams",
       "kinesis:PutRecord",
-      "kinesis:CreateStream"
+      "kinesis:CreateStream",
+      "cloudwatch:GetDashboard",
+      "cloudwatch:ListDashboards"
     ]
     resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
   }


### PR DESCRIPTION
We require Glue Permissions for Optimising the Glue ETL Jobs, Cloudwatch Permissions are required for Monitoring Glue Jobs, 

Ref: https://docs.aws.amazon.com/glue/latest/ug/getting-started-min-privs.html#getting-started-min-privs-cloudwatch