### PR TITLE
Allow access to Redshift VPC endpoint from on-premise networks

### DIFF
--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -38,7 +38,7 @@ jobs:
         id: ml
         # You can override MegaLinter flavor used to have faster performances
         # More info at https://megalinter.io/flavors/
-        uses: oxsecurity/megalinter/flavors/terraform@a7b1a3af0f3bd4de4db855969d27e224005665a6 #v7.1.0
+        uses: oxsecurity/megalinter/flavors/terraform@c72cdea919d17076dbc54f4864b1c82db0f181f2 #v7.2.0
         env:
           # All available variables are described in documentation
           # https://megalinter.io/configuration/#shared-variables

--- a/.github/workflows/terraform-member-environment.yml
+++ b/.github/workflows/terraform-member-environment.yml
@@ -43,7 +43,7 @@ jobs:
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             echo "CHANGED_DIRECTORIES=$(git diff HEAD origin/main ${{ github.event.pull_request.changes.paths }} --name-only | awk '{print $1}' | grep ".tf" | grep -a "environments//*" | cut -f1-3 -d"/" | uniq)"
           else
-            echo "CHANGED_DIRECTORIES=$(git diff HEAD HEAD~ ${{ github.event.changes.paths }} --name-only | | awk '{print $1}' | grep ".tf" | grep -a "environments//*" | cut -f1-3 -d"/" | uniq)"
+            echo "CHANGED_DIRECTORIES=$(git diff HEAD HEAD~ ${{ github.event.changes.paths }} --name-only | awk '{print $1}' | grep ".tf" | grep -a "environments//*" | cut -f1-3 -d"/" | uniq)"
           fi >> $GITHUB_OUTPUT
       - name: Display changed directories
         run: echo "Directories in scope:" ${{ steps.directories.outputs.CHANGED_DIRECTORIES }}

--- a/environments-networks/hq-development.json
+++ b/environments-networks/hq-development.json
@@ -10,7 +10,7 @@
   "options": {
     "bastion_linux": true,
     "additional_cidrs": [],
-    "additional_endpoints": ["redshift.eu-west-2.amazonaws.com"],
+    "additional_endpoints": ["redshift-serverless.eu-west-2.amazonaws.com"],
     "additional_vpcs": [],
     "dns_zone_extend": []
   }

--- a/environments-networks/hq-development.json
+++ b/environments-networks/hq-development.json
@@ -10,7 +10,7 @@
   "options": {
     "bastion_linux": true,
     "additional_cidrs": [],
-    "additional_endpoints": [],
+    "additional_endpoints": ["redshift.eu-west-2.amazonaws.com"],
     "additional_vpcs": [],
     "dns_zone_extend": []
   }

--- a/environments-networks/hq-preproduction.json
+++ b/environments-networks/hq-preproduction.json
@@ -10,7 +10,7 @@
   "options": {
     "bastion_linux": false,
     "additional_cidrs": [],
-    "additional_endpoints": ["redshift.eu-west-2.amazonaws.com"],
+    "additional_endpoints": ["redshift-serverless.eu-west-2.amazonaws.com"],
     "additional_vpcs": [],
     "dns_zone_extend": []
   }

--- a/environments-networks/hq-preproduction.json
+++ b/environments-networks/hq-preproduction.json
@@ -10,7 +10,7 @@
   "options": {
     "bastion_linux": false,
     "additional_cidrs": [],
-    "additional_endpoints": [],
+    "additional_endpoints": ["redshift.eu-west-2.amazonaws.com"],
     "additional_vpcs": [],
     "dns_zone_extend": []
   }

--- a/environments-networks/hq-production.json
+++ b/environments-networks/hq-production.json
@@ -10,7 +10,7 @@
   "options": {
     "bastion_linux": true,
     "additional_cidrs": [],
-    "additional_endpoints": ["redshift.eu-west-2.amazonaws.com"],
+    "additional_endpoints": ["redshift-serverless.eu-west-2.amazonaws.com"],
     "additional_vpcs": [],
     "dns_zone_extend": []
   }

