### PR TITLE
Amend how workflow compares on push to `main`

### DIFF
--- a/.github/workflows/terraform-member-environment.yml
+++ b/.github/workflows/terraform-member-environment.yml
@@ -45,7 +45,7 @@ jobs:
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             echo "CHANGED_DIRECTORIES=$(git diff HEAD origin/main ${{ github.event.pull_request.changes.paths }} --name-only | awk '{print $1}' | grep ".tf" | grep -a "environments//*" | cut -f1-3 -d"/" | uniq)"
           else
-            echo "CHANGED_DIRECTORIES=$(git diff HEAD HEAD~ ${{ github.event.changes.paths }} --name-only | awk '{print $1}' | grep ".tf" | grep -a "environments//*" | cut -f1-3 -d"/" | uniq)"
+            echo "CHANGED_DIRECTORIES=$(git diff HEAD HEAD^ ${{ github.event.changes.paths }} --name-only | awk '{print $1}' | grep ".tf" | grep -a "environments//*" | cut -f1-3 -d"/" | uniq)"
           fi >> $GITHUB_OUTPUT
       - name: Display changed directories
         run: echo "Directories in scope:" ${{ steps.directories.outputs.CHANGED_DIRECTORIES }}


### PR DESCRIPTION
Using `HEAD~` in the workflow results in the following error because it is ambiguous:
```
From https://github.com/ministryofjustice/modernisation-platform
 * branch            main       -> FETCH_HEAD
fatal: ambiguous argument 'HEAD~': unknown revision or path not in the working tree.
```
Using `HEAD^` should ensure the correct parent is used. You can see an example of the failure in action here: https://github.com/ministryofjustice/modernisation-platform/actions/runs/5830970854/job/15813426954