### PR TITLE
Enables access to prod from cloud platform over port 443 (https)

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/production_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/production_rules.json
@@ -41,6 +41,13 @@
     "destination_port": "5439",
     "protocol": "TCP"
   },
+  "cp_to_mp_hmpps_production_https": {
+    "action": "PASS",
+    "source_ip": "${cloud-platform}",
+    "destination_ip": "${hmpps-production}",
+    "destination_port": "443",
+    "protocol": "TCP"
+  },
   "mp_ppud_production_to_psn_ppud": {
     "action": "PASS",
     "source_ip": "${hmpps-production}",


### PR DESCRIPTION
## A reference to the issue / Description of it

We need to give access to PPUD in production to a set of k8s pods in Cloud Platform to enable an automation service to run

## How does this PR fix the problem?

This gives access to MP production from Cloud Platform 

## How has this been tested?

Have just tested syntatical correctness of json

{Please write here}

terraform?

Will this deployment impact the platform and / or services on it?

It will enable traffic on port 443 from cloud platform through to the modernisation platform's production environment

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

Discussed with Ewa on slack https://mojdt.slack.com/archives/C01A7QK5VM1/p1700478069757819
