### PR TITLE
Allow Redshift access to Redshift endpoints

### DIFF
--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -85,7 +85,7 @@ locals {
 module "vpc" {
   for_each = local.vpcs[terraform.workspace]
 
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-member-vpc?ref=11112dfebdb93069d730c643fd5b4dbaa6710935" #v2.0.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-member-vpc?ref=bdd69b375c09555389089d65b3d14014ccfdcfec" #v2.1.1
 
   subnet_sets = { for key, subnet in each.value.cidr.subnet_sets : key => subnet.cidr }
 


### PR DESCRIPTION
This PR updates the version of the `modernisation-platform-terraform-member-vpc` module; the latest release includes an amendment to the VPC Endpoint security group common to VPCs created with this module. In order to accommodate VPCs that make use of AWS Redshift endpoints, the security group needs to include `tcp/5439` in its allowed inbound traffic.

This should be the last piece needed for https://github.com/ministryofjustice/modernisation-platform/issues/4538