### PR TITLE
Adding a new ecr repo for future lambda image

### DIFF
--- a/terraform/environments/core-shared-services/ecr_repos.tf
+++ b/terraform/environments/core-shared-services/ecr_repos.tf
@@ -803,3 +803,26 @@ module "data_platform_delete_data_product_ecr_repo" {
   # Tags
   tags_common = local.tags
 }
+
+module "data_platform_jml_ecr_repo" {
+  source = "../../modules/app-ecr-repo"
+
+  app_name = "data-platform-jml-extract-lambda"
+
+  push_principals = [
+    "arn:aws:iam::${local.environment_management.account_ids["data-platform-development"]}:role/modernisation-platform-oidc-cicd",
+    local.environment_management.account_ids["data-platform-apps-and-tools-production"],
+  ]
+
+  pull_principals = [
+    "arn:aws:iam::${local.environment_management.account_ids["data-platform-development"]}:role/modernisation-platform-oidc-cicd",
+    local.environment_management.account_ids["data-platform-apps-and-tools-production"],
+  ]
+
+  enable_retrieval_policy_for_lambdas = [
+    "arn:aws:lambda:eu-west-2:${local.environment_management.account_ids["data-platform-apps-and-tools-production"]}:function:data_platform_jml_extract*",
+  ]
+
+  # Tags
+  tags_common = local.tags
+}


### PR DESCRIPTION
## A reference to the issue / Description of it.

We are creating a lambda function to read logs and output an excel file from them. As a consequence, we will need an ECR repo to store the image for the lambda/requirements file.

## How does this PR fix the problem?

This adds terraform to create the new repo.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

It has not, but is patterned on existing code to do the same.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it? 

No

## Checklist (check `x` in `[ ]` of list items)

- [ x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
