### PR TITLE
Adding permission to describe EKS cluster to member infra role

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -117,6 +117,7 @@ data "aws_iam_policy_document" "member-access" {
       "ecs:*",
       "elasticfilesystem:*",
       "elasticloadbalancing:*",
+      "eks:Describe*",
       "events:*",
       "fsx:*",
       "firehose:*",


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/data-platform/issues/2454
We are building out another catalogue candidate meant to be deployed into EKS. To minimise the dependencies on MP team, we would like to build out as much infra in the MPE repository as possible. This is a request for read-level EKS permissions to allow lookups via datasources.

## How does this PR fix the problem?

This gives the member infra role read-level permissions on the EKS cluster.

## How has this been tested?

The local plan works because this permission is already available in the sandbox account but the deployment via GHA fails.


## Deployment Plan / Instructions

This should have no impact on PROD. This adds rather than removes or restricts permissions. 


## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [?] I have made corresponding changes to the documentation
- [?] Plan and discussed how it should be deployed to PROD (If needed)
