### PR TITLE
Allow use of AWS managed firewall rule groups

### DIFF
--- a/terraform/modules/firewall-policy/main.tf
+++ b/terraform/modules/firewall-policy/main.tf
@@ -15,7 +15,6 @@ resource "aws_networkfirewall_firewall_policy" "main" {
       rule_order = "DEFAULT_ACTION_ORDER"
     }
     dynamic "stateful_rule_group_reference" {
-      #for_each = toset(var.fw_managed_rule_groups)
       for_each = length(var.fw_managed_rule_groups) > 0 ? toset(var.fw_managed_rule_groups) : []
       content {
         resource_arn = format("arn:aws:network-firewall:%s:aws-managed:stateful-rulegroup/%s", data.aws_region.current.name, stateful_rule_group_reference.key)

--- a/terraform/modules/firewall-policy/variables.tf
+++ b/terraform/modules/firewall-policy/variables.tf
@@ -23,6 +23,12 @@ variable "fw_kms_arn" {
   type        = string
 }
 
+variable "fw_managed_rule_groups" {
+  description = "Names of AWS managed rule groups from https://docs.aws.amazon.com/network-firewall/latest/developerguide/aws-managed-rule-groups-threat-signature.html"
+  type        = list(string)
+  default     = []
+}
+
 variable "fw_policy_name" {
   type = string
 }

--- a/terraform/modules/vpc-inspection/firewall.tf
+++ b/terraform/modules/vpc-inspection/firewall.tf
@@ -28,6 +28,7 @@ module "inline_inspection_policy" {
   fw_fqdn_rulegroup_name = format("%s-inlinefw-fqdn-rulegroup", var.tags_prefix)
   fw_allowed_domains     = var.fw_allowed_domains
   fw_home_net_ips        = var.fw_home_net_ips
+  fw_managed_rule_groups = var.fw_managed_rule_groups
   rules                  = var.fw_rules
 
   tags = merge(

--- a/terraform/modules/vpc-inspection/variables.tf
+++ b/terraform/modules/vpc-inspection/variables.tf
@@ -30,6 +30,12 @@ variable "fw_kms_arn" {
   type        = string
 }
 
+variable "fw_managed_rule_groups" {
+  description = "Names of AWS managed rule groups from https://docs.aws.amazon.com/network-firewall/latest/developerguide/aws-managed-rule-groups-threat-signature.html"
+  type        = list(string)
+  default     = []
+}
+
 variable "fw_rules" {
   description = "JSON map of maps containing stateless firewall rules"
   type        = map(any)


### PR DESCRIPTION
As part of https://github.com/ministryofjustice/modernisation-platform/issues/2934, this PR allows to optional use of a new variable for firewall policies: `fw_managed_rule_groups`.
The AWS managed firewall rule groups can be found here: https://docs.aws.amazon.com/network-firewall/latest/developerguide/aws-managed-rule-groups-threat-signature.html

To apply these rule groups to an existing firewall policy (for example. through the inspection VPC module in `core-network-services/vpc.tf` we would supply a list like so:
```
module "vpc_inspection" {
  for_each = local.networking

  source                = "../../modules/vpc-inspection"
  ...
  fw_managed_rule_groups = ["ThreatSignaturesBotnetActionOrder", "ThreatSignaturesEmergingEventsActionOrder"]
}
```
There might need to be further discussion about the utility of managed rule sets as our use of the default ordering means that any traffic we're explicitly allowing to pass (EG, any HTTPS traffic) will be permitted before managed rule sets are applied.