--- a/environments-networks/hq-production.json
+++ b/environments-networks/hq-production.json
@@ -10,7 +10,7 @@
   "options": {
     "bastion_linux": true,
     "additional_cidrs": [],
-    "additional_endpoints": [],
+    "additional_endpoints": ["redshift.eu-west-2.amazonaws.com"],
     "additional_vpcs": [],
     "dns_zone_extend": []
   }

--- a/terraform/environments/core-network-services/firewall-rules/development_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/development_rules.json
@@ -208,5 +208,12 @@
     "destination_ip": "${hmpps-development}",
     "destination_port": "389",
     "protocol": "TCP"
+  },
+  "rfc_10-0-0-0-8_to_dih_development_redshift": {
+    "action": "PASS",
+    "source_ip": "10.0.0.0/8",
+    "destination_ip": "${hq-development}",
+    "destination_port": "5439",
+    "protocol": "TCP"
   }
 }

--- a/terraform/environments/core-network-services/firewall-rules/development_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/development_rules.json
@@ -209,9 +209,9 @@
     "destination_port": "389",
     "protocol": "TCP"
   },
-  "rfc_10-0-0-0-8_to_dih_development_redshift": {
+  "global-protect_to_dih_development_redshift": {
     "action": "PASS",
-    "source_ip": "10.0.0.0/8",
+    "source_ip": "${global-protect}",
     "destination_ip": "${hq-development}",
     "destination_port": "5439",
     "protocol": "TCP"

--- a/terraform/environments/core-network-services/firewall-rules/inline_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/inline_rules.json
@@ -33,5 +33,19 @@
     "destination_ip": "0.0.0.0/0",
     "destination_port": "5721",
     "protocol": "TCP"
+  },
+  "hmpps-development_to_internet_smtp465": {
+    "action": "PASS",
+    "source_ip": "${hmpps-development}",
+    "destination_ip": "0.0.0.0/0",
+    "destination_port": "465",
+    "protocol": "TCP"
+  },
+  "hmpps-development_to_internet_smtp587": {
+    "action": "PASS",
+    "source_ip": "${hmpps-development}",
+    "destination_ip": "0.0.0.0/0",
+    "destination_port": "587",
+    "protocol": "TCP"
   }
 }

--- a/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
@@ -216,11 +216,18 @@
     "destination_port": "389",
     "protocol": "TCP"
   },
-  "rfc_10-0-0-0-8_to_ppud_production_https": {
+  "rfc_10-0-0-0-8_to_ppud_preproduction_https": {
     "action": "PASS",
     "source_ip": "10.0.0.0/8",
-    "destination_ip": "${hmpps-production}",
+    "destination_ip": "${hmpps-preproduction}",
     "destination_port": "443",
+    "protocol": "TCP"
+  },
+  "rfc_10-0-0-0-8_to_dih_preproduction_redshift": {
+    "action": "PASS",
+    "source_ip": "10.0.0.0/8",
+    "destination_ip": "${hq-preproduction}",
+    "destination_port": "5439",
     "protocol": "TCP"
   }
 }

--- a/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
@@ -223,9 +223,9 @@
     "destination_port": "443",
     "protocol": "TCP"
   },
