### PR TITLE
🚑 Fix applying to production logic

### DIFF
--- a/.github/workflows/terraform-member-environment.yml
+++ b/.github/workflows/terraform-member-environment.yml
@@ -199,7 +199,7 @@ jobs:
           echo "::warning ::Terraform plan was skipped as no valid workspace was found."
 
   terraform-apply-preprod-prod:
-    if: ${{ github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main' }}
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: [find-environments, terraform-plan]
     strategy:


### PR DESCRIPTION
## A reference to the issue / Description of it

Resolves https://github.com/ministryofjustice/modernisation-platform/issues/5432

## How does this PR fix the problem?

It runs this job when merging to main similar to how we do in [data-platform](https://github.com/ministryofjustice/data-platform/blob/46f0868b8c77bffc0de91a0e6825928811c15bd7/.github/workflows/reusable-workflow-terraform.yml#L345)

## How has this been tested?

Its the same logic as [data-platform](https://github.com/ministryofjustice/data-platform/blob/46f0868b8c77bffc0de91a0e6825928811c15bd7/.github/workflows/reusable-workflow-terraform.yml#L345)

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

We thought about using 

```yaml
if: github.event.pull_request.merged == true
```
but would need to add

```yaml
on:
  pull_request:
    types:
      - closed
```

which might require removing

```yaml
on:
  push:
    branches:
      - main
```