### PR TITLE
Exclude bootstrap subdirectories from member-environments updates

### DIFF
--- a/.github/workflows/terraform-member-environment.yml
+++ b/.github/workflows/terraform-member-environment.yml
@@ -7,6 +7,7 @@ on:
       - main
     paths:
       - 'terraform/environments/**/*.tf'
+      - '!terraform/environments/bootstrap/**/*.tf'
       - '!terraform/environments/core-*/*.tf'
   pull_request:
     types: [opened, edited, reopened, synchronize]
@@ -14,6 +15,7 @@ on:
       - 'date*'
     paths:
       - 'terraform/environments/**/*.tf'
+      - '!terraform/environments/bootstrap/**/*.tf'
       - '!terraform/environments/core-*/*.tf'
       - '.github/workflows/terraform-member-environment.yml'
 


### PR DESCRIPTION
As the `terraform-member-environments` workflow did not exclude the bootstrap directories, changes here caused an inappropriate triggering of the workflow.