### PR TITLE
Update defensive tests for core accounts

### DIFF
--- a/.github/workflows/core-logging-deployment.yml
+++ b/.github/workflows/core-logging-deployment.yml
@@ -40,6 +40,10 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+      - name: Setup Go
+        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+        with:
+          go-version: 1.21
       - name: Set Account Number
         run: echo "ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
       - name: configure aws credentials
@@ -66,18 +70,8 @@ jobs:
 
           #RUN TERRATEST
           pushd terraform/environments/core-logging/test
-          # Install GOLANG 1.21.1
-          if [ `whoami` != "runner" ]
-          then
-          wget -q https://dl.google.com/go/go1.21.1.linux-amd64.tar.gz
-          tar -zxvf go1.21.1.linux-amd64.tar.gz
-          sudo mv go /usr/local
-          echo "--  running newly installed go  --"
-          TEST=`/usr/local/go/bin/go test | ${git_dir}/scripts/redact-output.sh | tee /dev/stderr | tail -n 1`
-          else
-          echo "--  running native go  --"
+          go mod tidy
           TEST=`go test | ${git_dir}/scripts/redact-output.sh | tee /dev/stderr | tail -n 1`
-          fi
           popd
           TEST="> TERRATEST RESULT - core-logging
           ${TEST}"

--- a/.github/workflows/core-network-services-deployment.yml
+++ b/.github/workflows/core-network-services-deployment.yml
@@ -41,6 +41,11 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
 
+      - name: Setup Go
+        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+        with:
+          go-version: 1.21
+
       - name: Set Account Number
         run: echo "ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
 
@@ -70,18 +75,8 @@ jobs:
 
           #RUN TERRATEST
           pushd terraform/environments/core-network-services/test
-          # Install GOLANG 1.21.1
-          if [ `whoami` != "runner" ]
-          then
-          wget -q https://dl.google.com/go/go1.21.1.linux-amd64.tar.gz
-          tar -zxvf go1.21.1.linux-amd64.tar.gz
-          sudo mv go /usr/local
-          echo "--  running newly installed go  --"
-          TEST=`/usr/local/go/bin/go test | ${git_dir}/scripts/redact-output.sh | tee /dev/stderr | tail -n 1`
-          else
-          echo "--  running native go  --"
+          go mod tidy
           TEST=`go test | ${git_dir}/scripts/redact-output.sh | tee /dev/stderr | tail -n 1`
-          fi
           popd
           TEST="> TERRATEST RESULT - core-network-services
           ${TEST}"

--- a/.github/workflows/core-security-deployment.yml
+++ b/.github/workflows/core-security-deployment.yml
@@ -40,6 +40,10 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+      - name: Setup Go
+        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+        with:
+          go-version: 1.21
       - name: Set Account Number
         run: echo "ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
       - name: configure aws credentials
@@ -66,18 +70,8 @@ jobs:
 
           #RUN TERRATEST
           pushd terraform/environments/core-security/test
-          # Install GOLANG 1.21.1
-          if [ `whoami` != "runner" ]
-          then
-          wget -q https://dl.google.com/go/go1.21.1.linux-amd64.tar.gz
-          tar -zxvf go1.21.1.linux-amd64.tar.gz
-          sudo mv go /usr/local
-          echo "--  running newly installed go  --"
-          TEST=`/usr/local/go/bin/go test | ${git_dir}/scripts/redact-output.sh | tee /dev/stderr | tail -n 1`
-          else
-          echo "--  running native go  --"
+          go mod tidy
           TEST=`go test | ${git_dir}/scripts/redact-output.sh | tee /dev/stderr | tail -n 1`
-          fi
           popd
           TEST="> TERRATEST RESULT - core-security
           ${TEST}"

--- a/.github/workflows/core-shared-services-deployment.yml
+++ b/.github/workflows/core-shared-services-deployment.yml
@@ -57,6 +57,9 @@ jobs:
         with:
           terraform_version: "~1"
           terraform_wrapper: false
+      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+        with:
+          go-version: 1.21
  
       - name: Run terraform plan in terraform/environments/core-shared-services
         run: |
@@ -71,18 +74,7 @@ jobs:
 
           #RUN TERRATEST
           pushd terraform/environments/core-shared-services/test
-          # Install GOLANG 1.21.1
-          if [ `whoami` != "runner" ]
-          then
-          wget -q https://dl.google.com/go/go1.21.1.linux-amd64.tar.gz
-          tar -zxvf go1.21.1.linux-amd64.tar.gz
-          sudo mv go /usr/local
-          echo "--  running newly installed go  --"
-          TEST=`/usr/local/go/bin/go test | ${git_dir}/scripts/redact-output.sh | tee /dev/stderr | tail -n 1`
-          else
-          echo "--  running native go  --"
           TEST=`go test | ${git_dir}/scripts/redact-output.sh | tee /dev/stderr | tail -n 1`
-          fi
           popd
           TEST="> TERRATEST RESULT - core-shared-services
           ${TEST}"

--- a/.github/workflows/core-shared-services-deployment.yml
+++ b/.github/workflows/core-shared-services-deployment.yml
@@ -76,7 +76,7 @@ jobs:
           #RUN TERRATEST
           pushd terraform/environments/core-shared-services/test
           go mod tidy
-          TEST=`go test -v | ${git_dir}/scripts/redact-output.sh | tee /dev/stderr | tail -n 1`
+          TEST=`go test | ${git_dir}/scripts/redact-output.sh | tee /dev/stderr | tail -n 1`
           popd
           TEST="> TERRATEST RESULT - core-shared-services
           ${TEST}"

--- a/.github/workflows/core-shared-services-deployment.yml
+++ b/.github/workflows/core-shared-services-deployment.yml
@@ -45,6 +45,10 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+      - name: Setup Go
+        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+        with:
+          go-version: 1.21
       - name: Set Account Number
         run: echo "ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
       - name: configure aws credentials
@@ -57,9 +61,6 @@ jobs:
         with:
           terraform_version: "~1"
           terraform_wrapper: false
-      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
-        with:
-          go-version: 1.21
  
       - name: Run terraform plan in terraform/environments/core-shared-services
         run: |
@@ -74,7 +75,8 @@ jobs:
 
           #RUN TERRATEST
           pushd terraform/environments/core-shared-services/test
-          TEST=`go test | ${git_dir}/scripts/redact-output.sh | tee /dev/stderr | tail -n 1`
+          go mod tidy
+          TEST=`go test -v | ${git_dir}/scripts/redact-output.sh | tee /dev/stderr | tail -n 1`
           popd
           TEST="> TERRATEST RESULT - core-shared-services
           ${TEST}"


### PR DESCRIPTION
This PR resolves https://github.com/ministryofjustice/modernisation-platform/issues/5056
It replaces the direct acquisition of a Go runtime with one installed through a GitHub action, and trims the Terratest section of the Plan job to remove now unnecessary conditional handling.