### PR TITLE
allow TCP all from mp to related fixngo destinations

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/development_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/development_rules.json
@@ -125,10 +125,24 @@
     "destination_port": "ANY",
     "protocol": "TCP"
   },
+  "mp_hmpps_development_to_noms_test_dr_vnet": {
+    "action": "PASS",
+    "source_ip": "${hmpps-development}",
+    "destination_ip": "${noms-test-dr-vnet}",
+    "destination_port": "ANY",
+    "protocol": "TCP"
+  },
   "noms_test_vnet_to_mp_hmpps_development": {
     "action": "PASS",
     "source_ip": "${noms-test-vnet}",
     "destination_ip": "${hmpps-development}",
+    "destination_port": "ANY",
+    "protocol": "TCP"
+  },
+  "mp_hmpps_development_to_noms_test_vnet": {
+    "action": "PASS",
+    "source_ip": "${hmpps-development}",
+    "destination_ip": "${noms-test-vnet}",
     "destination_port": "ANY",
     "protocol": "TCP"
   },
@@ -139,10 +153,24 @@
     "destination_port": "ANY",
     "protocol": "TCP"
   },
+  "mp_hmpps_development_to_noms_mgmt_vnet": {
+    "action": "PASS",
+    "source_ip": "${hmpps-development}",
+    "destination_ip": "${noms-mgmt-vnet}",
+    "destination_port": "ANY",
+    "protocol": "TCP"
+  },
   "noms_mgmt_dr_vnet_to_mp_hmpps_developmemnt": {
     "action": "PASS",
     "source_ip": "${noms-mgmt-dr-vnet}",
-    "destination_ip": "${hmpps-test}",
+    "destination_ip": "${hmpps-development}",
+    "destination_port": "ANY",
+    "protocol": "TCP"
+  },
+  "mp_to_hmpps_development_to_noms_mgmt_dr_vnet": {
+    "action": "PASS",
+    "source_ip": "${hmpps-development}",
+    "destination_ip": "${noms-mgmt-dr-vnet}",
     "destination_port": "ANY",
     "protocol": "TCP"
   },

--- a/terraform/environments/core-network-services/firewall-rules/fqdn_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/fqdn_rules.json
@@ -1,6 +1,7 @@
 {
   "fw_allowed_domains": [
     "microsoft.com",
+    "onegetcdn.azureedge.net",
     ".windowsupdate.microsoft.com",
     ".update.microsoft.com",
     ".windowsupdate.com",

--- a/terraform/environments/core-network-services/firewall-rules/inline_fqdn_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/inline_fqdn_rules.json
@@ -1,6 +1,7 @@
 {
   "allowed_domains": [
     "microsoft.com",
+    "onegetcdn.azureedge.net",
     ".windowsupdate.microsoft.com",
     ".update.microsoft.com",
     ".windowsupdate.com",

--- a/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
@@ -90,10 +90,24 @@
     "destination_port": "ANY",
     "protocol": "TCP"
   },
+  "mp_hmpps_preproduction_to_noms_live": {
+    "action": "PASS",
+    "source_ip": "${hmpps-preproduction}",
+    "destination_ip": "${noms-live-vnet}",
+    "destination_port": "ANY",
+    "protocol": "TCP"
+  },
   "noms_live_dr_to_mp_hmpps_preproduction": {
     "action": "PASS",
     "source_ip": "${noms-live-dr-vnet}",
     "destination_ip": "${hmpps-preproduction}",
+    "destination_port": "ANY",
+    "protocol": "TCP"
+  },
+  "mp_hmpps_preproduction_to_noms_live_dr": {
+    "action": "PASS",
+    "source_ip": "${hmpps-preproduction}",
+    "destination_ip": "${noms-live-dr-vnet}",
     "destination_port": "ANY",
     "protocol": "TCP"
   },
@@ -104,10 +118,24 @@
     "destination_port": "ANY",
     "protocol": "TCP"
   },
+  "mp_hmpps_preproduction_to_noms_mgmt_live": {
+    "action": "PASS",
+    "source_ip": "${hmpps-preproduction}",
+    "destination_ip": "${noms-mgmt-live-vnet}",
+    "destination_port": "ANY",
+    "protocol": "TCP"
+  },
   "noms_mgmt_live_dr_to_mp_hmpps_preproduction": {
     "action": "PASS",
     "source_ip": "${noms-mgmt-live-dr-vnet}",
     "destination_ip": "${hmpps-preproduction}",
+    "destination_port": "ANY",
+    "protocol": "TCP"
+  },
+  "mp_hmpps_preproduction_to_noms_mgmt_live_dr": {
+    "action": "PASS",
+    "source_ip": "${hmpps-preproduction}",
+    "destination_ip": "${noms-mgmt-live-dr-vnet}",
     "destination_port": "ANY",
     "protocol": "TCP"
   },

--- a/terraform/environments/core-network-services/firewall-rules/production_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/production_rules.json
@@ -62,10 +62,24 @@
     "destination_port": "ANY",
     "protocol": "TCP"
   },
+  "mp_hmpps_production_to_noms_live": {
+    "action": "PASS",
+    "source_ip": "${hmpps-production}",
+    "destination_ip": "${noms-live-vnet}",
+    "destination_port": "ANY",
+    "protocol": "TCP"
+  },
   "noms_live_dr_to_mp_hmpps_production": {
     "action": "PASS",
     "source_ip": "${noms-live-dr-vnet}",
     "destination_ip": "${hmpps-production}",
+    "destination_port": "ANY",
+    "protocol": "TCP"
+  },
+  "mp_hmpps_production_to_noms_live_dr": {
+    "action": "PASS",
+    "source_ip": "${hmpps-production}",
+    "destination_ip": "${noms-live-dr-vnet}",
     "destination_port": "ANY",
     "protocol": "TCP"
   },
@@ -76,10 +90,24 @@
     "destination_port": "ANY",
     "protocol": "TCP"
   },
