### PR TITLE
Allow developer role to share RDS snapshots

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/policies.tf
+++ b/terraform/environments/bootstrap/delegate-access/policies.tf
@@ -170,6 +170,7 @@ data "aws_iam_policy_document" "developer_additional" {
       "rds:CopyDBClusterSnapshot",
       "rds:CreateDBSnapshot",
       "rds:CreateDBClusterSnapshot",
+      "rds:ModifyDBSnapshotAttribute",
       "rds:RestoreDBInstanceToPointInTime",
       "rds:RebootDB*",
       "rhelkb:GetRhelURL",


### PR DESCRIPTION
While developers can create manual RDS snapshots, they cannot share these snapshots between accounts.
As this is an occasional task that developers need to accomplish, this PR adds the `rds:ModifyDBSnapshotAttribute` permission to the `developer_addtional` policy which will permit this action.