### PR TITLE
🛂 Add MWAA User access for Data Platform Apps and Tools

### DIFF
--- a/environments/data-platform-apps-and-tools.json
+++ b/environments/data-platform-apps-and-tools.json
@@ -13,6 +13,11 @@
           "github_slug": "data-tech-archs",
           "level": "sandbox",
           "nuke": "exclude"
+        },
+        {
+          "github_slug": "data-platform-apps-and-tools-airflow-users",
+          "level": "mwaa-user",
+          "nuke": "exclude"
         }
       ]
     },

--- a/policies/environments/environment-definitions.rego
+++ b/policies/environments/environment-definitions.rego
@@ -21,7 +21,8 @@ allowed_access := [
   "read-only",
   "security-audit",
   "data-engineer",
-  "reporting-operations"
+  "reporting-operations",
+  "mwaa-user"
 ]
 
 allowed_nuke := [

--- a/policies/environments/environment-definitions_test.rego
+++ b/policies/environments/environment-definitions_test.rego
@@ -41,7 +41,7 @@ test_business_units_character{
 }
 
 test_unexpected_access {
-  deny["`example.json` uses an unexpected access level: got `incorrect-access`, expected one of: view-only, developer, sandbox, administrator, migration, instance-management, read-only, security-audit, data-engineer, reporting-operations"] with input as { "filename": "example.json", "environments": [{"access": [{"level": "incorrect-access"}]}]}
+  deny["`example.json` uses an unexpected access level: got `incorrect-access`, expected one of: view-only, developer, sandbox, administrator, migration, instance-management, read-only, security-audit, data-engineer, reporting-operations, mwaa-user"] with input as { "filename": "example.json", "environments": [{"access": [{"level": "incorrect-access"}]}]}
 }
 
 test_unexpected_nuke {


### PR DESCRIPTION
Resolves https://github.com/ministryofjustice/data-platform/issues/791

Enables access to [`modernisation-platform-mwaa-user`](https://github.com/ministryofjustice/aws-root-account/blob/main/management-account/terraform/sso-admin-permission-sets.tf#L181-L187)