### PR TITLE
Allow Create Step Functions for Sandbox Role

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/policies.tf
+++ b/terraform/environments/bootstrap/delegate-access/policies.tf
@@ -455,7 +455,9 @@ data "aws_iam_policy_document" "sandbox_additional" {
       "identitystore:DescribeUser",
       "sso:ListDirectoryAssociations",
       "wellarchitected:*",
-      "backup:StartRestoreJob"
+      "backup:StartRestoreJob",
+      "state:CreateStateMachine",
+      "state:ListStateMachines"
     ]
     resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
   }

--- a/terraform/environments/bootstrap/delegate-access/policies.tf
+++ b/terraform/environments/bootstrap/delegate-access/policies.tf
@@ -457,7 +457,8 @@ data "aws_iam_policy_document" "sandbox_additional" {
       "wellarchitected:*",
       "backup:StartRestoreJob",
       "state:CreateStateMachine",
-      "state:ListStateMachines"
+      "state:ListStateMachines",
+      "state:DeleteStateMachine"
     ]
     resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
   }


### PR DESCRIPTION
Allow Create Step Functions for Sandbox Role

We are looking for permissions to add Step Functions though Sandbox/Dev Role 

## How does this PR fix the problem?

Able to Add Step Functions

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

This will allow us to test the new step functions we are writing

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
