### PR TITLE
Added iam PassRole to Data engineering SSO

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/policies.tf
+++ b/terraform/environments/bootstrap/delegate-access/policies.tf
@@ -311,6 +311,12 @@ data "aws_iam_policy_document" "data_engineering_additional" {
     resources = ["arn:aws:airflow:eu-west-1:${local.environment_management.account_ids["analytical-platform-data-production"]}:role/*/User"]
   }
 
+   statement {
+    sid       = ""
+    effect    = "Allow"
+    actions   = ["iam:PassRole"]
+    resources = ["arn:aws:iam::${local.environment_management.account_ids["analytical-platform-data-production"]}:role/data-first-data-science"]
+  }
 }
 
 # data engineerin policy (developer + glue + some athena)


### PR DESCRIPTION
The PR was raised based on the [ticket#2457](https://github.com/ministryofjustice/data-platform/issues/2457). The data engineers who work in the Analytical Platform use the “restricted-admin” role to run the Glue jobs. It looks like using “restricted-admin” to run Glue jobs will be difficult as something is retiring. For this reason, the ticket proposes to add the pre-existing "data-first-data-science" (which has sufficient permissions to run the Glue jobs) role to the SSO role so that the users can continue running their Glue jobs.