### PR TITLE
create pagerduty integration for csr alarms

### DIFF
--- a/terraform/pagerduty/aws.tf
+++ b/terraform/pagerduty/aws.tf
@@ -42,7 +42,8 @@ resource "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {
     laa_portal_nonprod_alarms    = pagerduty_service_integration.laa_portal_nonprod_cloudwatch.integration_key,
     laa_portal_prod_alarms       = pagerduty_service_integration.laa_portal_prod_cloudwatch.integration_key
     laa_maat_nonprod_alarms      = pagerduty_service_integration.laa_maat_nonprod_cloudwatch.integration_key,
-    laa_maat_prod_alarms         = pagerduty_service_integration.laa_maat_prod_cloudwatch.integration_key
+    laa_maat_prod_alarm          = pagerduty_service_integration.laa_maat_prod_cloudwatch.integration_key,
+    csr_alarms                   = pagerduty_service_integration.csr_cloudwatch.integration_key,
   })
 }
 

--- a/terraform/pagerduty/member-services-integrations.tf
+++ b/terraform/pagerduty/member-services-integrations.tf
@@ -970,7 +970,7 @@ resource "pagerduty_slack_connection" "csr_connection" {
   source_id         = pagerduty_service.csr.id
   source_type       = "service_reference"
   workspace_id      = local.slack_workspace_id
-  channel_id        = "C04E4FM3KS7" # Sending to the same channel as dso-alerts-modernisation-platform
+  channel_id        = "C0617EZEVNZ" # Sending to csr_alerts_modernisation_platform
   notification_type = "responder"
   lifecycle {
     ignore_changes = [
@@ -1001,58 +1001,4 @@ resource "pagerduty_slack_connection" "csr_connection" {
   }
 }
 
-# Sending CSR alerts specifically to the same channel as dso-alerts-modernisation-platform
-# Slack channel: #dso_alerts_modernisation_platform
-
-resource "pagerduty_service" "planetfm" {
-  name                    = "PlanetFM Alarms"
-  description             = "PlanetFM Alarms"
-  auto_resolve_timeout    = 345600
-  acknowledgement_timeout = "null"
-  escalation_policy       = pagerduty_escalation_policy.member_policy.id
-  alert_creation          = "create_alerts_and_incidents"
-}
-
-resource "pagerduty_service_integration" "planetfm_cloudwatch" {
-  name    = data.pagerduty_vendor.cloudwatch.name
-  service = pagerduty_service.planetfm.id
-  vendor  = data.pagerduty_vendor.cloudwatch.id
-}
-
-resource "pagerduty_slack_connection" "planetfm_connection" {
-  source_id         = pagerduty_service.planetfm.id
-  source_type       = "service_reference"
-  workspace_id      = local.slack_workspace_id
-  channel_id        = "C04E4FM3KS7" # Sending to the same channel as dso-alerts-modernisation-platform
-  notification_type = "responder"
-  lifecycle {
-    ignore_changes = [
-      config,
-    ]
-  }
-  config {
-    events = [
-      "incident.triggered",
-      "incident.acknowledged",
-      "incident.escalated",
-      "incident.resolved",
-      "incident.reassigned",
-      "incident.annotated",
-      "incident.unacknowledged",
-      "incident.delegated",
-      "incident.priority_updated",
-      "incident.action_invocation.created",
-      "incident.action_invocation.terminated",
-      "incident.action_invocation.updated",
-      "incident.responder.added",
-      "incident.responder.replied",
-      "incident.status_update_published",
-      "incident.reopened"
-    ]
-
-    priorities = ["*"]
-  }
-}
-
-# Sending PlanetFM alerts specifically to the same channel as dso-alerts-modernisation-platform
-# Slack channel: #dso_alerts_modernisation_platform
+# Slack channel: #csr_alerts_modernisation_platform

--- a/terraform/pagerduty/member-services-integrations.tf
+++ b/terraform/pagerduty/member-services-integrations.tf
@@ -950,3 +950,109 @@ resource "pagerduty_service_integration" "laa_maat_prod_cloudwatch" {
 }
 
 # Slack channel: #laa-alerts-maat-prod
+
+resource "pagerduty_service" "csr" {
+  name                    = "Csr Alarms"
+  description             = "Csr Alarms"
+  auto_resolve_timeout    = 345600
+  acknowledgement_timeout = "null"
+  escalation_policy       = pagerduty_escalation_policy.member_policy.id
+  alert_creation          = "create_alerts_and_incidents"
+}
+
+resource "pagerduty_service_integration" "csr_cloudwatch" {
+  name    = data.pagerduty_vendor.cloudwatch.name
+  service = pagerduty_service.csr.id
+  vendor  = data.pagerduty_vendor.cloudwatch.id
+}
+
+resource "pagerduty_slack_connection" "csr_connection" {
+  source_id         = pagerduty_service.csr.id
+  source_type       = "service_reference"
+  workspace_id      = local.slack_workspace_id
+  channel_id        = "C04E4FM3KS7" # Sending to the same channel as dso-alerts-modernisation-platform
+  notification_type = "responder"
+  lifecycle {
+    ignore_changes = [
+      config,
+    ]
+  }
+  config {
+    events = [
+      "incident.triggered",
+      "incident.acknowledged",
+      "incident.escalated",
+      "incident.resolved",
+      "incident.reassigned",
+      "incident.annotated",
+      "incident.unacknowledged",
+      "incident.delegated",
+      "incident.priority_updated",
+      "incident.action_invocation.created",
+      "incident.action_invocation.terminated",
+      "incident.action_invocation.updated",
+      "incident.responder.added",
+      "incident.responder.replied",
+      "incident.status_update_published",
+      "incident.reopened"
+    ]
+
+    priorities = ["*"]
+  }
+}
+
+# Sending CSR alerts specifically to the same channel as dso-alerts-modernisation-platform
+# Slack channel: #dso_alerts_modernisation_platform
+
+resource "pagerduty_service" "planetfm" {
+  name                    = "PlanetFM Alarms"
+  description             = "PlanetFM Alarms"
+  auto_resolve_timeout    = 345600
+  acknowledgement_timeout = "null"
+  escalation_policy       = pagerduty_escalation_policy.member_policy.id
+  alert_creation          = "create_alerts_and_incidents"
+}
+
+resource "pagerduty_service_integration" "planetfm_cloudwatch" {
+  name    = data.pagerduty_vendor.cloudwatch.name
+  service = pagerduty_service.planetfm.id
+  vendor  = data.pagerduty_vendor.cloudwatch.id
+}
+
+resource "pagerduty_slack_connection" "planetfm_connection" {
+  source_id         = pagerduty_service.planetfm.id
+  source_type       = "service_reference"
+  workspace_id      = local.slack_workspace_id
+  channel_id        = "C04E4FM3KS7" # Sending to the same channel as dso-alerts-modernisation-platform
+  notification_type = "responder"
+  lifecycle {
+    ignore_changes = [
+      config,
+    ]
+  }
+  config {
+    events = [
+      "incident.triggered",
+      "incident.acknowledged",
+      "incident.escalated",
+      "incident.resolved",
+      "incident.reassigned",
+      "incident.annotated",
+      "incident.unacknowledged",
+      "incident.delegated",
+      "incident.priority_updated",
+      "incident.action_invocation.created",
+      "incident.action_invocation.terminated",
+      "incident.action_invocation.updated",
+      "incident.responder.added",
+      "incident.responder.replied",
+      "incident.status_update_published",
+      "incident.reopened"
+    ]
+
+    priorities = ["*"]
+  }
+}
+
+# Sending PlanetFM alerts specifically to the same channel as dso-alerts-modernisation-platform
+# Slack channel: #dso_alerts_modernisation_platform


### PR DESCRIPTION
- new slack channel for CSR alarms
- no distinction between prod and non-prod as all CSR environments are either production or pre-production