### PR TITLE
Add MigrationHub policy to MGN-Test user

### DIFF
--- a/terraform/environments/corporate-staff-rostering/iam.tf
+++ b/terraform/environments/corporate-staff-rostering/iam.tf
@@ -29,3 +29,10 @@ resource "aws_iam_user_policy_attachment" "mgn_attach_policy_service_access" {
   user       = aws_iam_user.mgn_user.name
   policy_arn = "arn:aws:iam::aws:policy/AWSApplicationDiscoveryServiceFullAccess"
 }
+
+resource "aws_iam_user_policy_attachment" "mgn_attach_policy_migrationhub_access" {
+  #tfsec:ignore:aws-iam-no-user-attached-policies "This is a short lived user, so allowing IAM policies attached directly to a user."
+  #checkov:skip=CKV_AWS_40: "Skipping as tfsec check is also ignored"
+  user       = aws_iam_user.mgn_user.name
+  policy_arn = "arn:aws:iam::aws:policy/AWSMigrationHubFullAccess"
+}


### PR DESCRIPTION
As per Slack conversation https://mojdt.slack.com/archives/C013RM6MFFW/p1689764646387769 this PR adds the `AWSMigrationHubFullAccess` policy to the MGN-Test user. 
