### PR TITLE
Adding AWSApplicationDiscoveryAgentAccess to CSR automation user

### DIFF
--- a/terraform/environments/corporate-staff-rostering/iam.tf
+++ b/terraform/environments/corporate-staff-rostering/iam.tf
@@ -9,9 +9,17 @@ resource "aws_iam_user" "mgn_user" {
 }
 #tfsec:ignore:aws-iam-no-user-attached-policies
 resource "aws_iam_user_policy_attachment" "mgn_attach_policy" {
-  #tfsec:ignore:aws-iam-no-user-attached-policies
+  #tfsec:ignore:aws-iam-no-user-attached-policies "This is a short lived user, so allowing IAM policies attached directly to a user."
   #checkov:skip=CKV_AWS_40: "Skipping as tfsec check is also ignored"
   user       = aws_iam_user.mgn_user.name
   policy_arn = "arn:aws:iam::aws:policy/AWSApplicationMigrationAgentInstallationPolicy"
+}
+
+#tfsec:ignore:aws-iam-no-user-attached-policies
+resource "aws_iam_user_policy_attachment" "mgn_attach_policy" {
+  #tfsec:ignore:aws-iam-no-user-attached-policies "This is a short lived user, so allowing IAM policies attached directly to a user."
+  #checkov:skip=CKV_AWS_40: "Skipping as tfsec check is also ignored"
+  user       = aws_iam_user.mgn_user.name
+  policy_arn = "arn:aws:iam::aws:policy/AWSApplicationDiscoveryAgentAccess"
 }
 

--- a/terraform/environments/corporate-staff-rostering/iam.tf
+++ b/terraform/environments/corporate-staff-rostering/iam.tf
@@ -8,7 +8,7 @@ resource "aws_iam_user" "mgn_user" {
   tags = local.tags
 }
 #tfsec:ignore:aws-iam-no-user-attached-policies
-resource "aws_iam_user_policy_attachment" "mgn_attach_policy" {
+resource "aws_iam_user_policy_attachment" "mgn_attach_policy_migration" {
   #tfsec:ignore:aws-iam-no-user-attached-policies "This is a short lived user, so allowing IAM policies attached directly to a user."
   #checkov:skip=CKV_AWS_40: "Skipping as tfsec check is also ignored"
   user       = aws_iam_user.mgn_user.name
@@ -16,7 +16,7 @@ resource "aws_iam_user_policy_attachment" "mgn_attach_policy" {
 }
 
 #tfsec:ignore:aws-iam-no-user-attached-policies
-resource "aws_iam_user_policy_attachment" "mgn_attach_policy" {
+resource "aws_iam_user_policy_attachment" "mgn_attach_policy_discovery" {
   #tfsec:ignore:aws-iam-no-user-attached-policies "This is a short lived user, so allowing IAM policies attached directly to a user."
   #checkov:skip=CKV_AWS_40: "Skipping as tfsec check is also ignored"
   user       = aws_iam_user.mgn_user.name


### PR DESCRIPTION
This is to add the`AWSApplicationDiscoveryAgentAccess` policy to the management/automation/migration user in the CSR accounts, as requested by CSR team [here](https://mojdt.slack.com/archives/C013RM6MFFW/p1689607431807879).