### PR TITLE
Allow traffic to wider range of office365 addresses

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/inline_fqdn_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/inline_fqdn_rules.json
@@ -10,6 +10,6 @@
     "stats.microsoft.com",
     "saas40.kaseya.net",
     ".dl.delivery.mp.microsoft.com",
-    "smtp.office365.com"
+    ".office365.com"
   ]
 }


### PR DESCRIPTION
In line with [this request](https://mojdt.slack.com/archives/C01A7QK5VM1/p1689849118728639), this PR amends the filtering for traffic to `office365.com`.