### PR TITLE
Add OpenSearch permissions

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -118,6 +118,7 @@ data "aws_iam_policy_document" "member-access" {
       "elasticfilesystem:*",
       "elasticloadbalancing:*",
       "eks:Describe*",
+      "es:*",
       "events:*",
       "fsx:*",
       "firehose:*",


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/data-platform/issues/2454

## How does this PR fix the problem?

This allows OpenSearch to be deployed from Modernisation Platform Environments repository

## How has this been tested?

Not feasible to test without permission being granted. This fixes an apply workflow which failed with lack of permission.


## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No. Permissions are additive.

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [X] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)


