### PR TITLE
:boom: Remove ability for users to assume deprecated read-dns-records role

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/policies.tf
+++ b/terraform/environments/bootstrap/delegate-access/policies.tf
@@ -73,7 +73,6 @@ data "aws_iam_policy_document" "common_statements" {
       "sts:AssumeRole"
     ]
     resources = [
-      "arn:aws:iam::*:role/read-dns-records",
       "arn:aws:iam::*:role/read-log-records",
       "arn:aws:iam::*:role/member-delegation-read-only",
       "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/member-shared-services",

--- a/terraform/modernisation-platform-account/iam.tf
+++ b/terraform/modernisation-platform-account/iam.tf
@@ -42,7 +42,7 @@ data "aws_iam_policy_document" "collaborator_local_plan" {
       "sts:AssumeRole"
     ]
     resources = [
-      "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/read-dns-records",
+      "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/read-log-records",
       "arn:aws:iam::${local.environment_management.account_ids["core-vpc-development"]}:role/member-delegation-read-only",
       "arn:aws:iam::${local.environment_management.account_ids["core-vpc-test"]}:role/member-delegation-read-only",
       "arn:aws:iam::${local.environment_management.account_ids["core-vpc-preproduction"]}:role/member-delegation-read-only",


### PR DESCRIPTION
As part of https://github.com/ministryofjustice/modernisation-platform/issues/5001, the deprecated `read-dns-records` role is to be removed from the developer trust relationship. Users of the `developer` role can utilise the `read-log-records` role which will give them the same level of access to Route53 records, as well as unrelated access to CloudWatch log groups for troubleshooting.