### PR TITLE
Create a github team to give long term storage

### DIFF
--- a/terraform/github/locals.tf
+++ b/terraform/github/locals.tf
@@ -54,6 +54,11 @@ locals {
     "isaacthomasMOJ"
   ]
 
+  # Members of the long term storage account team to acccess that account
+  long-term-storage = [
+    "davidkelliott"
+  ]
+
   # All members
   all_members = concat(local.general_members, local.engineers)
 

--- a/terraform/github/teams.tf
+++ b/terraform/github/teams.tf
@@ -62,6 +62,15 @@ module "security-team" {
   members     = local.security
 }
 
+module "long-term-storage" {
+  source      = "./modules/team"
+  name        = "modernisation-platform-long-term-storage"
+  description = "Modernisation Platform long term storage team"
+
+  maintainers = local.maintainers
+  members     = local.long-term-storage
+}
+
 # Allow github users to contribute to our repos
 module "contributor-access" {
   for_each          = toset(local.modernisation_platform_repositories)


### PR DESCRIPTION
This github team will be used to give users permissions to access the long term storage account.