### PR TITLE
base64 encoding/decoding multiline output to prevent errors when passing between jobs.

### DIFF
--- a/.github/workflows/terraform-member-environment.yml
+++ b/.github/workflows/terraform-member-environment.yml
@@ -42,9 +42,9 @@ jobs:
         run:  |
           git fetch origin main
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            echo "CHANGED_DIRECTORIES=$(git diff HEAD origin/main ${{ github.event.pull_request.changes.paths }} --name-only | awk '{print $1}' | grep ".tf" | grep -a "environments//*" | cut -f1-3 -d"/" | uniq)"
+            echo "CHANGED_DIRECTORIES=$(git diff HEAD origin/main ${{ github.event.pull_request.changes.paths }} --name-only | awk '{print $1}' | grep ".tf" | grep -a "environments//*" | cut -f1-3 -d"/" | uniq | base64 -w 0 )"
           else
-            echo "CHANGED_DIRECTORIES=$(git diff HEAD^ HEAD ${{ github.event.changes.paths }} --name-only | awk '{print $1}' | grep ".tf" | grep -a "environments//*" | cut -f1-3 -d"/" | uniq)"
+            echo "CHANGED_DIRECTORIES=$(git diff HEAD^ HEAD ${{ github.event.changes.paths }} --name-only | awk '{print $1}' | grep ".tf" | grep -a "environments//*" | cut -f1-3 -d"/" | uniq | base64 -w 0)"
           fi >> $GITHUB_OUTPUT
       - name: Display changed directories
         run: echo "Directories in scope:" ${{ steps.directories.outputs.CHANGED_DIRECTORIES }}
@@ -59,7 +59,6 @@ jobs:
         environment: [development, test, preproduction, production]
     env:
       TF_IN_AUTOMATION: "true"
