### PR TITLE
Add migration level access to CSR development

### DIFF
--- a/environments/corporate-staff-rostering.json
+++ b/environments/corporate-staff-rostering.json
@@ -8,6 +8,10 @@
           "github_slug": "studio-webops",
           "level": "sandbox",
           "nuke": "exclude"
+        },
+        {
+          "github_slug": "studio-webops",
+          "level": "migration"
         }
       ]
     },


### PR DESCRIPTION
Following on from some troubleshooting with Hope and the addition of permissions to the migration user, Hope has requested for the migration user to be configured on the development environment. 