### PR TITLE
Add application zone for dacp

### DIFF
--- a/terraform/environments/core-network-services/route53.tf
+++ b/terraform/environments/core-network-services/route53.tf
@@ -5,6 +5,7 @@ locals {
   application-zones = {
     equip    = "equip.service.justice.gov.uk",
     ccms-ebs = "ccms-ebs.service.justice.gov.uk",
+    dacp     = "dacp.service.justice.gov.uk",
     mlra     = "maat-libra-administration-tool.service.justice.gov.uk",
     mojfin   = "laa-finance-data.service.justice.gov.uk",
     tipstaff = "tipstaff.service.justice.gov.uk"


### PR DESCRIPTION
Following [this request](https://mojdt.slack.com/archives/C01A7QK5VM1/p1690384894123369) on Slack, and based on the name meeting suitable qualifying criteria (a well known, internal tool), this PR adds a DNS zone for `dacp.service.justice.gov.uk` to the `core-network-services` account.

We will need to liaise with the Ministry of Justice P&A Operations Engineering team to delegate this domain across to the Modernisation Platform.