### PR TITLE
Update Data Platform CIDR allocation

### DIFF
--- a/cidr-allocation.md
+++ b/cidr-allocation.md
@@ -24,78 +24,78 @@
 
 ### development and test /21s for member subnet-sets
 
-| CIDR        | mask | allocated to                    |
-| :---------- | :--- | :------------------------------ |
-| 10.26.0.0   | /21  | platforms test - general        |
-| 10.26.8.0   | /21  | hmpps test - general            |
-| 10.26.16.0  | /21  | platforms development - general |
-| 10.26.24.0  | /21  | hmpps development - general     |
-| 10.26.32.0  | /21  | cica development - general      |
-| 10.26.40.0  | /21  | hmcts development - general     |
-| 10.26.48.0  | /21  | hq development - general        |
-| 10.26.56.0  | /21  | laa development - general       |
-| 10.26.64.0  | /21  | opg test - general              |
-| 10.26.72.0  | /21  | opg development - general       |
-| 10.26.80.0  | /21  | cjse-development - general      |
-| 10.26.88.0  | /21  | cjse-test - general             |
-| 10.26.96.0  | /21  | laa-test - general              |
-| 10.26.104.0 | /21  | hmcts-test - general            |
-| 10.26.112.0 | /21  | cica-test - general             |
-| 10.26.120.0 | /21  | hq-test - general               |
-| 10.26.128.0 | /21  | -                               |
-| 10.26.136.0 | /21  | -                               |
-| 10.26.144.0 | /21  | -                               |
-| 10.26.152.0 | /21  | -                               |
-| 10.26.160.0 | /21  | -                               |
-| 10.26.168.0 | /21  | -                               |
-| 10.26.176.0 | /21  | -                               |
-| 10.26.184.0 | /21  | -                               |
-| 10.26.192.0 | /21  | -                               |
-| 10.26.200.0 | /21  | -                               |
-| 10.26.208.0 | /21  | -                               |
-| 10.26.216.0 | /21  | -                               |
-| 10.26.224.0 | /21  | -                               |
-| 10.26.232.0 | /21  | -                               |
-| 10.26.240.0 | /21  | -                               |
-| 10.26.248.0 | /21  | -                               |
+| CIDR        | mask | allocated to                        |
+| :---------- | :--- | :---------------------------------- |
+| 10.26.0.0   | /21  | platforms test - general            |
+| 10.26.8.0   | /21  | hmpps test - general                |
+| 10.26.16.0  | /21  | platforms development - general     |
+| 10.26.24.0  | /21  | hmpps development - general         |
+| 10.26.32.0  | /21  | cica development - general          |
+| 10.26.40.0  | /21  | hmcts development - general         |
+| 10.26.48.0  | /21  | hq development - general            |
+| 10.26.56.0  | /21  | laa development - general           |
+| 10.26.64.0  | /21  | opg test - general                  |
+| 10.26.72.0  | /21  | opg development - general           |
+| 10.26.80.0  | /21  | cjse-development - general          |
+| 10.26.88.0  | /21  | cjse-test - general                 |
+| 10.26.96.0  | /21  | laa-test - general                  |
+| 10.26.104.0 | /21  | hmcts-test - general                |
+| 10.26.112.0 | /21  | cica-test - general                 |
+| 10.26.120.0 | /21  | hq-test - general                   |
+| 10.26.128.0 | /21  | data-platform development - general |
+| 10.26.136.0 | /21  | -                                   |
+| 10.26.144.0 | /21  | -                                   |
+| 10.26.152.0 | /21  | -                                   |
+| 10.26.160.0 | /21  | -                                   |
+| 10.26.168.0 | /21  | -                                   |
+| 10.26.176.0 | /21  | -                                   |
+| 10.26.184.0 | /21  | -                                   |
+| 10.26.192.0 | /21  | -                                   |
+| 10.26.200.0 | /21  | -                                   |
+| 10.26.208.0 | /21  | -                                   |
+| 10.26.216.0 | /21  | -                                   |
+| 10.26.224.0 | /21  | -                                   |
+| 10.26.232.0 | /21  | -                                   |
+| 10.26.240.0 | /21  | -                                   |
+| 10.26.248.0 | /21  | -                                   |
 |             |      |
 
 ### preproduction and production /21s for member subnet-sets
 
