### PR TITLE
Bump secure baselines module

### DIFF
--- a/terraform/environments/bootstrap/secure-baselines/main.tf
+++ b/terraform/environments/bootstrap/secure-baselines/main.tf
@@ -5,7 +5,7 @@ data "aws_kms_key" "cloudtrail_key" {
 }
 
 module "baselines" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=ebcbdbad38f770c0c6488ccd68c93b387a68c2da" # v5.0.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=8bd4cb505039ddf968e1842a7998185ba8dcaaae" # v6.0.0
 
   providers = {
     # Default and replication regions


### PR DESCRIPTION
This will move update to the latest module removing the creation of the security hub resource which is now handled at the org level.

Note the plan for sprinkler secure baselines runs clean (security hub resource has been removed from state).