### PR TITLE
added rules for DOM1 devices to access mp dev

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/development_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/development_rules.json
@@ -348,5 +348,19 @@
     "destination_ip": "${noms-mgmt-vnet}",
     "destination_port": "138",
     "protocol": "UDP"
+  },
+  "DOM1_atos_arkc_ras_vpn_to_mp_development": {
+    "action": "PASS",
+    "source_ip": "10.175.0.0/16", 
+    "destination_ip": "${mp-development-test}",
+    "destination_port": "443",
+    "protocol": "TCP"
+  },
+  "DOM1_atos_arkf_ras_vpn_to_mp_developmen": {
+    "action": "PASS",
+    "source_ip": "10.176.0.0/16", 
+    "destination_ip": "${mp-development-test}",
+    "destination_port": "443",
+    "protocol": "TCP"
   }
 }

--- a/terraform/environments/core-network-services/firewall-rules/development_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/development_rules.json
@@ -351,14 +351,14 @@
   },
   "DOM1_atos_arkc_ras_vpn_to_mp_development": {
     "action": "PASS",
-    "source_ip": "10.175.0.0/16", 
+    "source_ip": "${atos_arkc_ras}", 
     "destination_ip": "${mp-development-test}",
     "destination_port": "443",
     "protocol": "TCP"
   },
-  "DOM1_atos_arkf_ras_vpn_to_mp_developmen": {
+  "DOM1_atos_arkf_ras_vpn_to_mp_development": {
     "action": "PASS",
-    "source_ip": "10.176.0.0/16", 
+    "source_ip": "${atos_arkf_ras}", 
     "destination_ip": "${mp-development-test}",
     "destination_port": "443",
     "protocol": "TCP"


### PR DESCRIPTION
## A reference to the issue / Description of it

This is for a some testing for connectivity between DOM1 devices connected to the ATOS VPNs to the MP development VPC where I have built a test loadbalancer/web server so w ecan test the connection.

## How does this PR fix the problem?

Adds connectivity required for the testing.
## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

No testing yet - we need the rule in place on the firewall so the network connectivity can be tested.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

It will open up connectivity from DOM1 to the MP development VPC so will open up connectivity to other users of that VPC although I think we are happy with this.

## Checklist (check `x` in `[ ]` of list items)

- [x ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)
