### PR TITLE
added static routes across both NOMS vpns for testing

### DIFF
--- a/terraform/environments/core-network-services/vpn.tf
+++ b/terraform/environments/core-network-services/vpn.tf
@@ -94,6 +94,18 @@ resource "aws_ec2_transit_gateway_route" "noms_live_routes" {
   transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.external_inspection_out.id
 }
 
+resource "aws_ec2_transit_gateway_route" "noms_live_1_test" {
+  destination_cidr_block         = "10.102.1.179/32"
+  transit_gateway_attachment_id  = aws_vpn_connection.this["NOMS-Transit-Live-VPN-VNG_1"].transit_gateway_attachment_id
+  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.external_inspection_out.id
+}
+
+resource "aws_ec2_transit_gateway_route" "noms_live_2_test" {
+  destination_cidr_block         = "10.102.1.179/32"
+  transit_gateway_attachment_id  = aws_vpn_connection.this["NOMS-Transit-Live-VPN-VNG_2"].transit_gateway_attachment_id
+  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.external_inspection_out.id
+}
+
 resource "aws_ec2_transit_gateway_route" "parole_board_routes" {
   for_each                       = toset(local.parole_board_vpn_static_routes)
   destination_cidr_block         = each.key


### PR DESCRIPTION
This PR relates to https://github.com/ministryofjustice/modernisation-platform/issues/4523
Adds a host route for each of the NOMS Transit Live VPNs for testing purposes.
With this we can attempt to connect to the endpoint host and confirm the routing behaviour.