### PR TITLE
Adding MODERNISATION_PLATFORM_ENVIRONMENTS to the configuration management repo

### DIFF
--- a/terraform/environments/secrets.tf
+++ b/terraform/environments/secrets.tf
@@ -111,7 +111,7 @@ locals {
 
 # Store environment management secret in Github secrets
 resource "github_actions_secret" "environment_management" {
-  for_each = toset(["modernisation-platform-environments", "modernisation-platform", "modernisation-platform-ami-builds"])
+  for_each = toset(["modernisation-platform-environments", "modernisation-platform", "modernisation-platform-ami-builds", "modernisation-platform-configuration-management"])
   # checkov:skip=CKV_SECRET_6: "secret_name is not a secret"
   secret_name = "MODERNISATION_PLATFORM_ENVIRONMENTS"
   repository  = each.key


### PR DESCRIPTION
This is to test the new OIDC role that will later be used for CICD in other repositories. This is to satisfy https://github.com/ministryofjustice/modernisation-platform/issues/3909 .