### PR TITLE
Add AWSApplicationMigrationFullAccess permission for CSR

### DIFF
--- a/terraform/environments/corporate-staff-rostering/iam.tf
+++ b/terraform/environments/corporate-staff-rostering/iam.tf
@@ -36,3 +36,10 @@ resource "aws_iam_user_policy_attachment" "mgn_attach_policy_migrationhub_access
   user       = aws_iam_user.mgn_user.name
   policy_arn = "arn:aws:iam::aws:policy/AWSMigrationHubFullAccess"
 }
+
+resource "aws_iam_user_policy_attachment" "mgn_attach_policy_app_migrationfull_access" {
+  #tfsec:ignore:aws-iam-no-user-attached-policies "This is a short lived user, so allowing IAM policies attached directly to a user."
+  #checkov:skip=CKV_AWS_40: "Skipping as tfsec check is also ignored"
+  user       = aws_iam_user.mgn_user.name
+  policy_arn = "arn:aws:iam::aws:policy/AWSApplicationMigrationFullAccess"
+}


### PR DESCRIPTION
Users have installed the agent on two servers (1 Windows, 1 Linux) using the mgn-test user however these are visible on the migration, this PR bumps up the permissions (same as ppud user) to hopefully resolve this while continuing to investigate. 