### PR TITLE
Address SCA issues for data-platform-apps-and-tools and observability-platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ megalinter-reports/
 *.tfstate*
 .tfsec/
 .tfsec/*
+!terraform/environments/my-application/.tfsec/
+!terraform/environments/my-application/.tfsec/*
 tmp/
 *.tsv
 .vscode/

--- a/terraform/environments/data-platform-apps-and-tools/.tfsec/config.yml
+++ b/terraform/environments/data-platform-apps-and-tools/.tfsec/config.yml
@@ -1,0 +1,4 @@
+---
+exclude:
+  # Add IDs of checks to ignore them
+  - aws-rds-enable-iam-auth

--- a/terraform/environments/data-platform-apps-and-tools/rds.tf
+++ b/terraform/environments/data-platform-apps-and-tools/rds.tf
@@ -1,7 +1,6 @@
-// TODO - Review this rule: "Instance does not have IAM Authentication enabled" IAM Auth not understood by our applications
 module "openmetadata_airflow_rds" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
-  source  = "terraform-aws-modules/rds/aws" #tfsec:ignore:AVD-AWS-0176
+  source  = "terraform-aws-modules/rds/aws"
   version = "~> 6.0"
 
   identifier = "openmetadata-airflow"
@@ -65,10 +64,8 @@ module "openmetadata_airflow_rds" {
   tags = local.tags
 }
 
-// TODO - Review this rule: "Instance does not have IAM Authentication enabled" IAM Auth not understood by our applications
 module "openmetadata_rds" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
-  source  = "terraform-aws-modules/rds/aws" #tfsec:ignore:AVD-AWS-0176
   version = "~> 6.0"
 
   identifier = "openmetadata"

--- a/terraform/environments/data-platform-apps-and-tools/rds.tf
+++ b/terraform/environments/data-platform-apps-and-tools/rds.tf
@@ -66,6 +66,7 @@ module "openmetadata_airflow_rds" {
 
 module "openmetadata_rds" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  source  = "terraform-aws-modules/rds/aws"
   version = "~> 6.0"
 
   identifier = "openmetadata"

--- a/terraform/environments/data-platform-apps-and-tools/rds.tf
+++ b/terraform/environments/data-platform-apps-and-tools/rds.tf
@@ -1,7 +1,7 @@
-// TODO - Review this rule: "Instance does not have IAM Authentication enabled" IAM Auth not understood by our applications 
+// TODO - Review this rule: "Instance does not have IAM Authentication enabled" IAM Auth not understood by our applications
 module "openmetadata_airflow_rds" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
-  source  = "terraform-aws-modules/rds/aws"
+  source  = "terraform-aws-modules/rds/aws" #tfsec:ignore:AVD-AWS-0176
   version = "~> 6.0"
 
   identifier = "openmetadata-airflow"
@@ -65,10 +65,10 @@ module "openmetadata_airflow_rds" {
   tags = local.tags
 }
 
-// TODO - Review this rule: "Instance does not have IAM Authentication enabled" IAM Auth not understood by our applications 
+// TODO - Review this rule: "Instance does not have IAM Authentication enabled" IAM Auth not understood by our applications
 module "openmetadata_rds" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
-  source  = "terraform-aws-modules/rds/aws"
+  source  = "terraform-aws-modules/rds/aws" #tfsec:ignore:AVD-AWS-0176
   version = "~> 6.0"
 
   identifier = "openmetadata"

--- a/terraform/environments/observability-platform/iam-roles.tf
+++ b/terraform/environments/observability-platform/iam-roles.tf
@@ -1,4 +1,5 @@
 module "data_platform_apps_tools_iam_role" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
   version = "~> 5.0"
 

--- a/terraform/environments/observability-platform/managed-grafana.tf
+++ b/terraform/environments/observability-platform/managed-grafana.tf
@@ -1,4 +1,5 @@
 module "managed_grafana" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   source  = "terraform-aws-modules/managed-service-grafana/aws"
   version = "~> 2.0"
 

--- a/terraform/environments/observability-platform/managed-prometheus.tf
+++ b/terraform/environments/observability-platform/managed-prometheus.tf
@@ -1,4 +1,5 @@
 module "managed_prometheus" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   source  = "terraform-aws-modules/managed-service-prometheus/aws"
   version = "~> 2.0"
 


### PR DESCRIPTION
Because tfsec will not obey inline exclusions (https://github.com/aquasecurity/tfsec/issues/1935) for the reported data-platform-apps-and-tools error, I've had to introduce a .tfsec/config.yml file to cover the exclusion.