### PR TITLE
✨ Add `testing-ci` user to `modernisation-platform-terraform-trusted-advisor`

### DIFF
--- a/terraform/github/repositories.tf
+++ b/terraform/github/repositories.tf
@@ -104,6 +104,7 @@ module "terraform-module-trusted-advisor" {
     "aws",
     "trusted-advisor"
   ]
+  secrets = nonsensitive(local.testing_ci_iam_user_keys)
 }
 
 module "terraform-module-bastion-linux" {


### PR DESCRIPTION
In relation to [Migrate modernisation-platform-terraform-trusted-advisor lambda function to Go#5054](https://github.com/ministryofjustice/modernisation-platform/issues/5054)

This change adds the `testing-ci` IAM user credentials to the `modernisation-platform-terraform-trusted-advisor` repository.

This will enable writing terratests for the current IaC to ensure migrating to Go does not impact current functionality.