### PR TITLE
Allow traffic from alpha vpn to platforms-dev

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/development_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/development_rules.json
@@ -376,5 +376,12 @@
     "destination_ip": "10.172.68.0/23",
     "destination_port": "389",
     "protocol": "TCP"
+  },
+  "alpha_vpn_to_mp_platforms_development": {
+    "action": "PASS",
+    "source_ip": "${alpha-vpn}",
+    "destination_ip": "${platforms-development}",
+    "destination_port": "443",
+    "protocol": "TCP"
   }
 }


### PR DESCRIPTION

## A reference to the issue / Description of it

This is to allow us to test connectivity to private mp ranges from alpha protect vpn.

## How has this been tested?

TF plan in checks

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

New firewall rule will be added.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
