### PR TITLE
🧱 Propagate advertised routes into Inspection route table

### DIFF
--- a/terraform/environments/core-network-services/locals.tf
+++ b/terraform/environments/core-network-services/locals.tf
@@ -41,6 +41,8 @@ locals {
 
   vpn_attachments = fileexists("./vpn_attachments.json") ? jsondecode(file("./vpn_attachments.json")) : {}
 
+  noms_vpn_attachment_ids = toset([for k in aws_vpn_connection.this : k.transit_gateway_attachment_id if(length(regexall("(?:NOMS)", k.tags.Name)) > 0)])
+
   noms_dr_vpn_static_routes = [
     "10.40.64.0/18",
     "10.40.144.0/20",

--- a/terraform/environments/core-network-services/transit_gateway_connections.tf
+++ b/terraform/environments/core-network-services/transit_gateway_connections.tf
@@ -161,14 +161,6 @@ resource "aws_ec2_transit_gateway_route" "tgw_external_egress_routes_for_live_da
   transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.route-tables["live_data"].id
 }
 
-# To prevent BGP routes from sending traffic via VPNs, we need static routes to override them
-resource "aws_ec2_transit_gateway_route" "azure_static_routes" {
-  for_each                       = toset(local.azure_static_routes)
-  destination_cidr_block         = each.value
-  transit_gateway_attachment_id  = data.aws_ec2_transit_gateway_peering_attachment.pttp-tgw.id
-  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.external_inspection_out.id
-}
-
 resource "aws_ec2_transit_gateway_route" "external_static_routes" {
   for_each                       = local.external_static_routes
   destination_cidr_block         = each.value


### PR DESCRIPTION
This PR does the following:
* Creates a filtered set of attachment IDs for the `NOMS` VPN connections
* Uses this set to create propagation statements to add advertised routes into the `Inspection` TGW route table
* Moves some config around to a more logical location (eg, where the rest of the VPN/TGW config is located)

This will ensure that once I remove static routes from the `Inspection` TGW route table they are immediately replaced by propagated routes learned via BGP. As a consequence I will then be in a position to start removing the locals that cover static routes for NOMS connections.