### PR TITLE
Add required permissions for managing Step Functions

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/policies.tf
+++ b/terraform/environments/bootstrap/delegate-access/policies.tf
@@ -458,7 +458,30 @@ data "aws_iam_policy_document" "sandbox_additional" {
       "backup:StartRestoreJob",
       "states:CreateStateMachine",
       "states:ListStateMachines",
-      "states:DeleteStateMachine"
+      "states:DeleteStateMachine",
+      "states:CreateActivity",
+      "states:CreateStateMachine",
+      "states:CreateStateMachineAlias",
+      "states:DescribeStateMachine",
+      "states:DescribeExecution",
+      "states:DeleteActivity",
+      "states:DeleteStateMachine",
+      "states:DeleteStateMachineAlias",
+      "states:ListExecutions",
+      "states:ListStateMachines",
+      "states:ListTagsForResource",
+      "states:DescribeExecution",
+      "states:UpdateStateMachine",
+      "states:UpdateMapRun",
+      "states:UpdateStateMachineAlias",
+      "states:TagResource",
+      "states:StopExecution",
+      "states:StartSyncExecution",
+      "states:StartExecution",
+      "states:SendTaskSuccess",
+      "states:SendTaskHeartbeat",
+      "states:SendTaskFailure",
+      "states:RedriveExecution"
     ]
     resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
   }

--- a/terraform/environments/bootstrap/delegate-access/policies.tf
+++ b/terraform/environments/bootstrap/delegate-access/policies.tf
@@ -456,32 +456,7 @@ data "aws_iam_policy_document" "sandbox_additional" {
       "sso:ListDirectoryAssociations",
       "wellarchitected:*",
       "backup:StartRestoreJob",
-      "states:CreateStateMachine",
-      "states:ListStateMachines",
-      "states:DeleteStateMachine",
-      "states:CreateActivity",
-      "states:CreateStateMachine",
-      "states:CreateStateMachineAlias",
-      "states:DescribeStateMachine",
-      "states:DescribeExecution",
-      "states:DeleteActivity",
-      "states:DeleteStateMachine",
-      "states:DeleteStateMachineAlias",
-      "states:ListExecutions",
-      "states:ListStateMachines",
-      "states:ListTagsForResource",
-      "states:DescribeExecution",
-      "states:UpdateStateMachine",
-      "states:UpdateMapRun",
-      "states:UpdateStateMachineAlias",
-      "states:TagResource",
-      "states:StopExecution",
-      "states:StartSyncExecution",
-      "states:StartExecution",
-      "states:SendTaskSuccess",
-      "states:SendTaskHeartbeat",
-      "states:SendTaskFailure",
-      "states:RedriveExecution"
+      "states:*"
     ]
     resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
   }


### PR DESCRIPTION
reference, https://aws.permissions.cloud/iam/states

## A reference to the issue / Description of it

We are unable to start, add tags, add actions and other activities with respect to step functions

## How does this PR fix the problem?

This will give permissions for managing under sandbox Role

## How has this been tested?

This permission will allow us to test this feature

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [x ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

[{Permission Reference Document}](https://aws.permissions.cloud/iam/states)
