### PR TITLE
update allowed_domains inline fqdn list to include archive.ubuntu.com

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/inline_fqdn_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/inline_fqdn_rules.json
@@ -10,6 +10,7 @@
     "stats.microsoft.com",
     "saas40.kaseya.net",
     ".dl.delivery.mp.microsoft.com",
-    ".office365.com"
+    ".office365.com",
+    "archive.ubuntu.com"
   ]
 }


### PR DESCRIPTION
PR to add `archive.ubuntu.com` to allowed domains as per slack request [here](https://mojdt.slack.com/archives/C01A7QK5VM1/p1691052534081459)