### PR TITLE
allow migration role to be passed to AWS service role

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/policies.tf
+++ b/terraform/environments/bootstrap/delegate-access/policies.tf
@@ -497,6 +497,16 @@ data "aws_iam_policy_document" "migration_additional" {
     ]
     resources = ["*"]
   }
+
+  statement {
+    sid    = "migrationPassRole"
+    effect = "Allow"
+    actions = [
+      "iam:GetRole",
+      "iam:PassRole"
+    ]
+    resources = ["arn:aws:iam::*:role/service-role/AWSApplicationMigrationConversionServerRole"]
+  }
 }
 
 


### PR DESCRIPTION
This PR resolves an issue in the use of the Migration role and the AWS Migration service. See [this](https://mojdt.slack.com/archives/C01A7QK5VM1/p1691569159990639) Slack conversation for the full context.