### PR TITLE
Add perms for asg scaling updates

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -364,6 +364,8 @@ data "aws_iam_policy_document" "policy" {
     actions = [
       "athena:StartQueryExecution",
       "athena:GetQueryExecution",
+      "autoscaling:PutScheduledUpdateGroupAction",
+      "autoscaling:SetDesiredCapacity",
       "backup:Start*",
       "codebuild:Start*",
       "codebuild:StartBuild",


### PR DESCRIPTION
## A reference to the issue / Description of it

error: `no identity-based policy allows the autoscaling:SetDesiredCapacity action`

## How does this PR fix the problem?

Adding:

"autoscaling:PutScheduledUpdateGroupAction",
"autoscaling:SetDesiredCapacity",

will allow the aws cli sub command `aws autoscaling put-scheduled-update-group-action`

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [  ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
