### PR TITLE
add pager duty config for pra, tipstaff and dacp apps

### DIFF
--- a/terraform/pagerduty/aws.tf
+++ b/terraform/pagerduty/aws.tf
@@ -50,6 +50,12 @@ resource "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {
     ncas_prod_alarms             = pagerduty_service_integration.ncas_prod_cloudwatch.integration_key,
     wardship_non_prod_alarms     = pagerduty_service_integration.wardship_non_prod_cloudwatch.integration_key,
     wardship_prod_alarms         = pagerduty_service_integration.wardship_prod_cloudwatch.integration_key,
+    pra_non_prod_alarms          = pagerduty_service_integration.pra_non_prod_cloudwatch.integration_key,
+    pra_prod_alarms              = pagerduty_service_integration.pra_prod_cloudwatch.integration_key,
+    tipstaff_non_prod_alarms     = pagerduty_service_integration.tipstaff_non_prod_cloudwatch.integration_key,
+    tipstaff_prod_alarms         = pagerduty_service_integration.tipstaff_prod_cloudwatch.integration_key,
+    dacp_non_prod_alarms         = pagerduty_service_integration.dacp_non_prod_cloudwatch.integration_key,
+    dacp_prod_alarms             = pagerduty_service_integration.dacp_prod_cloudwatch.integration_key,
   })
 }
 

--- a/terraform/pagerduty/member-services-integrations.tf
+++ b/terraform/pagerduty/member-services-integrations.tf
@@ -1296,3 +1296,285 @@ resource "pagerduty_slack_connection" "wardship_prod_connection" {
 }
 
 # Slack channel: #cloudwatch_alerts_modernisation_platform_legacy_apps
