### PR TITLE
Add discovery permissions to migration role

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/policies.tf
+++ b/terraform/environments/bootstrap/delegate-access/policies.tf
@@ -473,7 +473,8 @@ data "aws_iam_policy_document" "migration_additional" {
       "dms:*",
       "drs:*",
       "mgh:*",
-      "datasync:*"
+      "datasync:*",
+      "discovery:*"
     ]
     resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
   }


### PR DESCRIPTION
As per Slack conversation [here](https://mojdt.slack.com/archives/C013RM6MFFW/p1690193214354109) this PR adds the discovery:* permissions to the migration role. If this fails to resolve the issue for the users I believe the next step would be to add the 'AWSApplicationDiscoveryServiceFullAccess' policy to the migration role as per David E. suggestion.