### PR TITLE
Add Notify service domain to firewall FQDN

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/fqdn_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/fqdn_rules.json
@@ -15,7 +15,8 @@
     ".docker.io",
     ".docker.com",
     ".ghcr.io",
-    ".amazontrust.com"
+    ".amazontrust.com",
+    ".notifications.service.gov.uk"
   ],
   "fw_home_net_ips": ["10.26.0.0/16", "10.27.0.0/16"]
 }


### PR DESCRIPTION
It seems reasonable to have this widely allowed, but there may be implications I'm not aware of.