-| CIDR        | mask | allocated to                      |
-| :---------- | :--- | :-------------------------------- |
-| 10.27.0.0   | /21  | hmpps preproduction - general     |
-| 10.27.8.0   | /21  | hmpps production - general        |
-| 10.27.16.0  | /21  | hmcts production - general        |
-| 10.27.24.0  | /21  | hmcts preproduction - general     |
-| 10.27.32.0  | /21  | hq production - general           |
-| 10.27.40.0  | /21  | hq preproduction - general        |
-| 10.27.48.0  | /21  | opg production - general          |
-| 10.27.56.0  | /21  | opg preproduction - general       |
-| 10.27.64.0  | /21  | laa production - general          |
-| 10.27.72.0  | /21  | laa preproduction - general       |
-| 10.27.80.0  | /21  | cica production - general         |
-| 10.27.88.0  | /21  | cica preproduction - general      |
-| 10.27.96.0  | /21  | platforms production - general    |
-| 10.27.104.0 | /21  | platforms preproduction - general |
-| 10.27.112.0 | /21  | cjse production - general         |
-| 10.27.120.0 | /21  | cjse preproduction - general      |
-| 10.27.128.0 | /21  | data-platform common - networking |
-| 10.27.136.0 | /21  | -                                 |
-| 10.27.144.0 | /21  | -                                 |
-| 10.27.152.0 | /21  | -                                 |
-| 10.27.160.0 | /21  | -                                 |
-| 10.27.168.0 | /21  | -                                 |
-| 10.27.176.0 | /21  | -                                 |
-| 10.27.184.0 | /21  | -                                 |
-| 10.27.192.0 | /21  | -                                 |
-| 10.27.200.0 | /21  | -                                 |
-| 10.27.208.0 | /21  | -                                 |
-| 10.27.216.0 | /21  | -                                 |
-| 10.27.224.0 | /21  | -                                 |
-| 10.27.232.0 | /21  | -                                 |
-| 10.27.240.0 | /21  | -                                 |
-| 10.27.248.0 | /21  | -                                 |
+| CIDR        | mask | allocated to                       |
+| :---------- | :--- | :--------------------------------  |
+| 10.27.0.0   | /21  | hmpps preproduction - general      |
+| 10.27.8.0   | /21  | hmpps production - general         |
+| 10.27.16.0  | /21  | hmcts production - general         |
+| 10.27.24.0  | /21  | hmcts preproduction - general      |
+| 10.27.32.0  | /21  | hq production - general            |
+| 10.27.40.0  | /21  | hq preproduction - general         |
+| 10.27.48.0  | /21  | opg production - general           |
+| 10.27.56.0  | /21  | opg preproduction - general        |
+| 10.27.64.0  | /21  | laa production - general           |
+| 10.27.72.0  | /21  | laa preproduction - general        |
+| 10.27.80.0  | /21  | cica production - general          |
+| 10.27.88.0  | /21  | cica preproduction - general       |
+| 10.27.96.0  | /21  | platforms production - general     |
+| 10.27.104.0 | /21  | platforms preproduction - general  |
+| 10.27.112.0 | /21  | cjse production - general          |
+| 10.27.120.0 | /21  | cjse preproduction - general       |
+| 10.27.128.0 | /21  | data-platform production - general |
+| 10.27.136.0 | /21  | -                                  |
+| 10.27.144.0 | /21  | -                                  |
+| 10.27.152.0 | /21  | -                                  |
+| 10.27.160.0 | /21  | -                                  |
+| 10.27.168.0 | /21  | -                                  |
+| 10.27.176.0 | /21  | -                                  |
+| 10.27.184.0 | /21  | -                                  |
+| 10.27.192.0 | /21  | -                                  |
+| 10.27.200.0 | /21  | -                                  |
+| 10.27.208.0 | /21  | -                                  |
+| 10.27.216.0 | /21  | -                                  |
+| 10.27.224.0 | /21  | -                                  |
+| 10.27.232.0 | /21  | -                                  |
+| 10.27.240.0 | /21  | -                                  |
+| 10.27.248.0 | /21  | -                                  |
 |             |      |
 
 ### sandbox /21s for member subnet-sets

--- a/cidr-allocation.md
+++ b/cidr-allocation.md
@@ -24,78 +24,78 @@
 
 ### development and test /21s for member subnet-sets
 
