### PR TITLE
Add Regal for linting Rego

### DIFF
--- a/.github/workflows/opa-policies.yml
+++ b/.github/workflows/opa-policies.yml
@@ -18,10 +18,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Setup Regal
+        uses: styrainc/setup-regal@94ad2891f53efdb7ebe7c6836bc25ecc9504aec1 # v0.2.0
+        with:
+          version: v0.11.0
+      - name: Run Regal Lint
+        run: regal lint --format=github policies
       - name: Install Conftest
         run: |
-          wget https://github.com/open-policy-agent/conftest/releases/download/v0.21.0/conftest_0.21.0_Linux_x86_64.tar.gz
-          tar xzf conftest_0.21.0_Linux_x86_64.tar.gz
+          wget https://github.com/open-policy-agent/conftest/releases/download/v0.46.0/conftest_0.46.0_Linux_x86_64.tar.gz
+          tar xzf conftest_0.46.0_Linux_x86_64.tar.gz
           sudo mv conftest /usr/local/bin
       - name: Run Conftest
         run: bash scripts/tests/validate/run-opa-tests.sh

--- a/policies/.regal/config.yaml
+++ b/policies/.regal/config.yaml
@@ -1,0 +1,19 @@
+rules:
+  idiomatic:
+    # Not typically needed in conftest policy
+    # https://docs.styra.com/regal/rules/idiomatic/no-defined-entrypoint
+    no-defined-entrypoint:
+      level: ignore
+  # Style category mostly for following good style conventions,
+  # so certainly optional
+  # https://docs.styra.com/regal/category/style
+  style:
+    line-length:
+      level: ignore
+    opa-fmt:
+      level: ignore
+    prefer-some-in-iteration:
+      level: ignore
+  testing:
+    test-outside-test-package:
+      level: ignore

--- a/policies/collaborators/collaborators.rego
+++ b/policies/collaborators/collaborators.rego
@@ -1,5 +1,7 @@
 package main
 