-  "rfc_10-0-0-0-8_to_dih_preproduction_redshift": {
+  "global-protect_to_dih_preproduction_redshift": {
     "action": "PASS",
-    "source_ip": "10.0.0.0/8",
+    "source_ip": "${global-protect}",
     "destination_ip": "${hq-preproduction}",
     "destination_port": "5439",
     "protocol": "TCP"

--- a/terraform/environments/core-network-services/firewall-rules/production_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/production_rules.json
@@ -272,9 +272,9 @@
     "destination_port": "443",
     "protocol": "TCP"
   },
-  "rfc_10-0-0-0-8_to_dih_production_redshift": {
+  "global-protect_to_dih_production_redshift": {
     "action": "PASS",
-    "source_ip": "10.0.0.0/8",
+    "source_ip": "${global-protect}",
     "destination_ip": "${hq-production}",
     "destination_port": "5439",
     "protocol": "TCP"

--- a/terraform/environments/core-network-services/firewall-rules/production_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/production_rules.json
@@ -271,5 +271,12 @@
     "destination_ip": "${hmpps-production}",
     "destination_port": "443",
     "protocol": "TCP"
+  },
+  "rfc_10-0-0-0-8_to_dih_production_redshift": {
+    "action": "PASS",
+    "source_ip": "10.0.0.0/8",
+    "destination_ip": "${hq-production}",
+    "destination_port": "5439",
+    "protocol": "TCP"
   }
 }

--- a/terraform/environments/corporate-staff-rostering/iam.tf
+++ b/terraform/environments/corporate-staff-rostering/iam.tf
@@ -36,3 +36,10 @@ resource "aws_iam_user_policy_attachment" "mgn_attach_policy_migrationhub_access
   user       = aws_iam_user.mgn_user.name
   policy_arn = "arn:aws:iam::aws:policy/AWSMigrationHubFullAccess"
 }
+
+resource "aws_iam_user_policy_attachment" "mgn_attach_policy_app_migrationfull_access" {
+  #tfsec:ignore:aws-iam-no-user-attached-policies "This is a short lived user, so allowing IAM policies attached directly to a user."
+  #checkov:skip=CKV_AWS_40: "Skipping as tfsec check is also ignored"
+  user       = aws_iam_user.mgn_user.name
+  policy_arn = "arn:aws:iam::aws:policy/AWSApplicationMigrationFullAccess"
+}

--- a/terraform/modules/vpc-nacls/data.tf
+++ b/terraform/modules/vpc-nacls/data.tf
@@ -255,7 +255,7 @@ locals {
       to_port     = 587
     },
     allow_redshift_in = {
-      cidr_block  = "10.184.0.0/16"
+      cidr_block  = data.aws_vpc.current.cidr_block
       egress      = false
       from_port   = 5439
       protocol    = "tcp"

--- a/terraform/modules/vpc-nacls/data.tf
+++ b/terraform/modules/vpc-nacls/data.tf
@@ -245,6 +245,15 @@ locals {
       rule_number = 1100
       to_port     = 587
     },
+    allow_redshift_in = {
+      cidr_block  = "10.184.0.0/16"
+      egress      = false
+      from_port   = 5439
+      protocol    = "tcp"
+      rule_action = "allow"
+      rule_number = 1200
+      to_port     = 5439
+    },
     allow_dynamic_tcp_out = {
       cidr_block  = data.aws_vpc.current.cidr_block
       egress      = true

--- a/terraform/modules/vpc-nacls/data.tf
+++ b/terraform/modules/vpc-nacls/data.tf
@@ -158,6 +158,15 @@ locals {
       rule_number = 5100
       to_port     = 80
     },
+    allow_0-0-0-0_smtp_465_tcp_out = {
+      cidr_block  = "0.0.0.0/0"
+      egress      = true
+      from_port   = 465
+      protocol    = "tcp"
+      rule_action = "allow"
+      rule_number = 5200
+      to_port     = 465
+    },
     allow_0-0-0-0_smtp_submission_tcp_out = {
       cidr_block  = "0.0.0.0/0"
       egress      = true


### PR DESCRIPTION
As part of https://github.com/ministryofjustice/modernisation-platform/issues/4538, this PR allows traffic from MOJ internal networks to access a redshift VPC endpoint.
There would also need to be a corresponding change to the [modernisation-platform-terraform-member-vpc](https://github.com/ministryofjustice/modernisation-platform-terraform-member-vpc/blob/d568b0d83bb7cec82ee9eddb7c264cf8c02757a4/main.tf#L317) module, as well as supplying an additional value to the [subnet sets](https://github.com/ministryofjustice/modernisation-platform/blob/5d2666549a56c547edaf509295792ccedf9a0ffc/terraform/environments/core-vpc/vpc.tf#L90) defined in the code that creates the member VPCs, which would need some further planning.