-| CIDR        | mask | allocated to                        |
-| :---------- | :--- | :---------------------------------- |
-| 10.26.0.0   | /21  | platforms test - general            |
-| 10.26.8.0   | /21  | hmpps test - general                |
-| 10.26.16.0  | /21  | platforms development - general     |
-| 10.26.24.0  | /21  | hmpps development - general         |
-| 10.26.32.0  | /21  | cica development - general          |
-| 10.26.40.0  | /21  | hmcts development - general         |
-| 10.26.48.0  | /21  | hq development - general            |
-| 10.26.56.0  | /21  | laa development - general           |
-| 10.26.64.0  | /21  | opg test - general                  |
-| 10.26.72.0  | /21  | opg development - general           |
-| 10.26.80.0  | /21  | cjse-development - general          |
-| 10.26.88.0  | /21  | cjse-test - general                 |
-| 10.26.96.0  | /21  | laa-test - general                  |
-| 10.26.104.0 | /21  | hmcts-test - general                |
-| 10.26.112.0 | /21  | cica-test - general                 |
-| 10.26.120.0 | /21  | hq-test - general                   |
-| 10.26.128.0 | /21  | data-platform development - general |
-| 10.26.136.0 | /21  | -                                   |
-| 10.26.144.0 | /21  | -                                   |
-| 10.26.152.0 | /21  | -                                   |
-| 10.26.160.0 | /21  | -                                   |
-| 10.26.168.0 | /21  | -                                   |
-| 10.26.176.0 | /21  | -                                   |
-| 10.26.184.0 | /21  | -                                   |
-| 10.26.192.0 | /21  | -                                   |
-| 10.26.200.0 | /21  | -                                   |
-| 10.26.208.0 | /21  | -                                   |
-| 10.26.216.0 | /21  | -                                   |
-| 10.26.224.0 | /21  | -                                   |
-| 10.26.232.0 | /21  | -                                   |
-| 10.26.240.0 | /21  | -                                   |
-| 10.26.248.0 | /21  | -                                   |
+| CIDR        | mask | allocated to                           |
+| :---------- | :--- | :------------------------------------- |
+| 10.26.0.0   | /21  | platforms test - general               |
+| 10.26.8.0   | /21  | hmpps test - general                   |
+| 10.26.16.0  | /21  | platforms development - general        |
+| 10.26.24.0  | /21  | hmpps development - general            |
+| 10.26.32.0  | /21  | cica development - general             |
+| 10.26.40.0  | /21  | hmcts development - general            |
+| 10.26.48.0  | /21  | hq development - general               |
+| 10.26.56.0  | /21  | laa development - general              |
+| 10.26.64.0  | /21  | opg test - general                     |
+| 10.26.72.0  | /21  | opg development - general              |
+| 10.26.80.0  | /21  | cjse-development - general             |
+| 10.26.88.0  | /21  | cjse-test - general                    |
+| 10.26.96.0  | /21  | laa-test - general                     |
+| 10.26.104.0 | /21  | hmcts-test - general                   |
+| 10.26.112.0 | /21  | cica-test - general                    |
+| 10.26.120.0 | /21  | hq-test - general                      |
+| 10.26.128.0 | /21  | data-platform development - networking |
+| 10.26.136.0 | /21  | -                                      |
+| 10.26.144.0 | /21  | -                                      |
+| 10.26.152.0 | /21  | -                                      |
+| 10.26.160.0 | /21  | -                                      |
+| 10.26.168.0 | /21  | -                                      |
+| 10.26.176.0 | /21  | -                                      |
+| 10.26.184.0 | /21  | -                                      |
+| 10.26.192.0 | /21  | -                                      |
+| 10.26.200.0 | /21  | -                                      |
+| 10.26.208.0 | /21  | -                                      |
+| 10.26.216.0 | /21  | -                                      |
+| 10.26.224.0 | /21  | -                                      |
+| 10.26.232.0 | /21  | -                                      |
+| 10.26.240.0 | /21  | -                                      |
+| 10.26.248.0 | /21  | -                                      |
 |             |      |
 
 ### preproduction and production /21s for member subnet-sets
 
