### PR TITLE
Reintroduce read-dns role

### DIFF
--- a/terraform/environments/core-network-services/iam.tf
+++ b/terraform/environments/core-network-services/iam.tf
@@ -90,6 +90,38 @@ resource "aws_iam_role_policy" "dns" {
 }
 
 # Role to allow developer SSO user to read DNS records for ACM certificate validation for local plan
+resource "aws_iam_role" "read_dns" {
+  name = "read-dns-records"
+  assume_role_policy = jsonencode(
+    # checkov:skip=CKV_AWS_60: "the policy is secured with the condition"
+    # checkov:skip=CKV_AWS_355: "the policy is secured with the condition"
+    {
+      "Version" : "2012-10-17",
+      "Statement" : [
+        {
+          "Effect" : "Allow",
+          "Principal" : {
+            "AWS" : "*"
+          },
+          "Action" : "sts:AssumeRole",
+          "Condition" : {
+            "ForAnyValue:StringLike" : {
+              "aws:PrincipalOrgPaths" : ["${data.aws_organizations_organization.root_account.id}/*/${local.environment_management.modernisation_platform_organisation_unit_id}/*"]
+            }
+          }
+        }
+      ]
+  })
+
+  tags = merge(
+    local.tags,
+    {
+      Name = "read-dns-records"
+    },
+  )
+}
+
+# Role to allow developer SSO user to read DNS records for ACM certificate validation for local plan
 resource "aws_iam_role" "read_logs" {
   name = "read-log-records"
   assume_role_policy = jsonencode(
@@ -124,8 +156,9 @@ resource "aws_iam_role" "read_logs" {
 #tfsec:ignore:aws-iam-no-policy-wildcards
 resource "aws_iam_role_policy" "read_dns" {
   # checkov:skip=CKV_AWS_355: "the policy is secured with the condition"
+  for_each = toset([aws_iam_role.read_dns.id, aws_iam_role.read_logs.id])
   name = "ReadDNSRecords"
-  role = aws_iam_role.read_logs.id
+  role = each.key
 
   policy = jsonencode({
     Version = "2012-10-17"

--- a/terraform/environments/core-network-services/iam.tf
+++ b/terraform/environments/core-network-services/iam.tf
@@ -121,6 +121,12 @@ resource "aws_iam_role" "read_dns" {
   )
 }
 
+resource "aws_iam_policy_attachment" "read_dns_aws_managed" {
+  name       = "AmazonRoute53ReadOnlyAccess-read-dns-attachment"
+  policy_arn = "arn:aws:iam::aws:policy/AmazonRoute53ReadOnlyAccess"
+  roles      = [aws_iam_role.read_dns.name]
+}
+
 # Role to allow developer SSO user to read DNS records for ACM certificate validation for local plan
 resource "aws_iam_role" "read_logs" {
   name = "read-log-records"
@@ -156,9 +162,8 @@ resource "aws_iam_role" "read_logs" {
 #tfsec:ignore:aws-iam-no-policy-wildcards
 resource "aws_iam_role_policy" "read_dns" {
   # checkov:skip=CKV_AWS_355: "the policy is secured with the condition"
-  for_each = toset([aws_iam_role.read_dns.id, aws_iam_role.read_logs.id])
   name = "ReadDNSRecords"
-  role = each.key
+  role = aws_iam_role.read_logs.id
 
   policy = jsonencode({
     Version = "2012-10-17"


### PR DESCRIPTION
As part of #5001 I replaced the `read-dns` role with `read-logs`. This had some unanticipated side effects around how users were making use of the `read-dns` role and how it was assumed. While we work on the issues around assuming the `read-logs` role, this PR will create a role named `read-dns` and attach an AWS-managed IAM policy.

The policy details can be see here: https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AmazonRoute53ReadOnlyAccess.html

They broadly cover the same scope as the old `ReadDNSRecords` inline policy, but allow role assumers to also get the value that Route 53 returns in response to a DNS request.