### PR TITLE
add inline firewall rule and update nacls vpc

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/inline_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/inline_rules.json
@@ -33,5 +33,19 @@
     "destination_ip": "0.0.0.0/0",
     "destination_port": "5721",
     "protocol": "TCP"
+  },
+  "hmpps-development_to_internet_smtp465": {
+    "action": "PASS",
+    "source_ip": "${hmpps-development}",
+    "destination_ip": "0.0.0.0/0",
+    "destination_port": "465",
+    "protocol": "TCP"
+  },
+  "hmpps-development_to_internet_smtp587": {
+    "action": "PASS",
+    "source_ip": "${hmpps-development}",
+    "destination_ip": "0.0.0.0/0",
+    "destination_port": "587",
+    "protocol": "TCP"
   }
 }

--- a/terraform/modules/vpc-nacls/data.tf
+++ b/terraform/modules/vpc-nacls/data.tf
@@ -158,6 +158,15 @@ locals {
       rule_number = 5100
       to_port     = 80
     },
+    allow_0-0-0-0_smtp_465_tcp_out = {
+      cidr_block  = "0.0.0.0/0"
+      egress      = true
+      from_port   = 465
+      protocol    = "tcp"
+      rule_action = "allow"
+      rule_number = 5200
+      to_port     = 465
+    },
     allow_0-0-0-0_smtp_submission_tcp_out = {
       cidr_block  = "0.0.0.0/0"
       egress      = true


### PR DESCRIPTION
As per Slack conversation [here](https://mojdt.slack.com/archives/C01A7QK5VM1/p1689849118728639) this PR adds two new firewall rules for hmpps-dev to any for ports 465 & 587 and also updates the nacls to include port 465 (587 already existed)