### PR TITLE
Remove static routes to NOMS

### DIFF
--- a/terraform/environments/core-network-services/locals.tf
+++ b/terraform/environments/core-network-services/locals.tf
@@ -43,25 +43,6 @@ locals {
 
   noms_vpn_attachment_ids = toset([for k in aws_vpn_connection.this : k.transit_gateway_attachment_id if(length(regexall("(?:NOMS)", k.tags.Name)) > 0)])
 
-  noms_dr_vpn_static_routes = [
-    "10.40.64.0/18",
-    "10.40.144.0/20",
-    "10.40.176.0/20",
-    "10.111.0.0/16",
-    "10.112.0.0/16",
-    "10.244.0.0/20",
-    "10.247.0.0/20"
-  ]
-  noms_live_vpn_static_routes = [
-    "10.40.0.0/18",
-    "10.40.128.0/20",
-    "10.40.160.0/20",
-    "10.101.0.0/16",
-    "10.102.0.0/16",
-    "10.47.0.0/26",
-    "10.47.0.64/26",
-    "10.47.0.128/26"
-  ]
   azure_static_routes = [
     "10.0.0.0/11",
     "10.64.0.0/11",

--- a/terraform/environments/core-network-services/vpn.tf
+++ b/terraform/environments/core-network-services/vpn.tf
@@ -95,20 +95,6 @@ resource "aws_ec2_transit_gateway_route_table_propagation" "propagate_noms_route
   transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.external_inspection_out.id
 }
 
-resource "aws_ec2_transit_gateway_route" "noms_dr_routes" {
-  for_each                       = toset(local.noms_dr_vpn_static_routes)
-  destination_cidr_block         = each.key
-  transit_gateway_attachment_id  = aws_vpn_connection.this["NOMS-Transit-Live-DR-VPN-VNG_1"].transit_gateway_attachment_id
-  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.external_inspection_out.id
-}
-
-resource "aws_ec2_transit_gateway_route" "noms_live_routes" {
-  for_each                       = toset(local.noms_live_vpn_static_routes)
-  destination_cidr_block         = each.key
-  transit_gateway_attachment_id  = aws_vpn_connection.this["NOMS-Transit-Live-VPN-VNG_1"].transit_gateway_attachment_id
-  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.external_inspection_out.id
-}
-
 resource "aws_ec2_transit_gateway_route" "parole_board_routes" {
   for_each                       = toset(local.parole_board_vpn_static_routes)
   destination_cidr_block         = each.key


### PR DESCRIPTION
Now that NOMS VPN routes are being added through route propagation, and static routes for non-NOMS destinations are in place to route those networks through the MOJ TGW, we can safely remove the old static routes for NOMS.

This PR removes the local values and resource statements previously used. Early testing has shown that when the static route is removed, it is replaced by a propagated route.