### PR TITLE
changed redshift endpoint type to correct one

### DIFF
--- a/environments-networks/hq-development.json
+++ b/environments-networks/hq-development.json
@@ -10,7 +10,7 @@
   "options": {
     "bastion_linux": true,
     "additional_cidrs": [],
-    "additional_endpoints": ["com.amazonaws.eu-west-2.redshift-data"],
+    "additional_endpoints": ["com.amazonaws.eu-west-2.redshift"],
     "additional_private_zones": [],
     "additional_vpcs": [],
     "dns_zone_extend": []

--- a/environments-networks/hq-preproduction.json
+++ b/environments-networks/hq-preproduction.json
@@ -10,7 +10,7 @@
   "options": {
     "bastion_linux": false,
     "additional_cidrs": [],
-    "additional_endpoints": ["com.amazonaws.eu-west-2.redshift-data"],
+    "additional_endpoints": ["com.amazonaws.eu-west-2.redshift"],
     "additional_private_zones": [],
     "additional_vpcs": [],
     "dns_zone_extend": []

--- a/environments-networks/hq-production.json
+++ b/environments-networks/hq-production.json
@@ -10,7 +10,7 @@
   "options": {
     "bastion_linux": true,
     "additional_cidrs": [],
-    "additional_endpoints": ["com.amazonaws.eu-west-2.redshift-data"],
+    "additional_endpoints": ["com.amazonaws.eu-west-2.redshift"],
     "additional_private_zones": [],
     "additional_vpcs": [],
     "dns_zone_extend": []


### PR DESCRIPTION
From further research the `redshift-data` VPC endpoint type is used to connect a cluster to a private S3 bucket. As that is not our use case, this PR changes the redshift endpoint being offered in the `hq` VPCs.