### PR TITLE
Temporarily add aws dev legalservices hostedzone to dns iam policy

### DIFF
--- a/terraform/environments/core-network-services/iam.tf
+++ b/terraform/environments/core-network-services/iam.tf
@@ -73,7 +73,8 @@ resource "aws_iam_role_policy" "dns" {
           [for zone in aws_route53_zone.application_zones : format("arn:aws:route53:::hostedzone/%s", zone.id)],
           [
             "arn:aws:route53:::hostedzone/${aws_route53_zone.modernisation-platform.id}",
-            "arn:aws:route53:::hostedzone/${aws_route53_zone.modernisation-platform-internal.id}"
+            "arn:aws:route53:::hostedzone/${aws_route53_zone.modernisation-platform-internal.id}",
+            "arn:aws:route53:::hostedzone/Z0687537274RJMQHWH5UJ"
           ]
         )
       }


### PR DESCRIPTION
As per slack [request](https://mojdt.slack.com/archives/C01A7QK5VM1/p1691055181067629) i am adding the hosted zone to the policy as a temporary workaround while the bug/issue is investigated. 