### PR TITLE
Add migrationhhub strategy permissions

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/policies.tf
+++ b/terraform/environments/bootstrap/delegate-access/policies.tf
@@ -474,7 +474,8 @@ data "aws_iam_policy_document" "migration_additional" {
       "drs:*",
       "mgh:*",
       "datasync:*",
-      "discovery:*"
+      "discovery:*",
+      "migrationhub-strategy:*"
     ]
     resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
   }


### PR DESCRIPTION
A user is currently receiving an error when trying to view the recommendations on the migration hub. This PR adds the migrationhub-strategy permissions to the migration user.