### PR TITLE
:wrench: Create an assumable role for DynamoDB and S3 Bucket access

### DIFF
--- a/terraform/modernisation-platform-account/iam.tf
+++ b/terraform/modernisation-platform-account/iam.tf
@@ -177,7 +177,7 @@ data "aws_iam_policy_document" "modernisation_account_terraform_state_role" {
       "dynamodb:PutItem",
       "dynamodb:DeleteItem"
     ]
-    resources = "arn:aws:dynamodb:eu-west-2:${data.aws_caller_identity.current.account_id}:table/modernisation-platform-terraform-state-lock"
+    resources = ["arn:aws:dynamodb:eu-west-2:${data.aws_caller_identity.current.account_id}:table/modernisation-platform-terraform-state-lock"]
   }
   statement {
     sid    = "AllowS3AccessList"
@@ -185,7 +185,7 @@ data "aws_iam_policy_document" "modernisation_account_terraform_state_role" {
     actions = [
       "s3:ListBucket",
     ]
-    resources = "arn:aws:s3:::modernisation-platform-terraform-state"
+    resources = ["arn:aws:s3:::modernisation-platform-terraform-state"]
   }
   statement {
     sid    = "AllowS3AccessActions"
@@ -195,7 +195,7 @@ data "aws_iam_policy_document" "modernisation_account_terraform_state_role" {
       "s3:GetObject",
       "s3:PutObject",
     ]
-    resources = "arn:aws:s3:::modernisation-platform-terraform-state/environments/members/*"
+    resources = ["arn:aws:s3:::modernisation-platform-terraform-state/environments/members/*"]
   }
 }
 
@@ -233,7 +233,7 @@ resource "aws_iam_policy" "modernisation_account_terraform_state" {
   policy      = data.aws_iam_policy_document.modernisation_account_terraform_state_role.json
 }
 
-resource "aws_iam_role_policy_attachment" "modernisation_account_limited_read" {
+resource "aws_iam_role_policy_attachment" "modernisation_account_terraform_state" {
   role       = aws_iam_role.modernisation_account_terraform_state.id
   policy_arn = aws_iam_policy.modernisation_account_terraform_state.arn
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/5534

## How does this PR fix the problem?

Creates an assumable role allowing access to DynamoDB and S3.
S3 access is further restricted by a policy attached to the bucket.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Local `terraform plan` completed successfully

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

Not at this point.

## Checklist (check `x` in `[ ]` of list items)

- [ x ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

This PR is a precursory step to making use of backend terraform state locking from the `modernisation-platform-environments` repository. Once implemented, I can conduct testing from a non-production, platform-owned environment.
