### PR TITLE
Updating contact details for Tipstaff

### DIFF
--- a/environments/tipstaff.json
+++ b/environments/tipstaff.json
@@ -33,8 +33,8 @@
   "tags": {
     "application": "tipstaff",
     "business-unit": "HMCTS",
-    "infrastructure-support": "dts-legacy-apps-support-team@hmcts.net",
-    "owner": "dts-legacy-apps-support-team@hmcts.net"
+    "infrastructure-support": "DTS-ITServiceDesk@justice.gov.uk",
+    "owner": "DTS-ITServiceDesk@justice.gov.uk"
   },
   "github-oidc-team-repositories": ["ministryofjustice/Tipstaff"]
 }


### PR DESCRIPTION
The original email address that is in the environment file for Tipstaff has an automatic response saying the folowing:

> Thank you for your email. This mailbox closed on 31st August 2023 and is no longer monitored. Please resend your email to [DTS-ITServiceDesk@justice.gov.uk](mailto:DTS-ITServiceDesk@justice.gov.uk) to be actioned. This e-mail is private and is intended only for the addressee and any copy recipients. If you are not an intended recipient, please advise the sender immediately by reply e-mail and delete this message and any attachments without retaining a copy. Activity and use of this communication is monitored to secure their effective operation and for other lawful business purposes. Communications using these systems will also be monitored and may be recorded to secure effective operation and for other lawful business purposes.

hence updating the contact details.