### PR TITLE
Update modernisation-platform-terraform-baselines to v6.0.0

### DIFF
--- a/terraform/environments/bootstrap/secure-baselines/main.tf
+++ b/terraform/environments/bootstrap/secure-baselines/main.tf
@@ -5,7 +5,7 @@ data "aws_kms_key" "cloudtrail_key" {
 }
 
 module "baselines" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=5406c4583e90c5e56d5898257692a4232ce81703" # v6.0.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=ebcbdbad38f770c0c6488ccd68c93b387a68c2da" # v6.0.0
 
   providers = {
     # Default and replication regions

--- a/terraform/environments/bootstrap/secure-baselines/main.tf
+++ b/terraform/environments/bootstrap/secure-baselines/main.tf
@@ -5,7 +5,7 @@ data "aws_kms_key" "cloudtrail_key" {
 }
 
 module "baselines" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=ebcbdbad38f770c0c6488ccd68c93b387a68c2da" # v5.0.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=5406c4583e90c5e56d5898257692a4232ce81703" # v6.0.0
 
   providers = {
     # Default and replication regions

--- a/terraform/modernisation-platform-account/baselines.tf
+++ b/terraform/modernisation-platform-account/baselines.tf
@@ -16,7 +16,7 @@ locals {
 
 # Secure baselines (GuardDuty, Config, SecurityHub, etc)
 module "baselines-modernisation-platform" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=5406c4583e90c5e56d5898257692a4232ce81703" # v6.0.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=ebcbdbad38f770c0c6488ccd68c93b387a68c2da" # v6.0.0
   providers = {
     # Default and replication regions
     aws                    = aws.modernisation-platform-eu-west-2

--- a/terraform/modernisation-platform-account/baselines.tf
+++ b/terraform/modernisation-platform-account/baselines.tf
@@ -16,7 +16,7 @@ locals {
 
 # Secure baselines (GuardDuty, Config, SecurityHub, etc)
 module "baselines-modernisation-platform" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=ebcbdbad38f770c0c6488ccd68c93b387a68c2da" # v5.0.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=5406c4583e90c5e56d5898257692a4232ce81703" # v6.0.0
   providers = {
     # Default and replication regions
     aws                    = aws.modernisation-platform-eu-west-2


### PR DESCRIPTION
Contains the correct reference to the new release.