### PR TITLE
Revert "Bump terraform-aws-modules/eks/aws from 19.16.0 to 19.17.2 in /terraform/environments/data-platform-apps-and-tools"

### DIFF
--- a/terraform/environments/data-platform-apps-and-tools/eks-cluster.tf
+++ b/terraform/environments/data-platform-apps-and-tools/eks-cluster.tf
@@ -5,7 +5,7 @@ module "eks" {
   #checkov:skip=CKV_TF_1:Module is from Terraform registry
 
   source  = "terraform-aws-modules/eks/aws"
-  version = "19.17.2"
+  version = "19.16.0"
 
   cluster_name    = local.environment_configuration.eks_cluster_name
   cluster_version = local.environment_configuration.eks_versions.cluster


### PR DESCRIPTION
Reverts ministryofjustice/modernisation-platform#5258