### PR TITLE
Fix inappropriate triggering of `terraform-member-environments`

### DIFF
--- a/.github/workflows/terraform-member-environment.yml
+++ b/.github/workflows/terraform-member-environment.yml
@@ -7,14 +7,14 @@ on:
       - main
     paths:
       - 'terraform/environments/**/*.tf'
-      - '!terraform/environments/core-*'
+      - '!terraform/environments/core-*/*.tf'
   pull_request:
     types: [opened, edited, reopened, synchronize]
     branches-ignore:
       - 'date*'
     paths:
       - 'terraform/environments/**/*.tf'
-      - '!terraform/environments/core-*'
+      - '!terraform/environments/core-*/*.tf'
       - '.github/workflows/terraform-member-environment.yml'
 
 defaults:


### PR DESCRIPTION
According to the [GitHub documentation](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-including-and-excluding-paths) on path filtering, I believe that the current path options are causing the `terraform-member-environments` action to trigger inappropriately when changes are made to terraform files in `core-*`.

Although the ordering is correct, I think that the use of `**/*.tf` is being matched and as it is more specific than `!core-*`, exclusions are not being applied as originally anticipated.