### PR TITLE
Remove NOMS test routes

### DIFF
--- a/terraform/environments/core-network-services/vpn.tf
+++ b/terraform/environments/core-network-services/vpn.tf
@@ -94,18 +94,6 @@ resource "aws_ec2_transit_gateway_route" "noms_live_routes" {
   transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.external_inspection_out.id
 }
 
-resource "aws_ec2_transit_gateway_route" "noms_live_1_test" {
-  destination_cidr_block         = "10.102.1.179/32"
-  transit_gateway_attachment_id  = aws_vpn_connection.this["NOMS-Transit-Live-VPN-VNG_1"].transit_gateway_attachment_id
-  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.external_inspection_out.id
-}
-
-resource "aws_ec2_transit_gateway_route" "noms_live_2_test" {
-  destination_cidr_block         = "10.102.1.179/32"
-  transit_gateway_attachment_id  = aws_vpn_connection.this["NOMS-Transit-Live-VPN-VNG_2"].transit_gateway_attachment_id
-  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.external_inspection_out.id
-}
-
 resource "aws_ec2_transit_gateway_route" "parole_board_routes" {
   for_each                       = toset(local.parole_board_vpn_static_routes)
   destination_cidr_block         = each.key


### PR DESCRIPTION
This PR relates to https://github.com/ministryofjustice/modernisation-platform/issues/4523 and proves that we can't apply duplicate static routes to a TGW route table:

```
Error: creating EC2 Transit Gateway Route (tgw-rtb-xxxxxxxxxxxx_10.102.1.179/32): RouteAlreadyExists: Route 10.102.1.179/32 already exists in Transit Gateway Route Table tgw-rtb-xxxxxxxxxxxx.
```