### PR TITLE
Only create OIDC role when repositories are supplied

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -337,12 +337,12 @@ resource "aws_iam_policy" "member-access-us-east" {
 
 # Github OIDC role
 module "github_oidc_role" {
+  count               = length(compact(jsondecode(data.http.environments_file.response_body).github-oidc-team-repositories)) > 0 ? 1 : 0
   source              = "github.com/ministryofjustice/modernisation-platform-github-oidc-role?ref=c3bde7c787038ff5536bfb1b73781072edbb74da" # v3.0.0
   github_repositories = jsondecode(data.http.environments_file.response_body).github-oidc-team-repositories
   role_name           = "modernisation-platform-oidc-cicd"
   policy_jsons        = [data.aws_iam_policy_document.policy.json]
   tags                = local.tags
-
 }
 
 #tfsec:ignore:aws-iam-no-policy-wildcards


### PR DESCRIPTION
This PR resolves #5291 by using a conditional count statement.

I looked at using a `for_each` as an alternative, but as that would separate the contents of the `github-oidc-team-repositories` list into separate values, it would necessitate work on the `modernisation-platform-github-oidc-role` module that would then require a breaking change to the version.