### PR TITLE
🔧 Add state access role to dynamodb encryption key

### DIFF
--- a/terraform/modernisation-platform-account/dynamodb.tf
+++ b/terraform/modernisation-platform-account/dynamodb.tf
@@ -38,9 +38,10 @@ data "aws_iam_policy_document" "dynamo_encryption" {
     }
 
     principals {
-      type = "AWS"
+      type        = "AWS"
       identifiers = [
-        data.aws_caller_identity.current.account_id
+        data.aws_caller_identity.current.account_id,
+        aws_iam_role.modernisation_account_terraform_state.arn,
       ]
     }
 


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/5534

Added a new role - `modernisation-platform-member-state-access` - to allow Modernisation Platform Environments repository accounts to make use of a role in the Modernisation Platform account for state locking.

However, initial testing from `sprinkler` gave the following error:
```
api error AccessDeniedException: KMS key access denied
Unable to retrieve item from DynamoDB table "modernisation-platform-terraform-state-lock": operation error DynamoDB: GetItem
```

## How does this PR fix the problem?

This PR grants the `modernisation-account-terraform-state-member-access` role access to the `dynamodb-state-lock` key, allowing Terraform to make use of the relevant table for state locking

## How has this been tested?

Amended KMS policy manually to add role to permissions list.

Conducted successful Terraform Plan from `sprinkler-development` which had previously failed

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
