### PR TITLE
mojo access to csr app in pre-prod

### DIFF
--- a/terraform/environments/core-network-services/cidr-ranges.tf
+++ b/terraform/environments/core-network-services/cidr-ranges.tf
@@ -68,10 +68,8 @@ locals {
     laa-appstream-vpc              = "10.200.32.0/19"
     laa-appstream-vpc_additional   = "10.200.68.0/22"
 
-    # csr app cidr ranges
-    csr-preprod = "10.27.0.0/22"
-    # csr-prod = "10.27.10.0/22" not yet implemented
-
+    hmpps-preproduction-general-private-subnets = "10.27.0.0/22"
+    # hmpps-production-general-private-subnets = "10.27.10.0/22" not yet implemented
   }
 
   all_cidr_ranges = merge(

--- a/terraform/environments/core-network-services/cidr-ranges.tf
+++ b/terraform/environments/core-network-services/cidr-ranges.tf
@@ -68,6 +68,10 @@ locals {
     laa-appstream-vpc              = "10.200.32.0/19"
     laa-appstream-vpc_additional   = "10.200.68.0/22"
 
+    # csr app cidr ranges
+    csr-preprod = "10.27.0.0/22"
+    # csr-prod = "10.27.10.0/22" not yet implemented
+
   }
 
   all_cidr_ranges = merge(

--- a/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
@@ -341,5 +341,54 @@
     "destination_ip": "${noms-mgmt-vnet}",
     "destination_port": "138",
     "protocol": "UDP"
+  },
+  "mojo_to_csr_preproduction_http": {
+    "action": "PASS",
+    "source_ip": "10.0.0.0/8",
+    "destination_ip": "${csr-preprod}",
+    "destination_port": "80",
+    "protocol": "TCP"
+  },
+  "mojo_to_csr_preproduction_app_core_7770": {
+    "action": "PASS",
+    "source_ip": "10.0.0.0/8",
+    "destination_ip": "${csr-preprod}",
+    "destination_port": "7770",
+    "protocol": "TCP"
+  },
+  "mojo_to_csr_preproduction_app_core_7771": {
+    "action": "PASS",
+    "source_ip": "10.0.0.0/8",
+    "destination_ip": "${csr-preprod}",
+    "destination_port": "7771",
+    "protocol": "TCP"
+  },
+  "mojo_to_csr_preproduction_app_custom_7780": {
+    "action": "PASS",
+    "source_ip": "10.0.0.0/8",
+    "destination_ip": "${csr-preprod}",
+    "destination_port": "7780",
+    "protocol": "TCP"
+  },
+  "mojo_to_csr_preproduction_app_custom_7781": {
+    "action": "PASS",
+    "source_ip": "10.0.0.0/8",
+    "destination_ip": "${csr-preprod}",
+    "destination_port": "7781",
+    "protocol": "TCP"
+  },
+  "mojo_to_csr_preproduction_2109": {
+    "action": "PASS",
+    "source_ip": "10.0.0.0/8",
+    "destination_ip": "${csr-preprod}",
+    "destination_port": "2109",
+    "protocol": "TCP"
+  },
+  "mojo_to_csr_preproduction_45054": {
+    "action": "PASS",
+    "source_ip": "10.0.0.0/8",
+    "destination_ip": "${csr-preprod}",
+    "destination_port": "45054",
+    "protocol": "TCP"
   }
 }

