### PR TITLE
:wrench: Allow Helm releases from Data Platform to EKS

### DIFF
--- a/terraform/environments/data-platform-apps-and-tools/eks-cluster.tf
+++ b/terraform/environments/data-platform-apps-and-tools/eks-cluster.tf
@@ -83,6 +83,11 @@ module "eks" {
       rolearn  = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${local.environment_configuration.airflow_execution_role_name}"
       groups   = ["airflow"]
       username = "airflow"
+    },
+    {
+      rolearn  = "arn:aws:iam::${local.environment_management.account_ids["analytical-platform-management-production"]}:role/GlobalGitHubActionAccess"
+      groups   = ["system:masters"]
+      username = "globalgithubactionaccess"
     }
   ]
 

--- a/terraform/environments/data-platform-apps-and-tools/eks-cluster.tf
+++ b/terraform/environments/data-platform-apps-and-tools/eks-cluster.tf
@@ -85,7 +85,7 @@ module "eks" {
       username = "airflow"
     },
     {
-      rolearn  = "arn:aws:iam::${local.environment_management.account_ids["analytical-platform-management-production"]}:role/GlobalGitHubActionAccess"
+      rolearn  = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/data-platform-eks-access"
       groups   = ["system:masters"]
       username = "globalgithubactionaccess"
     }

--- a/terraform/environments/data-platform-apps-and-tools/eks-cluster.tf
+++ b/terraform/environments/data-platform-apps-and-tools/eks-cluster.tf
@@ -87,7 +87,7 @@ module "eks" {
     {
       rolearn  = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/data-platform-eks-access"
       groups   = ["system:masters"]
-      username = "globalgithubactionaccess"
+      username = "data-platform-eks-access"
     }
   ]
 

--- a/terraform/environments/data-platform-apps-and-tools/eks-iam-policies.tf
+++ b/terraform/environments/data-platform-apps-and-tools/eks-iam-policies.tf
@@ -35,3 +35,22 @@ module "prometheus_iam_policy" {
 
   policy = data.aws_iam_policy_document.prometheus.json
 }
+
+data "aws_iam_policy_document" "data_platform_eks_access" {
+  statement {
+    sid       = "AllowEKSDescribeCluster"
+    effect    = "Allow"
+    actions   = ["eks:DescribeCluster"]
+    resources = [module.eks.cluster_arn]
+  }
+}
+
+module "data_platform_eks_access_iam_policy" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
+  version = "~> 5.0"
+
+  name_prefix = "data-platform-eks-access"
+
+  policy = data.aws_iam_policy_document.data_platform_eks_access.json
+}

--- a/terraform/environments/data-platform-apps-and-tools/eks-iam-roles.tf
+++ b/terraform/environments/data-platform-apps-and-tools/eks-iam-roles.tf
@@ -199,7 +199,7 @@ module "iam_assumable_role_admin" {
   version = "~> 5.0"
 
   trusted_role_arns = [
-    "arn:aws:iam::${local.environment_management.account_ids["analytical-platform-management-production"]}:role/GlobalGitHubActionAccess"
+    "arn:aws:iam::${local.environment_management.account_ids["analytical-platform-management-production"]}:role/GlobalGitHubActionAccess",
     "arn:aws:iam::${local.environment_management.account_ids["analytical-platform-management-production"]}:role/aws-reserved/sso.amazonaws.com/eu-west-2/AWSReservedSSO_AdministratorAccess_75c6567ee233c758"
   ]
 

--- a/terraform/environments/data-platform-apps-and-tools/eks-iam-roles.tf
+++ b/terraform/environments/data-platform-apps-and-tools/eks-iam-roles.tf
@@ -193,3 +193,22 @@ module "prometheus_iam_role" {
     }
   }
 }
+
+module "iam_assumable_role_admin" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
+  version = "~> 5.0"
+
+  trusted_role_arns = [
+    "arn:aws:iam::${local.environment_management.account_ids["analytical-platform-management-production"]}:role/GlobalGitHubActionAccess"
+  ]
+
+  create_role       = true
+  role_name         = "data-platform-eks-access"
+  role_requires_mfa = false
+
+  custom_role_policy_arns = [
+    module.data_platform_eks_access_iam_policy.arn
+  ]
+
+  tags = local.tags
+}

--- a/terraform/environments/data-platform-apps-and-tools/eks-iam-roles.tf
+++ b/terraform/environments/data-platform-apps-and-tools/eks-iam-roles.tf
@@ -200,6 +200,7 @@ module "iam_assumable_role_admin" {
 
   trusted_role_arns = [
     "arn:aws:iam::${local.environment_management.account_ids["analytical-platform-management-production"]}:role/GlobalGitHubActionAccess"
+    "arn:aws:iam::042130406152:role/aws-reserved/sso.amazonaws.com/eu-west-2/AWSReservedSSO_AdministratorAccess_75c6567ee233c758"
   ]
 
   create_role       = true

--- a/terraform/environments/data-platform-apps-and-tools/eks-iam-roles.tf
+++ b/terraform/environments/data-platform-apps-and-tools/eks-iam-roles.tf
@@ -200,7 +200,7 @@ module "iam_assumable_role_admin" {
 
   trusted_role_arns = [
     "arn:aws:iam::${local.environment_management.account_ids["analytical-platform-management-production"]}:role/GlobalGitHubActionAccess"
-    "arn:aws:iam::042130406152:role/aws-reserved/sso.amazonaws.com/eu-west-2/AWSReservedSSO_AdministratorAccess_75c6567ee233c758"
+    "arn:aws:iam::${local.environment_management.account_ids["analytical-platform-management-production"]}:role/aws-reserved/sso.amazonaws.com/eu-west-2/AWSReservedSSO_AdministratorAccess_75c6567ee233c758"
   ]
 
   create_role       = true


### PR DESCRIPTION
This PR allows us to create kubernetes resources from our `data-platform` repository.

This mirrors how we operate on Cloud Platform.