### PR TITLE
add delius-core test networking configuration

### DIFF
--- a/environments-networks/hmpps-test.json
+++ b/environments-networks/hmpps-test.json
@@ -13,7 +13,8 @@
           "corporate-staff-rostering-test",
           "planetfm-test",
           "hmpps-oem-test",
-          "hmpps-domain-services-test"
+          "hmpps-domain-services-test",
+          "delius-core-test"
         ]
       }
     }

--- a/policies/networking/expected.rego
+++ b/policies/networking/expected.rego
@@ -96,7 +96,8 @@ expected =
           "corporate-staff-rostering-test",
           "planetfm-test",
           "hmpps-oem-test",
-          "hmpps-domain-services-test"
+          "hmpps-domain-services-test",
+          "delius-core-test"
         ]
       }
     },


### PR DESCRIPTION
Delius-core-test networking configuration as per steps in https://user-guide.modernisation-platform.service.justice.gov.uk/runbooks/creating-accounts-for-end-users.html#3-create-a-pull-request-for-the-changes-in-step-1-and-2