### PR TITLE
New iam user for planetfm

### DIFF
--- a/environments/planetfm.json
+++ b/environments/planetfm.json
@@ -8,6 +8,10 @@
           "github_slug": "studio-webops",
           "level": "sandbox",
           "nuke": "exclude"
+        },
+        {
+          "github_slug": "studio-webops",
+          "level": "migration"
         }
       ]
     },
@@ -26,6 +30,10 @@
         {
           "github_slug": "studio-webops",
           "level": "developer"
+        },
+        {
+          "github_slug": "studio-webops",
+          "level": "migration"
         }
       ]
     },
@@ -35,6 +43,10 @@
         {
           "github_slug": "studio-webops",
           "level": "developer"
+        },
+        {
+          "github_slug": "studio-webops",
+          "level": "migration"
         }
       ]
     }

--- a/environments/planetfm.json
+++ b/environments/planetfm.json
@@ -8,10 +8,6 @@
           "github_slug": "studio-webops",
           "level": "sandbox",
           "nuke": "exclude"
-        },
-        {
-          "github_slug": "studio-webops",
-          "level": "migration"
         }
       ]
     },
@@ -30,10 +26,6 @@
         {
           "github_slug": "studio-webops",
           "level": "developer"
-        },
-        {
-          "github_slug": "studio-webops",
-          "level": "migration"
         }
       ]
     },
@@ -43,10 +35,6 @@
         {
           "github_slug": "studio-webops",
           "level": "developer"
-        },
-        {
-          "github_slug": "studio-webops",
-          "level": "migration"
         }
       ]
     }

--- a/terraform/environments/planetfm/iam.tf
+++ b/terraform/environments/planetfm/iam.tf
@@ -1,0 +1,45 @@
+# Create user for MGN
+
+#tfsec:ignore:aws-iam-no-user-attached-policies
+#tfsec:ignore:AWS273
+resource "aws_iam_user" "mgn_user" {
+  #checkov:skip=CKV_AWS_273: "Skipping as tfsec check is also set to ignore"
+  name = "MGN-User"
+  tags = local.tags
+}
+#tfsec:ignore:aws-iam-no-user-attached-policies
+resource "aws_iam_user_policy_attachment" "mgn_attach_policy_migration" {
+  #tfsec:ignore:aws-iam-no-user-attached-policies "This is a short lived user, so allowing IAM policies attached directly to a user."
+  #checkov:skip=CKV_AWS_40: "Skipping as tfsec check is also ignored"
+  user       = aws_iam_user.mgn_user.name
+  policy_arn = "arn:aws:iam::aws:policy/AWSApplicationMigrationAgentInstallationPolicy"
+}
+
+#tfsec:ignore:aws-iam-no-user-attached-policies
+resource "aws_iam_user_policy_attachment" "mgn_attach_policy_discovery" {
+  #tfsec:ignore:aws-iam-no-user-attached-policies "This is a short lived user, so allowing IAM policies attached directly to a user."
+  #checkov:skip=CKV_AWS_40: "Skipping as tfsec check is also ignored"
+  user       = aws_iam_user.mgn_user.name
+  policy_arn = "arn:aws:iam::aws:policy/AWSApplicationDiscoveryAgentAccess"
+}
+
+resource "aws_iam_user_policy_attachment" "mgn_attach_policy_service_access" {
+  #tfsec:ignore:aws-iam-no-user-attached-policies "This is a short lived user, so allowing IAM policies attached directly to a user."
+  #checkov:skip=CKV_AWS_40: "Skipping as tfsec check is also ignored"
+  user       = aws_iam_user.mgn_user.name
+  policy_arn = "arn:aws:iam::aws:policy/AWSApplicationDiscoveryServiceFullAccess"
+}
+
+resource "aws_iam_user_policy_attachment" "mgn_attach_policy_migrationhub_access" {
+  #tfsec:ignore:aws-iam-no-user-attached-policies "This is a short lived user, so allowing IAM policies attached directly to a user."
+  #checkov:skip=CKV_AWS_40: "Skipping as tfsec check is also ignored"
+  user       = aws_iam_user.mgn_user.name
+  policy_arn = "arn:aws:iam::aws:policy/AWSMigrationHubFullAccess"
+}
+
+resource "aws_iam_user_policy_attachment" "mgn_attach_policy_app_migrationfull_access" {
+  #tfsec:ignore:aws-iam-no-user-attached-policies "This is a short lived user, so allowing IAM policies attached directly to a user."
+  #checkov:skip=CKV_AWS_40: "Skipping as tfsec check is also ignored"
+  user       = aws_iam_user.mgn_user.name
+  policy_arn = "arn:aws:iam::aws:policy/AWSApplicationMigrationFullAccess"
+}


### PR DESCRIPTION
This PR covers work requested from the ask channel bellow
Hope Aitchison
:spiral_calendar_pad:  [09:02](https://mojdt.slack.com/archives/C01A7QK5VM1/p1695369742393229)
Morning Mod platform! :slightly_smiling_face:
We need analogous IAM changes made to Planet FM environments (Dev to Prod) as we have had made in CSR (corporate staff rostering)
If you could please create us this MGN user https://github.com/ministryofjustice/modernisation-platform/blob/main/terraform/environments/corporate-staff-rostering/iam.tf
And we'll need the federated user migration role added to the Planet FM environments too https://github.com/ministryofjustice/modernisation-platform/blob/c480b10e3a23cc7dd547db8f75e06beb0b04fd11/terraform/environments/bootstrap/delegate-access/policies.tf#L471
We'll be replicating all Azure Planet FM servers into AWS using the Application Migration Service tool so will need all the same policies as we have previously requested for CSR. Thank you!