### PR TITLE
Docs/pager duty status documentation

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -104,6 +104,7 @@ This documentation is for anyone interested in the Modernisation Platform and it
 - [Enabling AWS Shield Advanced](runbooks/enabling-shield-advanced.html)
 - [How to create an AWS account for end users](runbooks/creating-accounts-for-end-users.html)
 - [How to rotate secrets](runbooks/rotating-secrets.html)
+- [how to update external status page](user-guide/how-to-update-pagerduty-status-page.html)
 - [How VPCs access the internet](runbooks/how-vpcs-access-the-internet.html)
 - [Joining the team](runbooks/joining-the-team.html)
 - [Manage an incident](runbooks/manage-an-incident.html)
@@ -119,3 +120,8 @@ This documentation is for anyone interested in the Modernisation Platform and it
 
 ## Getting help
 - [Ask for help](getting-help)
+
+## Checking Modernisation platform status
+To check the operational status of the Modernisation Platform click on the link below, this page will display the current status of any incidents as well as any planned maintenance windows.
+
+[External status page](https://status.modernisation-platform.service.justice.gov.uk)

--- a/source/user-guide/how-to-update-pagerduty-status-page.html.md.erb
+++ b/source/user-guide/how-to-update-pagerduty-status-page.html.md.erb
@@ -28,5 +28,5 @@ Approvers will be notified of the new incident once it has been raised, approver
 The status page will be updated automatically upon the pressing of the publish button and users will then be able to subscribe for updates.
 ### Subscribing to the status page
 
-In the event of an incident you can subscribe to the incident for e-mail updates addtionally you can also subscribe to the whole page if you want to be informed of future updates.
+In the event of an incident you can subscribe to the incident for email updates additionally you can also subscribe to the whole page if you want to be informed of future updates.
 You can also chose to follow just one of the business services or all of them.

--- a/source/user-guide/how-to-update-pagerduty-status-page.html.md.erb
+++ b/source/user-guide/how-to-update-pagerduty-status-page.html.md.erb
@@ -11,7 +11,7 @@ review_in: 6 months
 If there is an incident or planned you will need to update the external status page for the modernisation platform [modernisation platform status page](https://status.modernisation-platform.service.justice.gov.uk/) this guide will show you how to do this.
 
 ### Manually creating and updating status changes
-Incidents and maintenance window status can be created and updated in two ways, the first way is by logging on to the PagerDuty site and the other is by using the PugerDuty incident creation app within slack via the /PD command.
+Incidents and maintenance window status can be created and updated in two ways, the first way is by logging on to the PagerDuty site and the other is by using the PugerDuty incident creation app within slack via the /pd command.
 More information on how to raise an incident via slack is avalible on the incident process page [here](../runbooks/manage-an-incident.html#2-declare-the-incident)
 
 The next way you change change the status on the status page is by logging in to the pager duty site via the following [Link](https://moj-digital-tools.pagerduty.com/). Once logged in hover over the status menu option at the top right of the page then click on external status.

--- a/source/user-guide/how-to-update-pagerduty-status-page.html.md.erb
+++ b/source/user-guide/how-to-update-pagerduty-status-page.html.md.erb
@@ -15,7 +15,7 @@ Status changes can be created in two ways the first way is by logging on to the 
 More information on how to raise an incident via slack is avalible on the incident process page [here](../runbooks/manage-an-incident.html#2-declare-the-incident)
 
 The next way you change change the status on the status page is by logging in to the pager duty site via the following [Link](https://moj-digital-tools.pagerduty.com/). Once logged in hover over the status menu option at the top right of the page then click on external status.
-when this page loads there will be two options to choice form click on the modernisation platform, it is from here you can click on post new incident and are presented with a form to fill.
+When this page loads there will be two options to choose from, click on the Modernisation Platform, from here you can click on post new incident, and will be presented with a form to fill in.
 
 On the form you will need to select the incident status add a incident title and also a description, once you have done that you will also need to select which business service is impacted and also the impact to that service. The last item that needs to be selected is the amount of time until the next update, if you are happy with the information imputted click on the Post button.
 

--- a/source/user-guide/how-to-update-pagerduty-status-page.html.md.erb
+++ b/source/user-guide/how-to-update-pagerduty-status-page.html.md.erb
@@ -23,7 +23,7 @@ This will then need to be approved before the status page is updated.
 
 ### Approving status changes
 
-Approvers will be notified of the new incident once it has been raised, approvers will then need to log in to PagerDuty to review the incident.  Once they are happy they can click on the publish button and the incident page will be updated.
+Approvers will be notified of the new incident once it has been raised by email, approvers will then need to log in to PagerDuty to review the incident.  Once they are happy they can click on the publish button and the incident page will be updated.
 
 The status page will be updated automatically upon the pressing of the publish button and users will then be able to subscribe for updates.
 ### Subscribing to the status page

--- a/source/user-guide/how-to-update-pagerduty-status-page.html.md.erb
+++ b/source/user-guide/how-to-update-pagerduty-status-page.html.md.erb
@@ -14,6 +14,19 @@ Sometime you may need to update the external status page for the modernisation p
 Status changes can be created in two ways the first way is by logging on ot the pager duty site and the other is by using the pugerduty incident creation app within slack via the /PD command.
 More information on how to raise an incident via slack is avalible on the incident process page [here](../runbooks/manage-an-incident.html#2-declare-the-incident)
 
+The next way you change change the status on the status page is by logging in to the pager duty site via the following [Link](https://moj-digital-tools.pagerduty.com/). Once logged in hover over the status menu option at the top right of the page then click on external status
+when this page loads there will be two options to choice form click on the modernisation platform, it is from here you can click on post new incident and are presented with a form to fill.
+
+On the form you will need to select the incident status add a incident title and also a description, once you have done that you will also need to select which business service is impacted and also the impact to that service. The last item that needs to be selected is the amount of time until the next update, if you are happy with the information imputted click on the Post button.
+
+This in will then need to be approved before the status page is updated.
+
 ### Approving status changes
 
+Approvers will be notified of the new incident once it has been raised, approvers will then login to pagerduty to review the incident and once they are happy they will click on the publish button and the incident page will be updated
+
+The status page will be updated automatically upon the pressing of the publish button and users will then be able to subscribe for updates.
 ### Subscribing to the status page
+
+In the event of an incident you can subscribe to the incident for e-mail updates addtionally you can also subscribe to the whole page if you want to be informed of future updates.
+You can also chose to follow just one of the business services or all of them.

--- a/source/user-guide/how-to-update-pagerduty-status-page.html.md.erb
+++ b/source/user-guide/how-to-update-pagerduty-status-page.html.md.erb
@@ -14,7 +14,7 @@ If there is an incident you will need to update the external status page for the
 Status changes can be created in two ways the first way is by logging on to the pagerduty site and the other is by using the pugerduty incident creation app within slack via the /PD command.
 More information on how to raise an incident via slack is avalible on the incident process page [here](../runbooks/manage-an-incident.html#2-declare-the-incident)
 
-The next way you change change the status on the status page is by logging in to the pager duty site via the following [Link](https://moj-digital-tools.pagerduty.com/). Once logged in hover over the status menu option at the top right of the page then click on external status
+The next way you change change the status on the status page is by logging in to the pager duty site via the following [Link](https://moj-digital-tools.pagerduty.com/). Once logged in hover over the status menu option at the top right of the page then click on external status.
 when this page loads there will be two options to choice form click on the modernisation platform, it is from here you can click on post new incident and are presented with a form to fill.
 
 On the form you will need to select the incident status add a incident title and also a description, once you have done that you will also need to select which business service is impacted and also the impact to that service. The last item that needs to be selected is the amount of time until the next update, if you are happy with the information imputted click on the Post button.

--- a/source/user-guide/how-to-update-pagerduty-status-page.html.md.erb
+++ b/source/user-guide/how-to-update-pagerduty-status-page.html.md.erb
@@ -8,7 +8,7 @@ review_in: 6 months
 # <%= current_page.data.title %>
 
 ## Introduction
-Sometime you may need to update the external status page for the modernisation platform [modernisation platform status page](https://status.modernisation-platform.service.justice.gov.uk/) this guide will show you how to do this.
+If there is an incident you will need to update the external status page for the modernisation platform [modernisation platform status page](https://status.modernisation-platform.service.justice.gov.uk/) this guide will show you how to do this.
 
 ### Manually creating and updating status changes
 Status changes can be created in two ways the first way is by logging on to the pagerduty site and the other is by using the pugerduty incident creation app within slack via the /PD command.

--- a/source/user-guide/how-to-update-pagerduty-status-page.html.md.erb
+++ b/source/user-guide/how-to-update-pagerduty-status-page.html.md.erb
@@ -14,7 +14,7 @@ If there is an incident or planned you will need to update the external status p
 Incidents and maintenance window status can be created and updated in two ways, the first way is by logging on to the PagerDuty site and the other is by using the PugerDuty incident creation app within slack via the /pd command.
 More information on how to raise an incident via slack is avalible on the incident process page [here](../runbooks/manage-an-incident.html#2-declare-the-incident)
 
-The next way you change change the status on the status page is by logging in to the pager duty site via the following [Link](https://moj-digital-tools.pagerduty.com/). Once logged in hover over the status menu option at the top right of the page then click on external status.
+The next way you change the status on the status page is by logging in to the pager duty site via the following [Link](https://moj-digital-tools.pagerduty.com/). Once logged in hover over the status menu option at the top right of the page then click on external status.
 When this page loads there will be two options to choose from, click on the Modernisation Platform, from here you can click on post new incident, and will be presented with a form to fill in.
 
 On the form you will need to select the incident status add an incident title and also a description, once you have done that you will also need to select which business service is impacted and also the impact to that service. The last item that needs to be selected is the amount of time until the next update, if you are happy with the information inputted click on the Post button.

--- a/source/user-guide/how-to-update-pagerduty-status-page.html.md.erb
+++ b/source/user-guide/how-to-update-pagerduty-status-page.html.md.erb
@@ -8,7 +8,7 @@ review_in: 6 months
 # <%= current_page.data.title %>
 
 ## Introduction
-If there is an incident or planned you will need to update the external status page for the modernisation platform [modernisation platform status page](https://status.modernisation-platform.service.justice.gov.uk/) this guide will show you how to do this.
+If there is an incident or planned maintenance you will need to update the external status page for the modernisation platform [modernisation platform status page](https://status.modernisation-platform.service.justice.gov.uk/) this guide will show you how to do this.
 
 ### Manually creating and updating status changes
 Incidents and maintenance window status can be created and updated in two ways, the first way is by logging on to the PagerDuty site and the other is by using the PugerDuty incident creation app within slack via the /pd command.

--- a/source/user-guide/how-to-update-pagerduty-status-page.html.md.erb
+++ b/source/user-guide/how-to-update-pagerduty-status-page.html.md.erb
@@ -14,7 +14,7 @@ If there is an incident or planned maintenance you will need to update the exter
 Incidents and maintenance window status can be created and updated in two ways, the first way is by logging on to the PagerDuty site and the other is by using the PugerDuty incident creation app within slack via the /pd command.
 More information on how to raise an incident via slack is avalible on the incident process page [here](../runbooks/manage-an-incident.html#2-declare-the-incident)
 
-The next way you change the status on the status page is by logging in to the pager duty site via the following [Link](https://moj-digital-tools.pagerduty.com/). Once logged in hover over the status menu option at the top right of the page then click on external status.
+The other way you change the status on the status page is by logging in to the pager duty site via the following [Link](https://moj-digital-tools.pagerduty.com/). Once logged in hover over the status menu option at the top right of the page then click on external status.
 When this page loads there will be two options to choose from, click on the Modernisation Platform, from here you can click on post new incident, and will be presented with a form to fill in.
 
 On the form you will need to select the incident status add an incident title and also a description, once you have done that you will also need to select which business service is impacted and also the impact to that service. The last item that needs to be selected is the amount of time until the next update, if you are happy with the information inputted click on the Post button.

--- a/source/user-guide/how-to-update-pagerduty-status-page.html.md.erb
+++ b/source/user-guide/how-to-update-pagerduty-status-page.html.md.erb
@@ -11,7 +11,7 @@ review_in: 6 months
 If there is an incident you will need to update the external status page for the modernisation platform [modernisation platform status page](https://status.modernisation-platform.service.justice.gov.uk/) this guide will show you how to do this.
 
 ### Manually creating and updating status changes
-Status changes can be created in two ways the first way is by logging on to the pagerduty site and the other is by using the pugerduty incident creation app within slack via the /PD command.
+Incidents and associated status updates can be created in two ways, the first way is by logging on to the PagerDuty site and the other is by using the PugerDuty incident creation app within slack via the /PD command.
 More information on how to raise an incident via slack is avalible on the incident process page [here](../runbooks/manage-an-incident.html#2-declare-the-incident)
 
 The next way you change change the status on the status page is by logging in to the pager duty site via the following [Link](https://moj-digital-tools.pagerduty.com/). Once logged in hover over the status menu option at the top right of the page then click on external status.

--- a/source/user-guide/how-to-update-pagerduty-status-page.html.md.erb
+++ b/source/user-guide/how-to-update-pagerduty-status-page.html.md.erb
@@ -1,0 +1,19 @@
+---
+owner_slack: "#modernisation-platform"
+title: How to update the pagerduty status page in the Modernisation Platform
+last_reviewed_on: 2023-11-02
+review_in: 6 months
+---
+
+# <%= current_page.data.title %>
+
+## Introduction
+Sometime you may need to update the external status page for the modernisation platform [modernisation platform status page](https://status.modernisation-platform.service.justice.gov.uk/) this guide will show you how to do this.
+
+### Manually creating and updating status changes
+Status changes can be created in two ways the first way is by logging on ot the pager duty site and the other is by using the pugerduty incident creation app within slack via the /PD command.
+More information on how to raise an incident via slack is avalible on the incident process page [here](../runbooks/manage-an-incident.html#2-declare-the-incident)
+
+### Approving status changes
+
+### Subscribing to the status page

--- a/source/user-guide/how-to-update-pagerduty-status-page.html.md.erb
+++ b/source/user-guide/how-to-update-pagerduty-status-page.html.md.erb
@@ -23,7 +23,7 @@ This will then need to be approved before the status page is updated.
 
 ### Approving status changes
 
-Approvers will be notified of the new incident once it has been raised, approvers will then login to pagerduty to review the incident and once they are happy they will click on the publish button and the incident page will be updated
+Approvers will be notified of the new incident once it has been raised, approvers will then need to log in to PagerDuty to review the incident.  Once they are happy they can click on the publish button and the incident page will be updated.
 
 The status page will be updated automatically upon the pressing of the publish button and users will then be able to subscribe for updates.
 ### Subscribing to the status page

--- a/source/user-guide/how-to-update-pagerduty-status-page.html.md.erb
+++ b/source/user-guide/how-to-update-pagerduty-status-page.html.md.erb
@@ -8,10 +8,10 @@ review_in: 6 months
 # <%= current_page.data.title %>
 
 ## Introduction
-If there is an incident you will need to update the external status page for the modernisation platform [modernisation platform status page](https://status.modernisation-platform.service.justice.gov.uk/) this guide will show you how to do this.
+If there is an incident or planned you will need to update the external status page for the modernisation platform [modernisation platform status page](https://status.modernisation-platform.service.justice.gov.uk/) this guide will show you how to do this.
 
 ### Manually creating and updating status changes
-Incidents and associated status updates can be created in two ways, the first way is by logging on to the PagerDuty site and the other is by using the PugerDuty incident creation app within slack via the /PD command.
+Incidents and maintenance window status can be created and updated in two ways, the first way is by logging on to the PagerDuty site and the other is by using the PugerDuty incident creation app within slack via the /PD command.
 More information on how to raise an incident via slack is avalible on the incident process page [here](../runbooks/manage-an-incident.html#2-declare-the-incident)
 
 The next way you change change the status on the status page is by logging in to the pager duty site via the following [Link](https://moj-digital-tools.pagerduty.com/). Once logged in hover over the status menu option at the top right of the page then click on external status.

--- a/source/user-guide/how-to-update-pagerduty-status-page.html.md.erb
+++ b/source/user-guide/how-to-update-pagerduty-status-page.html.md.erb
@@ -17,7 +17,7 @@ More information on how to raise an incident via slack is avalible on the incide
 The next way you change change the status on the status page is by logging in to the pager duty site via the following [Link](https://moj-digital-tools.pagerduty.com/). Once logged in hover over the status menu option at the top right of the page then click on external status.
 When this page loads there will be two options to choose from, click on the Modernisation Platform, from here you can click on post new incident, and will be presented with a form to fill in.
 
-On the form you will need to select the incident status add a incident title and also a description, once you have done that you will also need to select which business service is impacted and also the impact to that service. The last item that needs to be selected is the amount of time until the next update, if you are happy with the information imputted click on the Post button.
+On the form you will need to select the incident status add an incident title and also a description, once you have done that you will also need to select which business service is impacted and also the impact to that service. The last item that needs to be selected is the amount of time until the next update, if you are happy with the information inputted click on the Post button.
 
 This in will then need to be approved before the status page is updated.
 

--- a/source/user-guide/how-to-update-pagerduty-status-page.html.md.erb
+++ b/source/user-guide/how-to-update-pagerduty-status-page.html.md.erb
@@ -11,7 +11,7 @@ review_in: 6 months
 Sometime you may need to update the external status page for the modernisation platform [modernisation platform status page](https://status.modernisation-platform.service.justice.gov.uk/) this guide will show you how to do this.
 
 ### Manually creating and updating status changes
-Status changes can be created in two ways the first way is by logging on ot the pager duty site and the other is by using the pugerduty incident creation app within slack via the /PD command.
+Status changes can be created in two ways the first way is by logging on to the pagerduty site and the other is by using the pugerduty incident creation app within slack via the /PD command.
 More information on how to raise an incident via slack is avalible on the incident process page [here](../runbooks/manage-an-incident.html#2-declare-the-incident)
 
 The next way you change change the status on the status page is by logging in to the pager duty site via the following [Link](https://moj-digital-tools.pagerduty.com/). Once logged in hover over the status menu option at the top right of the page then click on external status

--- a/source/user-guide/how-to-update-pagerduty-status-page.html.md.erb
+++ b/source/user-guide/how-to-update-pagerduty-status-page.html.md.erb
@@ -19,7 +19,7 @@ When this page loads there will be two options to choose from, click on the Mode
 
 On the form you will need to select the incident status add an incident title and also a description, once you have done that you will also need to select which business service is impacted and also the impact to that service. The last item that needs to be selected is the amount of time until the next update, if you are happy with the information inputted click on the Post button.
 
-This in will then need to be approved before the status page is updated.
+This will then need to be approved before the status page is updated.
 
 ### Approving status changes
 


### PR DESCRIPTION
This PR is for the documentation for the external pager duty page as part of [Configure and publish external status page#3784](https://github.com/ministryofjustice/modernisation-platform/issues/3784) 