### PR TITLE
The email on close code for review

### DIFF
--- a/.github/workflows/email-requester-onboarding-close.yml
+++ b/.github/workflows/email-requester-onboarding-close.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@b4ffde6 # v4.1.1
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/email-requester-onboarding-close.yml
+++ b/.github/workflows/email-requester-onboarding-close.yml
@@ -1,0 +1,47 @@
+name: Send Message on Onboarding Issue Close
+
+on:
+  issues:
+    types:
+      - closed
+
+jobs:
+  send-message:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 14
+
+      - name: Install dependencies
+        run: npm install github-actions-toolkit
+
+      - name: Send message to user on onboarding issue close
+        if: github.event.issue.labels.filter(label '=>' label.name '=' 'onboarding').length > 0
+        run: |
+          const { GitHub, context } = require('github-actions-toolkit');
+
+          const github = new GitHub();
+
+          const issue = context.payload.issue;
+
+          // Get the user who opened the issue
+          const user = issue.user.login;
+
+          // Send a message as a comment when the onboarding issue is closed
+          const message = `Hello @${user}! 
+          Welcome to the Modernisation Platform! Your new accounts have now been created. Please see the user guidance for details on how to build and access infrastructure in the 
+          Modernisation Platform - https://user-guide.modernisation-platform.service.justice.gov.uk/#getting-started
+
+          If you need any help or assistance please contact us in the [#ask-modernisation-platform](https://moj.enterprise.slack.com/archives/C01A7QK5VM1)`;
+          github.issues.createComment({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: issue.number,
+            body: message,
+          });

--- a/.github/workflows/email-requester-onboarding-close.yml
+++ b/.github/workflows/email-requester-onboarding-close.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 14
+          node-version: 20
 
       - name: Install dependencies
         run: npm install github-actions-toolkit

--- a/.github/workflows/email-requester-onboarding-close.yml
+++ b/.github/workflows/email-requester-onboarding-close.yml
@@ -22,7 +22,7 @@ jobs:
         run: npm install github-actions-toolkit
 
       - name: Send message to user on onboarding issue close
-        if: github.event.issue.labels.filter(label '=>' label.name '=' 'onboarding').length > 0
+        if: contains(github.event.issue.labels.*.name, 'onboarding') && github.event.issue.state == 'closed'
         run: |
           const { GitHub, context } = require('github-actions-toolkit');
 


### PR DESCRIPTION
## A reference to the issue / Description of it

See [Automation to provide info for new onboarders#3451](https://github.com/ministryofjustice/modernisation-platform/issues/3451) got full details

## How does this PR fix the problem?

Sends the email once the request is closed

## How has this been tested?

Used act to test, initially, via "act -W 'email-requester-onboarding-close.yml'"

Initial errors corrected in updated version.

## Deployment Plan / Instructions

No impact to other services

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed

## Additional comments (if any)

This will be tested by creating a dummy onboarding release and seeing if it sends an email to the person listed as the owner (me). Should only take place on close
