### PR TITLE
Adjust path filtering and diffing for member environments workflow

### DIFF
--- a/.github/workflows/terraform-member-environment.yml
+++ b/.github/workflows/terraform-member-environment.yml
@@ -6,17 +6,17 @@ on:
     branches:
       - main
     paths:
-      - 'terraform/environments/**/*.tf'
-      - '!terraform/environments/bootstrap/**/*.tf'
-      - '!terraform/environments/core-*/*.tf'
+      - '!terraform/environments/bootstrap/**'
+      - '!terraform/environments/core-*'
+      - 'terraform/environments/**'
   pull_request:
     types: [opened, edited, reopened, synchronize]
     branches-ignore:
       - 'date*'
     paths:
-      - 'terraform/environments/**/*.tf'
-      - '!terraform/environments/bootstrap/**/*.tf'
-      - '!terraform/environments/core-*/*.tf'
+      - '!terraform/environments/bootstrap/**'
+      - '!terraform/environments/core-*'
+      - 'terraform/environments/**'
       - '.github/workflows/terraform-member-environment.yml'
 
 defaults:
@@ -45,7 +45,7 @@ jobs:
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             echo "CHANGED_DIRECTORIES=$(git diff HEAD origin/main ${{ github.event.pull_request.changes.paths }} --name-only | awk '{print $1}' | grep ".tf" | grep -a "environments//*" | cut -f1-3 -d"/" | uniq)"
           else
-            echo "CHANGED_DIRECTORIES=$(git diff HEAD HEAD^ ${{ github.event.changes.paths }} --name-only | awk '{print $1}' | grep ".tf" | grep -a "environments//*" | cut -f1-3 -d"/" | uniq)"
+            echo "CHANGED_DIRECTORIES=$(git diff HEAD^ HEAD ${{ github.event.changes.paths }} --name-only | awk '{print $1}' | grep ".tf" | grep -a "environments//*" | cut -f1-3 -d"/" | uniq)"
           fi >> $GITHUB_OUTPUT
       - name: Display changed directories
         run: echo "Directories in scope:" ${{ steps.directories.outputs.CHANGED_DIRECTORIES }}


### PR DESCRIPTION
I've been seeing the `Terraform Member Environments` workflow inappropriately start when changes are made in the bootstrap subdirectories. After some re-reading I think that a change to - for example `terraform/environments/bootstrap/delegate-access/iam.tf` matches the positive, even though it should be excluded by the negative. The match "wins" over the negative, so the action triggers.