### PR TITLE
data-and-insights-wepi subnet association

### DIFF
--- a/terraform/environments/data-and-insights-wepi/additional_subnet_share.tf
+++ b/terraform/environments/data-and-insights-wepi/additional_subnet_share.tf
@@ -1,0 +1,19 @@
+data "aws_ram_resource_share" "protected" {
+  provider = aws.core-vpc
+
+  name = "${var.networking[0].business-unit}-${local.environment}-protected-resource-share" # Resource share to lookup
+
+  resource_owner = "SELF"
+
+  filter {
+    name   = "Name"
+    values = ["${var.networking[0].business-unit}-${local.environment}-protected"]
+  }
+}
+
+resource "aws_ram_principal_association" "protected" {
+  provider = aws.core-vpc
+
+  principal          = data.aws_caller_identity.current.account_id
+  resource_share_arn = data.aws_ram_resource_share.protected.arn
+}


### PR DESCRIPTION
As part of https://github.com/ministryofjustice/modernisation-platform/issues/4797, this PR handles the association between the `data-and-insights-wepi` accounts, and the resource share for the protected subnets.