-| CIDR        | mask | allocated to                       |
-| :---------- | :--- | :--------------------------------  |
-| 10.27.0.0   | /21  | hmpps preproduction - general      |
-| 10.27.8.0   | /21  | hmpps production - general         |
-| 10.27.16.0  | /21  | hmcts production - general         |
-| 10.27.24.0  | /21  | hmcts preproduction - general      |
-| 10.27.32.0  | /21  | hq production - general            |
-| 10.27.40.0  | /21  | hq preproduction - general         |
-| 10.27.48.0  | /21  | opg production - general           |
-| 10.27.56.0  | /21  | opg preproduction - general        |
-| 10.27.64.0  | /21  | laa production - general           |
-| 10.27.72.0  | /21  | laa preproduction - general        |
-| 10.27.80.0  | /21  | cica production - general          |
-| 10.27.88.0  | /21  | cica preproduction - general       |
-| 10.27.96.0  | /21  | platforms production - general     |
-| 10.27.104.0 | /21  | platforms preproduction - general  |
-| 10.27.112.0 | /21  | cjse production - general          |
-| 10.27.120.0 | /21  | cjse preproduction - general       |
-| 10.27.128.0 | /21  | data-platform production - general |
-| 10.27.136.0 | /21  | -                                  |
-| 10.27.144.0 | /21  | -                                  |
-| 10.27.152.0 | /21  | -                                  |
-| 10.27.160.0 | /21  | -                                  |
-| 10.27.168.0 | /21  | -                                  |
-| 10.27.176.0 | /21  | -                                  |
-| 10.27.184.0 | /21  | -                                  |
-| 10.27.192.0 | /21  | -                                  |
-| 10.27.200.0 | /21  | -                                  |
-| 10.27.208.0 | /21  | -                                  |
-| 10.27.216.0 | /21  | -                                  |
-| 10.27.224.0 | /21  | -                                  |
-| 10.27.232.0 | /21  | -                                  |
-| 10.27.240.0 | /21  | -                                  |
-| 10.27.248.0 | /21  | -                                  |
+| CIDR        | mask | allocated to                          |
+| :---------- | :--- | :------------------------------------ |
+| 10.27.0.0   | /21  | hmpps preproduction - general         |
+| 10.27.8.0   | /21  | hmpps production - general            |
+| 10.27.16.0  | /21  | hmcts production - general            |
+| 10.27.24.0  | /21  | hmcts preproduction - general         |
+| 10.27.32.0  | /21  | hq production - general               |
+| 10.27.40.0  | /21  | hq preproduction - general            |
+| 10.27.48.0  | /21  | opg production - general              |
+| 10.27.56.0  | /21  | opg preproduction - general           |
+| 10.27.64.0  | /21  | laa production - general              |
+| 10.27.72.0  | /21  | laa preproduction - general           |
+| 10.27.80.0  | /21  | cica production - general             |
+| 10.27.88.0  | /21  | cica preproduction - general          |
+| 10.27.96.0  | /21  | platforms production - general        |
+| 10.27.104.0 | /21  | platforms preproduction - general     |
+| 10.27.112.0 | /21  | cjse production - general             |
+| 10.27.120.0 | /21  | cjse preproduction - general          |
+| 10.27.128.0 | /21  | data-platform production - networking |
+| 10.27.136.0 | /21  | -                                     |
+| 10.27.144.0 | /21  | -                                     |
+| 10.27.152.0 | /21  | -                                     |
+| 10.27.160.0 | /21  | -                                     |
+| 10.27.168.0 | /21  | -                                     |
+| 10.27.176.0 | /21  | -                                     |
+| 10.27.184.0 | /21  | -                                     |
+| 10.27.192.0 | /21  | -                                     |
+| 10.27.200.0 | /21  | -                                     |
+| 10.27.208.0 | /21  | -                                     |
+| 10.27.216.0 | /21  | -                                     |
+| 10.27.224.0 | /21  | -                                     |
+| 10.27.232.0 | /21  | -                                     |
+| 10.27.240.0 | /21  | -                                     |
+| 10.27.248.0 | /21  | -                                     |
 |             |      |
 
 ### sandbox /21s for member subnet-sets


### PR DESCRIPTION
Originally it was thought that Data Platform would only consume a small amount of compute for Amazon MWAA, but that is changing now we're also hosting other components that require non-shared networking.

This PR:

- allocates a development/test range
- updates allocation name