### PR TITLE
Update VPC module reference

### DIFF
--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -85,7 +85,7 @@ locals {
 module "vpc" {
   for_each = local.vpcs[terraform.workspace]
 
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-member-vpc?ref=bdd69b375c09555389089d65b3d14014ccfdcfec" #v2.1.1
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-member-vpc?ref=e8447fc0906270e0e67bf329e8355cd306ef9fef" #v2.2.0
 
   subnet_sets = { for key, subnet in each.value.cidr.subnet_sets : key => subnet.cidr }
 


### PR DESCRIPTION
As part of https://github.com/ministryofjustice/modernisation-platform/issues/4797, this PR updates the reference to the `modernisation-platform-terraform-member-vpc` module.

The new version includes a map of protected subnet ARNs, which will be consumed by the VPC `resource-share` module to create RAM shares of the protected subnets. A following PR will be raised to accept these resource shares in accounts where they're needed.