### PR TITLE
Ensure OIDC policy allows required SSM Session actions for Ansible automation

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -459,9 +459,7 @@ data "aws_iam_policy_document" "policy" {
       "secretsmanager:GetResourcePolicy",
       "ssm:GetParameter",
       "ssm:PutParameter",
-      "ssm:StartSession",
       "ssm:DescribeSessions",
-      "ssm:GetConnectionStatus",
       "ssm:ResumeSession",
       "ssm:StartSession",
       "ssm:TerminateSession"

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -458,7 +458,13 @@ data "aws_iam_policy_document" "policy" {
       "secretsmanager:DescribeSecret",
       "secretsmanager:GetResourcePolicy",
       "ssm:GetParameter",
-      "ssm:PutParameter"
+      "ssm:PutParameter",
+      "ssm:StartSession",
+      "ssm:DescribeSessions",
+      "ssm:GetConnectionStatus",
+      "ssm:ResumeSession",
+      "ssm:StartSession",
+      "ssm:TerminateSession"
     ]
     resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
   }

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -462,7 +462,6 @@ data "aws_iam_policy_document" "policy" {
       "ssm:DescribeSessions",
       "ssm:ResumeSession",
       "ssm:StartSession",
-      "ssm:TerminateSession"
     ]
     resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
   }


### PR DESCRIPTION
We have multiple GitHub Workflows located [here](https://github.com/ministryofjustice/hmpps-delius-operational-automation) which utilise Ansible to perform certain operational automation tasks. Ansible accesses EC2 instances via SSH over SSM, currently the OIDC role does not permit establishing or managing SSM instance sessions. This PR adds the required permissions.