### PR TITLE
Allow customers to send outbound email through egress VPCs

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/inline_fqdn_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/inline_fqdn_rules.json
@@ -9,6 +9,7 @@
     "ntservicepack.microsoft.com",
     "stats.microsoft.com",
     "saas40.kaseya.net",
-    ".dl.delivery.mp.microsoft.com"
+    ".dl.delivery.mp.microsoft.com",
+    "smtp.office365.com"
   ]
 }

--- a/terraform/environments/delius-jitbit/iam.tf
+++ b/terraform/environments/delius-jitbit/iam.tf
@@ -64,36 +64,3 @@ resource "aws_secretsmanager_secret_version" "s3_user_secret_key" {
   secret_id     = aws_secretsmanager_secret.s3_user_secret_key.id
   secret_string = aws_iam_access_key.s3_user.secret
 }
-
-#tfsec:ignore:aws-iam-no-user-attached-policies
-resource "aws_iam_user" "email" {
-  #checkov:skip=CKV_AWS_273: "Skipping as tfsec check is also ignored"
-  name  = format("%s-%s-email_user", local.application_name, local.environment)
-  tags = merge(local.tags,
-    { Name = format("%s-%s-email_user", local.application_name, local.environment) }
-  )
-}
-
-resource "aws_iam_access_key" "email" {
-  user  = aws_iam_user.email.name
-}
-
-#tfsec:ignore:aws-iam-no-policy-wildcards
-resource "aws_iam_user_policy" "email_policy" {
-  # checkov:skip=CKV_AWS_40:"Directly attaching the policy makes more sense here"
-  name   = "AmazonSesSendingAccess"
-  user   = aws_iam_user.email.name
-  policy = data.aws_iam_policy_document.email.json
-}
-
-#tfsec:ignore:aws-iam-no-policy-wildcards
-data "aws_iam_policy_document" "email" {
-  #checkov:skip=CKV_AWS_111
-  #checkov:skip=CKV_AWS_356: Policy follows AWS guidance
-  statement {
-    actions = [
-      "ses:SendRawEmail"
-    ]
-    resources = ["*"]
-  }
-}

--- a/terraform/modules/vpc-nacls/data.tf
+++ b/terraform/modules/vpc-nacls/data.tf
@@ -158,13 +158,22 @@ locals {
       rule_number = 5100
       to_port     = 80
     },
+    allow_0-0-0-0_smtp_submission_tcp_out = {
+      cidr_block  = "0.0.0.0/0"
+      egress      = true
+      from_port   = 587
+      protocol    = "tcp"
+      rule_action = "allow"
+      rule_number = 5300
+      to_port     = 587
+    },
     allow_0-0-0-0_agent_tcp_out = {
       cidr_block  = "0.0.0.0/0"
       egress      = true
       from_port   = 5721
       protocol    = "tcp"
       rule_action = "allow"
-      rule_number = 5200
+      rule_number = 5400
       to_port     = 5721
     },
     allow_0-0-0-0_dynamic_tcp_in = {


### PR DESCRIPTION
As discussed in [this slack thread](https://mojdt.slack.com/archives/C01A7QK5VM1/p1689849118728639), SES is not always an appropriate choice for customers to relay outbound email through. While we would generally prefer that SES be used, this PR will allow customers in the same situation as the JitBit application to send traffic out over the [SMTP submission port](https://www.cloudflare.com/en-gb/learning/email-security/smtp-port-25-587/#:~:text=The%20official%20default%20port%20for%20SMTPS%20is%20port%20587.%20SMTPS%20connections%20start%20with%20a%20%22STARTTLS%22%20command%20to%20let%20the%20mail%20server%20know%20that%20the%20SMTP%20traffic%20will%20be%20sent%20over%20TLS.)

Further to this, this PR removes the now-unneeded SES users that were created previously.