### PR TITLE
Add application migration services permissions to migration user

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/policies.tf
+++ b/terraform/environments/bootstrap/delegate-access/policies.tf
@@ -470,11 +470,12 @@ data "aws_iam_policy_document" "migration_additional" {
     sid    = "migrationAllow"
     effect = "Allow"
     actions = [
+      "datasync:*",
+      "discovery:*",
       "dms:*",
       "drs:*",
       "mgh:*",
-      "datasync:*",
-      "discovery:*",
+      "mgn:*",
       "migrationhub-strategy:*"
     ]
     resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097


### PR DESCRIPTION
As per Slack request [here](https://mojdt.slack.com/archives/C01A7QK5VM1/p1690461621394229) Ijaz has requested Application Migration Service permissions. 


(also sorted permissions alphabetically)