### PR TITLE
Add firewall rules to allow PPUD server docker build

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/fqdn_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/fqdn_rules.json
@@ -9,8 +9,10 @@
     "ntservicepack.microsoft.com",
     "stats.microsoft.com",
     "saas40.kaseya.net",
-    "archive.ubuntu.com",
-    "security.ubuntu.com"
+    ".ubuntu.com",
+    ".docker.io",
+    ".docker.com",
+    ".ghcr.io"
   ],
   "fw_home_net_ips": ["10.26.0.0/16", "10.27.0.0/16"]
 }


### PR DESCRIPTION
As per Slack conversation [here](https://mojdt.slack.com/archives/C01A7QK5VM1/p1691052534081459) Umesh has request the below domain be whitelisted for the PPUD server docker build. 

```
.docker.io
.docker.com
.ubuntu.com
.ghcr.io
```