### PR TITLE
Allow developers to self-service quota requests

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/policies.tf
+++ b/terraform/environments/bootstrap/delegate-access/policies.tf
@@ -165,6 +165,7 @@ data "aws_iam_policy_document" "developer_additional" {
       "secretsmanager:UpdateSecret",
       "secretsmanager:RestoreSecret",
       "secretsmanager:RotateSecret",
+      "servicequotas:*",
       "ses:PutAccountDetails",
       "ssm:*",
       "ssm-guiconnect:*",


### PR DESCRIPTION
Customers should be empowered to raise appropriate service requests. This PR adds the `servicequotas:*` permission to the developers policy which will allow customers to handle their own quota requests.