### PR TITLE
add outbound udp rules for fixngo domain joins

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
@@ -243,5 +243,75 @@
     "destination_ip": "${hq-preproduction}",
     "destination_port": "5439",
     "protocol": "TCP"
+  },
+  "mp_hmpps_development_to_noms_mgmt_vnet_ntp": {
+    "action": "PASS",
+    "source_ip": "${hmpps-preproduction}",
+    "destination_ip": "${noms-mgmt-vnet}",
+    "destination_port": "123",
+    "protocol": "UDP"
+  },
+  "mp_hmpps_development_to_noms_mgmt_vnet_ldap": {
+    "action": "PASS",
+    "source_ip": "${hmpps-preproduction}",
+    "destination_ip": "${noms-mgmt-vnet}",
+    "destination_port": "389",
+    "protocol": "UDP"
+  },
+  "mp_hmpps_development_to_noms_mgmg_vnet_ldap_ssl": {
+    "action": "PASS",
+    "source_ip": "${hmpps-preproduction}",
+    "destination_ip": "${noms-mgmt-vnet}",
+    "destination_port": "636",
+    "protocol": "UDP"
+  },
+  "mp_hmpps_development_to_noms_mgmt_vnet_kerberos": {
+    "action": "PASS",
+    "source_ip": "${hmpps-preproduction}",
+    "destination_ip": "${noms-mgmt-vnet}",
+    "destination_port": "88",
+    "protocol": "UDP"
+  },
+  "mp_hmpps_development_to_noms_mgmt_vnet_kerberos_password_change": {
+    "action": "PASS",
+    "source_ip": "${hmpps-preproduction}",
+    "destination_ip": "${noms-mgmt-vnet}",
+    "destination_port": "464",
+    "protocol": "UDP"
+  },
+  "mp_hmpps_development_to_noms_mgmt_vnet_smb": {
+    "action": "PASS",
+    "source_ip": "${hmpps-preproduction}",
+    "destination_ip": "${noms-mgmt-vnet}",
+    "destination_port": "445",
+    "protocol": "UDP"
+  },
+  "mp_hmpps_development_to_noms_mgmt_vnet_global_catalog_3268": {
+    "action": "PASS",
+    "source_ip": "${hmpps-preproduction}",
+    "destination_ip": "${noms-mgmt-vnet}",
+    "destination_port": "3268",
+    "protocol": "UDP"
+  },
+  "mp_hmpps_development_to_noms_mgmt_vnet_global_catalog_3269": {
+    "action": "PASS",
+    "source_ip": "${hmpps-preproduction}",
+    "destination_ip": "${noms-mgmt-vnet}",
+    "destination_port": "3269",
+    "protocol": "UDP"
+  },
+  "mp_hmpps_development_to_noms_mgmt_vnet_netbios_137": {
+    "action": "PASS",
+    "source_ip": "${hmpps-preproduction}",
+    "destination_ip": "${noms-mgmt-vnet}",
+    "destination_port": "137",
+    "protocol": "UDP"
+  },
+  "mp_hmpps_development_to_noms_mgmt_vnet_netbios_138": {
+    "action": "PASS",
+    "source_ip": "${hmpps-preproduction}",
+    "destination_ip": "${noms-mgmt-vnet}",
+    "destination_port": "138",
+    "protocol": "UDP"
   }
 }

--- a/terraform/environments/core-network-services/firewall-rules/production_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/production_rules.json
@@ -292,5 +292,75 @@
     "destination_ip": "${hq-production}",
     "destination_port": "5439",
     "protocol": "TCP"
