### PR TITLE
Adding permission to modify a dms replication task in the console

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/policies.tf
+++ b/terraform/environments/bootstrap/delegate-access/policies.tf
@@ -267,6 +267,7 @@ data "aws_iam_policy_document" "data_engineering_additional" {
       "ce:CreateReport",
       "dms:StartReplicationTask",
       "dms:StopReplicationTask",
+      "dms:ModifyReplicationTask",
       "glue:BatchCreatePartition",
       "glue:BatchDeletePartition",
       "glue:BatchDeleteTable",


### PR DESCRIPTION
Adding permission to allow modifying DMS replication tasks in the console in addition to starting and stopping them.