### PR TITLE
Add Ubuntu to firewall rules

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/fqdn_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/fqdn_rules.json
@@ -8,7 +8,9 @@
     "wustat.windows.com",
     "ntservicepack.microsoft.com",
     "stats.microsoft.com",
-    "saas40.kaseya.net"
+    "saas40.kaseya.net",
+    "archive.ubuntu.com",
+    "security.ububtu.com"
   ],
   "fw_home_net_ips": ["10.26.0.0/16", "10.27.0.0/16"]
 }


### PR DESCRIPTION
As per Slack conversation: [here](https://mojdt.slack.com/archives/C01A7QK5VM1/p1691052534081459) adding ubuntu domain to fqdn rules. 