### PR TITLE
allow UDP 1434 in from noms_mgmt_live_vnet in azure

### DIFF
--- a/terraform/environments/core-network-services/cidr-ranges.tf
+++ b/terraform/environments/core-network-services/cidr-ranges.tf
@@ -69,7 +69,7 @@ locals {
     laa-appstream-vpc_additional   = "10.200.68.0/22"
 
     hmpps-preproduction-general-private-subnets = "10.27.0.0/22"
-    # hmpps-production-general-private-subnets = "10.27.10.0/22" not yet implemented
+    hmpps-production-general-private-subnets = "10.27.10.0/22"
   }
 
   all_cidr_ranges = merge(

--- a/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
@@ -390,5 +390,12 @@
     "destination_ip": "${ hmpps-preproduction-general-private-subnets}",
     "destination_port": "45054",
     "protocol": "TCP"
+  },
+  "noms_mgmt_live_to_planetfm_preproduction_sql_1434_udp": {
+    "action": "PASS",
+    "source_ip": "${noms-mgmt-live-vnet}",
+    "destination_ip": "${hmpps-preproduction-general-private-subnets}",
+    "destination_port": "1434",
+    "protocol": "UDP"
   }
 }

--- a/terraform/environments/core-network-services/firewall-rules/production_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/production_rules.json
@@ -390,5 +390,12 @@
     "destination_ip": "${noms-mgmt-vnet}",
     "destination_port": "138",
     "protocol": "UDP"
+  },
+  "noms_mgmt_live_to_planetfm_production_sql_1434_udp": {
+    "action": "PASS",
+    "source_ip": "${noms-mgmt-live-vnet}",
+    "destination_ip": "${hmpps-production-general-private-subnets}",
+    "destination_port": "1434",
+    "protocol": "UDP"
   }
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

SQL UDP connection required in from azure/fixngo jumpservers to PlanetFM sql db for testing

## How does this PR fix the problem?

Opens UDP port 1434 in the AWS firewall

## How has this been tested?

Will see the connection working once this port is open

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

Included in Prod as well