--- a/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
@@ -345,49 +345,49 @@
   "mojo_to_csr_preproduction_http": {
     "action": "PASS",
     "source_ip": "10.0.0.0/8",
-    "destination_ip": "${csr-preprod}",
+    "destination_ip": "${ hmpps-preproduction-general-private-subnets}",
     "destination_port": "80",
     "protocol": "TCP"
   },
   "mojo_to_csr_preproduction_app_core_7770": {
     "action": "PASS",
     "source_ip": "10.0.0.0/8",
-    "destination_ip": "${csr-preprod}",
+    "destination_ip": "${ hmpps-preproduction-general-private-subnets}",
     "destination_port": "7770",
     "protocol": "TCP"
   },
   "mojo_to_csr_preproduction_app_core_7771": {
     "action": "PASS",
     "source_ip": "10.0.0.0/8",
-    "destination_ip": "${csr-preprod}",
+    "destination_ip": "${ hmpps-preproduction-general-private-subnets}",
     "destination_port": "7771",
     "protocol": "TCP"
   },
   "mojo_to_csr_preproduction_app_custom_7780": {
     "action": "PASS",
     "source_ip": "10.0.0.0/8",
-    "destination_ip": "${csr-preprod}",
+    "destination_ip": "${ hmpps-preproduction-general-private-subnets}",
     "destination_port": "7780",
     "protocol": "TCP"
   },
   "mojo_to_csr_preproduction_app_custom_7781": {
     "action": "PASS",
     "source_ip": "10.0.0.0/8",
-    "destination_ip": "${csr-preprod}",
+    "destination_ip": "${ hmpps-preproduction-general-private-subnets}",
     "destination_port": "7781",
     "protocol": "TCP"
   },
   "mojo_to_csr_preproduction_2109": {
     "action": "PASS",
     "source_ip": "10.0.0.0/8",
-    "destination_ip": "${csr-preprod}",
+    "destination_ip": "${ hmpps-preproduction-general-private-subnets}",
     "destination_port": "2109",
     "protocol": "TCP"
   },
   "mojo_to_csr_preproduction_45054": {
     "action": "PASS",
     "source_ip": "10.0.0.0/8",
-    "destination_ip": "${csr-preprod}",
+    "destination_ip": "${ hmpps-preproduction-general-private-subnets}",
     "destination_port": "45054",
     "protocol": "TCP"
   }


### PR DESCRIPTION
## A reference to the issue / Description of it.

CSR application needs to have external MoJo devices access it directly on the following ports - 80, 7770, 7771, 7780, 7781, 2109, 45054. 

**IMPORTANT** This has been implemented in the pre-prod environment only at the moment for testing MoJo connectivity and app performance wrt CSR. 

Initially attempted to lock this down so that 'incomiing' (sources) is restricted to the following: -

```
mojo-azure-landing-zone          = “10.192.0.0/16”
mojo-aws-globalprotect-vpc       = “10.184.0.0/16"
mojo-wifi                        = “10.154.0.0/15”
vodafone_wan_nicts_aggregate     = “10.80.0.0/12"
atos_arkc_ras                    = “10.175.0.0/16”
atos_arkf_ras                    = “10.176.0.0/16"
aks-studio-hosting-live-1-vnet   = “10.244.0.0/20”
```

But, neither `source_ip` or `destination_ip` values allowed in pre_production.json allow lists so the source_ip value is currently set for all these rules to `10.0.0.0/8` 

Destination value is set to `10.27.0.0/22` which covers all the CSR preproduction private subnets but has been named `hmpps-preproduction-general-private-subnets` as there's no way to limit this further. Above all I'm trying to not create many, many rules per port 
 
## How does this PR fix the problem?

Allows the external mojo devices to connect in to the pre-prod CSR instances running the app

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Mojo devices on Global Protect were blocked on port 45054 and others are required

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it? 

Should allow us to test CSR Pre-Prod with MoJo devices and diagnose any other app connectivity issues

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation - no changes needed
- [ ] Plan and discussed how it should be deployed to PROD (If needed) - SEE BELOW

## Additional comments (if any)

- not sure about the naming of the rule rfc_10-0-0-0-8_to_ppud_preproduction_https as it's not ppud specific? 
  - Does this need renaming to be more generic?

- Suggest improving the firewall rules to allow lists, as per [specifications using rule variables](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/networkfirewall_rule_group#stateful-inspection-from-rule-group-specifications-using-rule-variables-and-suricata-format-rules) 

- If it's possible to make the access more restrictive we should _probably_ aim to do this for production

- **IMPORTANT** Either I don't understand the plan output when it comes to the firewall OR there are a number of changes in here that _seem_ to be radically changing rules? 