### PR TITLE
Add ssm:TerminateSession action to OIDC role policy

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -462,6 +462,7 @@ data "aws_iam_policy_document" "policy" {
       "ssm:DescribeSessions",
       "ssm:ResumeSession",
       "ssm:StartSession",
+      "ssm:TerminateSession"
     ]
     resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
   }


### PR DESCRIPTION
A follow-up to the previous PR to add various permissions to allow SSH over SSM for our GitHub Workflows:
https://github.com/ministryofjustice/modernisation-platform/pull/5384

The session can be established, however it cannot close cleanly without the `ssm:TerminateSession` action permission. Adding it back in.