### PR TITLE
Automate changes to new environments

### DIFF
--- a/.github/workflows/terraform-member-environments.yml
+++ b/.github/workflows/terraform-member-environments.yml
@@ -31,8 +31,6 @@ permissions:
 
 jobs:
   terraform-plan:
-    if: ${{ github.event_name == 'pull_request' }}
-    environment: ${{ matrix.environment }}
     name: 'Terraform Plan'
     runs-on: ubuntu-latest
     strategy:
@@ -63,7 +61,7 @@ jobs:
 
       - name: Populate list of changed directories
         id: directories
-        run: echo "CHANGED_DIRECTORIES=$(git --no-pager diff --name-only ${{ github.base_ref }} ${{ github.head_ref }} | awk '{print $1}' | grep ".tf" | grep -a "terraform/environments//*" | uniq)" >> $GITHUB_OUTPUT
+        run: echo "CHANGED_DIRECTORIES=$(git diff --no-commit-id --name-only --diff-filter=AM -r @^ | awk '{print $1}' | grep ".tf" | grep -a "environments//*" | uniq | cut -f1-3 -d"/")" >> $GITHUB_OUTPUT
 
       - name: Terraform init
         run:
@@ -80,6 +78,77 @@ jobs:
             bash scripts/terraform-plan $directory
             unset environment
           done
+
+      - name: Slack failure notification
+        if: ${{ failure() }}
+        uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0
+        with:
+          payload: |
+            {"blocks":[{"type": "section","text": {"type": "mrkdwn","text": ":no_entry: Failed GitHub Action:"}},{"type": "section","fields":[{"type": "mrkdwn","text": "*Workflow:*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>"},{"type": "mrkdwn","text": "*Job:*\n${{ github.job }}"},{"type": "mrkdwn","text": "*Repo:*\n${{ github.repository }}"}]}]}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+
+  terraform-apply-dev-test:
+    if: ${{ github.event_name == 'pull_request' && needs.terraform-plan.result == 'success' }}
+    needs: terraform-plan
+    environment: ${{ matrix.environment }}
+    name: 'Terraform Plan'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        environment: [development, test]
+    env:
+      TF_IN_AUTOMATION: "true"
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+
+      - name: Set account number
+        run: echo "ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+          role-session-name: githubactionsrolesession
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
+        with:
+          terraform_version: "~1"
+          terraform_wrapper: false
+
+      - name: Populate list of changed directories
+        id: directories
+        run: echo "CHANGED_DIRECTORIES=$(git diff --no-commit-id --name-only --diff-filter=AM -r @^ | awk '{print $1}' | grep ".tf" | grep -a "environments//*" | uniq | cut -f1-3 -d"/")" >> $GITHUB_OUTPUT
+
+      - name: Terraform init
+        run:
+          for directory in ${{ steps.directories.outputs.CHANGED_DIRECTORIES }}; do
+            echo "Running 'terraform init' in $directory"
+            bash scripts/terraform-init.sh $directory
+          done
+
+      - name: Terraform plan
+        run:
+          for directory in ${{ steps.directories.outputs.CHANGED_DIRECTORIES }}; do
+            environment=$(basename $directory)
+            bash scripts/terraform-workspace.sh $directory $environment-${{ matrix.environment }}
+            bash scripts/terraform-plan $directory -out tfplan/$environment-${{ matrix.environment }}.tfplan
+            unset environment
+          done
+
+#      - name: Terraform apply
+#        run:
+#          for directory in ${{ steps.directories.outputs.CHANGED_DIRECTORIES }}; do
+#            environment=$(basename $directory)
+#            bash scripts/terraform-workspace.sh $directory $environment-${{ matrix.environment }}
+#            bash scripts/terraform-apply $directory tfplan/$environment-${{ matrix.environment }}.tfplan
+#            unset environment
+#          done
 
       - name: Slack failure notification
         if: ${{ failure() }}

