### PR TITLE
❇️ Add Cost Explorer's Create Report permission for Data Engineers

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/policies.tf
+++ b/terraform/environments/bootstrap/delegate-access/policies.tf
@@ -244,7 +244,7 @@ data "aws_iam_policy_document" "data_engineering_additional" {
       "athena:DeleteNamedQuery",
       "athena:StartQueryExecution",
       "athena:StopQueryExecution",
-      "ce:CreateReport"
+      "ce:CreateReport",
       "dms:StartReplicationTask",
       "dms:StopReplicationTask",
       "glue:BatchCreatePartition",

--- a/terraform/environments/bootstrap/delegate-access/policies.tf
+++ b/terraform/environments/bootstrap/delegate-access/policies.tf
@@ -244,6 +244,7 @@ data "aws_iam_policy_document" "data_engineering_additional" {
       "athena:DeleteNamedQuery",
       "athena:StartQueryExecution",
       "athena:StopQueryExecution",
+      "ce:CreateReport"
       "dms:StartReplicationTask",
       "dms:StopReplicationTask",
       "glue:BatchCreatePartition",


### PR DESCRIPTION
Adds `ce:CreateReport` to data engineering role

Resolves https://github.com/ministryofjustice/data-platform-support/issues/152