### PR TITLE
create planetfm alarms slack/pagerduty connection

### DIFF
--- a/terraform/pagerduty/aws.tf
+++ b/terraform/pagerduty/aws.tf
@@ -45,6 +45,7 @@ resource "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {
     laa_maat_prod_alarm          = pagerduty_service_integration.laa_maat_prod_cloudwatch.integration_key,
     csr_alarms                   = pagerduty_service_integration.csr_cloudwatch.integration_key,
     dpr_nonprod_alarms           = pagerduty_service_integration.dpr_nonprod_cloudwatch.integration_key,
+    planetfm_alarms              = pagerduty_service_integration.planetfm_cloudwatch.integration_key,
   })
 }
 

--- a/terraform/pagerduty/member-services-integrations.tf
+++ b/terraform/pagerduty/member-services-integrations.tf
@@ -951,6 +951,7 @@ resource "pagerduty_service_integration" "laa_maat_prod_cloudwatch" {
 
 # Slack channel: #laa-alerts-maat-prod
 
+# Slack channel: #csr_alerts_modernisation_platform
 resource "pagerduty_service" "csr" {
   name                    = "Csr Alarms"
   description             = "Csr Alarms"
@@ -1053,3 +1054,57 @@ resource "pagerduty_slack_connection" "dpr_nonprod_connection" {
     priorities = ["*"]
   }
 }
+
+# DPR Non Prod
+
+# Slack channel: #planetfm_alerts_modernisation_platform
+resource "pagerduty_service" "planetfm" {
+  name                    = "PlanetFM Alarms"
+  description             = "PlanetFM Alarms"
+  auto_resolve_timeout    = 345600
+  acknowledgement_timeout = "null"
+  escalation_policy       = pagerduty_escalation_policy.member_policy.id
+  alert_creation          = "create_alerts_and_incidents"
+}
+
+resource "pagerduty_service_integration" "planetfm_cloudwatch" {
+  name    = data.pagerduty_vendor.cloudwatch.name
+  service = pagerduty_service.planetfm.id
+  vendor  = data.pagerduty_vendor.cloudwatch.id
+}
+
+resource "pagerduty_slack_connection" "planetfm_connection" {
+  source_id         = pagerduty_service.planetfm.id
+  source_type       = "service_reference"
+  workspace_id      = local.slack_workspace_id
+  channel_id        = "C064KHB3HB9" # Sending to planetfm_alerts_modernisation_platform
+  notification_type = "responder"
+  lifecycle {
+    ignore_changes = [
+      config,
+    ]
+  }
+  config {
+    events = [
+      "incident.triggered",
+      "incident.acknowledged",
+      "incident.escalated",
+      "incident.resolved",
+      "incident.reassigned",
+      "incident.annotated",
+      "incident.unacknowledged",
+      "incident.delegated",
+      "incident.priority_updated",
+      "incident.action_invocation.created",
+      "incident.action_invocation.terminated",
+      "incident.action_invocation.updated",
+      "incident.responder.added",
+      "incident.responder.replied",
+      "incident.status_update_published",
+      "incident.reopened"
+    ]
+
+    priorities = ["*"]
+  }
+}
+# Slack channel: #planetfm_alerts_modernisation_platform


### PR DESCRIPTION
## A reference to the issue / Description of it

Adding pagerduty integration for PlanetFM instance alarms

## How does this PR fix the problem?

Makes sns topic planetfm_alarms available for alarms to be sent to 

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Reproduces what's already working for nomis etc.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

Will implement the sns topic part for alarms for planetfm in the modernisation-platform-environments repo shortly