### PR TITLE
Fix/5001 permissions

### DIFF
--- a/terraform/environments/core-network-services/iam.tf
+++ b/terraform/environments/core-network-services/iam.tf
@@ -170,7 +170,7 @@ resource "aws_iam_role_policy" "read_firewall" {
           "network-firewall:Describe*",
           "network-firewall:List*"
         ],
-        "Resource" : "arn:aws:network-firewall:*:*:firewall/*"
+        "Resource" : "arn:aws:network-firewall:*:*:*/*"
       }
     ]
   })

--- a/terraform/environments/core-network-services/iam.tf
+++ b/terraform/environments/core-network-services/iam.tf
@@ -158,7 +158,11 @@ resource "aws_iam_role_policy" "read_firewall" {
           "logs:DescribeLogStreams",
           "logs:GetLogEvents"
         ],
-        "Resource" : "arn:aws:logs:*:*:log-group/fw-*"
+        "Resource" : [
+          "arn:aws:logs:*:*:log-group::log-stream:",
+          "arn:aws:logs:*:*:log-group:fw-*:log-stream:",
+          "arn:aws:logs:*:*:log-group:fw-*:log-stream:/aws/network-firewall/*/*"
+        ],
       },
       {
         "Effect" : "Allow",


### PR DESCRIPTION
Updates resource statements to allow restricted access to `fw-*` CloudWatch Log Groups, Log Streams, and events.

Updates resource statement to allow restricted access to AWS Network Firewall policies and rule groups.