### PR TITLE
✨ : Add Additional Reviewers Functionality

### DIFF
--- a/environments/sprinkler.json
+++ b/environments/sprinkler.json
@@ -10,7 +10,7 @@
           "nuke": "rebuild"
         }
       ],
-      "additional_reviewers": ["astrobinson"]
+      "additional_reviewers": ["markgov"]
     }
   ],
   "tags": {

--- a/scripts/git-create-environments.sh
+++ b/scripts/git-create-environments.sh
@@ -41,6 +41,7 @@ get_github_team_id() {
     -H "Authorization: token ${secret}" \
     https://api.github.com/orgs/${github_org}/teams/${team_slug})
   team_id=$(echo ${response} | jq -r '.id')
+  # echo "Team ID for ${team_slug}: ${team_id}"
   team_ids=(${team_ids} ${team_id})
 }
 
@@ -76,7 +77,8 @@ create_environment() {
   environment_name=$1
   github_teams=$2
   
-  # Construct the payload
+  echo "Creating environment ${environment_name}..."
+  # echo "Teams for payload: ${github_teams}"
   if [ "${env}" == "preproduction" ] || [ "${env}" == "production" ]
   then
     # Include both github_teams and additional_reviewers in the payload

--- a/scripts/git-create-environments.sh
+++ b/scripts/git-create-environments.sh
@@ -41,8 +41,6 @@ get_github_team_id() {
     -H "Authorization: token ${secret}" \
     https://api.github.com/orgs/${github_org}/teams/${team_slug})
   team_id=$(echo ${response} | jq -r '.id')
-  # echo "Team ID for ${team_slug}: ${team_id}"
-  team_ids=(${team_ids} ${team_id})
 }
 
 get_github_user_id() {

--- a/scripts/git-create-environments.sh
+++ b/scripts/git-create-environments.sh
@@ -114,6 +114,7 @@ create_reviewers_json() {
 
   # Add user reviewers to reviewers JSON (if any)
   for user_id in "${user_ids[@]}"
+  do
     if [ -n "$user_id" ]; then
       raw_jq=$(jq -cn --arg user_id "$user_id" '{ "type": "User", "id": ($user_id|tonumber) }')
       reviewers_json="${reviewers_json}${raw_jq},"

--- a/scripts/git-create-environments.sh
+++ b/scripts/git-create-environments.sh
@@ -204,7 +204,7 @@ main() {
           # Create reviewers json for teams and users
           team_reviewers_json=$(create_team_reviewers_json "${team_ids[@]}")
           user_reviewers_json=$(create_user_reviewers_json "${user_ids[@]}")
-          create_reviewers_json "${team_reviewers_json}" "${user_reviewers_json}"
+          reviewers_json=$(create_reviewers_json "${team_reviewers_json}" "${user_reviewers_json}")
           create_environment ${environment} "${reviewers_json}"
         fi
       else

--- a/scripts/git-create-environments.sh
+++ b/scripts/git-create-environments.sh
@@ -69,17 +69,17 @@ check_if_change_to_application_json() {
 
 create_environment() {
   environment_name=$1
-  github_teams=$2
+  reviewers_json=$2  # Accept the reviewers_json parameter
   
   echo "Creating environment ${environment_name}..."
   # echo "Teams for payload: ${github_teams}"
   if [ "${env}" == "preproduction" ] || [ "${env}" == "production" ]
   then
     # Include both github_teams and additional_reviewers in the payload
-    payload="{\"deployment_branch_policy\":{\"protected_branches\":true,\"custom_branch_policies\":false},\"reviewers\": [${github_teams}]}"
+    payload="{\"deployment_branch_policy\":{\"protected_branches\":true,\"custom_branch_policies\":false},\"reviewers\": [${reviewers_json}]}"
   else
     # Include both github_teams and additional_reviewers in the payload
-    payload="{\"reviewers\": [${github_teams}]}"
+    payload="{\"reviewers\": [${reviewers_json}]}"
   fi
 
   echo "Payload: $payload"

--- a/scripts/git-create-environments.sh
+++ b/scripts/git-create-environments.sh
@@ -114,9 +114,10 @@ create_reviewers_json() {
 
   # Add user reviewers to reviewers JSON (if any)
   for user_id in "${user_ids[@]}"
-  do
-    raw_jq=$(jq -cn --arg user_id "$user_id" '{ "type": "User", "id": ($user_id|tonumber) }')
-    reviewers_json="${reviewers_json}${raw_jq},"
+    if [ -n "$user_id" ]; then
+      raw_jq=$(jq -cn --arg user_id "$user_id" '{ "type": "User", "id": ($user_id|tonumber) }')
+      reviewers_json="${reviewers_json}${raw_jq},"
+    fi
   done
 
   # Remove trailing comma


### PR DESCRIPTION
Following on from PR https://github.com/ministryofjustice/modernisation-platform/pull/4945 where the additional_reviewers function could not be used to 'patch' in additional reviewers I have created/updated the below functions...

`get_github_team_id`: Retrieves GitHub Team ID
`get_github_user_id`: Retrieves GitHub User ID 
`create_team_reviewers_json`:  formats team reviewers ready for the GitHub API.
`create_user_reviewers_json`: formats user reviewers ready for the GitHub API.
`create_reviewers_json`: combines the above outputs ready for the environment creation/update.


Previous payload example: `Payload: {"reviewers": [{"type":"Team","id":1234567}]`

New payload example (including additional reviewer:  `payload='{"reviewers": [{"type":"Team","id":1234567},{"type":"Team","id":7654321},{"type":"User","id":1234567}]}'`

In addition, debugging/troubleshooting flags have been left enabled, I will remove these once we've confirmed everything is working correctly (line 4:  set -x & line 87: -i)