### PR TITLE
Allow http traffic to amazontrust.com

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/inline_fqdn_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/inline_fqdn_rules.json
@@ -14,6 +14,7 @@
     ".dl.delivery.mp.microsoft.com",
     ".office365.com",
     "archive.ubuntu.com",
-    "security.ubuntu.com"
+    "security.ubuntu.com",
+    ".amazontrust.com"
   ]
 }


### PR DESCRIPTION
Following a request in [this Slack thread](https://mojdt.slack.com/archives/C01A7QK5VM1/p1696332394159879), this PR adds a domain to the list of allowed HTTP destinations through the egress VPCs and their inline AWS Network Firewalls.