### PR TITLE
Change of the time for instance schedular

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
@@ -341,12 +341,5 @@
     "destination_ip": "${noms-mgmt-vnet}",
     "destination_port": "138",
     "protocol": "UDP"
-  },
-  "mojo_to_csr_preproduction_2109": {
-    "action": "PASS",
-    "source_ip": "10.192.1.1",
-    "destination_ip": "10.27.2.12",
-    "destination_port": "2109",
-    "protocol": "TCP"
   }
 }

--- a/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
@@ -341,5 +341,12 @@
     "destination_ip": "${noms-mgmt-vnet}",
     "destination_port": "138",
     "protocol": "UDP"
+  },
+  "mojo_to_csr_preproduction_2109": {
+    "action": "PASS",
+    "source_ip": "10.192.1.1",
+    "destination_ip": "10.27.2.12",
+    "destination_port": "2109",
+    "protocol": "TCP"
   }
 }

--- a/terraform/environments/core-shared-services/instance-scheduler-lambda-function.tf
+++ b/terraform/environments/core-shared-services/instance-scheduler-lambda-function.tf
@@ -39,7 +39,7 @@ module "instance_scheduler" {
 resource "aws_cloudwatch_event_rule" "instance_scheduler_weekly_stop_at_night" {
   name                = "instance_scheduler_weekly_stop_at_night"
   description         = "Call Instance Scheduler with Stop action at 8:00 pm (UTC) every Monday through Friday"
-  schedule_expression = "cron(0 20 ? * MON-FRI *)"
+  schedule_expression = "cron(0 21 ? * MON-FRI *)"
 }
 
 resource "aws_cloudwatch_event_target" "instance_scheduler_weekly_stop_at_night" {
@@ -60,7 +60,7 @@ resource "aws_cloudwatch_event_target" "instance_scheduler_weekly_stop_at_night"
 resource "aws_cloudwatch_event_rule" "instance_scheduler_weekly_start_in_the_morning" {
   name                = "instance_scheduler_weekly_start_in_the_morning"
   description         = "Call Instance Scheduler with Start action at 5:00 am (UTC) every Monday through Friday"
-  schedule_expression = "cron(0 5 ? * MON-FRI *)"
+  schedule_expression = "cron(0 6 ? * MON-FRI *)"
 }
 
 resource "aws_cloudwatch_event_target" "instance_scheduler_weekly_start_in_the_morning" {

--- a/terraform/environments/core-shared-services/instance-scheduler-lambda-function.tf
+++ b/terraform/environments/core-shared-services/instance-scheduler-lambda-function.tf
@@ -39,7 +39,7 @@ module "instance_scheduler" {
 resource "aws_cloudwatch_event_rule" "instance_scheduler_weekly_stop_at_night" {
   name                = "instance_scheduler_weekly_stop_at_night"
   description         = "Call Instance Scheduler with Stop action at 8:00 pm (UTC) every Monday through Friday"
-  schedule_expression = "cron(0 21 ? * MON-FRI *)"
+  schedule_expression = "cron(0 19 ? * MON-FRI *)"
 }
 
 resource "aws_cloudwatch_event_target" "instance_scheduler_weekly_stop_at_night" {
@@ -60,7 +60,7 @@ resource "aws_cloudwatch_event_target" "instance_scheduler_weekly_stop_at_night"
 resource "aws_cloudwatch_event_rule" "instance_scheduler_weekly_start_in_the_morning" {
   name                = "instance_scheduler_weekly_start_in_the_morning"
   description         = "Call Instance Scheduler with Start action at 5:00 am (UTC) every Monday through Friday"
-  schedule_expression = "cron(0 6 ? * MON-FRI *)"
+  schedule_expression = "cron(0 4 ? * MON-FRI *)"
 }
 
 resource "aws_cloudwatch_event_target" "instance_scheduler_weekly_start_in_the_morning" {


### PR DESCRIPTION
## A reference to the issue / Description of it

The current way we schedule the lambda to run for instance scheduler is based on UTC time and does not take into account daylight savings time

## How does this PR fix the problem?

This PR amends the cron job to account for the daylights savings

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

it will implement a temporary fix that will stop the instances from being shutdown to early

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
