### PR TITLE
New Account request for ERIC

### DIFF
--- a/environments/eric.json
+++ b/environments/eric.json
@@ -1,0 +1,30 @@
+{
+  "account-type": "member",
+  "environments": [
+    {
+      "name": "test",
+      "access": [
+        {
+          "github_slug": "laa-aws-infrastructure",
+          "level": "developer"
+        }
+      ]
+    },
+    {
+      "name": "production",
+      "access": [
+        {
+          "github_slug": "laa-aws-infrastructure",
+          "level": "view-only"
+        }
+      ]
+    }
+  ],
+  "tags": {
+    "application": "eric",
+    "business-unit": "LAA",
+    "infrastructure-support": "aws-webops-laa@digital.justice.gov.uk",
+    "owner": "get-acccess-service-improvement@digital.justice.gov.uk"
+  },
+  "github-oidc-team-repositories": [""]
+}

--- a/policies/environments/expected.rego
+++ b/policies/environments/expected.rego
@@ -28,6 +28,7 @@ expected =
     "delius-jitbit",
     "digital-prison-reporting",
     "equip",
+    "eric",
     "example",
     "hmpps-domain-services",
     "hmpps-intelligence-management",


### PR DESCRIPTION
Account request from the ask channel

This PR covers the work for creation of the Eric accounts requested bellow

Hello Team,

As part of migrating LAA application to MP can you create an aws account for application called eric for test and production environment please. We want to start moving the ec2 instance across to the MP account

Regards
Tunde