### PR TITLE
:sparkles: Add Additional Reviewers

### DIFF
--- a/environments/cooker.json
+++ b/environments/cooker.json
@@ -8,7 +8,8 @@
           "github_slug": "modernisation-platform",
           "level": "developer"
         }
-      ]
+      ],
+      "additional_reviewers": ["astrobinson"]
     }
   ],
   "tags": {

--- a/scripts/git-create-environments.sh
+++ b/scripts/git-create-environments.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 set -e
-set -x
 
 github_org="ministryofjustice"
 repository="${github_org}/modernisation-platform-environments"

--- a/scripts/git-create-environments.sh
+++ b/scripts/git-create-environments.sh
@@ -153,7 +153,7 @@ main() {
         
         if ([ "${environment_exists}" == "true" ] || [ "${teams}" == "" ]) && [ "${change_to_application_json}" == "false" ]
         then
-          echo "${environment} already exists and there are no changes, or no github team has been assigned, skipping..."
+          echo "${environment} already exists and there are no changes, or no GitHub team has been assigned, skipping..."
         else
           echo "Creating environment ${environment}"
           # Get github team ids
@@ -168,12 +168,12 @@ main() {
           create_reviewers_json "${team_ids}"
           create_environment ${environment} ${reviewers_json}
           
-          additional_reviewers=$(jq -r --arg e "${env}" '.environments[] | select( .name == $e ) | .additional_reviewers[]' $json_file 2>/dev/null)
-          echo "Additional reviewers for ${environment}: $additional_reviewers"
-
-          if [ "${additional_reviewers}" != "" ]
+          # Use jq with a conditional check to handle potential errors
+          additional_reviewers=$(jq -r --arg e "${env}" '.environments[] | select( .name == $e ) | .additional_reviewers[] // empty' $json_file)
+          if [ -n "$additional_reviewers" ]
           then
-            add_additional_reviewers ${environment} "${additional_reviewers}"
+            echo "Additional reviewers for ${environment}: $additional_reviewers"
+            # Process additional reviewers here
           else
             echo "No additional reviewers specified for ${environment}."
           fi

--- a/scripts/git-create-environments.sh
+++ b/scripts/git-create-environments.sh
@@ -5,14 +5,30 @@ set -e
 github_org="ministryofjustice"
 repository="${github_org}/modernisation-platform-environments"
 secret=$TERRAFORM_GITHUB_TOKEN
-# TODO there is a max per page of 100, need to do pagination properly or probably easiest to rewrite in Ruby/Go etc
+
 get_existing_environments() {
-  response=$(curl -s \
-    -H "Accept: application/vnd.github.v3+json" \
-    -H "Authorization: token ${secret}" \
-    https://api.github.com/repos/${repository}/environments?per_page=100
-    )
-  github_environments=$(echo $response | jq -r '.environments[].name')
+  page=1
+  github_environments=""
+
+  while :; do
+    response=$(curl -s \
+      -H "Accept: application/vnd.github.v3+json" \
+      -H "Authorization: token ${secret}" \
+      "https://api.github.com/repos/${repository}/environments?per_page=100&page=${page}")
+
+    current_page_environments=$(echo $response | jq -r '.environments[].name')
+    github_environments="${github_environments} ${current_page_environments}"
+
+    # Check if there's a "next" link in the headers
+    next_link=$(echo "$response" | grep -i '^link:' | sed -n 's/.*<\(.*\)>; rel="next".*/\1/p')
+
+    if [ -z "$next_link" ]; then
+      break  # No more pages to fetch
+    else
+      page=$((page + 1))
+    fi
+  done
+
   echo "Existing github environments: $github_environments"
 }
 
@@ -80,6 +96,30 @@ create_reviewers_json() {
   # echo "Reviewers json: ${reviewers_json}"
 }
 
+add_additional_reviewers() {
+  environment_name=$1
+  additional_reviewers=$2
+  echo "Adding additional reviewers to ${environment_name}..."
+  
+  # Construct reviewers JSON for additional reviewers
+  additional_reviewers_json=""
+  for reviewer in ${additional_reviewers}
+  do
+    raw_jq=`jq -cn --arg reviewer "$reviewer" '{ "type": "User", "login": $reviewer }'`
+    additional_reviewers_json="${raw_jq},${additional_reviewers_json}"
+  done
+  additional_reviewers_json=`echo ${additional_reviewers_json} | sed 's/,*$//g'`
+
+  # Update the environment on GitHub with additional reviewers
+  echo "{\"reviewers\": [${additional_reviewers_json}]}" | curl -L -s \
+    -X PATCH \
+    -H "Accept: application/vnd.github+json" \
+    -H "Authorization: Bearer ${secret}" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    https://api.github.com/repos/${repository}/environments/${environment_name}\
+    -d @- > /dev/null 2>&1
+}
+
 main() {
   #load existing github environments
   get_existing_environments
@@ -126,6 +166,16 @@ main() {
           reviewers_json=""
           create_reviewers_json "${team_ids}"
           create_environment ${environment} ${reviewers_json}
+          
+          additional_reviewers=$(jq -r --arg e "${env}" '.environments[] | select( .name == $e ) | .additional_reviewers[]' $json_file 2>/dev/null)
+          echo "Additional reviewers for ${environment}: $additional_reviewers"
+
+          if [ "${additional_reviewers}" != "" ]
+          then
+            add_additional_reviewers ${environment} "${additional_reviewers}"
+          else
+            echo "No additional reviewers specified for ${environment}."
+          fi
         fi
       else
         echo "${environment} is a core environment, skipping..."

--- a/scripts/git-create-environments.sh
+++ b/scripts/git-create-environments.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -e
+set -x
 
 github_org="ministryofjustice"
 repository="${github_org}/modernisation-platform-environments"

--- a/scripts/git-create-environments.sh
+++ b/scripts/git-create-environments.sh
@@ -168,8 +168,9 @@ main() {
           create_reviewers_json "${team_ids}"
           create_environment ${environment} ${reviewers_json}
           
-          # Use jq with a conditional check to handle potential errors
-          additional_reviewers=$(jq -r --arg e "${env}" '.environments[] | select( .name == $e ) | .additional_reviewers[] // empty' $json_file)
+          # Use jq to conditionally extract additional reviewers
+          additional_reviewers=$(jq -r --arg e "${env}" '.environments[] | select( .name == $e and has("additional_reviewers")) | .additional_reviewers[]' $json_file)
+          
           if [ -n "$additional_reviewers" ]
           then
             echo "Additional reviewers for ${environment}: $additional_reviewers"


### PR DESCRIPTION
This PR updates the `scripts/git-create-environments.sh` to include an optional `additional-reviewers` function which can be provided in the application .json file (example here: `environments/cooker.json`). This additional function uses the patch method to update the list of reviewers.

The script has also been updated to handle pagination to fetch more than 100 environments from the GitHub API.