### PR TITLE
Conditionally generate tfvars for non-core accounts

### DIFF
--- a/scripts/provision-member-directories.sh
+++ b/scripts/provision-member-directories.sh
@@ -45,6 +45,8 @@ provision_environment_directories() {
     echo "This is file: $file"
     application_name=$(basename "$file" .json)
     echo "This is the application name: $application_name"
+    account_type=$(jq -r '."account-type"' "$file")
+    echo "This is a " $account_type " account"
     directory=$basedir/$application_name
     echo "This is the directory: $directory"
     account_type=$(jq -r '."account-type"' ${environment_json_dir}/${application_name}.json)
@@ -93,7 +95,10 @@ provision_environment_directories() {
       RAW_OUTPUT=`jq -n --arg APPLICATION_NAME "$application_name" '{ "business-unit": "", "set": "", "application": $APPLICATION_NAME }'`
     fi
     # wrap raw json output with a header and store the result in the applications folder
-    jq -rn --argjson DATA "${RAW_OUTPUT}" '{ networking: [ $DATA ] }' > "$directory"/networking.auto.tfvars.json
+    # Only populate networking.auto.tfvars.json if account type is not core
+    if [ "$account_type" != "core" ]; then
+      jq -rn --argjson DATA "${RAW_OUTPUT}" '{ networking: [ $DATA ] }' > "$directory"/networking.auto.tfvars.json
+    fi
   done
 }
 

--- a/terraform/environments/core-logging/base_variables.tf
+++ b/terraform/environments/core-logging/base_variables.tf
@@ -1,5 +1,10 @@
 variable "networking" {
-
   type = list(any)
-
+  default = [
+    {
+      "business-unit": "",
+      "set": "",
+      "application": "core-logging"
+    }
+  ]
 }

--- a/terraform/environments/core-logging/networking.auto.tfvars.json
+++ b/terraform/environments/core-logging/networking.auto.tfvars.json
@@ -1,9 +1,0 @@
-{
-  "networking": [
-    {
-      "business-unit": "",
-      "set": "",
-      "application": "core-logging"
-    }
-  ]
-}

--- a/terraform/environments/core-network-services/base_variables.tf
+++ b/terraform/environments/core-network-services/base_variables.tf
@@ -1,5 +1,10 @@
 variable "networking" {
-
   type = list(any)
-
+  default = [
+    {
+      "business-unit": "",
+      "set": "",
+      "application": "core-network-services"
+    }
+  ]
 }

--- a/terraform/environments/core-network-services/networking.auto.tfvars.json
+++ b/terraform/environments/core-network-services/networking.auto.tfvars.json
@@ -1,9 +1,0 @@
-{
-  "networking": [
-    {
-      "business-unit": "",
-      "set": "",
-      "application": "core-network-services"
-    }
-  ]
-}

--- a/terraform/environments/core-sandbox/base_variables.tf
+++ b/terraform/environments/core-sandbox/base_variables.tf
@@ -20,6 +20,12 @@ variable "account_name" {
 variable "networking" {
 
   type    = list(any)
-  default = [{}]
+  default = [
+    {
+      "business-unit": "",
+      "set": "",
+      "application": ""
+    }
+  ]
 
 }

--- a/terraform/environments/core-sandbox/base_variables.tf
+++ b/terraform/environments/core-sandbox/base_variables.tf
@@ -19,6 +19,7 @@ variable "account_name" {
 
 variable "networking" {
 
-  type = list(any)
+  type    = list(any)
+  default = [{}]
 
 }

--- a/terraform/environments/core-sandbox/base_variables.tf
+++ b/terraform/environments/core-sandbox/base_variables.tf
@@ -18,14 +18,12 @@ variable "account_name" {
 
 
 variable "networking" {
-
   type    = list(any)
   default = [
     {
       "business-unit": "",
       "set": "",
-      "application": ""
+      "application": "core-sandbox"
     }
   ]
-
 }

--- a/terraform/environments/core-sandbox/locals.tf
+++ b/terraform/environments/core-sandbox/locals.tf
@@ -20,8 +20,6 @@ locals {
     owner         = "Modernisation Platform: modernisation-platform@digital.justice.gov.uk"
   }
 
-  json_data = jsondecode(file("networking.auto.tfvars.json"))
-
   acm_pca = [substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-production" || substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-preproduction" ? "acm-pca-live" : "acm-pca-non-live"]
 
 }

--- a/terraform/environments/core-sandbox/networking.auto.tfvars.json
+++ b/terraform/environments/core-sandbox/networking.auto.tfvars.json
@@ -1,9 +1,0 @@
-{
-  "networking": [
-    {
-      "business-unit": "",
-      "set": "",
-      "application": "core-sandbox"
-    }
-  ]
-}

--- a/terraform/environments/core-sandbox/playground.tf
+++ b/terraform/environments/core-sandbox/playground.tf
@@ -1,32 +1,11 @@
 data "aws_caller_identity" "current" {}
 
-module "ram-principal-association" {
-
-  count = (var.networking[0].set == "") ? 0 : 1
-
-  source = "../../modules/ram-principal-association"
-
-  providers = {
-    aws.share-acm    = aws.core-network-services
-    aws.share-host   = aws.core-vpc
-    aws.share-tenant = aws
-  }
-  principal   = data.aws_caller_identity.current.account_id
-  vpc_name    = var.networking[0].business-unit
-  subnet_set  = var.networking[0].set
-  acm_pca     = "acm-pca-${local.is_live[0]}"
-  environment = local.environment
-
-}
-
 data "aws_ami_ids" "example" {
   owners     = ["self"]
-  name_regex = "^(?!oracle-linux-5.11)*"
-  # filter {
-  #   name   = "name"
-  #   values = ["oracle-linux-5.11*"]
-  # }
-
+   filter {
+     name   = "name"
+     values = ["oracle-linux-5.11*"]
+   }
 }
 
 output "amis" {

--- a/terraform/environments/core-security/base_variables.tf
+++ b/terraform/environments/core-security/base_variables.tf
@@ -1,5 +1,10 @@
 variable "networking" {
-
   type = list(any)
-
+  default = [
+    {
+      "business-unit": "",
+      "set": "",
+      "application": "core-security"
+    }
+  ]
 }

--- a/terraform/environments/core-security/networking.auto.tfvars.json
+++ b/terraform/environments/core-security/networking.auto.tfvars.json
@@ -1,9 +1,0 @@
-{
-  "networking": [
-    {
-      "business-unit": "",
-      "set": "",
-      "application": "core-security"
-    }
-  ]
-}

--- a/terraform/environments/core-shared-services/base_variables.tf
+++ b/terraform/environments/core-shared-services/base_variables.tf
@@ -1,7 +1,12 @@
 variable "networking" {
-
   type = list(any)
-
+  default = [
+    {
+      "business-unit": "",
+      "set": "",
+      "application": "core-shared-services"
+    }
+  ]
 }
 
 variable "app_name" {

--- a/terraform/environments/core-shared-services/networking.auto.tfvars.json
+++ b/terraform/environments/core-shared-services/networking.auto.tfvars.json
@@ -1,9 +1,0 @@
-{
-  "networking": [
-    {
-      "business-unit": "",
-      "set": "",
-      "application": "core-shared-services"
-    }
-  ]
-}

--- a/terraform/environments/core-vpc/base_variables.tf
+++ b/terraform/environments/core-vpc/base_variables.tf
@@ -1,5 +1,10 @@
 variable "networking" {
-
   type = list(any)
-
+  default = [
+    {
+      "business-unit": "",
+      "set": "",
+      "application": "core-vpc"
+    }
+  ]
 }

--- a/terraform/environments/core-vpc/networking.auto.tfvars.json
+++ b/terraform/environments/core-vpc/networking.auto.tfvars.json
@@ -1,9 +1,0 @@
-{
-  "networking": [
-    {
-      "business-unit": "",
-      "set": "",
-      "application": "core-vpc"
-    }
-  ]
-}

--- a/terraform/environments/sprinkler/base_variables.old
+++ b/terraform/environments/sprinkler/base_variables.old
@@ -1,5 +1,0 @@
-variable "networking" {
-
-  type = list(any)
-
-}


### PR DESCRIPTION
This PR relates to https://github.com/ministryofjustice/modernisation-platform/issues/4139. As we make use of `networking.auto.terraform.tfvars` to share resources, it's not relevant to our core accounts and as such this PR makes its creation conditional.
* Updates the scripts that output this file to conditionally skip the creation when we read the account type from `environments/*.json` and see that they account-type value is core.
* Removes `networking.auto.terraform.tfvars` from core accounts.
* Adds defaults to `base_variables.tf` for both core-sandbox and core-vpc accounts to accommodate removal of tfvars.
* Tidies up some of core-sandbox account to remove some unused code and fix a broken data call.
