### PR TITLE
Extra permissions on sandbox

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/policies.tf
+++ b/terraform/environments/bootstrap/delegate-access/policies.tf
@@ -443,7 +443,8 @@ data "aws_iam_policy_document" "sandbox_additional" {
       "rhelkb:GetRhelURL",
       "identitystore:DescribeUser",
       "sso:ListDirectoryAssociations",
-      "wellarchitected:*"
+      "wellarchitected:*",
+      "backup:StartRestoreJob"
     ]
     resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
   }


### PR DESCRIPTION
User has requested extra permission for a restore
Silviana Horga
  [9 minutes ago](https://mojdt.slack.com/archives/C01A7QK5VM1/p1692106046491899)
Hi MP team,
I’m trying to perform an EFS backup restore locally using AWS CLI but I get the following error
An error occurred (AccessDeniedException) when calling the StartRestoreJob operation: User:xxxx is not authorized to perform: backup:StartRestoreJob on resource: arn:aws:backup:eu-west-2:326912278139:recovery-point:ef633021-fdd3-4db6-b986-2beb406e1aad because no identity-based policy allows the backup:StartRestoreJob action
Can I be granted permissions to perform the action above? Or is there another method we must use to perform a backup restore?

adding backup:StartRestoreJob to the sandbox policy