### PR TITLE
Allow all HMPPS VPCs to send SMTPS and SMTP-TLS out

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/inline_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/inline_rules.json
@@ -34,16 +34,58 @@
     "destination_port": "5721",
     "protocol": "TCP"
   },
-  "hmpps-development_to_internet_smtp465": {
+  "hmpps-development_to_internet_smtps5": {
     "action": "PASS",
     "source_ip": "${hmpps-development}",
     "destination_ip": "0.0.0.0/0",
     "destination_port": "465",
     "protocol": "TCP"
   },
-  "hmpps-development_to_internet_smtp587": {
+  "hmpps-development_to_internet_smtp-submission": {
     "action": "PASS",
     "source_ip": "${hmpps-development}",
+    "destination_ip": "0.0.0.0/0",
+    "destination_port": "587",
+    "protocol": "TCP"
+  },
+  "hmpps-test_to_internet_smtps": {
+    "action": "PASS",
+    "source_ip": "${hmpps-test}",
+    "destination_ip": "0.0.0.0/0",
+    "destination_port": "465",
+    "protocol": "TCP"
+  },
+  "hmpps-test_to_internet_smtp-submission": {
+    "action": "PASS",
+    "source_ip": "${hmpps-test}",
+    "destination_ip": "0.0.0.0/0",
+    "destination_port": "587",
+    "protocol": "TCP"
+  },
+  "hmpps-preproduction_to_internet_smtps": {
+    "action": "PASS",
+    "source_ip": "${hmpps-preproduction}",
+    "destination_ip": "0.0.0.0/0",
+    "destination_port": "465",
+    "protocol": "TCP"
+  },
+  "hmpps-preproduction_to_internet_smtp-submission": {
+    "action": "PASS",
+    "source_ip": "${hmpps-preproduction}",
+    "destination_ip": "0.0.0.0/0",
+    "destination_port": "587",
+    "protocol": "TCP"
+  },
+  "hmpps-production_to_internet_smtps": {
+    "action": "PASS",
+    "source_ip": "${hmpps-production}",
+    "destination_ip": "0.0.0.0/0",
+    "destination_port": "465",
+    "protocol": "TCP"
+  },
+  "hmpps-production_to_internet_smtp-submission": {
+    "action": "PASS",
+    "source_ip": "${hmpps-production}",
     "destination_ip": "0.0.0.0/0",
     "destination_port": "587",
     "protocol": "TCP"


### PR DESCRIPTION
See [this Slack thread](https://mojdt.slack.com/archives/C01A7QK5VM1/p1689849118728639) for details.
This PR expands the source ranges that can send traffic out on SMTP-TLS or SMTP-Submission ports.