### PR TITLE
Add security.ubuntu.com to allowed_domains

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/inline_fqdn_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/inline_fqdn_rules.json
@@ -11,6 +11,7 @@
     "saas40.kaseya.net",
     ".dl.delivery.mp.microsoft.com",
     ".office365.com",
-    "archive.ubuntu.com"
+    "archive.ubuntu.com",
+    "security.ububtu.com"
   ]
 }


### PR DESCRIPTION
As per Slack conversation: https://mojdt.slack.com/archives/C01A7QK5VM1/p1691052534081459 if further Ubuntu subdomains are required can update the list reflect *.ubuntu.com 