### PR TITLE
Allow DE sandbox to pull image for testing POC

### DIFF
--- a/terraform/environments/core-shared-services/ecr_repos.tf
+++ b/terraform/environments/core-shared-services/ecr_repos.tf
@@ -263,6 +263,7 @@ module "data_platform_authorizer_ecr_repo" {
     local.environment_management.account_ids["data-platform-test"],
     local.environment_management.account_ids["data-platform-preproduction"],
     local.environment_management.account_ids["data-platform-production"],
+    local.environment_management.account_ids["analytical-platform-data-engineering-sandbox-a"],
   ]
 
   enable_retrieval_policy_for_lambdas = [
@@ -270,6 +271,7 @@ module "data_platform_authorizer_ecr_repo" {
     "arn:aws:lambda:eu-west-2:${local.environment_management.account_ids["data-platform-test"]}:function:data_product_authorizer*",
     "arn:aws:lambda:eu-west-2:${local.environment_management.account_ids["data-platform-preproduction"]}:function:data_product_authorizer*",
     "arn:aws:lambda:eu-west-2:${local.environment_management.account_ids["data-platform-production"]}:function:data_product_authorizer*",
+    "arn:aws:lambda:eu-west-2:${local.environment_management.account_ids["analytical-platform-data-engineering-sandbox-a"]}:function:data_product_authorizer*",
   ]
 
   # Tags

--- a/terraform/environments/core-shared-services/ecr_repos.tf
+++ b/terraform/environments/core-shared-services/ecr_repos.tf
@@ -230,7 +230,7 @@ module "data_platform_presigned_url_ecr_repo" {
     local.environment_management.account_ids["data-platform-test"],
     local.environment_management.account_ids["data-platform-preproduction"],
     local.environment_management.account_ids["data-platform-production"],
-    local.environment_management.account_ids["analytical-platform-data-engineering-sandbox-a"]
+    local.environment_management.account_ids["analytical-platform-data-engineering-sandboxa"]
   ]
 
   enable_retrieval_policy_for_lambdas = [
@@ -238,7 +238,7 @@ module "data_platform_presigned_url_ecr_repo" {
     "arn:aws:lambda:eu-west-2:${local.environment_management.account_ids["data-platform-test"]}:function:data_product_presigned_url*",
     "arn:aws:lambda:eu-west-2:${local.environment_management.account_ids["data-platform-preproduction"]}:function:data_product_presigned_url*",
     "arn:aws:lambda:eu-west-2:${local.environment_management.account_ids["data-platform-production"]}:function:data_product_presigned_url*",
-    "arn:aws:lambda:eu-west-2:${local.environment_management.account_ids["analytical-platform-data-engineering-sandbox-a"]}:function:data_product_presigned_url*",
+    "arn:aws:lambda:eu-west-2:${local.environment_management.account_ids["analytical-platform-data-engineering-sandboxa"]}:function:data_product_presigned_url*",
   ]
 
   # Tags
@@ -265,7 +265,7 @@ module "data_platform_authorizer_ecr_repo" {
     local.environment_management.account_ids["data-platform-test"],
     local.environment_management.account_ids["data-platform-preproduction"],
     local.environment_management.account_ids["data-platform-production"],
-    local.environment_management.account_ids["analytical-platform-data-engineering-sandbox-a"],
+    local.environment_management.account_ids["analytical-platform-data-engineering-sandboxa"],
   ]
 
   enable_retrieval_policy_for_lambdas = [
@@ -273,7 +273,7 @@ module "data_platform_authorizer_ecr_repo" {
     "arn:aws:lambda:eu-west-2:${local.environment_management.account_ids["data-platform-test"]}:function:data_product_authorizer*",
     "arn:aws:lambda:eu-west-2:${local.environment_management.account_ids["data-platform-preproduction"]}:function:data_product_authorizer*",
     "arn:aws:lambda:eu-west-2:${local.environment_management.account_ids["data-platform-production"]}:function:data_product_authorizer*",
-    "arn:aws:lambda:eu-west-2:${local.environment_management.account_ids["analytical-platform-data-engineering-sandbox-a"]}:function:data_product_authorizer*",
+    "arn:aws:lambda:eu-west-2:${local.environment_management.account_ids["analytical-platform-data-engineering-sandboxa"]}:function:data_product_authorizer*",
   ]
 
   # Tags

--- a/terraform/environments/core-shared-services/ecr_repos.tf
+++ b/terraform/environments/core-shared-services/ecr_repos.tf
@@ -230,6 +230,7 @@ module "data_platform_presigned_url_ecr_repo" {
     local.environment_management.account_ids["data-platform-test"],
     local.environment_management.account_ids["data-platform-preproduction"],
     local.environment_management.account_ids["data-platform-production"],
+    local.environment_management.account_ids["analytical-platform-data-engineering-sandbox-a"]
   ]
 
   enable_retrieval_policy_for_lambdas = [
@@ -237,6 +238,7 @@ module "data_platform_presigned_url_ecr_repo" {
     "arn:aws:lambda:eu-west-2:${local.environment_management.account_ids["data-platform-test"]}:function:data_product_presigned_url*",
     "arn:aws:lambda:eu-west-2:${local.environment_management.account_ids["data-platform-preproduction"]}:function:data_product_presigned_url*",
     "arn:aws:lambda:eu-west-2:${local.environment_management.account_ids["data-platform-production"]}:function:data_product_presigned_url*",
+    "arn:aws:lambda:eu-west-2:${local.environment_management.account_ids["analytical-platform-data-engineering-sandbox-a"]}:function:data_product_presigned_url*",
   ]
 
   # Tags


### PR DESCRIPTION
We want to terratest locally connected to DE sandbox . This has capability to apply from locally . We need for POC.  The infrastructure has lambda image which need to be pulled  and created in sandbox account 