### PR TITLE
Add firewall rule for CP to Laa Test

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/test_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/test_rules.json
@@ -292,5 +292,12 @@
     "destination_ip": "${noms-mgmt-vnet}",
     "destination_port": "138",
     "protocol": "UDP"
+  },
+  "cp_to_mp_laa_test": {
+    "action": "PASS",
+    "source_ip": "${cloud-platform}",
+    "destination_ip": "${laa-test}",
+    "destination_port": "1521",
+    "protocol": "TCP"
   }
 }


### PR DESCRIPTION
as per slack request https://mojdt.slack.com/archives/C01A7QK5VM1/p1695998966079929 this PR adds a firewall rule for cloud platform to laa-test on port 1521