### PR TITLE
add locals for csr

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "workspace/dora-the-explora"]
+	path = workspace/dora-the-explora
+	url = https://github.com/ministryofjustice/dora-the-explora

--- a/terraform/environments/core-network-services/cidr-ranges.tf
+++ b/terraform/environments/core-network-services/cidr-ranges.tf
@@ -22,6 +22,9 @@ locals {
     i2n                              = "10.110.0.0/16"
     moj-core-azure-1                 = "10.50.25.0/27"
     moj-core-azure-2                 = "10.50.26.0/24"
+    mojo-azure-landing-zone          = "10.192.0.0/16"
+    mojo-aws-globalprotect-vpc       = "10.184.0.0/16"
+    mojo-wifi                        = "10.154.0.0/15"
     parole-board                     = "10.50.0.0/16"
     psn                              = "51.0.0.0/8"
     psn-ppud                         = "51.247.2.115/32"
@@ -57,6 +60,15 @@ locals {
     delius-training = "10.162.96.0/20"
     delius-prod     = "10.160.16.0/20"
 
+    # csr application subnets
+    csr-pre-prod-private-west-2a = "10.27.0.0/24"
+    csr-pre-prod-private-west-2b = "10.27.1.0/24"
+    csr-pre-prod-private-west-2c = "10.27.2.0/24"
+
+    csr-prod-private-west-2a = "10.27.8.0/24"
+    csr-prod-private-west-2b = "10.27.9.0/24"
+    csr-prod-private-west-2c = "10.27.10.0/24"
+
     # laa landing zone cidr ranges
     laa-lz-development             = "10.202.0.0/20"
     laa-lz-test                    = "10.203.0.0/20"
@@ -74,5 +86,27 @@ locals {
     local.mp_core_cidr_ranges,
     local.platform_general_set_cidr_ranges,
     local.other_cidr_ranges
+  )
+
+  csr_preprod_cidr_ranges = merge(
+    local.other_cidr_ranges.csr-pre-prod-private-west-2a,
+    local.other_cidr_ranges.csr-pre-prod-private-west-2b,
+    local.other_cidr_ranges.csr-pre-prod-private-west-2c,
+  )
+
+  csr_prod_cidr_ranges = merge(
+    local.other_cidr_ranges.csr-prod-private-west-2a,
+    local.other_cidr_ranges.csr-prod-private-west-2b,
+    local.other_cidr_ranges.csr-prod-private-west-2c,
+  )
+
+  csr_external_access = merge(
+    local.other_cidr_ranges.mojo-azure-landing-zone,
+    local.other_cidr_ranges.mojo-aws-globalprotect-vpc,
+    local.other_cidr_ranges.mojo-wifi,
+    local.other_cidr_ranges.vodafone_wan_nicts_aggregate,
+    local.other_cidr_ranges.aks-studio-hosting-live-1-vnet,
+    local.other_cidr_ranges.atos_arkc_ras,
+    local.other_cidr_ranges.atos_arkf_ras,
   )
 }

--- a/terraform/environments/core-network-services/cidr-ranges.tf
+++ b/terraform/environments/core-network-services/cidr-ranges.tf
@@ -88,23 +88,19 @@ locals {
     local.other_cidr_ranges
   )
 
-  csr_preprod_cidr_ranges = {
-
+  csr_preprod_cidr_ranges = [
     local.other_cidr_ranges.csr-pre-prod-private-west-2a,
     local.other_cidr_ranges.csr-pre-prod-private-west-2b,
     local.other_cidr_ranges.csr-pre-prod-private-west-2c,
+  ]
 
-  }
-
-  csr_prod_cidr_ranges = {
-
+  csr_prod_cidr_ranges = [
     local.other_cidr_ranges.csr-prod-private-west-2a,
     local.other_cidr_ranges.csr-prod-private-west-2b,
     local.other_cidr_ranges.csr-prod-private-west-2c,
+  ]
 
-  }
-
-  csr_external_access = {
+  csr_external_access = [
     local.other_cidr_ranges.mojo-azure-landing-zone,
     local.other_cidr_ranges.mojo-aws-globalprotect-vpc,
     local.other_cidr_ranges.mojo-wifi,
@@ -112,5 +108,5 @@ locals {
     local.other_cidr_ranges.aks-studio-hosting-live-1-vnet,
     local.other_cidr_ranges.atos_arkc_ras,
     local.other_cidr_ranges.atos_arkf_ras,
-  }
+  ]
 }

--- a/terraform/environments/core-network-services/cidr-ranges.tf
+++ b/terraform/environments/core-network-services/cidr-ranges.tf
@@ -88,19 +88,23 @@ locals {
     local.other_cidr_ranges
   )
 
-  csr_preprod_cidr_ranges = merge(
+  csr_preprod_cidr_ranges = {
+
     local.other_cidr_ranges.csr-pre-prod-private-west-2a,
     local.other_cidr_ranges.csr-pre-prod-private-west-2b,
     local.other_cidr_ranges.csr-pre-prod-private-west-2c,
-  )
 
-  csr_prod_cidr_ranges = merge(
+  }
+
+  csr_prod_cidr_ranges = {
+
     local.other_cidr_ranges.csr-prod-private-west-2a,
     local.other_cidr_ranges.csr-prod-private-west-2b,
     local.other_cidr_ranges.csr-prod-private-west-2c,
-  )
 
-  csr_external_access = merge(
+  }
+
+  csr_external_access = {
     local.other_cidr_ranges.mojo-azure-landing-zone,
     local.other_cidr_ranges.mojo-aws-globalprotect-vpc,
     local.other_cidr_ranges.mojo-wifi,
@@ -108,5 +112,5 @@ locals {
     local.other_cidr_ranges.aks-studio-hosting-live-1-vnet,
     local.other_cidr_ranges.atos_arkc_ras,
     local.other_cidr_ranges.atos_arkf_ras,
-  )
+  }
 }

--- a/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
@@ -341,5 +341,12 @@
     "destination_ip": "${noms-mgmt-vnet}",
     "destination_port": "138",
     "protocol": "UDP"
+  },
+  "csr_external_to_csr_preproduction_45054": {
+    "action": "PASS",
+    "source_ip": "${local.csr_external_access}",
+    "destination_ip": "${local.csr_preprod_cidr_ranges}",
+    "destination_port": "45054",
+    "protocol": "TCP"
   }
 }

