### PR TITLE
Fix pointer for securityhub script

### DIFF
--- a/scripts/internal/get-security-hub-findings/go.mod
+++ b/scripts/internal/get-security-hub-findings/go.mod
@@ -1,6 +1,6 @@
 module modernisation-platform/get-security-hub-findings
 
-go 1.18
+go 1.21
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.21.2

--- a/scripts/internal/get-security-hub-findings/main.go
+++ b/scripts/internal/get-security-hub-findings/main.go
@@ -77,7 +77,7 @@ func getFindings(client *securityhub.Client, accountName string, productName str
 				WorkflowStatus: []types.StringFilter{{Comparison: types.StringFilterComparisonEquals, Value: aws.String("NEW")}, {Comparison: types.StringFilterComparisonEquals, Value: aws.String("NOTIFIED")}},
 				SeverityLabel:  []types.StringFilter{{Comparison: types.StringFilterComparisonEquals, Value: aws.String("CRITICAL")}, {Comparison: types.StringFilterComparisonEquals, Value: aws.String("HIGH")}},
 			},
-			MaxResults: int32(100),
+			MaxResults: aws.Int32(100),
 		}
 
 		// get findings


### PR DESCRIPTION
This PR fixes the MaxResults pointer for the securityhub findings script, and raises the minimum Go version to `1.21`