### PR TITLE
Update redshift VPC endpoint type

### DIFF
--- a/environments-networks/hq-development.json
+++ b/environments-networks/hq-development.json
@@ -10,7 +10,7 @@
   "options": {
     "bastion_linux": true,
     "additional_cidrs": [],
-    "additional_endpoints": ["redshift-serverless.eu-west-2.amazonaws.com"],
+    "additional_endpoints": ["redshift-data.eu-west-2.amazonaws.com"],
     "additional_vpcs": [],
     "dns_zone_extend": []
   }

--- a/environments-networks/hq-preproduction.json
+++ b/environments-networks/hq-preproduction.json
@@ -10,7 +10,7 @@
   "options": {
     "bastion_linux": false,
     "additional_cidrs": [],
-    "additional_endpoints": ["redshift-serverless.eu-west-2.amazonaws.com"],
+    "additional_endpoints": ["redshift-data.eu-west-2.amazonaws.com"],
     "additional_vpcs": [],
     "dns_zone_extend": []
   }

--- a/environments-networks/hq-production.json
+++ b/environments-networks/hq-production.json
@@ -10,7 +10,7 @@
   "options": {
     "bastion_linux": true,
     "additional_cidrs": [],
-    "additional_endpoints": ["redshift-serverless.eu-west-2.amazonaws.com"],
+    "additional_endpoints": ["redshift-data.eu-west-2.amazonaws.com"],
     "additional_vpcs": [],
     "dns_zone_extend": []
   }


### PR DESCRIPTION
From further research, it appears that the `redshift-data` endpoint is the appropriate option for RedShift Serverless querying.