--- a/terraform/environments/core-network-services/locals.tf
+++ b/terraform/environments/core-network-services/locals.tf
@@ -32,8 +32,8 @@ locals {
 
   development_rules     = fileexists("./firewall-rules/development_rules.json") ? jsondecode(templatefile("./firewall-rules/development_rules.json", local.all_cidr_ranges)) : {}
   test_rules            = fileexists("./firewall-rules/test_rules.json") ? jsondecode(templatefile("./firewall-rules/test_rules.json", local.all_cidr_ranges)) : {}
-  preproduction_rules   = fileexists("./firewall-rules/preproduction_rules.json") ? jsondecode(templatefile("./firewall-rules/preproduction_rules.json", local.all_cidr_ranges)) : {}
-  production_rules      = fileexists("./firewall-rules/production_rules.json") ? jsondecode(templatefile("./firewall-rules/production_rules.json", local.all_cidr_ranges)) : {}
+  preproduction_rules   = fileexists("./firewall-rules/preproduction_rules.json") ? jsondecode(templatefile("./firewall-rules/preproduction_rules.json", local.all_cidr_ranges, local.csr_preprod_cidr_ranges, local.csr_external_access)) : {}
+  production_rules      = fileexists("./firewall-rules/production_rules.json") ? jsondecode(templatefile("./firewall-rules/production_rules.json", local.all_cidr_ranges, local.csr_prod_cidr_ranges, local.csr_external_access)) : {}
   fqdn_firewall_rules   = fileexists("./firewall-rules/fqdn_rules.json") ? jsondecode(file("./firewall-rules/fqdn_rules.json")) : {}
   inline_firewall_rules = fileexists("./firewall-rules/inline_rules.json") ? jsondecode(templatefile("./firewall-rules/inline_rules.json", local.all_cidr_ranges)) : {}
   firewall_rules        = merge(local.development_rules, local.test_rules, local.preproduction_rules, local.production_rules)

--- a/terraform/environments/core-network-services/outputs.tf
+++ b/terraform/environments/core-network-services/outputs.tf
@@ -1,0 +1,11 @@
+output "all_cidr_ranges" {
+    value = local.all_cidr_ranges
+}
+
+output "csr_preprod_cidr_ranges" {
+    value = local.csr_preprod_cidr_ranges
+}
+
+output "csr_external_access" {
+    value = local.csr_external_access
+}


### PR DESCRIPTION
## A reference to the issue / Description of it.

Need very specific external access from MoJo devices to CSR prod and pre-prod application hosts ONLY

## How does this PR fix the problem?

Not yet, I need to see the plan output to check my terraform even works

## How has this been tested?

Will be tested from MoJo devices post deployment. It is pretty clear that MoJo -> AWS Instance traffic is blocked by the AWS firewall however

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it? 

No

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

As I'm unable to run plans locally at the moment this PR is still in progress. Ignore for now 