### PR TITLE
🔧 Allow member-delegation and read-log-records ability to read flow logs

### DIFF
--- a/terraform/environments/core-network-services/iam.tf
+++ b/terraform/environments/core-network-services/iam.tf
@@ -200,10 +200,10 @@ resource "aws_iam_role_policy" "read_firewall" {
           "arn:aws:logs:*:*:log-group::log-stream:",
           "arn:aws:logs:*:*:log-group:fw-*:log-stream:",
           "arn:aws:logs:*:*:log-group:fw-*:log-stream:/aws/network-firewall/*/*",
-          "arn:aws:logs:*:*:log-group:*-vpc-flow-logs-*:log-stream:",
-          "arn:aws:logs:*:*:log-group:*-vpc-flow-logs-*:log-stream:/log-events/eni-*",
-          "arn:aws:logs:*:*:log-group:external-inspection-flow-logs:log-stream:",
-          "arn:aws:logs:*:*:log-group:external-inspection-flow-logs:/log-events/eni-*"
+          "arn:aws:logs:*:*:log-group:*-vpc-flow-logs-*:log-stream:*",
+          "arn:aws:logs:*:*:log-group:*-vpc-flow-logs-*:log-stream:log-events/eni-*",
+          "arn:aws:logs:*:*:log-group:external-inspection-flow-logs:log-stream:*",
+          "arn:aws:logs:*:*:log-group:external-inspection-flow-logs:log-events/eni-*"
         ],
       },
       {

--- a/terraform/environments/core-network-services/iam.tf
+++ b/terraform/environments/core-network-services/iam.tf
@@ -199,7 +199,11 @@ resource "aws_iam_role_policy" "read_firewall" {
         "Resource" : [
           "arn:aws:logs:*:*:log-group::log-stream:",
           "arn:aws:logs:*:*:log-group:fw-*:log-stream:",
-          "arn:aws:logs:*:*:log-group:fw-*:log-stream:/aws/network-firewall/*/*"
+          "arn:aws:logs:*:*:log-group:fw-*:log-stream:/aws/network-firewall/*/*",
+          "arn:aws:logs:*:*:log-group:*-vpc-flow-logs-*:log-stream:",
+          "arn:aws:logs:*:*:log-group:*-vpc-flow-logs-*:log-stream:/log-events/eni-*",
+          "arn:aws:logs:*:*:log-group:external-inspection-flow-logs:log-stream:",
+          "arn:aws:logs:*:*:log-group:external-inspection-flow-logs:/log-events/eni-*"
         ],
       },
       {

--- a/terraform/environments/core-network-services/iam.tf
+++ b/terraform/environments/core-network-services/iam.tf
@@ -199,7 +199,6 @@ resource "aws_iam_role_policy" "read_firewall" {
         "Resource" : [
           "arn:aws:logs:*:*:log-group::log-stream:",
           "arn:aws:logs:*:*:log-group:fw-*:log-stream:*",
-          "arn:aws:logs:*:*:log-group:fw-*:log-stream:/aws/network-firewall/*/*",
           "arn:aws:logs:*:*:log-group:*-vpc-flow-logs-*:log-stream:*",
           "arn:aws:logs:*:*:log-group:external-inspection-flow-logs:log-stream:*",
         ],

--- a/terraform/environments/core-network-services/iam.tf
+++ b/terraform/environments/core-network-services/iam.tf
@@ -198,12 +198,10 @@ resource "aws_iam_role_policy" "read_firewall" {
         ],
         "Resource" : [
           "arn:aws:logs:*:*:log-group::log-stream:",
-          "arn:aws:logs:*:*:log-group:fw-*:log-stream:",
+          "arn:aws:logs:*:*:log-group:fw-*:log-stream:*",
           "arn:aws:logs:*:*:log-group:fw-*:log-stream:/aws/network-firewall/*/*",
           "arn:aws:logs:*:*:log-group:*-vpc-flow-logs-*:log-stream:*",
-          "arn:aws:logs:*:*:log-group:*-vpc-flow-logs-*:log-stream:log-events/eni-*",
           "arn:aws:logs:*:*:log-group:external-inspection-flow-logs:log-stream:*",
-          "arn:aws:logs:*:*:log-group:external-inspection-flow-logs:log-events/eni-*"
         ],
       },
       {

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -309,6 +309,19 @@ resource "aws_iam_role_policy" "member-delegation" {
           "arn:aws:route53:::hostedzone/${module.dns-zone[each.key].zone_private}"
         ]
       },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "logs:DescribeLogGroups",
+          "logs:DescribeLogStreams",
+          "logs:GetLogEvents"
+        ],
+        "Resource" : [
+          "arn:aws:logs:*:*:log-group::log-stream:",
+          "arn:aws:logs:*:*:log-group:*-vpc-flow-logs-*:log-stream:",
+          "arn:aws:logs:*:*:log-group:*-vpc-flow-logs-*:log-stream:/log-events/eni-*"
+        ],
+      },
     ]
   })
 }

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -319,7 +319,6 @@ resource "aws_iam_role_policy" "member-delegation" {
         "Resource" : [
           "arn:aws:logs:*:*:log-group::log-stream:",
           "arn:aws:logs:*:*:log-group:*-vpc-flow-logs-*:log-stream:*",
-          "arn:aws:logs:*:*:log-group:*-vpc-flow-logs-*:log-stream:log-events/eni-*"
         ],
       },
     ]

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -318,8 +318,8 @@ resource "aws_iam_role_policy" "member-delegation" {
         ],
         "Resource" : [
           "arn:aws:logs:*:*:log-group::log-stream:",
-          "arn:aws:logs:*:*:log-group:*-vpc-flow-logs-*:log-stream:",
-          "arn:aws:logs:*:*:log-group:*-vpc-flow-logs-*:log-stream:/log-events/eni-*"
+          "arn:aws:logs:*:*:log-group:*-vpc-flow-logs-*:log-stream:*",
+          "arn:aws:logs:*:*:log-group:*-vpc-flow-logs-*:log-stream:log-events/eni-*"
         ],
       },
     ]


### PR DESCRIPTION
As part of #5001, this PR expands the inline IAM policies for the `member-delegation-read-only` and `read-log-records` roles so that Modernisation Platform customers who can assume these roles will be able to view VPC flow logs.