--- a/.github/workflows/terraform-member-environments.yml
+++ b/.github/workflows/terraform-member-environments.yml
@@ -1,0 +1,92 @@
+name: "Terraform: Member environments"
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'terraform/environments/**/*.tf'
+      - '!terraform/environments/core-*'
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+    branches-ignore:
+      - 'date*'
+    paths:
+      - 'terraform/environments/**/*.tf'
+      - '!terraform/environments/core-*'
+      - '.github/workflows/terraform-member-environments.yml'
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  TF_IN_AUTOMATION: true
+  AWS_REGION: "eu-west-2"
+  ENVIRONMENT_MANAGEMENT: ${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENTS }}
+
+permissions:
+  id-token: write # This is required for requesting the JWT
+  contents: read # This is required for actions/checkout
+
+jobs:
+  terraform-plan:
+    if: ${{ github.event_name == 'pull_request' }}
+    environment: ${{ matrix.environment }}
+    name: 'Terraform Plan'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        environment: [development, test, preproduction, production]
+    env:
+      TF_IN_AUTOMATION: "true"
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+
+      - name: Set account number
+        run: echo "ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+          role-session-name: githubactionsrolesession
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
+        with:
+          terraform_version: "~1"
+          terraform_wrapper: false
+
+      - name: Populate list of changed directories
+        id: directories
+        run: echo "CHANGED_DIRECTORIES=$(git --no-pager diff --name-only ${{ github.base_ref }} ${{ github.head_ref }} | awk '{print $1}' | grep ".tf" | grep -a "terraform/environments//*" | uniq | d" >> $GITHUB_OUTPUT
+
+      - name: Terraform init
+        run:
+          for directory in ${{ steps.directories.outputs.CHANGED_DIRECTORIES }}; do
+            echo "Running 'terraform init' in $directory"
+            bash scripts/terraform-init.sh $directory
+          done
+
+      - name: Terraform plan
+        run:
+          for directory in ${{ steps.directories.outputs.CHANGED_DIRECTORIES }}; do
+            environment=$(basename $directory)
+            bash scripts/terraform-workspace.sh $directory $environment-${{ matrix.environment }}
+            bash scripts/terraform-plan $directory
+            unset environment
+          done
+
+      - name: Slack failure notification
+        if: ${{ failure() }}
+        uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0
+        with:
+          payload: |
+            {"blocks":[{"type": "section","text": {"type": "mrkdwn","text": ":no_entry: Failed GitHub Action:"}},{"type": "section","fields":[{"type": "mrkdwn","text": "*Workflow:*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>"},{"type": "mrkdwn","text": "*Job:*\n${{ github.job }}"},{"type": "mrkdwn","text": "*Repo:*\n${{ github.repository }}"}]}]}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/terraform-member-environments.yml
+++ b/.github/workflows/terraform-member-environments.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Populate list of changed directories
         id: directories
-        run: echo "CHANGED_DIRECTORIES=$(git --no-pager diff --name-only ${{ github.base_ref }} ${{ github.head_ref }} | awk '{print $1}' | grep ".tf" | grep -a "terraform/environments//*" | uniq | d" >> $GITHUB_OUTPUT
+        run: echo "CHANGED_DIRECTORIES=$(git --no-pager diff --name-only ${{ github.base_ref }} ${{ github.head_ref }} | awk '{print $1}' | grep ".tf" | grep -a "terraform/environments//*" | uniq)" >> $GITHUB_OUTPUT
 
       - name: Terraform init
         run:

--- a/scripts/terraform-workspace.sh
+++ b/scripts/terraform-workspace.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -o pipefail
+set -e
+
+# This script runs terraform workspace with input set to false and no color outputs, suitable for running as part of a CI/CD pipeline.
+# You need to pass through a Terraform directory as the first argument an an environment as the second argument, e.g.
+# sh terraform-workspace.sh terraform/environments cooker-development
+
+# This script pipes the output of terraform plan to ./scripts/redact-output.sh to redact sensitive things, such as AWS keys if they
+# are exposed via terraform plan.
+
+# Make redact-output.sh executable
+chmod +x ./scripts/redact-output.sh
+
+if [ -z "$1" ]; then
+  echo "Unsure where to run terraform, exiting"
+  exit 1
+fi
+
+if [ -z "$2" ]; then
+  echo "Unsure which workspace to select, exiting"
+  exit 1
+fi
+
+terraform -chdir="$1" workspace select "$2" -input=false -no-color | ./scripts/redact-output.sh

--- a/terraform/environments/cooker/locals.tf
+++ b/terraform/environments/cooker/locals.tf
@@ -28,6 +28,8 @@ locals {
   is_live       = [substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-production" || substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-preproduction" ? "live" : "non-live"]
   provider_name = "core-vpc-${local.environment}"
 
+  is_cooker = true
+
   # environment specfic variables
   # example usage:
   # example_data = local.application_data.accounts[local.environment].example_var


### PR DESCRIPTION
* Adds a local to `cooker` to trigger the job.

Adds a workflow that scans for changes to `*.tf` files in the customer directories in `terraform/environments`.
On triggering, the workflow will carry out a `terraform plan` for all four environments (development, test, preproduction, and production) in the affected environment.

Should the plan succeed, **and if the workflow was triggered by a pull request** then the workflow will move on to a job that conducts a `terraform apply` in the development and test environments.

**NB**. For the moment I've commented out the `terraform apply` in the dev-test job so I can observe the behaviour before any changes are made.