### PR TITLE
Allow internal networks to send redshift traffic to `hq-development` VPC

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/development_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/development_rules.json
@@ -251,9 +251,9 @@
     "destination_port": "5439",
     "protocol": "TCP"
   },
-  "internal-network_to_data-insights-hub_development_redshift": {
+  "internal-networks_to_data-insights-hub_development_redshift": {
     "action": "PASS",
-    "source_ip": "10.56.0.0/16",
+    "source_ip": "10.0.0.0/8",
     "destination_ip": "${hq-development}",
     "destination_port": "5439",
     "protocol": "TCP"


### PR DESCRIPTION
This PR ensures that most traffic from internal networks will be able to reach the `hq-development` VPC when sending redshift traffic.

This should allow the successful testing of https://github.com/ministryofjustice/modernisation-platform/issues/4797