### PR TITLE
SCA Fix Ignores

### DIFF
--- a/terraform/environments/digital-prison-reporting/iam.tf
+++ b/terraform/environments/digital-prison-reporting/iam.tf
@@ -17,8 +17,10 @@ resource "aws_iam_role" "circleci_iam_role" {
   })
 }
 
-
+#tfsec:ignore:aws-iam-no-policy-wildcards
 data "aws_iam_policy_document" "circleci_iam_policy" {
+  #checkov:skip=CKV_AWS_111
+  #checkov:skip=CKV_AWS_356: 
   statement {
     actions = [
       "ec2:RunInstances",


### PR DESCRIPTION
Failed SCA run, removing ones which are currently ignored on the cicd member user.