### PR TITLE
Moving from cicd to modernisation-platform-oidc-cicd

### DIFF
--- a/terraform/environments/core-shared-services/ecr_repos.tf
+++ b/terraform/environments/core-shared-services/ecr_repos.tf
@@ -5,9 +5,9 @@ module "performance_hub_ecr_repo" {
   app_name = "performance-hub"
 
   push_principals = [
-    "arn:aws:iam::${local.environment_management.account_ids["performance-hub-development"]}:user/cicd-member-user",
-    "arn:aws:iam::${local.environment_management.account_ids["performance-hub-preproduction"]}:user/cicd-member-user",
-    "arn:aws:iam::${local.environment_management.account_ids["performance-hub-production"]}:user/cicd-member-user"
+    "arn:aws:iam::${local.environment_management.account_ids["performance-hub-development"]}:user/modernisation-platform-oidc-cicd",
+    "arn:aws:iam::${local.environment_management.account_ids["performance-hub-preproduction"]}:user/modernisation-platform-oidc-cicd",
+    "arn:aws:iam::${local.environment_management.account_ids["performance-hub-production"]}:user/modernisation-platform-oidc-cicd"
   ]
 
   pull_principals = [

--- a/terraform/environments/core-shared-services/ecr_repos.tf
+++ b/terraform/environments/core-shared-services/ecr_repos.tf
@@ -5,9 +5,9 @@ module "performance_hub_ecr_repo" {
   app_name = "performance-hub"
 
   push_principals = [
-    "arn:aws:iam::${local.environment_management.account_ids["performance-hub-development"]}:user/modernisation-platform-oidc-cicd",
-    "arn:aws:iam::${local.environment_management.account_ids["performance-hub-preproduction"]}:user/modernisation-platform-oidc-cicd",
-    "arn:aws:iam::${local.environment_management.account_ids["performance-hub-production"]}:user/modernisation-platform-oidc-cicd"
+    "arn:aws:iam::${local.environment_management.account_ids["performance-hub-development"]}:role/modernisation-platform-oidc-cicd",
+    "arn:aws:iam::${local.environment_management.account_ids["performance-hub-preproduction"]}:role/modernisation-platform-oidc-cicd",
+    "arn:aws:iam::${local.environment_management.account_ids["performance-hub-production"]}:role/modernisation-platform-oidc-cicd"
   ]
 
   pull_principals = [


### PR DESCRIPTION
This will hopefully fix permission errors when pushing to core-shared-services.

example here - . https://github.com/ministryofjustice/performance-hub/actions/runs/6458192620/job/17531368318#step:5:937