### PR TITLE
Add WAF & WAFv2 permissions to us-east IAM policy.

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -268,7 +268,9 @@ data "aws_iam_policy_document" "member-access-us-east" {
     #checkov:skip=CKV_AWS_356: Needs to access multiple resources
     effect = "Allow"
     actions = ["acm:*",
-      "logs:*"
+      "logs:*",
+      "waf:*",
+      "wafv2:*"
     ]
     resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
   }


### PR DESCRIPTION
As per slack conversion [here](https://mojdt.slack.com/archives/C01A7QK5VM1/p1691054598336779) this PR adds the WAF / WAFV2 permissions to the us-east IAM policy. 