### PR TITLE
Workflow for customer environment changes

### DIFF
--- a/.github/workflows/terraform-member-environments.yml
+++ b/.github/workflows/terraform-member-environments.yml
@@ -13,6 +13,7 @@ on:
       - 'terraform/environments/**/*.tf'
       - '!terraform/environments/core-*'
       - '.github/workflows/terraform-member-environments.yml'
+  workflow_dispatch:
 
 env:
   TF_IN_AUTOMATION: true

--- a/.github/workflows/terraform-member-environments.yml
+++ b/.github/workflows/terraform-member-environments.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
         with:
-          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/ModernisationPlatformGithubActionsRole"
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
           role-session-name: githubactionsrolesession
           aws-region: ${{ env.AWS_REGION }}
 

--- a/.github/workflows/terraform-member-environments.yml
+++ b/.github/workflows/terraform-member-environments.yml
@@ -12,6 +12,7 @@ on:
     paths:
       - 'terraform/environments/**/*.tf'
       - '!terraform/environments/core-*'
+      - '.github/workflows/terraform-member-environments.yml'
 
 env:
   TF_IN_AUTOMATION: true

--- a/.github/workflows/terraform-member-environments.yml
+++ b/.github/workflows/terraform-member-environments.yml
@@ -13,6 +13,7 @@ on:
       - 'terraform/environments/**/*.tf'
       - '!terraform/environments/core-*'
       - '.github/workflows/terraform-member-environments.yml'
+  workflow_dispatch:
 
 defaults:
   run:
@@ -29,7 +30,6 @@ permissions:
 
 jobs:
   terraform-plan:
-    if: github.ref != 'refs/heads/main'
     environment: ${{ matrix.environment }}
     name: 'Terraform Plan'
     permissions:

--- a/.github/workflows/terraform-member-environments.yml
+++ b/.github/workflows/terraform-member-environments.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
 
       - name: Set Account Number
-        run: echo "ACCOUNT_NUMBER=$(jq -r -e '.aws_organizations_root_account_id' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+        run: echo "ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0

--- a/.github/workflows/terraform-member-environments.yml
+++ b/.github/workflows/terraform-member-environments.yml
@@ -13,16 +13,19 @@ on:
       - 'terraform/environments/**/*.tf'
       - '!terraform/environments/core-*'
       - '.github/workflows/terraform-member-environments.yml'
-  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
 
 env:
   TF_IN_AUTOMATION: true
   AWS_REGION: "eu-west-2"
   ENVIRONMENT_MANAGEMENT: ${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENTS }}
 
-defaults:
-  run:
-    shell: bash
+permissions:
+  id-token: write # This is required for requesting the JWT
+  contents: read # This is required for actions/checkout
 
 jobs:
   terraform-plan:

--- a/.github/workflows/terraform-member-environments.yml
+++ b/.github/workflows/terraform-member-environments.yml
@@ -6,14 +6,12 @@ on:
       - main
     paths:
       - 'terraform/environments/**/*.tf'
-    paths-ignore:
-      - 'terraform/environments/core-*'
+      - '!terraform/environments/core-*'
   pull_request:
     types: [opened, edited, reopened, synchronize]
     paths:
       - 'terraform/environments/**/*.tf'
-    paths-ignore:
-      - 'terraform/environments/core-*'
+      - '!terraform/environments/core-*'
 
 env:
   TF_IN_AUTOMATION: true

--- a/.github/workflows/terraform-member-environments.yml
+++ b/.github/workflows/terraform-member-environments.yml
@@ -37,23 +37,34 @@ jobs:
         environment: [development, test, preproduction, production]
     env:
       TF_IN_AUTOMATION: "true"
