### PR TITLE
Version change within the example

### DIFF
--- a/source/user-guide/integrating-alarms-with-pagerduty-with-slack.html.md.erb
+++ b/source/user-guide/integrating-alarms-with-pagerduty-with-slack.html.md.erb
@@ -61,7 +61,7 @@ module "pagerduty_core_alerts" {
   depends_on = [
     aws_sns_topic.<my sns topic>
   ]
-  source                    = "github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration?ref=v1.0.0"
+  source                    = "github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration?ref=v2.0.0"
   sns_topics                = [aws_sns_topic.<my sns topic>.name]
   pagerduty_integration_key = local.pagerduty_integration_keys["<my integration key name>"]
 }


### PR DESCRIPTION
This PR corrects and error in the documentation of the example given for pager duty integration it currently states v1 of the module pager duty integration but there has been a recent release to that module that bumps it to version 2 there for amending to show that change