### PR TITLE
Add repo name for performance-hub

### DIFF
--- a/environments/performance-hub.json
+++ b/environments/performance-hub.json
@@ -35,6 +35,6 @@
     "infrastructure-support": "performance-hub@digital.justice.gov.uk",
     "owner": "hubusers@justice.gov.uk"
   },
-  "github-oidc-team-repositories": [""],
+  "github-oidc-team-repositories": ["ministryofjustice/performance-hub"],
   "go-live-date": "2021-11-10"
 }


### PR DESCRIPTION
following on a rebase that went a little bit wrong (https://github.com/ministryofjustice/modernisation-platform/pull/5003) I have created a new PR on @jemnery's behalf with the oidc changes they committed. 