### PR TITLE
Enable Apps-Tools Helm Deployments from MPE Repo

### DIFF
--- a/terraform/environments/data-platform-apps-and-tools/eks-cluster.tf
+++ b/terraform/environments/data-platform-apps-and-tools/eks-cluster.tf
@@ -88,6 +88,11 @@ module "eks" {
       rolearn  = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/data-platform-eks-access"
       groups   = ["system:masters"]
       username = "data-platform-eks-access"
+    },
+    {
+      rolearn  = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/MemberInfrastructureAccess"
+      groups   = ["system:masters"]
+      username = "modernisation-platform-env-eks-access"
     }
   ]
 


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/data-platform/issues/2454

## How does this PR fix the problem?

This adds the Member Infra role to the list of cluster masters for the apps and tools cluster, allowing helm and k8 deployments via Terraform from the MPE repo.

## How has this been tested?

This requires deployment to test.


## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

