### PR TITLE
GitHub member environments Plan feature

### DIFF
--- a/.github/workflows/terraform-github.yml
+++ b/.github/workflows/terraform-github.yml
@@ -82,7 +82,12 @@ jobs:
         - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
           with:
             fetch-depth: 0 # or "2" To retrieve the preceding commit.
-        - name: Create GitHub member environments
+        - name: Create GitHub member environments plan
+          run: bash ./scripts/git-create-environments.sh
+          env:
+            DRY_RUN: true
+            TERRAFORM_GITHUB_TOKEN: ${{ secrets.TERRAFORM_GITHUB_TOKEN }}
+        - name: Create GitHub member environments apply
           if: github.event.ref == 'refs/heads/main'
           run: bash ./scripts/git-create-environments.sh
           env:

--- a/environments/sprinkler.json
+++ b/environments/sprinkler.json
@@ -10,7 +10,7 @@
           "nuke": "rebuild"
         }
       ],
-      "additional_reviewers": ["markgov"]
+      "additional_reviewers": ["astrobinson"]
     }
   ],
   "tags": {

--- a/environments/sprinkler.json
+++ b/environments/sprinkler.json
@@ -10,7 +10,7 @@
           "nuke": "rebuild"
         }
       ],
-      "additional_reviewers": ["astrobinson"]
+      "additional_reviewers": ["markgov"]
     }
   ],
   "tags": {

--- a/scripts/git-create-environments.sh
+++ b/scripts/git-create-environments.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 set -e
-set -x
 
 github_org="ministryofjustice"
 repository="${github_org}/modernisation-platform-environments"

--- a/scripts/git-create-environments.sh
+++ b/scripts/git-create-environments.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -e
+set -x
 
 github_org="ministryofjustice"
 repository="${github_org}/modernisation-platform-environments"
@@ -84,7 +85,7 @@ create_environment() {
   if [ "${DRY_RUN}" == "true" ]; then
     echo "Payload: $payload"
     echo "Repository: ${repository}"
-    response=$(echo "${payload}" | curl -L -s \
+    response=$(echo "${payload}" | curl -L -s -i \
       -X PUT \
       -H "Accept: application/vnd.github+json" \
       -H "Authorization: Bearer ${secret}" \
@@ -98,7 +99,7 @@ create_environment() {
   else
     echo "Payload: $payload"
     echo "Repository: ${repository}"
-    response=$(echo "${payload}" | curl -L -s \
+    response=$(echo "${payload}" | curl -L -s -i \
       -X PUT \
       -H "Accept: application/vnd.github+json" \
       -H "Authorization: Bearer ${secret}" \

--- a/scripts/git-create-environments.sh
+++ b/scripts/git-create-environments.sh
@@ -81,18 +81,33 @@ create_environment() {
     payload="{\"reviewers\": [${reviewers_json}]}"
   fi
 
-  echo "Payload: $payload"
-  echo "Repository: ${repository}"
-  response=$(echo "${payload}" | curl -L -s \
-    -X PUT \
-    -H "Accept: application/vnd.github+json" \
-    -H "Authorization: Bearer ${secret}" \
-    -H "X-GitHub-Api-Version: 2022-11-28" \
-    https://api.github.com/repos/${repository}/environments/${environment_name}\
-    -d @- > /dev/null 2>&1)
+  if [ "${DRY_RUN}" == "true" ]; then
+    echo "Payload: $payload"
+    echo "Repository: ${repository}"
+    response=$(echo "${payload}" | curl -L -s \
+      -X PUT \
+      -H "Accept: application/vnd.github+json" \
+      -H "Authorization: Bearer ${secret}" \
+      -H "X-GitHub-Api-Version: 2022-11-28" \
+      -H "X-GitHub-Environments-Preview: true" \
+      https://api.github.com/repos/${repository}/environments/${environment_name}\
+      -d @- > /dev/null 2>&1)
+
+    echo "API Response: $response"  # Print the API response
+
+  else
+    echo "Payload: $payload"
+    echo "Repository: ${repository}"
+    response=$(echo "${payload}" | curl -L -s \
+      -X PUT \
+      -H "Accept: application/vnd.github+json" \
+      -H "Authorization: Bearer ${secret}" \
+      -H "X-GitHub-Api-Version: 2022-11-28" \
+      https://api.github.com/repos/${repository}/environments/${environment_name}\
+      -d @- > /dev/null 2>&1)
 
   echo "API Response: $response"  # Print the API response
-
+  fi
 }
 
 create_team_reviewers_json() {

--- a/scripts/git-create-environments.sh
+++ b/scripts/git-create-environments.sh
@@ -83,18 +83,9 @@ create_environment() {
   fi
 
   if [ "${DRY_RUN}" == "true" ]; then
-    echo "Payload: $payload"
+    echo "DRY Run Payload: $payload"
     echo "Repository: ${repository}"
-    response=$(echo "${payload}" | curl -L -s -i \
-      -X PUT \
-      -H "Accept: application/vnd.github+json" \
-      -H "Authorization: Bearer ${secret}" \
-      -H "X-GitHub-Api-Version: 2022-11-28" \
-      -H "X-GitHub-Environments-Preview: true" \
-      https://api.github.com/repos/${repository}/environments/${environment_name}\
-      -d @- > /dev/null 2>&1)
-
-    echo "API Response: $response"  # Print the API response
+    echo "DRY Run Only no payload submission to GitHub API"
 
   else
     echo "Payload: $payload"


### PR DESCRIPTION
## A reference to the issue / Description of it

As per ticket https://github.com/ministryofjustice/modernisation-platform/issues/5363 this PR updates the `terraform-github.yml` workflow to add a 'plan' to the `create-github-environments` job. This job passes through a `dry_run` flag which in turn omits the GitHub API submission 

## How does this PR fix the problem?

This change will ensure that API submissions will only be applied when changes are merged into `main`

## How has this been tested?

I have tested that changes are not submitted to the API when a pull request is raised. Once this PR is merged I will raise a small change to ensure changes are still being applied correctly on merge to `main`.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

This PR should have no impact on the platform or services. 

## Checklist (check `x` in `[ ]` of list items)

- [ X ] I have performed a self-review of my own code
- [ X ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
