### PR TITLE
🪛 Fix member-environments bespoke changes workflow to avoid accidental recursive matching

### DIFF
--- a/.github/workflows/terraform-member-environment.yml
+++ b/.github/workflows/terraform-member-environment.yml
@@ -6,17 +6,17 @@ on:
     branches:
       - main
     paths:
-      - '!terraform/environments/bootstrap/**'
+      - 'terraform/environments/*'
+      - '!terraform/environments/bootstrap'
       - '!terraform/environments/core-*'
-      - 'terraform/environments/**'
   pull_request:
     types: [opened, edited, reopened, synchronize]
     branches-ignore:
       - 'date*'
     paths:
-      - '!terraform/environments/bootstrap/**'
+      - 'terraform/environments/*'
+      - '!terraform/environments/bootstrap'
       - '!terraform/environments/core-*'
-      - 'terraform/environments/**'
       - '.github/workflows/terraform-member-environment.yml'
 
 defaults:

--- a/.github/workflows/terraform-member-environment.yml
+++ b/.github/workflows/terraform-member-environment.yml
@@ -17,7 +17,6 @@ on:
       - 'terraform/environments/*'
       - '!terraform/environments/bootstrap'
       - '!terraform/environments/core-*'
-      - '.github/workflows/terraform-member-environment.yml'
 
 defaults:
   run:


### PR DESCRIPTION
The current path filtering still appears to be triggering inappropriately. This change should prevent changes anywhere but in customer environments from triggering the workflow