-      TF_WORKSPACE: ${{ matrix.environment }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+
       - name: Set Account Number
         run: echo "ACCOUNT_NUMBER=$(jq -r -e '.aws_organizations_root_account_id' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
         with:
           role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/ModernisationPlatformGithubActionsRole"
           role-session-name: githubactionsrolesession
           aws-region: ${{ env.AWS_REGION }}
+
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
           terraform_version: "~1"
           terraform_wrapper: false
+
       - name: Populate list of changed directories
-        run: echo "CHANGED_DIRECTORIES=$(git --no-pager diff --name-only ${{ github.base_ref }} ${{ github.head_ref }} | awk '{print $1}' | grep ".tf" | grep -a "terraform/environments//*" | uniq | cut -f1-3 -d"/"" >> GITHUB_OUTPUT
+        id: directories
+        run: echo "CHANGED_DIRECTORIES=$(git --no-pager diff --name-only ${{ github.base_ref }} ${{ github.head_ref }} | awk '{print $1}' | grep ".tf" | grep -a "terraform/environments//*" | uniq | cut -f1-3 -d"/"" >> $GITHUB_OUTPUT
+
+      - name: Run Terraform
+        run:
+          for directory in ${{ steps.directories.outputs.CHANGED_DIRECTORIES }}; do
+          echo "Running 'terraform init' in $directory"
+          bash scripts/terraform-init.sh $directory
+          done

--- a/.github/workflows/terraform-member-environments.yml
+++ b/.github/workflows/terraform-member-environments.yml
@@ -60,11 +60,20 @@ jobs:
 
       - name: Populate list of changed directories
         id: directories
-        run: echo "CHANGED_DIRECTORIES=$(git --no-pager diff --name-only ${{ github.base_ref }} ${{ github.head_ref }} | awk '{print $1}' | grep ".tf" | grep -a "terraform/environments//*" | uniq | cut -f1-3 -d"/"" >> $GITHUB_OUTPUT
+        run: echo "CHANGED_DIRECTORIES=$(git --no-pager diff --name-only ${{ github.base_ref }} ${{ github.head_ref }} | awk '{print $1}' | grep ".tf" | grep -a "terraform/environments//*" | uniq | d" >> $GITHUB_OUTPUT
 
-      - name: Run Terraform
+      - name: Run Terraform Init
         run:
           for directory in ${{ steps.directories.outputs.CHANGED_DIRECTORIES }}; do
-          echo "Running 'terraform init' in $directory"
-          bash scripts/terraform-init.sh $directory
+            echo "Running 'terraform init' in $directory"
+            bash scripts/terraform-init.sh $directory
+          done
+
+      - name: Loop through Terraform Workspaces and Plan
+        run:
+          for directory in ${{ steps.directories.outputs.CHANGED_DIRECTORIES }}; do
+            environment=$(basename $directory)
+            bash scripts/terraform-workspace.sh $directory $environment-${{ matrix.environment }}
+            bash scripts/terraform-plan $directory
+            unset environment
           done

--- a/.github/workflows/terraform-member-environments.yml
+++ b/.github/workflows/terraform-member-environments.yml
@@ -1,0 +1,59 @@
+name: "Terraform: Member environments"
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'terraform/environments/**/*.tf'
+    paths-ignore:
+      - 'terraform/environments/core-*'
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+    paths:
+      - 'terraform/environments/**/*.tf'
+    paths-ignore:
+      - 'terraform/environments/core-*'
+
+env:
+  TF_IN_AUTOMATION: true
+  AWS_REGION: "eu-west-2"
+  ENVIRONMENT_MANAGEMENT: ${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENTS }}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  terraform-plan:
+    if: github.ref != 'refs/heads/main'
+    environment: ${{ matrix.environment }}
+    name: 'Terraform Plan'
+    permissions:
+      pull-requests: write
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        environment: [development, test, preproduction, production]
+    env:
+      TF_IN_AUTOMATION: "true"
+      TF_WORKSPACE: ${{ matrix.environment }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - name: Set Account Number
+        run: echo "ACCOUNT_NUMBER=$(jq -r -e '.aws_organizations_root_account_id' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/ModernisationPlatformGithubActionsRole"
+          role-session-name: githubactionsrolesession
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
+        with:
+          terraform_version: "~1"
+          terraform_wrapper: false
+      - name: Populate list of changed directories
+        run: echo "CHANGED_DIRECTORIES=$(git --no-pager diff --name-only ${{ github.base_ref }} ${{ github.head_ref }} | awk '{print $1}' | grep ".tf" | grep -a "terraform/environments//*" | uniq | cut -f1-3 -d"/"" >> GITHUB_OUTPUT

--- a/scripts/terraform-workspace.sh
+++ b/scripts/terraform-workspace.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -o pipefail
+set -e
+
+# This script runs terraform workspace with input set to false and no color outputs, suitable for running as part of a CI/CD pipeline.
+# You need to pass through a Terraform directory as the first argument an an environment as the second argument, e.g.
+# sh terraform-workspace.sh terraform/environments cooker-development
+
+# This script pipes the output of terraform plan to ./scripts/redact-output.sh to redact sensitive things, such as AWS keys if they
+# are exposed via terraform plan.
+
+# Make redact-output.sh executable
+chmod +x ./scripts/redact-output.sh
+
+if [ -z "$1" ]; then
+  echo "Unsure where to run terraform, exiting"
+  exit 1
+fi
+
+if [ -z "$2" ]; then
+  echo "Unsure which workspace to select, exiting"
+  exit 1
+fi
+
+terraform -chdir="$1" workspace select "$2" -input=false -no-color | ./scripts/redact-output.sh


### PR DESCRIPTION
In line with [this story](https://github.com/ministryofjustice/modernisation-platform/issues/4365), this PR introduces a workflow that watches for changes to `terraform/environments/**/*.tf`.
This new action should, on the creation of a PR, get a list of directories with changes, and then use this to run a `terraform plan` for each workflow of the changed environment.

A future PR will then introduce the following:
* Output a .tfplan from the plan step
* Introduce a `terraform apply` job with `development` and `test` environments that consumes the relevant .tfplan files.

Following this, another PR will add a `terraform apply` job that will be executed when a branch is merged into main with `preproduction` and `production` with environment protection rules that require approval before deployment.