### PR TITLE
Granting Hackathon Team Sandbox Access

### DIFF
--- a/environments/data-platform.json
+++ b/environments/data-platform.json
@@ -10,6 +10,11 @@
           "nuke": "exclude"
         },
         {
+          "github_slug": "data-platform-hackathon",
+          "level": "sandbox",
+          "nuke": "exclude"
+        },
+        {
           "github_slug": "data-tech-archs",
           "level": "sandbox",
           "nuke": "exclude"


### PR DESCRIPTION
Data Platform is holding a hackathon on its All-Hand on the 11th of July. This group is a temporary way to grant participants AWS access and will be retired after the hackathon is complete.