### PR TITLE
set tipstaff preprod permissions level to developer

### DIFF
--- a/environments/tipstaff.json
+++ b/environments/tipstaff.json
@@ -16,7 +16,7 @@
       "access": [
         {
           "github_slug": "dts-legacy",
-          "level": "migration"
+          "level": "developer"
         }
       ]
     },


### PR DESCRIPTION
As requested by @matt-k1998 , this PR lowers the SSO permission level that Tipstaff developers will use to access their preproduction environment