### PR TITLE
Add missing base64 decode to terraform-member-environments action

### DIFF
--- a/.github/workflows/terraform-member-environment.yml
+++ b/.github/workflows/terraform-member-environment.yml
@@ -87,6 +87,7 @@ jobs:
       - name: Terraform workspace
         id: workspace
         run: |
+          export CHANGED_DIRECTORIES=$(echo "${{ needs.find-environments.outputs.directories }}" | base64 --decode)
           for directory in $CHANGED_DIRECTORIES; do
                 workspace="$(basename $directory)-${{ matrix.environment }}"
 


### PR DESCRIPTION
This export allows the correct decoding of directories from the base64 output.