+import future.keywords.in
+
 allowed_access := [
   "read-only",
   "developer",
@@ -54,6 +56,6 @@ deny[msg] {
 
 deny[msg] {
   accounts := input.users[_].accounts[_]
-  not array_contains(allowed_access, accounts.access)
+  not accounts.access in allowed_access
   msg := sprintf("`%v` uses an unexpected access: got `%v`, expected one of: %v", [input.filename, accounts.access, concat(", ", allowed_access) ])
 }

--- a/policies/collaborators/utilities.rego
+++ b/policies/collaborators/utilities.rego
@@ -4,7 +4,3 @@ has_field(object, field) {
   object[field]
   object[field] != ""
 }
-
-array_contains(array, element) {
-  array[_] = element
-}

--- a/policies/environments/environment-definitions.rego
+++ b/policies/environments/environment-definitions.rego
@@ -1,5 +1,7 @@
 package main
 
+import future.keywords.in
+
 allowed_business_units := [
   "HQ",
   "HMPPS",
@@ -77,12 +79,12 @@ deny[msg] {
 }
 
 deny[msg] {
-  not array_contains(allowed_business_units, input.tags["business-unit"])
+  not input.tags["business-unit"] in allowed_business_units
   msg := sprintf("`%v` uses an unexpected business-unit: got `%v`, expected one of: %v", [input.filename, input.tags["business-unit"], concat(", ", allowed_business_units) ])
 }
 
 deny[msg] {
-  not regex.match("^[a-zA-Z-]{1,20}$", input.tags["business-unit"])
+  not regex.match(`^[a-zA-Z-]{1,20}$`, input.tags["business-unit"])
   msg := sprintf("`%v` Business unit name does not meet requirements", [input.filename])
 }
 
@@ -93,12 +95,12 @@ deny[msg] {
 
 deny[msg] {
   access:=input.environments[_].access[_].level
-  not array_contains(allowed_access, access)
+  not access in allowed_access
   msg := sprintf("`%v` uses an unexpected access level: got `%v`, expected one of: %v", [input.filename, access, concat(", ", allowed_access) ])
 }
 
 deny[msg] {
   nuke:=input.environments[_].access[_].nuke
-  not array_contains(allowed_nuke, nuke)
+  not nuke in allowed_nuke
   msg := sprintf("`%v` uses an unexpected nuke value: got `%v`, expected one of: %v", [input.filename, nuke, concat(", ", allowed_nuke) ])
 }

--- a/policies/environments/expected.rego
+++ b/policies/environments/expected.rego
@@ -1,6 +1,6 @@
 package main
 
-expected =
+expected :=
 {
   "accounts": [
     "analytical-platform",

--- a/policies/environments/utilities.rego
+++ b/policies/environments/utilities.rego
@@ -4,7 +4,3 @@ has_field(object, field) {
   object[field]
   object[field] != ""
 }
-
-array_contains(array, element) {
-  array[_] = element
-}

--- a/policies/member/environment-definitions.rego
+++ b/policies/member/environment-definitions.rego
@@ -1,5 +1,7 @@
 package main
 
+import future.keywords.in
+
 allowed_environments := [
   "development",
   "test",
@@ -8,11 +10,12 @@ allowed_environments := [
 ]
 
 deny[msg] {
-  not array_contains(allowed_environments, input.environments[i].name)
-  msg := sprintf("`%v` uses an unexpected environment: got `%v`, expected one of: %v", [input.filename, input.environments[i].name, concat(", ", allowed_environments) ])
+  some environment in input.environments
+  not environment.name in allowed_environments
+  msg := sprintf("`%v` uses an unexpected environment: got `%v`, expected one of: %v", [input.filename, environment.name, concat(", ", allowed_environments) ])
 }
 
 deny[msg] {
-  not regex.match("^environments\\/[a-z-]{1,30}\\.json$",input.filename)
+  not regex.match(`^environments\/[a-z-]{1,30}\.json$`,input.filename)
   msg := sprintf("`%v` filename does not meet requirements", [input.filename])
 }

--- a/policies/member/utilities.rego
+++ b/policies/member/utilities.rego
@@ -4,7 +4,3 @@ has_field(object, field) {
   object[field]
   object[field] != ""
 }
-
-array_contains(array, element) {
-  array[_] = element
-}

--- a/policies/networking/core-vpc.rego
+++ b/policies/networking/core-vpc.rego
@@ -3,6 +3,7 @@ package main
 nice_name := replace(replace(input.filename, ".json", ""), "environments-networks/", "")
 
 deny[msg] {
+  some key
   expected["subnet_sets"][nice_name][key].cidr != input.cidr.subnet_sets[key].cidr
 
   msg := sprintf("Subnet sets mismatch: `%v` should equal `%v` for `%v (%v)`", [input.cidr.subnet_sets[key].cidr, expected["subnet_sets"][nice_name][key].cidr, nice_name, key])

--- a/policies/networking/expected.rego
+++ b/policies/networking/expected.rego
@@ -1,6 +1,6 @@
 package main
 
-expected =
+expected :=
 {
   "subnet_sets": {
     "garden-sandbox": {

--- a/policies/networking/utilities.rego
+++ b/policies/networking/utilities.rego
@@ -4,7 +4,3 @@ has_field(object, field) {
   object[field]
   object[field] != ""
 }
-
-array_contains(array, element) {
-  array[_] = element
-}


### PR DESCRIPTION
Hi there! 👋 This PR introduces [Regal](https://github.com/styrainc/regal) for linting the Rego in this project. A few of the linter violations reported have been fixed as part of the PR:

* [non-raw-regex-pattern](https://docs.styra.com/regal/rules/idiomatic/non-raw-regex-pattern)
* [use-assignment-operator](https://docs.styra.com/regal/rules/style/use-assignment-operator)
* [use-some-for-output-vars](https://docs.styra.com/regal/rules/idiomatic/use-some-for-output-vars)

Rules related mostly to style have been disabled in the configuration file also included here, and may be enabled later if desired.

The Conftest version used here was ancient (from 2020!), which prevented using some modern constructs like the `in` keyword. I've had that updated in the CI pipeline, but if there was any reason to use that version, do let me know.

I've also added Regal to the beforementioned workflow to have it run as part of CI.