### PR TITLE
Removing cicd user from delegate access.

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -20,15 +20,6 @@ module "cross-account-access" {
   additional_trust_roles = terraform.workspace == "testing-test" ? ["arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:user/testing-ci"] : []
 }
 
-module "cicd-member-user" {
-  count  = local.account_data.account-type == "member" ? 1 : 0
-  source = "../../../modules/iam_baseline"
-  providers = {
-    aws = aws.workspace
-  }
-}
-
-
 # Create a parameter for the modernisation platform environment management secret ARN that can be used to gain
 # access to the environments parameter when running a tf plan locally
 


### PR DESCRIPTION
Removed as part of migrating to OIDC, goodbye long lived creds.


Tested on sprinkler.

If any errors occur on the plan / apply it means that someone has re generated keys. I shall remove them and re run the terraform and it will pass.


Although its removing the user, a lot of code will be left for a week in case we need to revert. Changing as little as possible here seems sensible.