### PR TITLE
Ask channel request

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/policies.tf
+++ b/terraform/environments/bootstrap/delegate-access/policies.tf
@@ -108,6 +108,7 @@ data "aws_iam_policy_document" "developer_additional" {
       "application-autoscaling:ListTagsForResource",
       "autoscaling:UpdateAutoScalingGroup",
       "autoscaling:SetDesiredCapacity",
+      "athena:StartQueryExecution",
       "aws-marketplace:ViewSubscriptions",
       "cloudwatch:DisableAlarmActions",
       "cloudwatch:EnableAlarmActions",


### PR DESCRIPTION
User is having issues running Athena queries from the console see bellow: - 

Morning team, no rush on this, but I’m trying to query nomis-preproduction load balancer logs via Athena in AWS console but get below error.  If I try athena:StartQueryExecutionin [IAM Policy Simulator](https://policysim.aws.amazon.com/home/index.jsp?#roles/developer) it says denied by AWS Organization SCPs.  Any clues?
You are not authorized to perform: athena:StartQueryExecution on the resource. After your AWS administrator or you have updated your permissions, please try again.

adding this permission to the developer role