### PR TITLE
add ability to read transit-gateway flow logs

### DIFF
--- a/terraform/environments/core-network-services/iam.tf
+++ b/terraform/environments/core-network-services/iam.tf
@@ -164,6 +164,7 @@ resource "aws_iam_role_policy" "read_firewall" {
           "arn:aws:logs:*:*:log-group:fw-*:log-stream:*",
           "arn:aws:logs:*:*:log-group:*-vpc-flow-logs-*:log-stream:*",
           "arn:aws:logs:*:*:log-group:external-inspection-flow-logs:log-stream:*",
+          "arn:aws:logs:*:*:log-group:tgw-*:log-stream:*"
         ],
       },
       {


### PR DESCRIPTION
## A reference to the issue / Description of it

Going through the process of debugging network connectivity issue(s) from MoJo devices in to an app that's being moved from Azure/fixngo to AWS we can't see the whole story. Not just for this instance but generally DSO/users are going to want to check that inbound traffic is hitting the transit gateway as expected

## How does this PR fix the problem?

Allows others to read the transit gateway logs

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Added arn for tgw-* to resource allow list 

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)