### PR TITLE
Give Developer role ability to restore objects from Glacier storage

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/policies.tf
+++ b/terraform/environments/bootstrap/delegate-access/policies.tf
@@ -178,6 +178,7 @@ data "aws_iam_policy_document" "developer_additional" {
       "s3:PutObject",
       "s3:DeleteObject",
       "s3:DeleteObjectVersion",
+      "s3:RestoreObject",
       "secretsmanager:GetResourcePolicy",
       "secretsmanager:GetSecretValue",
       "secretsmanager:DescribeSecret",


### PR DESCRIPTION
So we can trigger Glacier S3 restores from AWS Console.