### PR TITLE
Add firewall rules for DPAT to DOM1 (development)

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/development_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/development_rules.json
@@ -362,5 +362,19 @@
     "destination_ip": "${mp-development-test}",
     "destination_port": "443",
     "protocol": "TCP"
+  },
+  "platforms_to_DOM1_nas_445": {
+    "action": "PASS",
+    "source_ip": "${platforms-development}",
+    "destination_ip": "10.172.68.0/23",
+    "destination_port": "445",
+    "protocol": "TCP"
+  },
+  "platforms_to_DOM1_nas_389": {
+    "action": "PASS",
+    "source_ip": "${platforms-development}",
+    "destination_ip": "10.172.68.0/23",
+    "destination_port": "389",
+    "protocol": "TCP"
   }
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

Slack request here: https://mojdt.slack.com/archives/C01A7QK5VM1/p1699975122396359

## How does this PR fix the problem?

This PR adds firewall rules from Data Platform Apps and Tools to DOM1 NAS filer for ports 445 & 389

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

All automated testes have completed successfully

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No this PR only adds additional rules and will not impact any services. 

## Checklist (check `x` in `[ ]` of list items)

- [ X ] I have performed a self-review of my own code
- [ X ] All checks have passed

