### PR TITLE
SQLWorkbench Policy Updates

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/policies.tf
+++ b/terraform/environments/bootstrap/delegate-access/policies.tf
@@ -675,6 +675,7 @@ data "aws_iam_policy_document" "reporting-operations" {
       "sqlworkbench:GetConnection",
       "sqlworkbench:UpdateConnection",
       "sqlworkbench:GetAutocompletionMetadata",
+      "sqlworkbench:GetAutocompletionResource",
       "secretsmanager:GetSecretValue",
       "secretsmanager:DescribeSecret",
       "secretsmanager:List*",


### PR DESCRIPTION
"sqlworkbench:GetAutocompletionResource",

## A reference to the issue / Description of it

https://dsdmoj.atlassian.net/jira/software/c/projects/DPR2/boards/1282?selectedIssue=DPR2-182

## How does this PR fix the problem?

Add sqlworkbench:GetAutocompletionMetadata to reporting_operations role  so that users can use the Redshift Query Editor without being interrupted by alerts.


## How has this been tested?

Yes tested on Sandbox Environment 


## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [x ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
