### PR TITLE
Corrected resource statement to deny all access to S3 resources

### DIFF
--- a/terraform/modernisation-platform-account/iam.tf
+++ b/terraform/modernisation-platform-account/iam.tf
@@ -150,7 +150,7 @@ data "aws_iam_policy_document" "modernisation_account_limited_read" {
   statement {
     effect    = "Deny"
     actions   = [ "s3:*" ]
-    resources = [ "arn:aws:s3:eu-west-2:${data.aws_caller_identity.current.account_id}:*" ]
+    resources = [ "arn:aws:s3:::*" ]
   }
 }
 resource "aws_iam_policy" "modernisation_account_limited_read" {


### PR DESCRIPTION
Previous resource statement was incorrectly formatted.