### PR TITLE
Allow access to Redshift VPC endpoint from Global Protect users

### DIFF
--- a/environments-networks/hq-development.json
+++ b/environments-networks/hq-development.json
@@ -10,7 +10,7 @@
   "options": {
     "bastion_linux": true,
     "additional_cidrs": [],
-    "additional_endpoints": [],
+    "additional_endpoints": ["redshift-serverless.eu-west-2.amazonaws.com"],
     "additional_vpcs": [],
     "dns_zone_extend": []
   }

--- a/environments-networks/hq-preproduction.json
+++ b/environments-networks/hq-preproduction.json
@@ -10,7 +10,7 @@
   "options": {
     "bastion_linux": false,
     "additional_cidrs": [],
-    "additional_endpoints": [],
+    "additional_endpoints": ["redshift-serverless.eu-west-2.amazonaws.com"],
     "additional_vpcs": [],
     "dns_zone_extend": []
   }

--- a/environments-networks/hq-production.json
+++ b/environments-networks/hq-production.json
@@ -10,7 +10,7 @@
   "options": {
     "bastion_linux": true,
     "additional_cidrs": [],
-    "additional_endpoints": [],
+    "additional_endpoints": ["redshift-serverless.eu-west-2.amazonaws.com"],
     "additional_vpcs": [],
     "dns_zone_extend": []
   }

--- a/terraform/environments/core-network-services/firewall-rules/development_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/development_rules.json
@@ -208,5 +208,12 @@
     "destination_ip": "${hmpps-development}",
     "destination_port": "389",
     "protocol": "TCP"
+  },
+  "global-protect_to_data-insights-hub_development_redshift": {
+    "action": "PASS",
+    "source_ip": "${global-protect}",
+    "destination_ip": "${hq-development}",
+    "destination_port": "5439",
+    "protocol": "TCP"
   }
 }

--- a/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
@@ -216,11 +216,18 @@
     "destination_port": "389",
     "protocol": "TCP"
   },
-  "rfc_10-0-0-0-8_to_ppud_production_https": {
+  "rfc_10-0-0-0-8_to_ppud_preproduction_https": {
     "action": "PASS",
     "source_ip": "10.0.0.0/8",
-    "destination_ip": "${hmpps-production}",
+    "destination_ip": "${hmpps-preproduction}",
     "destination_port": "443",
+    "protocol": "TCP"
+  },
+  "global-protect_to_data-insights-hub_preproduction_redshift": {
+    "action": "PASS",
+    "source_ip": "${global-protect}",
+    "destination_ip": "${hq-preproduction}",
+    "destination_port": "5439",
     "protocol": "TCP"
   }
 }

--- a/terraform/environments/core-network-services/firewall-rules/production_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/production_rules.json
@@ -271,5 +271,12 @@
     "destination_ip": "${hmpps-production}",
     "destination_port": "443",
     "protocol": "TCP"
+  },
+  "global-protect_to_data-insights-hub_production_redshift": {
+    "action": "PASS",
+    "source_ip": "${global-protect}",
+    "destination_ip": "${hq-production}",
+    "destination_port": "5439",
+    "protocol": "TCP"
   }
 }

--- a/terraform/modules/vpc-nacls/data.tf
+++ b/terraform/modules/vpc-nacls/data.tf
@@ -254,6 +254,15 @@ locals {
       rule_number = 1100
       to_port     = 587
     },
+    allow_redshift_in = {
+      cidr_block  = data.aws_vpc.current.cidr_block
+      egress      = false
+      from_port   = 5439
+      protocol    = "tcp"
+      rule_action = "allow"
+      rule_number = 1200
+      to_port     = 5439
+    },
     allow_dynamic_tcp_out = {
       cidr_block  = data.aws_vpc.current.cidr_block
       egress      = true


### PR DESCRIPTION
As part of https://github.com/ministryofjustice/modernisation-platform/issues/4538, this PR allows traffic from MOJ Global Protect users to access a redshift VPC endpoint.
There would also need to be a corresponding change to the [modernisation-platform-terraform-member-vpc](https://github.com/ministryofjustice/modernisation-platform-terraform-member-vpc/blob/d568b0d83bb7cec82ee9eddb7c264cf8c02757a4/main.tf#L317) module to amend the security group, and a method for an AWS Load Balancer target group attachment to discover the relevant IP address (probably a combination of a data call and a for_each expression).