### PR TITLE
Bump Go version

### DIFF
--- a/.github/workflows/core-logging-deployment.yml
+++ b/.github/workflows/core-logging-deployment.yml
@@ -66,11 +66,11 @@ jobs:
 
           #RUN TERRATEST
           pushd terraform/environments/core-logging/test
-          # Install GOLANG 1.20.3
+          # Install GOLANG 1.21.1
           if [ `whoami` != "runner" ]
           then
-          wget -q https://dl.google.com/go/go1.20.3.linux-amd64.tar.gz
-          tar -zxvf go1.20.3.linux-amd64.tar.gz
+          wget -q https://dl.google.com/go/go1.21.1.linux-amd64.tar.gz
+          tar -zxvf go1.21.1.linux-amd64.tar.gz
           sudo mv go /usr/local
           echo "--  running newly installed go  --"
           TEST=`/usr/local/go/bin/go test | ${git_dir}/scripts/redact-output.sh | tee /dev/stderr | tail -n 1`

--- a/.github/workflows/core-network-services-deployment.yml
+++ b/.github/workflows/core-network-services-deployment.yml
@@ -70,11 +70,11 @@ jobs:
 
           #RUN TERRATEST
           pushd terraform/environments/core-network-services/test
-          # Install GOLANG 1.20.3
+          # Install GOLANG 1.21.1
           if [ `whoami` != "runner" ]
           then
-          wget -q https://dl.google.com/go/go1.20.3.linux-amd64.tar.gz
-          tar -zxvf go1.20.3.linux-amd64.tar.gz
+          wget -q https://dl.google.com/go/go1.21.1.linux-amd64.tar.gz
+          tar -zxvf go1.21.1.linux-amd64.tar.gz
           sudo mv go /usr/local
           echo "--  running newly installed go  --"
           TEST=`/usr/local/go/bin/go test | ${git_dir}/scripts/redact-output.sh | tee /dev/stderr | tail -n 1`

--- a/.github/workflows/core-security-deployment.yml
+++ b/.github/workflows/core-security-deployment.yml
@@ -66,11 +66,11 @@ jobs:
 
           #RUN TERRATEST
           pushd terraform/environments/core-security/test
-          # Install GOLANG 1.20.3
+          # Install GOLANG 1.21.1
           if [ `whoami` != "runner" ]
           then
-          wget -q https://dl.google.com/go/go1.20.3.linux-amd64.tar.gz
-          tar -zxvf go1.20.3.linux-amd64.tar.gz
+          wget -q https://dl.google.com/go/go1.21.1.linux-amd64.tar.gz
+          tar -zxvf go1.21.1.linux-amd64.tar.gz
           sudo mv go /usr/local
           echo "--  running newly installed go  --"
           TEST=`/usr/local/go/bin/go test | ${git_dir}/scripts/redact-output.sh | tee /dev/stderr | tail -n 1`

--- a/.github/workflows/core-shared-services-deployment.yml
+++ b/.github/workflows/core-shared-services-deployment.yml
@@ -71,11 +71,11 @@ jobs:
 
           #RUN TERRATEST
           pushd terraform/environments/core-shared-services/test
-          # Install GOLANG 1.20.3
+          # Install GOLANG 1.21.1
           if [ `whoami` != "runner" ]
           then
-          wget -q https://dl.google.com/go/go1.20.3.linux-amd64.tar.gz
-          tar -zxvf go1.20.3.linux-amd64.tar.gz
+          wget -q https://dl.google.com/go/go1.21.1.linux-amd64.tar.gz
+          tar -zxvf go1.21.1.linux-amd64.tar.gz
           sudo mv go /usr/local
           echo "--  running newly installed go  --"
           TEST=`/usr/local/go/bin/go test | ${git_dir}/scripts/redact-output.sh | tee /dev/stderr | tail -n 1`


### PR DESCRIPTION
The new Terratest versions highlighted by dependabot require Go version `1.21.x` to run. This PR bumps the versions in use by our current tests.