### PR TITLE
feat: adding new application support github group to CSR envs

### DIFF
--- a/environments/corporate-staff-rostering.json
+++ b/environments/corporate-staff-rostering.json
@@ -25,6 +25,10 @@
         {
           "github_slug": "studio-webops",
           "level": "migration"
+        },
+        {
+          "github_slug": "csr-application-support",
+          "level": "instance-management"
         }
       ]
     },
@@ -38,6 +42,10 @@
         {
           "github_slug": "studio-webops",
           "level": "migration"
+        },
+        {
+          "github_slug": "csr-application-support",
+          "level": "instance-management"
         }
       ]
     },
@@ -51,6 +59,10 @@
         {
           "github_slug": "studio-webops",
           "level": "migration"
+        },
+        {
+          "github_slug": "csr-application-support",
+          "level": "instance-management"
         }
       ]
     }


### PR DESCRIPTION
New group csr-application-support created to allow App support team access to CSR resources in AWS. 
Added to Test, PreProd, and Prod.