### PR TITLE
Allow access to PPUD UAT environment

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
@@ -215,5 +215,12 @@
     "destination_ip": "${hmpps-preproduction}",
     "destination_port": "389",
     "protocol": "TCP"
+  },
+  "rfc_10-0-0-0-8_to_ppud_production_https": {
+    "action": "PASS",
+    "source_ip": "10.0.0.0/8",
+    "destination_ip": "${hmpps-production}",
+    "destination_port": "443",
+    "protocol": "TCP"
   }
 }

--- a/terraform/environments/core-network-services/firewall-rules/production_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/production_rules.json
@@ -258,7 +258,7 @@
     "destination_port": "5432",
     "protocol": "TCP"
   },
-  "fitzwan_to_ppud_production_https": {
+  "rfc_10-0-0-0-8_to_ppud_production_https": {
     "action": "PASS",
     "source_ip": "10.0.0.0/8",
     "destination_ip": "${hmpps-production}",


### PR DESCRIPTION
As the PPUD team do not presently have a definitive list of customer network address ranges, this PR allows internal users to get access to the PPUD UAT environment.