### PR TITLE
Restrict `modernisation-account-limited-read-member-access`

### DIFF
--- a/terraform/modernisation-platform-account/iam.tf
+++ b/terraform/modernisation-platform-account/iam.tf
@@ -147,6 +147,11 @@ data "aws_iam_policy_document" "modernisation_account_limited_read" {
       "arn:aws:secretsmanager:eu-west-2:${data.aws_caller_identity.current.account_id}:secret:pagerduty_integration_keys-??????",
     ]
   }
+  statement {
+    effect    = "Deny"
+    actions   = [ "s3:*" ]
+    resources = [ "arn:aws:s3:eu-west-2:${data.aws_caller_identity.current.account_id}:*" ]
+  }
 }
 resource "aws_iam_policy" "modernisation_account_limited_read" {
   name        = "ModernisationAccountLimitedRead"


### PR DESCRIPTION
Because roles are implicitly allowed access to S3 buckets in an account, this PR denies this for the limited read role to prevent unexpected disclosure of objects in S3.