### PR TITLE
Decode added to migration role for fault finding

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/policies.tf
+++ b/terraform/environments/bootstrap/delegate-access/policies.tf
@@ -478,6 +478,7 @@ data "aws_iam_policy_document" "migration_additional" {
       "drs:*",
       "mgh:*",
       "mgn:*",
+      "sts:DecodeAuthorizationMessage",
       "migrationhub-strategy:*"
     ]
     resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097


### PR DESCRIPTION
as part of the bellow request from the ask channel i have added the decode permission to the migration role

Hi MP. Update regarding the Migration tool issue that was raised last week after raising the issue with AWS they have gotten back to us and told us the following message :
"As we can confirm from the backend and your screenshot that the Test EC2 instance is not getting launched due to conversion failed, the internal team to further review your issue has checked the "RunInstances" API call to see if the conversion server has been launched successfully. We can confirm that the conversion server is not getting launched with the following information:
Error code: Client.UnauthorizedOperation"
They then asked us to run the following command from CLI :
aws sts decode-authorization-message --encoded-message Kqrv7rqm0Iuv30uKGOeEfqeHthvKBrqMfT9Ny5f5yKBqMjAXkP7Q5dtvbmTb91Lrx50zcLF2jOO1Hf9s7QEb8SnnYJNVBzYfPEpsjUk_eCNoFyvagRflMu3AALnLJqiD0NE1WQeleeoldDuIcz517yQ1VPYm94F_t5AUooQ-vlKLr3yVJvpLXcHUu0lAhBznXKvr9grH-FM1qomf3YrGurf_6fHe_UAVy9z7OBpV5gZjm8oJFIDezMbMyL07HcknvFEd3e2-GmLEBrpzkUg_JnWDOTOAe9qZE4o9v6DO3ve0-Srm1W_689CJ5DwJN3XfBpuqq5_B5kubgBp9fcdpga-7wL_-8IH2W19XICaA4yfFcdH1XVhx0erf3Kiu80LgfqWrZbCeHCW79__8ClUml7HJbiF-kfcEsIoHV5Xz_sKvE0qVPhsoSBDdiOoxSi3ies0JiuEg1dBoyPptG6broX6rJzW9K-UJqkTdaf4m026521WtvrxNHLeN8aWkt_NEd_bMtj49KDB9Hoq2Xu7W03LoyfgEbufdgbdOOey8UeaiENrHeOKz2t8qQ7WnPBilVSNATGDJZsqn5xMHvD9vo_AhvZkd1C_tLlc8X0Nc8lgfjNKPDsJHstNxjTH2BY2Tfsuaflm_Hw
And asked we send them the output so they can further troubleshoot
And when i attempted to do that  i received the following output:
An error occurred (AccessDenied) when calling the DecodeAuthorizationMessage operation: User: arn:aws:sts::950286732765:assumed-role/AWSReservedSSO_modernisation-platform-migration_1abd198a9be9af2b/ijazmoj@digital.justice.gov.uk is not authorized to perform: sts:DecodeAuthorizationMessage because no identity-based policy allows the sts:DecodeAuthorizationMessage action
So was wondering if it was possible to get the correct decoding permissions in the CSR-test environment for the federated users or more ideally in the MGN-Test Users in IAM so that we can get back to AWS ?