### PR TITLE
🔧 Replace read-dns-records with read-log-records role 

### DIFF
--- a/terraform/templates/modernisation-platform-environments/platform_providers.tf
+++ b/terraform/templates/modernisation-platform-environments/platform_providers.tf
@@ -35,7 +35,7 @@ provider "aws" {
   alias  = "core-network-services"
   region = "eu-west-2"
   assume_role {
-    role_arn = !can(regex("githubactionsrolesession|AdministratorAccess", data.aws_caller_identity.original_session.arn)) ? "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/read-dns-records" : "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/modify-dns-records"
+    role_arn = !can(regex("githubactionsrolesession|AdministratorAccess", data.aws_caller_identity.original_session.arn)) ? "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/read-log-records" : "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/modify-dns-records"
   }
 }
 


### PR DESCRIPTION
This PR relates to https://github.com/ministryofjustice/modernisation-platform/issues/5001
This PR is also related to https://github.com/ministryofjustice/modernisation-platform-environments/pull/3618

The read-dns-records role is in scope for expansion to allow Modernisation Platform customers wider access to records stored in our core-network-services account. As this expands the role beyond reading DNS records, the role is being replaced by read-log-records.

This PR updates the platform_providers.tf template file so that when new Modernisation Platform accounts are created, the provider template contains a valid role and will allow us to prune the legacy role without impact to future customers.