+  },
+  "mp_hmpps_development_to_noms_mgmt_vnet_ntp": {
+    "action": "PASS",
+    "source_ip": "${hmpps-production}",
+    "destination_ip": "${noms-mgmt-vnet}",
+    "destination_port": "123",
+    "protocol": "UDP"
+  },
+  "mp_hmpps_development_to_noms_mgmt_vnet_ldap": {
+    "action": "PASS",
+    "source_ip": "${hmpps-production}",
+    "destination_ip": "${noms-mgmt-vnet}",
+    "destination_port": "389",
+    "protocol": "UDP"
+  },
+  "mp_hmpps_development_to_noms_mgmg_vnet_ldap_ssl": {
+    "action": "PASS",
+    "source_ip": "${hmpps-production}",
+    "destination_ip": "${noms-mgmt-vnet}",
+    "destination_port": "636",
+    "protocol": "UDP"
+  },
+  "mp_hmpps_development_to_noms_mgmt_vnet_kerberos": {
+    "action": "PASS",
+    "source_ip": "${hmpps-production}",
+    "destination_ip": "${noms-mgmt-vnet}",
+    "destination_port": "88",
+    "protocol": "UDP"
+  },
+  "mp_hmpps_development_to_noms_mgmt_vnet_kerberos_password_change": {
+    "action": "PASS",
+    "source_ip": "${hmpps-production}",
+    "destination_ip": "${noms-mgmt-vnet}",
+    "destination_port": "464",
+    "protocol": "UDP"
+  },
+  "mp_hmpps_development_to_noms_mgmt_vnet_smb": {
+    "action": "PASS",
+    "source_ip": "${hmpps-production}",
+    "destination_ip": "${noms-mgmt-vnet}",
+    "destination_port": "445",
+    "protocol": "UDP"
+  },
+  "mp_hmpps_development_to_noms_mgmt_vnet_global_catalog_3268": {
+    "action": "PASS",
+    "source_ip": "${hmpps-production}",
+    "destination_ip": "${noms-mgmt-vnet}",
+    "destination_port": "3268",
+    "protocol": "UDP"
+  },
+  "mp_hmpps_development_to_noms_mgmt_vnet_global_catalog_3269": {
+    "action": "PASS",
+    "source_ip": "${hmpps-production}",
+    "destination_ip": "${noms-mgmt-vnet}",
+    "destination_port": "3269",
+    "protocol": "UDP"
+  },
+  "mp_hmpps_development_to_noms_mgmt_vnet_netbios_137": {
+    "action": "PASS",
+    "source_ip": "${hmpps-production}",
+    "destination_ip": "${noms-mgmt-vnet}",
+    "destination_port": "137",
+    "protocol": "UDP"
+  },
+  "mp_hmpps_development_to_noms_mgmt_vnet_netbios_138": {
+    "action": "PASS",
+    "source_ip": "${hmpps-production}",
+    "destination_ip": "${noms-mgmt-vnet}",
+    "destination_port": "138",
+    "protocol": "UDP"
   }
 }

--- a/terraform/environments/core-network-services/firewall-rules/test_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/test_rules.json
@@ -194,5 +194,75 @@
     "destination_ip": "${hmpps-test}",
     "destination_port": "389",
     "protocol": "TCP"
+  },
+  "mp_hmpps_development_to_noms_mgmt_vnet_ntp": {
+    "action": "PASS",
+    "source_ip": "${hmpps-test}",
+    "destination_ip": "${noms-mgmt-vnet}",
+    "destination_port": "123",
+    "protocol": "UDP"
+  },
+  "mp_hmpps_development_to_noms_mgmt_vnet_ldap": {
+    "action": "PASS",
+    "source_ip": "${hmpps-test}",
+    "destination_ip": "${noms-mgmt-vnet}",
+    "destination_port": "389",
+    "protocol": "UDP"
+  },
+  "mp_hmpps_development_to_noms_mgmg_vnet_ldap_ssl": {
+    "action": "PASS",
+    "source_ip": "${hmpps-test}",
+    "destination_ip": "${noms-mgmt-vnet}",
+    "destination_port": "636",
+    "protocol": "UDP"
+  },
+  "mp_hmpps_development_to_noms_mgmt_vnet_kerberos": {
+    "action": "PASS",
+    "source_ip": "${hmpps-test}",
+    "destination_ip": "${noms-mgmt-vnet}",
+    "destination_port": "88",
+    "protocol": "UDP"
+  },
+  "mp_hmpps_development_to_noms_mgmt_vnet_kerberos_password_change": {
+    "action": "PASS",
+    "source_ip": "${hmpps-test}",
+    "destination_ip": "${noms-mgmt-vnet}",
+    "destination_port": "464",
+    "protocol": "UDP"
+  },
+  "mp_hmpps_development_to_noms_mgmt_vnet_smb": {
+    "action": "PASS",
+    "source_ip": "${hmpps-test}",
+    "destination_ip": "${noms-mgmt-vnet}",
+    "destination_port": "445",
+    "protocol": "UDP"
+  },
+  "mp_hmpps_development_to_noms_mgmt_vnet_global_catalog_3268": {
+    "action": "PASS",
+    "source_ip": "${hmpps-test}",
+    "destination_ip": "${noms-mgmt-vnet}",
+    "destination_port": "3268",
+    "protocol": "UDP"
+  },
+  "mp_hmpps_development_to_noms_mgmt_vnet_global_catalog_3269": {
+    "action": "PASS",
+    "source_ip": "${hmpps-test}",
+    "destination_ip": "${noms-mgmt-vnet}",
+    "destination_port": "3269",
+    "protocol": "UDP"
+  },
+  "mp_hmpps_development_to_noms_mgmt_vnet_netbios_137": {
+    "action": "PASS",
+    "source_ip": "${hmpps-test}",
+    "destination_ip": "${noms-mgmt-vnet}",
+    "destination_port": "137",
+    "protocol": "UDP"
+  },
+  "mp_hmpps_development_to_noms_mgmt_vnet_netbios_138": {
+    "action": "PASS",
+    "source_ip": "${hmpps-test}",
+    "destination_ip": "${noms-mgmt-vnet}",
+    "destination_port": "138",
+    "protocol": "UDP"
   }
 }


### PR DESCRIPTION
- add allowed udp ports out to fixngo ad domains
- test, preproduction and production
- succeeded in development environment already