### PR TITLE
add ecr repo for get_glue_metadata lambda function

### DIFF
--- a/terraform/environments/core-shared-services/ecr_repos.tf
+++ b/terraform/environments/core-shared-services/ecr_repos.tf
@@ -206,6 +206,28 @@ module "data_platform_athena_load_ecr_repo" {
   tags_common = local.tags
 }
 
+module "data_platform_get_glue_metadata_ecr_repo" {
+  source = "../../modules/app-ecr-repo"
+
+  app_name = "data-platform-get-glue-metadata-lambda"
+
+  push_principals = [
+    "arn:aws:iam::${local.environment_management.account_ids["data-platform-development"]}:user/cicd-member-user",
+    "arn:aws:iam::${local.environment_management.account_ids["data-platform-development"]}:role/data-platform-gha",
+    local.environment_management.account_ids["data-platform-development"]
+  ]
+
+  pull_principals = [
+    "arn:aws:iam::${local.environment_management.account_ids["data-platform-development"]}:user/cicd-member-user",
+    local.environment_management.account_ids["data-platform-development"],
+  ]
+
+  enable_retrieval_policy_for_lambdas = ["arn:aws:lambda:eu-west-2:${local.environment_management.account_ids["data-platform-development"]}:function:data_product_get_glue_metadata*"]
+
+  # Tags
+  tags_common = local.tags
+}
+
 # ECR repo holding the hmpps delius core ansible aws automation container image
 module "delius_core_ansible_aws_ecr_repo" {
   source = "../../modules/app-ecr-repo"


### PR DESCRIPTION
Adds ECR repo to store containers used for the get_glue_metadata lambda function