### PR TITLE
Fix typo in workflow file

### DIFF
--- a/.github/workflows/terraform-member-environment.yml
+++ b/.github/workflows/terraform-member-environment.yml
@@ -43,7 +43,7 @@ jobs:
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             echo "CHANGED_DIRECTORIES=$(git diff HEAD origin/main ${{ github.event.pull_request.changes.paths }} --name-only | awk '{print $1}' | grep ".tf" | grep -a "environments//*" | cut -f1-3 -d"/" | uniq)"
           else
-            echo "CHANGED_DIRECTORIES=$(git diff HEAD HEAD~ ${{ github.event.changes.paths }} --name-only | | awk '{print $1}' | grep ".tf" | grep -a "environments//*" | cut -f1-3 -d"/" | uniq)"
+            echo "CHANGED_DIRECTORIES=$(git diff HEAD HEAD~ ${{ github.event.changes.paths }} --name-only | awk '{print $1}' | grep ".tf" | grep -a "environments//*" | cut -f1-3 -d"/" | uniq)"
           fi >> $GITHUB_OUTPUT
       - name: Display changed directories
         run: echo "Directories in scope:" ${{ steps.directories.outputs.CHANGED_DIRECTORIES }}


### PR DESCRIPTION
The `terraform-member-environments` workflow file has an accidental typo in it where it conducts a `git diff` on a completed pull request. This PR removes the typo.

You can see an example of this causing a workflow to fail [here](https://github.com/ministryofjustice/modernisation-platform/actions/runs/5656256881/job/15324268633).