### PR TITLE
Fix for delegated access

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/locals.tf
+++ b/terraform/environments/bootstrap/delegate-access/locals.tf
@@ -29,15 +29,15 @@ locals {
   # skip the following alias creation if the alias is used by another account (they are globally unique)
   skip_alias = sort([
     "apex-development",
+    "data-platform-production",
+    "eric-test",
+    "eric-production",
     "nomis-production",
     "testing-test",
     "nomis-development",
     "oas-test",
     "portal-development",
     "portal-production",
-    "portal-test",
-    "data-platform-production",
-    "eric-test",
-    "eric-production"
+    "portal-test"
   ])
 }

--- a/terraform/environments/bootstrap/delegate-access/locals.tf
+++ b/terraform/environments/bootstrap/delegate-access/locals.tf
@@ -36,6 +36,8 @@ locals {
     "portal-development",
     "portal-production",
     "portal-test",
-    "data-platform-production"
+    "data-platform-production",
+    "eric-test",
+    "eric-production"
   ])
 }


### PR DESCRIPTION
Delegated access work flow failed for the eric account as the alias was not unique this pr adds eric to the skip list on delegated access locals