-      CHANGED_DIRECTORIES: ${{ needs.find-environments.outputs.directories }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
@@ -80,6 +79,7 @@ jobs:
       - name: Terraform init
         id: init
         run: |
+          export CHANGED_DIRECTORIES=$(echo "${{ needs.find-environments.outputs.directories }}" | base64 --decode)
           for directory in $CHANGED_DIRECTORIES; do
             echo "Running 'terraform init' in" $directory
             scripts/terraform-init.sh $directory
@@ -89,15 +89,15 @@ jobs:
         run: |
           for directory in $CHANGED_DIRECTORIES; do
                 workspace="$(basename $directory)-${{ matrix.environment }}"
-                
+
                 if terraform -chdir="$directory" workspace list | grep "$workspace"; then
                   terraform -chdir="$directory" workspace select "$workspace"
 
                 else
-                  echo "Workspace '$workspace' does not exist, skipping further processing"  
+                  echo "Workspace '$workspace' does not exist, skipping further processing"
                   echo "skip_plan=true" >> $GITHUB_OUTPUT
                 fi
-                
+
                 unset workspace
           done
           echo "Selected $(terraform -chdir="$directory" workspace show)"
@@ -105,6 +105,7 @@ jobs:
         id: plan
         if: ${{ steps.workspace.outputs.skip_plan != 'true' }}
         run: |
+          export CHANGED_DIRECTORIES=$(echo "${{ needs.find-environments.outputs.directories }}" | base64 --decode)
           for directory in $CHANGED_DIRECTORIES; do
             workspace="$(basename $directory)-${{ matrix.environment }}"
             scripts/terraform-plan.sh $directory
@@ -125,7 +126,6 @@ jobs:
     environment: ${{ matrix.environment }}
     env:
       TF_IN_AUTOMATION: "true"
-      CHANGED_DIRECTORIES: ${{ needs.find-environments.outputs.directories }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
@@ -146,6 +146,7 @@ jobs:
       - name: Terraform init
         id: init
         run: |
+          export CHANGED_DIRECTORIES=$(echo "${{ needs.find-environments.outputs.directories }}" | base64 --decode)
           for directory in $CHANGED_DIRECTORIES; do
             echo "Running 'terraform init' in" $directory
             scripts/terraform-init.sh $directory
@@ -153,17 +154,18 @@ jobs:
       - name: Terraform workspace
         id: workspace
         run: |
+          export CHANGED_DIRECTORIES=$(echo "${{ needs.find-environments.outputs.directories }}" | base64 --decode)
           for directory in $CHANGED_DIRECTORIES; do
                 workspace="$(basename $directory)-${{ matrix.environment }}"
-                
+
                 if terraform -chdir="$directory" workspace list | grep "$workspace"; then
                   terraform -chdir="$directory" workspace select "$workspace"
 
                 else
-                  echo "Workspace '$workspace' does not exist, skipping further processing"  
+                  echo "Workspace '$workspace' does not exist, skipping further processing"
                   echo "skip_plan=true" >> $GITHUB_OUTPUT
                 fi
-                
+
                 unset workspace
           done
           echo "Selected $(terraform -chdir="$directory" workspace show)"
@@ -171,6 +173,7 @@ jobs:
         id: plan
         if: ${{ steps.workspace.outputs.skip_plan != 'true' }}
         run: |
+          export CHANGED_DIRECTORIES=$(echo "${{ needs.find-environments.outputs.directories }}" | base64 --decode)
           for directory in $CHANGED_DIRECTORIES; do
             workspace="$(basename $directory)-${{ matrix.environment }}"
             scripts/terraform-plan.sh $directory -out="$workspace.tfplan"
@@ -180,6 +183,7 @@ jobs:
         id: apply
         if: ${{ steps.plan.conclusion == 'success' }}
         run: |
+          export CHANGED_DIRECTORIES=$(echo "${{ needs.find-environments.outputs.directories }}" | base64 --decode)
           for directory in $CHANGED_DIRECTORIES; do
             workspace="$(basename $directory)-${{ matrix.environment }}"
             scripts/terraform-apply.sh $directory "$workspace.tfplan"
@@ -201,7 +205,6 @@ jobs:
     environment: ${{ matrix.environment }}
     env:
       TF_IN_AUTOMATION: "true"
-      CHANGED_DIRECTORIES: ${{ needs.find-environments.outputs.directories }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
@@ -222,6 +225,7 @@ jobs:
       - name: Terraform init
         id: init
         run: |
+          export CHANGED_DIRECTORIES=$(echo "${{ needs.find-environments.outputs.directories }}" | base64 --decode)
           for directory in $CHANGED_DIRECTORIES; do
             echo "Running 'terraform init' in" $directory
             scripts/terraform-init.sh $directory
@@ -229,17 +233,18 @@ jobs:
       - name: Terraform workspace
         id: workspace
         run: |
+          export CHANGED_DIRECTORIES=$(echo "${{ needs.find-environments.outputs.directories }}" | base64 --decode)
           for directory in $CHANGED_DIRECTORIES; do
                 workspace="$(basename $directory)-${{ matrix.environment }}"
-                
+
                 if terraform -chdir="$directory" workspace list | grep "$workspace"; then
                   terraform -chdir="$directory" workspace select "$workspace"
 
                 else
-                  echo "Workspace '$workspace' does not exist, skipping further processing"  
+                  echo "Workspace '$workspace' does not exist, skipping further processing"
                   echo "skip_plan=true" >> $GITHUB_OUTPUT
                 fi
-                
+
                 unset workspace
           done
           echo "Selected $(terraform -chdir="$directory" workspace show)"
@@ -247,6 +252,7 @@ jobs:
         id: plan
         if: ${{ steps.workspace.outputs.skip_plan != 'true' }}
         run: |
+          export CHANGED_DIRECTORIES=$(echo "${{ needs.find-environments.outputs.directories }}" | base64 --decode)
           for directory in $CHANGED_DIRECTORIES; do
             workspace="$(basename $directory)-${{ matrix.environment }}"
             scripts/terraform-plan.sh $directory -out="$workspace.tfplan"
@@ -256,6 +262,7 @@ jobs:
         id: apply
         if: ${{ steps.plan.conclusion == 'success' }}
         run: |
+          export CHANGED_DIRECTORIES=$(echo "${{ needs.find-environments.outputs.directories }}" | base64 --decode)
           for directory in $CHANGED_DIRECTORIES; do
             workspace="$(basename $directory)-${{ matrix.environment }}"
             scripts/terraform-apply.sh $directory "$workspace.tfplan"


### PR DESCRIPTION
GIHUB_OUTPUT doe not play well with multi-line outputs so in order to pass changed directories when more than one directory is impacted, what works is to encode the value as 
base64.

GITHUB_ENV has a similar problem which is why there's an export statement in every step that uses it.

An alternative approach is to pass it as json.

Example of failure here: https://github.com/ministryofjustice/modernisation-platform/actions/runs/6430537080/job/17461731958#step:3:18
