### PR TITLE
Enrolling Mark and Aaron onto MP on-call rota

### DIFF
--- a/terraform/pagerduty/locals.tf
+++ b/terraform/pagerduty/locals.tf
@@ -40,6 +40,8 @@ locals {
     sean_privett   = data.pagerduty_user.sean_privett,
     stephen_linden = data.pagerduty_user.stephen_linden,
     simon_pledger  = data.pagerduty_user.simon_pledger,
+    mark_roberts   = data.pagerduty_user.mark_roberts,
+    aaron_robinson = data.pagerduty_user.aaron_robinson
   }
 
   modernisation_platform_users = merge(local.existing_users, tomap(pagerduty_user.pager_duty_users))
@@ -50,6 +52,8 @@ locals {
   stephen_linden = data.pagerduty_user.stephen_linden.id
   edward_proctor = pagerduty_user.pager_duty_users["edward_proctor"].id
   ewa_stempel    = pagerduty_user.pager_duty_users["ewa_stempel"].id
+  mark_roberts   = data.pagerduty_user.mark_roberts.id
+  aaron_robinson = data.pagerduty_user.aaron_robinson.id
 
   tags = {
     business-unit = "Platforms"
@@ -78,4 +82,12 @@ data "pagerduty_user" "jake_mulley" {
 
 data "pagerduty_user" "simon_pledger" {
   email = "simon.pledger${local.digital_email_suffix}"
+}
+
+data "pagerduty_user" "mark_roberts" {
+  email = "mark.roberts${local.digital_email_suffix}"
+}
+
+data "pagerduty_user" "aaron_robinson" {
+  email = "aaron.robinson${local.digital_email_suffix}"
 }

--- a/terraform/pagerduty/policy-schedules.tf
+++ b/terraform/pagerduty/policy-schedules.tf
@@ -68,7 +68,9 @@ resource "pagerduty_schedule" "primary" {
       local.david_elliott,
       local.stephen_linden,
       local.edward_proctor,
-      local.ewa_stempel
+      local.ewa_stempel,
+      local.mark_roberts,
+      local.aaron_robinson
     ]
   }
 
@@ -96,7 +98,9 @@ resource "pagerduty_schedule" "secondary" {
       local.stephen_linden,
       local.david_sibley,
       local.ewa_stempel,
-      local.edward_proctor
+      local.edward_proctor,
+      local.aaron_robinson,
+      local.mark_roberts
     ]
   }
 


### PR DESCRIPTION
As discussed within the team, adding Mark and Aaron to our MP on-call rota.
Note, the immediate on-call schedule (~next two months) will be preserved by manual overrides after this code gets merged.
The TF plan has been run manually with no issues.