### PR TITLE
Add data block for use in portal-dev dns IAM policy

### DIFF
--- a/terraform/environments/core-network-services/iam.tf
+++ b/terraform/environments/core-network-services/iam.tf
@@ -3,7 +3,6 @@ data "aws_iam_role" "vpc-flow-log" {
 }
 
 data "aws_route53_zone" "portal-development" {
-  provider     = aws.core-network-services
   name         = "dev.legalservices.gov.uk."
   private_zone = true
 }

--- a/terraform/environments/core-network-services/iam.tf
+++ b/terraform/environments/core-network-services/iam.tf
@@ -2,6 +2,12 @@ data "aws_iam_role" "vpc-flow-log" {
   name = "AWSVPCFlowLog"
 }
 
+data "aws_route53_zone" "portal-development" {
+  provider     = aws.core-network-services
+  name         = "dev.legalservices.gov.uk."
+  private_zone = true
+}
+
 # Role to allow ci/cd to update DNS records for ACM certificate validation
 resource "aws_iam_role" "dns" {
   #checkov:skip=CKV_AWS_60:Wildcard constrained by condition checks
@@ -74,7 +80,7 @@ resource "aws_iam_role_policy" "dns" {
           [
             "arn:aws:route53:::hostedzone/${aws_route53_zone.modernisation-platform.id}",
             "arn:aws:route53:::hostedzone/${aws_route53_zone.modernisation-platform-internal.id}",
-            "arn:aws:route53:::hostedzone/Z0013240MPA5G8GDXJUA"
+            format("arn:aws:route53:::hostedzone/%s", data.aws_route53_zone.portal-development.zone_id)
           ]
         )
       }


### PR DESCRIPTION
Following slack conversation [here](https://mojdt.slack.com/archives/C01A7QK5VM1/p1691484375454639) as the hosted zone id changing following an update this PR uses s `data` block to obtain the zone_id. 