### PR TITLE
Update dev legalservices hostedzone id in dns iam policy

### DIFF
--- a/terraform/environments/core-network-services/iam.tf
+++ b/terraform/environments/core-network-services/iam.tf
@@ -74,7 +74,7 @@ resource "aws_iam_role_policy" "dns" {
           [
             "arn:aws:route53:::hostedzone/${aws_route53_zone.modernisation-platform.id}",
             "arn:aws:route53:::hostedzone/${aws_route53_zone.modernisation-platform-internal.id}",
-            "arn:aws:route53:::hostedzone/Z0687537274RJMQHWH5UJ"
+            "arn:aws:route53:::hostedzone/Z0013240MPA5G8GDXJUA"
           ]
         )
       }

--- a/terraform/environments/core-network-services/iam.tf
+++ b/terraform/environments/core-network-services/iam.tf
@@ -74,7 +74,7 @@ resource "aws_iam_role_policy" "dns" {
           [
             "arn:aws:route53:::hostedzone/${aws_route53_zone.modernisation-platform.id}",
             "arn:aws:route53:::hostedzone/${aws_route53_zone.modernisation-platform-internal.id}",
-            "arn:aws:route53:::hostedzone/${data.aws_route53_zone.selected.zone_id}"
+            "arn:aws:route53:::hostedzone/Z0013240MPA5G8GDXJUA"
           ]
         )
       }

--- a/terraform/environments/core-network-services/iam.tf
+++ b/terraform/environments/core-network-services/iam.tf
@@ -74,7 +74,7 @@ resource "aws_iam_role_policy" "dns" {
           [
             "arn:aws:route53:::hostedzone/${aws_route53_zone.modernisation-platform.id}",
             "arn:aws:route53:::hostedzone/${aws_route53_zone.modernisation-platform-internal.id}",
-            "arn:aws:route53:::hostedzone/Z0013240MPA5G8GDXJUA"
+            "arn:aws:route53:::hostedzone/${data.aws_route53_zone.selected.zone_id}"
           ]
         )
       }


### PR DESCRIPTION
This PR updates the hosted zone id for the dev.legalservices.gov.uk - This is an update from https://github.com/ministryofjustice/modernisation-platform/pull/4731 