### PR TITLE
Update baselines reference

### DIFF
--- a/source/concepts/environments/backups.html.md.erb
+++ b/source/concepts/environments/backups.html.md.erb
@@ -20,6 +20,7 @@ Please note that some resources may need extra configuration and new services ma
 ### What is backed up?
 
 Resources which have the tag - `is-production = true` will be backed up.
+Resources which have the tag - `is-production = true` **and** the tag `backup = false` will **not** be backed up.
 
 ### Backup schedule
 
@@ -27,7 +28,7 @@ Backups are taken daily at 00:30.
 
 ### Retention period
 
-Backups are retained for 4 months.  After one month they will be transferred to cold storage.
+Backups are retained for 30 days.
 
 ## Non production backups
 

--- a/terraform/environments/bootstrap/secure-baselines/main.tf
+++ b/terraform/environments/bootstrap/secure-baselines/main.tf
@@ -5,7 +5,7 @@ data "aws_kms_key" "cloudtrail_key" {
 }
 
 module "baselines" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=98bf536ee2c66b268dfb7670f416fc1103935212" # v6.1.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=e57a3d6ffa5865e4b8d678126ac410b965541562" # v6.2.0
 
   providers = {
     # Default and replication regions


### PR DESCRIPTION
This PR uses the latest release of `modernisation-platform-terraform-baselines` which allows users to opt out of production backups.

More information can be seen in the release notes here: https://github.com/ministryofjustice/modernisation-platform-terraform-baselines/releases/tag/v6.2.0

This PR resolves https://github.com/ministryofjustice/modernisation-platform/issues/4802