### PR TITLE
Allow RDP from LAA LZ to MP LAA

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/development_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/development_rules.json
@@ -55,7 +55,7 @@
     "destination_port": "ANY",
     "protocol": "IP"
   },
-  "laa_shared_services_to_mp_laa_development_rdp": {
+  "laa_shared_services_to_mp_laa_development_rdp_temp": {
     "action": "PASS",
     "source_ip": "${laa-lz-shared-services-nonprod}",
     "destination_ip": "${laa-development}",

--- a/terraform/environments/core-network-services/firewall-rules/development_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/development_rules.json
@@ -55,6 +55,13 @@
     "destination_port": "ANY",
     "protocol": "IP"
   },
+  "laa_shared_services_to_mp_laa_development_rdp": {
+    "action": "PASS",
+    "source_ip": "${laa-lz-shared-services-nonprod}",
+    "destination_ip": "${laa-development}",
+    "destination_port": "3389",
+    "protocol": "TCP"
+  },
   "analytical_platform_to_mp_laa_development": {
     "action": "PASS",
     "source_ip": "${analytical-platform-airflow-dev}",


### PR DESCRIPTION
This PR is to allow LAA Landing Zone WorkSpaces access to our Portal Windows Instance via RDP for testing purposes. Once the environment is good and ready for cutover, this rule will be removed.

https://dsdmoj.atlassian.net/browse/LAWS-3432