### PR TITLE
Doc/amend vision - correct typos

### DIFF
--- a/source/team/vision.html.md.erb
+++ b/source/team/vision.html.md.erb
@@ -9,4 +9,4 @@ review_in: 3 months
 
 To provide a modern, robust and secure environment to support more complex applications.
 
-We aim to provide Ministry of Justice applications teams with self service modules enabling them to build consistent environments with limited infrastructure knowledge.
+We aim to provide Ministry of Justice application teams with self service modules enabling them to build consistent environments with limited infrastructure knowledge.

--- a/source/team/vision.html.md.erb
+++ b/source/team/vision.html.md.erb
@@ -7,6 +7,6 @@ review_in: 3 months
 
 # <%= current_page.data.title %>
 
-To provide a modern, robust and secure environment to support more complex applications.
+To provide a modern, robust and secure platform to support more complex applications.
 
 We aim to provide Ministry of Justice application teams with self service modules enabling them to build consistent environments with limited infrastructure knowledge.


### PR DESCRIPTION
Correcting a typo and replacing 'environment' with 'platform' in first line