### PR TITLE
Update dacp domain name

### DIFF
--- a/terraform/environments/core-network-services/route53.tf
+++ b/terraform/environments/core-network-services/route53.tf
@@ -5,7 +5,7 @@ locals {
   application-zones = {
     equip    = "equip.service.justice.gov.uk",
     ccms-ebs = "ccms-ebs.service.justice.gov.uk",
-    dacp     = "dacp.service.justice.gov.uk",
+    dacp     = "divorce-section-search.service.justice.gov.uk",
     mlra     = "maat-libra-administration-tool.service.justice.gov.uk",
     mojfin   = "laa-finance-data.service.justice.gov.uk",
     tipstaff = "tipstaff.service.justice.gov.uk"


### PR DESCRIPTION
After discussion with technical architect team and service team, this PR updates the name for the DACP application to better align with MOJ & gov.uk naming standards.