### PR TITLE
Updated subject value used in oidc role for cicd user

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -325,7 +325,7 @@ resource "aws_iam_policy" "member-access-us-east" {
 # Github OIDC role
 module "github_oidc_role" {
   source              = "github.com/ministryofjustice/modernisation-platform-github-oidc-role?ref=a16117ed5fd373bc28011342b7b8117077a84f19" # v2.0.0
-  github_repositories = ["ministryofjustice/modernisation-platform-configuration-management"]
+  github_repositories = ["ministryofjustice/modernisation-platform-configuration-management:*"]
   role_name           = "modernisation-platform-oidc-cicd"
   #  policy_arns                 = [aws_iam_policy.member-access[0].id]
   policy_jsons = [data.aws_iam_policy_document.policy.json]


### PR DESCRIPTION
Investigating the use of this OIDC policy showed that the original value was insufficient for use cases of the role.
When an attempt was made to use this through a PR in a different repository (`ministryofjustice/modernisation-platform-configuration-management`), a subject value was being supplied through as `sub:ministryofjustice/modernisation-platform-configuration-management:pull_request`).

This PR updates the permitted subject claims to allow any value. You can see more detail on subject claims [here](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#example-subject-claims).