### PR TITLE
git-create-environments fix apply on open PR

### DIFF
--- a/.github/workflows/terraform-github.yml
+++ b/.github/workflows/terraform-github.yml
@@ -33,7 +33,6 @@ permissions:
 jobs:
   github-plan-and-apply:
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_run' && github.event.workflow == 'Terraform: GitHub resources' && github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     env:
       TF_VAR_github_token: ${{ secrets.TERRAFORM_GITHUB_TOKEN }}
       TF_IN_AUTOMATION: true

--- a/.github/workflows/terraform-github.yml
+++ b/.github/workflows/terraform-github.yml
@@ -33,6 +33,7 @@ permissions:
 jobs:
   github-plan-and-apply:
     runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_run' && github.event.workflow == 'Terraform: GitHub resources' && github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     env:
       TF_VAR_github_token: ${{ secrets.TERRAFORM_GITHUB_TOKEN }}
       TF_IN_AUTOMATION: true
@@ -83,6 +84,7 @@ jobs:
           with:
             fetch-depth: 0 # or "2" To retrieve the preceding commit.
         - name: Create GitHub member environments
+          if: github.event.ref == 'refs/heads/main'
           run: bash ./scripts/git-create-environments.sh
           env:
             TERRAFORM_GITHUB_TOKEN: ${{ secrets.TERRAFORM_GITHUB_TOKEN }}


### PR DESCRIPTION
## A reference to the issue / Description of it

`/scripts/git-create-environments.sh` is running on the opening of a pull request and subsequently applying changes. (as described here: https://github.com/ministryofjustice/modernisation-platform/issues/5363).

## How does this PR fix the problem?

This PR updates the workflow to only run the script when updates are made to the `main` branch. 

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

All test green. I won't be able to fully test until the change is merged into `main` and then a relevant change to trigger the script is submitted. 

## Deployment Plan / Instructions

Will this deployment impact the platform and/or services on it?

This change shouldn't impact the platform or any services, worse case would be that the scrip continues to run without the changes being merged into main. 

## Checklist (check `x` in `[ ]` of list items)

- [ X ] I have performed a self-review of my own code
- [ X ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
