### PR TITLE
Change SSM resource sync to be opt in

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/locals.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/locals.tf
@@ -44,4 +44,13 @@ locals {
     component     = "member-bootstrap"
     source-code   = "https://github.com/ministryofjustice/modernisation-platform/tree/main/terraform/environments/bootstrap/member-bootstrap"
   }
+
+  # When a new account has been added, the organisation-security Terraform must be run before an environment is added here
+  ssm_resource_sync_opt_in = [
+    "ccms-ebs-development",
+    "ccms-ebs-test",
+    "ccms-ebs-preproduction",
+    "ccms-ebs-production",
+    "example-development"
+  ]
 }

--- a/terraform/environments/bootstrap/member-bootstrap/ssm.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/ssm.tf
@@ -119,7 +119,7 @@ resource "aws_iam_policy" "execution-combined-policy" {
 # # sync ssm data to the S3 bucket created in the stack
 # # https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-inventory-resource-data-sync.html
 resource "aws_ssm_resource_data_sync" "security_account" {
-  count = local.account_data.account-type == "member" && terraform.workspace != "testing-test" ? 1 : 0
+  count = contains (local.ssm_resource_sync_opt_in, terraform.workspace) ? 1 : 0
   name  = "OrgSecurityDataSync"
   s3_destination {
     bucket_name = local.environment_management.ssm_resource_sync_bucket_name


### PR DESCRIPTION
Currently the bucket policy and KMS policy in the organisation security account SSM resource sync bucket require account numbers to be added in order to restrict access to the organisation, as you can't use org principal paths with service principals (ssm in this case).  This has been raised with AWS and a feature request added.  Until then our options are limited as we can't create the resource sync until the org sec terraform has run after the new account is created and then the account has permissions to the bucket.

Triggering the org sec to run after the env is created but before the bootstrap runs is a possibility, but not at this point as the org sec tf is run manually.  This looks to be the only way to ensure that this pipeline doesn't fail because of this, but it does mean there is an extra step for users wishing to use the Oracle licensing solution.  That will be added to the user guidance when it is created.

Note that the apply to sprinkler destroyed the ssm sync as it's not in the opt in list.  I've run a plan for example-development and that doesn't destroy the sync.