### PR TITLE
move auth0 logs

### DIFF
--- a/terraform/environments/data-platform-apps-and-tools/auth0-log-streams.tf
+++ b/terraform/environments/data-platform-apps-and-tools/auth0-log-streams.tf
@@ -1,0 +1,10 @@
+resource "auth0_log_stream" "aws_eventbridge" {
+  name   = "AWS Eventbridge"
+  type   = "eventbridge"
+  status = "active"
+
+  sink {
+    aws_account_id = data.aws_caller_identity.current.account_id
+    aws_region     = data.aws_region.current.name
+  }
+}

--- a/terraform/environments/data-platform-apps-and-tools/cloudwatch-log-groups.tf
+++ b/terraform/environments/data-platform-apps-and-tools/cloudwatch-log-groups.tf
@@ -30,3 +30,8 @@ resource "aws_cloudwatch_log_resource_policy" "opensearch_cloudwatch_logs" {
   policy_name     = "opensearch-cloudwatch-logs"
   policy_document = data.aws_iam_policy_document.opensearch_cloudwatch_logs.json
 }
+
+resource "aws_cloudwatch_log_group" "auth0" {
+  #ts:skip=AWS.ACLG.LM.MEDIUM.0068 this is nonproduction code, will be addresses when productionised
+  name = "/aws/events/auth0/alpha-analytics-moj"
+}

--- a/terraform/environments/data-platform-apps-and-tools/data.tf
+++ b/terraform/environments/data-platform-apps-and-tools/data.tf
@@ -51,19 +51,19 @@ data "aws_secretsmanager_secret_version" "openmetadata_entra_id_tenant_id" {
 ##################################################
 
 data "aws_secretsmanager_secret_version" "auth0_domain" {
-  provider = aws.analytical-platform-management-production
+  provider = aws.modernisation-platform
 
   secret_id = "auth0/domain"
 }
 
 data "aws_secretsmanager_secret_version" "auth0_client_id" {
-  provider = aws.analytical-platform-management-production
+  provider = aws.modernisation-platform
 
   secret_id = "auth0/client-id"
 }
 
 data "aws_secretsmanager_secret_version" "auth0_client_secret" {
-  provider = aws.analytical-platform-management-production
+  provider = aws.modernisation-platform
 
   secret_id = "auth0/client-secret"
 }

--- a/terraform/environments/data-platform-apps-and-tools/data.tf
+++ b/terraform/environments/data-platform-apps-and-tools/data.tf
@@ -45,3 +45,29 @@ data "aws_secretsmanager_secret_version" "openmetadata_entra_id_client_id" {
 data "aws_secretsmanager_secret_version" "openmetadata_entra_id_tenant_id" {
   secret_id = "openmetadata/entra-id/tenant-id"
 }
+
+##################################################
+# Data Platform Apps and Tools AuthO
+##################################################
+
+data "aws_secretsmanager_secret_version" "auth0_domain" {
+  provider = aws.analytical-platform-management-production
+
+  secret_id = "auth0/domain"
+}
+
+data "aws_secretsmanager_secret_version" "auth0_client_id" {
+  provider = aws.analytical-platform-management-production
+
+  secret_id = "auth0/client-id"
+}
+
+data "aws_secretsmanager_secret_version" "auth0_client_secret" {
+  provider = aws.analytical-platform-management-production
+
+  secret_id = "auth0/client-secret"
+}
+
+data "aws_cloudwatch_event_bus" "auth0" {
+  name = "aws.partner/auth0.com/alpha-analytics-moj-c855a398-59a4-44d3-b042-7873e5a9ba75/auth0.logs" // This was created by Auth0, we accepted it in the UI
+}

--- a/terraform/environments/data-platform-apps-and-tools/eventbridge-rules.tf
+++ b/terraform/environments/data-platform-apps-and-tools/eventbridge-rules.tf
@@ -1,0 +1,10 @@
+resource "aws_cloudwatch_event_rule" "auth0_cloudwatch" {
+  name           = "auth0-to-cloudwatch-logs"
+  event_bus_name = data.aws_cloudwatch_event_bus.auth0.name
+
+  event_pattern = jsonencode({
+    source = [{
+      prefix = "aws.partner/auth0.com"
+    }]
+  })
+}

--- a/terraform/environments/data-platform-apps-and-tools/eventbridge-targets.tf
+++ b/terraform/environments/data-platform-apps-and-tools/eventbridge-targets.tf
@@ -1,0 +1,6 @@
+resource "aws_cloudwatch_event_target" "auth0" {
+  target_id      = "Idebe8360d-2f5a-4136-9bbe-977efb26a16a" // This is because I ClickOps'd the target in the UI
+  event_bus_name = data.aws_cloudwatch_event_bus.auth0.name
+  rule           = aws_cloudwatch_event_rule.auth0_cloudwatch.name
+  arn            = aws_cloudwatch_log_group.auth0.arn
+}

--- a/terraform/environments/data-platform-apps-and-tools/providers.tf
+++ b/terraform/environments/data-platform-apps-and-tools/providers.tf
@@ -53,3 +53,9 @@ provider "helm" {
     }
   }
 }
+
+provider "auth0" {
+  domain        = data.aws_secretsmanager_secret_version.auth0_domain.secret_string
+  client_id     = data.aws_secretsmanager_secret_version.auth0_client_id.secret_string
+  client_secret = data.aws_secretsmanager_secret_version.auth0_client_secret.secret_string
+}

--- a/terraform/environments/data-platform-apps-and-tools/versions.tf
+++ b/terraform/environments/data-platform-apps-and-tools/versions.tf
@@ -20,6 +20,10 @@ terraform {
       source  = "hashicorp/random"
       version = "~> 3.0"
     }
+    auth0 = {
+      source  = "auth0/auth0"
+      version = "1.0.0"
+    }
   }
   required_version = "~> 1.0"
 }


### PR DESCRIPTION
This pr is to enable the move of Auth0 logs to MP 

Value / Purpose
Currently we are collecting auth0 logs in a cloudwatch log group in Analytical Platform account and we'd like to collect this in the data-platform-apps-and-tools account  so we can ingest them into our logging stack.
