### PR TITLE
Removed rule for alpha VPN traffic

### DIFF
--- a/terraform/environments/core-network-services/cidr-ranges.tf
+++ b/terraform/environments/core-network-services/cidr-ranges.tf
@@ -12,7 +12,6 @@ locals {
   }
 
   other_cidr_ranges = {
-    alpha-vpn                        = "100.64.0.0/16"
     analytical-platform-airflow-dev  = "10.200.0.0/16"
     analytical-platform-airflow-prod = "10.201.0.0/16"
     atos_arkc_ras                    = "10.175.0.0/16" # for DOM1 devices connected to Cisco RAS VPN

--- a/terraform/environments/core-network-services/firewall-rules/development_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/development_rules.json
@@ -265,13 +265,6 @@
     "destination_port": "5439",
     "protocol": "TCP"
   },
-  "alpha-vpn_to_data-insights-hub_development_redshift": {
-    "action": "PASS",
-    "source_ip": "${alpha-vpn}",
-    "destination_ip": "${hq-development}",
-    "destination_port": "5439",
-    "protocol": "TCP"
-  },
   "internal-networks_to_data-insights-hub_development_redshift": {
     "action": "PASS",
     "source_ip": "10.0.0.0/8",
@@ -375,13 +368,6 @@
     "source_ip": "${platforms-development}",
     "destination_ip": "10.172.68.0/23",
     "destination_port": "389",
-    "protocol": "TCP"
-  },
-  "alpha_vpn_to_mp_platforms_development": {
-    "action": "PASS",
-    "source_ip": "${alpha-vpn}",
-    "destination_ip": "${platforms-development}",
-    "destination_port": "443",
     "protocol": "TCP"
   }
 }


### PR DESCRIPTION
Following a discussion with the MOJ Networks Team around Alpha VPN traffic traversing MOJ private networks, this PR removes any rules allowing traffic from devices using the GlobalProtect Alpha VPN to the Modernisation Platform.