+
+# PRA non prod
+resource "pagerduty_service" "pra_non_prod" {
+  name                    = "pra non prod alarms"
+  description             = "pra non prod alarms (preproduction)"
+  auto_resolve_timeout    = 345600
+  acknowledgement_timeout = "null"
+  escalation_policy       = pagerduty_escalation_policy.member_policy.id
+  alert_creation          = "create_alerts_and_incidents"
+}
+
+resource "pagerduty_service_integration" "pra_non_prod_cloudwatch" {
+  name    = data.pagerduty_vendor.cloudwatch.name
+  service = pagerduty_service.pra_non_prod.id
+  vendor  = data.pagerduty_vendor.cloudwatch.id
+}
+
+resource "pagerduty_slack_connection" "pra_non_prod_connection" {
+  source_id = pagerduty_service.pra_non_prod.id
+  source_type = "service_reference"
+  workspace_id = local.slack_workspace_id
+  channel_id = "C065VSLNFTJ"
+  notification_type = "responder"
+  config {
+    events = [
+      "incident.triggered",
+      "incident.acknowledged",
+      "incident.escalated",
+      "incident.resolved",
+      "incident.reassigned",
+      "incident.annotated",
+      "incident.unacknowledged",
+      "incident.delegated",
+      "incident.priority_updated",
+      "incident.responder.added",
+      "incident.responder.replied",
+      "incident.action_invocation.created",
+      "incident.action_invocation.terminated",
+      "incident.action_invocation.updated",
+      "incident.status_update_published",
+      "incident.reopened"
+    ]
+    priorities = ["*"]
+  }
+}
+
+# Slack channel: #cloudwatch_alerts_modernisation_platform_legacy_apps
+
+# pra prod
+resource "pagerduty_service" "pra_prod" {
+  name                    = "pra prod alarms"
+  description             = "pra prod alarms"
+  auto_resolve_timeout    = 345600
+  acknowledgement_timeout = "null"
+  escalation_policy       = pagerduty_escalation_policy.member_policy.id
+  alert_creation          = "create_alerts_and_incidents"
+}
+
+resource "pagerduty_service_integration" "pra_prod_cloudwatch" {
+  name    = data.pagerduty_vendor.cloudwatch.name
+  service = pagerduty_service.pra_prod.id
+  vendor  = data.pagerduty_vendor.cloudwatch.id
+}
+
+resource "pagerduty_slack_connection" "pra_prod_connection" {
+  source_id = pagerduty_service.pra_prod.id
+  source_type = "service_reference"
+  workspace_id = local.slack_workspace_id
+  channel_id = "C065VSLNFTJ"
+  notification_type = "responder"
+  config {
+    events = [
+      "incident.triggered",
+      "incident.acknowledged",
+      "incident.escalated",
+      "incident.resolved",
+      "incident.reassigned",
+      "incident.annotated",
+      "incident.unacknowledged",
+      "incident.delegated",
+      "incident.priority_updated",
+      "incident.responder.added",
+      "incident.responder.replied",
+      "incident.action_invocation.created",
+      "incident.action_invocation.terminated",
+      "incident.action_invocation.updated",
+      "incident.status_update_published",
+      "incident.reopened"
+    ]
+    priorities = ["*"]
+  }
+}
+
+# Slack channel: #cloudwatch_alerts_modernisation_platform_legacy_apps
+
+# Tipstaff non prod
+resource "pagerduty_service" "tipstaff_non_prod" {
+  name                    = "tipstaff non prod alarms"
+  description             = "tipstaff non prod alarms (preproduction)"
+  auto_resolve_timeout    = 345600
+  acknowledgement_timeout = "null"
+  escalation_policy       = pagerduty_escalation_policy.member_policy.id
+  alert_creation          = "create_alerts_and_incidents"
+}
+
+resource "pagerduty_service_integration" "tipstaff_non_prod_cloudwatch" {
+  name    = data.pagerduty_vendor.cloudwatch.name
+  service = pagerduty_service.tipstaff_non_prod.id
+  vendor  = data.pagerduty_vendor.cloudwatch.id
+}
+
+resource "pagerduty_slack_connection" "tipstaff_non_prod_connection" {
+  source_id = pagerduty_service.tipstaff_non_prod.id
+  source_type = "service_reference"
+  workspace_id = local.slack_workspace_id
+  channel_id = "C065VSLNFTJ"
+  notification_type = "responder"
+  config {
+    events = [
+      "incident.triggered",
+      "incident.acknowledged",
+      "incident.escalated",
+      "incident.resolved",
+      "incident.reassigned",
+      "incident.annotated",
+      "incident.unacknowledged",
+      "incident.delegated",
+      "incident.priority_updated",
+      "incident.responder.added",
+      "incident.responder.replied",
+      "incident.action_invocation.created",
+      "incident.action_invocation.terminated",
+      "incident.action_invocation.updated",
+      "incident.status_update_published",
+      "incident.reopened"
+    ]
+    priorities = ["*"]
+  }
+}
+
+# Slack channel: #cloudwatch_alerts_modernisation_platform_legacy_apps
+
+# tipstaff prod
+resource "pagerduty_service" "tipstaff_prod" {
+  name                    = "tipstaff prod alarms"
+  description             = "tipstaff prod alarms"
+  auto_resolve_timeout    = 345600
+  acknowledgement_timeout = "null"
+  escalation_policy       = pagerduty_escalation_policy.member_policy.id
+  alert_creation          = "create_alerts_and_incidents"
+}
+
+resource "pagerduty_service_integration" "tipstaff_prod_cloudwatch" {
+  name    = data.pagerduty_vendor.cloudwatch.name
+  service = pagerduty_service.tipstaff_prod.id
+  vendor  = data.pagerduty_vendor.cloudwatch.id
+}
+
+resource "pagerduty_slack_connection" "tipstaff_prod_connection" {
+  source_id = pagerduty_service.tipstaff_prod.id
+  source_type = "service_reference"
+  workspace_id = local.slack_workspace_id
+  channel_id = "C065VSLNFTJ"
+  notification_type = "responder"
+  config {
+    events = [
+      "incident.triggered",
+      "incident.acknowledged",
+      "incident.escalated",
+      "incident.resolved",
+      "incident.reassigned",
+      "incident.annotated",
+      "incident.unacknowledged",
+      "incident.delegated",
+      "incident.priority_updated",
+      "incident.responder.added",
+      "incident.responder.replied",
+      "incident.action_invocation.created",
+      "incident.action_invocation.terminated",
+      "incident.action_invocation.updated",
+      "incident.status_update_published",
+      "incident.reopened"
+    ]
+    priorities = ["*"]
+  }
+}
+
+# Slack channel: #cloudwatch_alerts_modernisation_platform_legacy_apps
+
+# DACP non prod
+resource "pagerduty_service" "dacp_non_prod" {
+  name                    = "dacp non prod alarms"
+  description             = "dacp non prod alarms (preproduction)"
+  auto_resolve_timeout    = 345600
+  acknowledgement_timeout = "null"
+  escalation_policy       = pagerduty_escalation_policy.member_policy.id
+  alert_creation          = "create_alerts_and_incidents"
+}
+
+resource "pagerduty_service_integration" "dacp_non_prod_cloudwatch" {
+  name    = data.pagerduty_vendor.cloudwatch.name
+  service = pagerduty_service.dacp_non_prod.id
+  vendor  = data.pagerduty_vendor.cloudwatch.id
+}
+
+resource "pagerduty_slack_connection" "dacp_non_prod_connection" {
+  source_id = pagerduty_service.dacp_non_prod.id
+  source_type = "service_reference"
+  workspace_id = local.slack_workspace_id
+  channel_id = "C065VSLNFTJ"
+  notification_type = "responder"
+  config {
+    events = [
+      "incident.triggered",
+      "incident.acknowledged",
+      "incident.escalated",
+      "incident.resolved",
+      "incident.reassigned",
+      "incident.annotated",
+      "incident.unacknowledged",
+      "incident.delegated",
+      "incident.priority_updated",
+      "incident.responder.added",
+      "incident.responder.replied",
+      "incident.action_invocation.created",
+      "incident.action_invocation.terminated",
+      "incident.action_invocation.updated",
+      "incident.status_update_published",
+      "incident.reopened"
+    ]
+    priorities = ["*"]
+  }
+}
+
+# Slack channel: #cloudwatch_alerts_modernisation_platform_legacy_apps
+
+# DACP prod
+resource "pagerduty_service" "dacp_prod" {
+  name                    = "dacp prod alarms"
+  description             = "dacp prod alarms"
+  auto_resolve_timeout    = 345600
+  acknowledgement_timeout = "null"
+  escalation_policy       = pagerduty_escalation_policy.member_policy.id
+  alert_creation          = "create_alerts_and_incidents"
+}
+
+resource "pagerduty_service_integration" "dacp_prod_cloudwatch" {
+  name    = data.pagerduty_vendor.cloudwatch.name
+  service = pagerduty_service.dacp_prod.id
+  vendor  = data.pagerduty_vendor.cloudwatch.id
+}
+
+resource "pagerduty_slack_connection" "dacp_prod_connection" {
+  source_id = pagerduty_service.dacp_prod.id
+  source_type = "service_reference"
+  workspace_id = local.slack_workspace_id
+  channel_id = "C065VSLNFTJ"
+  notification_type = "responder"
+  config {
+    events = [
+      "incident.triggered",
+      "incident.acknowledged",
+      "incident.escalated",
+      "incident.resolved",
+      "incident.reassigned",
+      "incident.annotated",
+      "incident.unacknowledged",
+      "incident.delegated",
+      "incident.priority_updated",
+      "incident.responder.added",
+      "incident.responder.replied",
+      "incident.action_invocation.created",
+      "incident.action_invocation.terminated",
+      "incident.action_invocation.updated",
+      "incident.status_update_published",
+      "incident.reopened"
+    ]
+    priorities = ["*"]
+  }
+}
+
+# Slack channel: #cloudwatch_alerts_modernisation_platform_legacy_apps


### PR DESCRIPTION
## A reference to the issue / Description of it

Integrating CloudWatch Alarms with PagerDuty and Slack

## How does this PR fix the problem?

Adds it to PRA, Tipstaff and DACP preprod and prod environments

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [X] All checks have passed
- [X] I have made corresponding changes to the documentation
- [X] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