+  "mp_hmpps_production_to_noms_mgmt_live": {
+    "action": "PASS",
+    "source_ip": "${hmpps-production}",
+    "destination_ip": "${noms-mgmt-live-vnet}",
+    "destination_port": "ANY",
+    "protocol": "TCP"
+  },
   "noms_mgmt_live_dr_to_mp_hmpps_production": {
     "action": "PASS",
     "source_ip": "${noms-mgmt-live-dr-vnet}",
     "destination_ip": "${hmpps-production}",
+    "destination_port": "ANY",
+    "protocol": "TCP"
+  },
+  "mp_hmpps_production_to_noms_mgmt_live_dr": {
+    "action": "PASS",
+    "source_ip": "${hmpps-production}",
+    "destination_ip": "${noms-mgmt-live-dr-vnet}",
     "destination_port": "ANY",
     "protocol": "TCP"
   },

--- a/terraform/environments/core-network-services/firewall-rules/test_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/test_rules.json
@@ -55,10 +55,24 @@
     "destination_port": "ANY",
     "protocol": "TCP"
   },
+  "mp_hmpps_test_to_noms_test_dr_vnet": {
+    "action": "PASS",
+    "source_ip": "${hmpps-test}",
+    "destination_ip": "${noms-test-dr-vnet}",
+    "destination_port": "ANY",
+    "protocol": "TCP"
+  },
   "noms_test_vnet_to_mp_hmpps_test": {
     "action": "PASS",
     "source_ip": "${noms-test-vnet}",
     "destination_ip": "${hmpps-test}",
+    "destination_port": "ANY",
+    "protocol": "TCP"
+  },
+  "mp_hmpps_test_to_noms_test_vnet": {
+    "action": "PASS",
+    "source_ip": "${hmpps-test}",
+    "destination_ip": "${noms-test-vnet}",
     "destination_port": "ANY",
     "protocol": "TCP"
   },
@@ -76,10 +90,24 @@
     "destination_port": "ANY",
     "protocol": "TCP"
   },
+  "mp_hmpps_test_to_noms_mgmt_vnet": {
+    "action": "PASS",
+    "source_ip": "${hmpps-test}",
+    "destination_ip": "${noms-mgmt-vnet}",
+    "destination_port": "ANY",
+    "protocol": "TCP"
+  },
   "noms_mgmt_dr_vnet_to_mp_hmpps_test": {
     "action": "PASS",
     "source_ip": "${noms-mgmt-dr-vnet}",
     "destination_ip": "${hmpps-test}",
+    "destination_port": "ANY",
+    "protocol": "TCP"
+  },
+  "mp_hmpps_test_to_noms_mgmt_dr_vnet": {
+    "action": "PASS",
+    "source_ip": "${hmpps-test}",
+    "destination_ip": "${noms-mgmt-dr-vnet}",
     "destination_port": "ANY",
     "protocol": "TCP"
   },


### PR DESCRIPTION
- allow all TCP traffic back from mp environments to the related azure fixngo NSG's
- allow PowerShell Gallery CDN endpoint for external traffix
- fix incorrect destination_ip in the development rules