### PR TITLE
Add ability for developers to assume read-log-records

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/policies.tf
+++ b/terraform/environments/bootstrap/delegate-access/policies.tf
@@ -268,6 +268,7 @@ data "aws_iam_policy_document" "data_engineering_additional" {
       "ce:CreateReport",
       "dms:StartReplicationTask",
       "dms:StopReplicationTask",
+      "dms:ModifyReplicationTask",
       "glue:BatchCreatePartition",
       "glue:BatchDeletePartition",
       "glue:BatchDeleteTable",

--- a/terraform/environments/bootstrap/delegate-access/policies.tf
+++ b/terraform/environments/bootstrap/delegate-access/policies.tf
@@ -74,6 +74,7 @@ data "aws_iam_policy_document" "common_statements" {
     ]
     resources = [
       "arn:aws:iam::*:role/read-dns-records",
+      "arn:aws:iam::*:role/read-log-records",
       "arn:aws:iam::*:role/member-delegation-read-only",
       "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/member-shared-services",
       "arn:aws:iam::${local.modernisation_platform_account.id}:role/modernisation-account-limited-read-member-access"
@@ -267,7 +268,6 @@ data "aws_iam_policy_document" "data_engineering_additional" {
       "ce:CreateReport",
       "dms:StartReplicationTask",
       "dms:StopReplicationTask",
-      "dms:ModifyReplicationTask",
       "glue:BatchCreatePartition",
       "glue:BatchDeletePartition",
       "glue:BatchDeleteTable",


### PR DESCRIPTION
As part of #5001 , this PR allows the `developer` role to assume `read-log-records` so that developers with console access can read firewall logs in the `core-network-services` account.