### PR TITLE
Feature/5548 secrets rotation alerting

### DIFF
--- a/.github/workflows/secrets-rotation-reminder.yml
+++ b/.github/workflows/secrets-rotation-reminder.yml
@@ -1,9 +1,16 @@
 ---
 name: Secrets Rotation Reminder
 on:
-    workflow_dispatch:
-    schedule: 
-        - cron: '30 9 * * *' # run at 9:30 daily
+  push:
+    branches:
+      - "feature/5548-secrets-rotation-alerting"
+  pull_request:
+    branches:
+      - "main" 
+    paths:
+      - ".github/workflows/secrets-rotation-reminder.yaml"
+  # schedule: 
+  #     - cron: '30 9 * * *' # run at 9:30 daily
 
 env:
     AWS_REGION: "eu-west-2"

--- a/.github/workflows/secrets-rotation-reminder.yml
+++ b/.github/workflows/secrets-rotation-reminder.yml
@@ -10,7 +10,7 @@ on:
     paths:
       - ".github/workflows/secrets-rotation-reminder.yaml"
   # schedule: 
-  #     - cron: '30 9 * * *' # run at 9:30 daily
+      # - cron: '30 9 * * *' # run at 9:30 daily 
 
 env:
     AWS_REGION: "eu-west-2"
@@ -45,19 +45,18 @@ jobs:
             run: |
               # Get the list of secret names from AWS Secrets Manager
               secrets=$(aws secretsmanager list-secrets --region $AWS_REGION --query "SecretList[].Name" --output text)
-              echo $secrets // debugging
               
               # Remove secrets from list that are exempt from rotation
               
-              delete=("environment_management" "nuke_account_ids" "github_ci_user_password" "nuke_account_blocklist" "mod-platform-circleci")
+              delete=("environment_management" "nuke_account_ids" "nuke_account_blocklist" "mod-platform-circleci")
               for del in ${delete[@]}
               do
                 secrets=("${secrets[@]/$del}")
               done
-              echo "New list:" $secrets // debugging
               
               # Define the threshold in seconds (180 days)
               threshold=$((180 * 24 * 60 * 60))
+              ten_day_warning=$((170 * 24 * 60 * 60))
               
               # Get the current timestamp in seconds
               current_timestamp=$(date +%s)
@@ -76,11 +75,26 @@ jobs:
               
                 # Check if the secret is older than the threshold
                 if [ $age -gt $threshold ]; then
-                  echo "$secret secret is older than 180 days (age: $((age / (24 * 60 * 60))) days)"
+                SLACK_PAYLOAD=$(echo "$secret secret is older than 180 days (age: $((age / (24 * 60 * 60))) days)")
+                fi
+
+                # Check if secret is nearing expiry
+                if [ $age -gt $ten_day_warning ] && [ $age -lt $threshold ]; then
+                  echo "$secret secret will expire within the next 10 days (age: $((age / (24 * 60 * 60))) days)"
                 fi
               done
 
             env:
               SECRET: ${{ secrets.GITHUB_TOKEN }}
               GITHUB_REPOSITORY: ${{ secrets.GITHUB_REPOSITORY }}
+              SLACK_PAYLOAD: ''
 
+          # - name: Slack Notification
+          #   uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0
+          #   with:
+          #     payload: |
+          #       {"blocks":[{"type": "section","text": {"type": "mrkdwn","text": ":no_entry: GitHub Action:"}},{"type": "section","fields":[{"type": "mrkdwn","text": "*Workflow:*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>"},{"type": "mrkdwn","text": "*Job:*\n${{ github.job }}"},{"type": "mrkdwn","text": "*Repo:*\n${{ github.repository }}"}]}]}
+          #   env:
+          #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          #     SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+          #   if: 

--- a/.github/workflows/secrets-rotation-reminder.yml
+++ b/.github/workflows/secrets-rotation-reminder.yml
@@ -1,0 +1,48 @@
+---
+name: Secrets Rotation Reminder
+on:
+    workflow_dispatch:
+    schedule: 
+        - cron: '30 9 * * *' # run at 9:30 daily
+
+env:
+    AWS_REGION: "eu-west-2"
+    ENVIRONMENT_MANAGEMENT: ${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENTS }}
+    
+permissions:
+    id-token: write # This is required for requesting the JWT
+    contents: read # This is required for actions/checkout
+    
+defaults:
+    run:
+        shell: bash
+
+jobs:
+    secrets-rotation-reminder:
+        runs-on: ubuntu-latest
+        steps:
+          - name: Checkout Repository
+            uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+    
+          - name: Set Account Number
+            run: echo "ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+    
+          - name: Configure AWS Credentials
+            uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
+            with:
+              role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+              role-session-name: githubactionsrolesession
+              aws-region: ${{ env.AWS_REGION }}
+    
+          - name: Run Secrets Rotation Reminder Script
+            run: |
+              # Get the list of secret names from AWS Secrets Manager
+              secrets=$(aws secretsmanager list-secrets --region $AWS_REGION --query "SecretList[].Name" --output text)
+
+              # Print secret names to logs
+              echo $secrets
+
+            env:
+              SECRET: ${{ secrets.GITHUB_TOKEN }}
+              GITHUB_REPOSITORY: ${{ secrets.GITHUB_REPOSITORY }}
+

--- a/.github/workflows/secrets-rotation-reminder.yml
+++ b/.github/workflows/secrets-rotation-reminder.yml
@@ -61,7 +61,7 @@ jobs:
               
               # Loop through each secret,  check its last changed date and raise issue if required
               for secret in $secrets; do
-                last_changed=$(aws secretsmanager describe-secret --secret-id $secret --region $AWS_REGION --query "LastChangedDate" --output text | sort -r | head -n 1)
+                last_changed=$(aws secretsmanager list-secret-version-ids --secret-id $secret --region $AWS_REGION --query "Versions[?contains(VersionStages,'AWSCURRENT')].CreatedDate" --output text | sort -r | head -n 1)
                 
                 # If the secret has never been changed, set the last_changed date to 0
                 if [ -z "$last_changed" ]; then
@@ -78,7 +78,9 @@ jobs:
                 if [ $age -gt $threshold ] && [ -z "$open_issue" ]; then
                 echo "$secret secret is older than 180 days (age: $((age / (24 * 60 * 60))) days)"
                 echo "Creating GitHub Issue to rotate $secret"
-                # gh issue create --title "Rotate $secret Credential" --label security --body "The secrets-rotation-reminder workflow ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} has identified that the $secret credential requires rotation as it is close to or exceeding the threshold of 180 days. For more information see https://user-guide.modernisation-platform.service.justice.gov.uk/runbooks/rotating-secrets.html#how-to-rotate-secrets"
+                # gh issue create --title "Rotate $secret Credential" --label security --body "The [secrets-rotation-reminder workflow](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) has identified that the $secret credential requires rotation as it is close to or exceeding the threshold of 180 days. 
+
+                # Consult [this documentation](https://user-guide.modernisation-platform.service.justice.gov.uk/runbooks/rotating-secrets.html#how-to-rotate-secrets) which describes the process for rotation."
                 else 
                 echo "The $secret secret has not been identified for rotation (age: $((age / (24 * 60 * 60))) days)"
                 fi

--- a/.github/workflows/secrets-rotation-reminder.yml
+++ b/.github/workflows/secrets-rotation-reminder.yml
@@ -88,3 +88,4 @@ jobs:
             env:
               SECRET: ${{ secrets.GITHUB_TOKEN }}
               GITHUB_REPOSITORY: ${{ secrets.GITHUB_REPOSITORY }}
+              GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/secrets-rotation-reminder.yml
+++ b/.github/workflows/secrets-rotation-reminder.yml
@@ -1,16 +1,13 @@
 ---
 name: Secrets Rotation Reminder
 on:
-  push:
-    branches:
-      - "feature/5548-secrets-rotation-alerting"
   pull_request:
     branches:
       - "main" 
     paths:
       - ".github/workflows/secrets-rotation-reminder.yaml"
-  # schedule: 
-      # - cron: '30 9 * * *' # run at 9:30 daily 
+  schedule: 
+      - cron: '30 9 * * *' # run at 9:30 daily 
 
 env:
     AWS_REGION: "eu-west-2"
@@ -78,9 +75,9 @@ jobs:
                 if [ $age -gt $threshold ] && [ -z "$open_issue" ]; then
                 echo "$secret secret is older than 180 days (age: $((age / (24 * 60 * 60))) days)"
                 echo "Creating GitHub Issue to rotate $secret"
-                # gh issue create --title "Rotate $secret Credential" --label security --body "The [secrets-rotation-reminder workflow](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) has identified that the $secret credential requires rotation as it is close to or exceeding the threshold of 180 days. 
+                gh issue create --title "Rotate $secret Credential" --label security --body "The [secrets-rotation-reminder workflow](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) has identified that the $secret credential requires rotation as it is close to or exceeding the threshold of 180 days. 
 
-                # Consult [this documentation](https://user-guide.modernisation-platform.service.justice.gov.uk/runbooks/rotating-secrets.html#how-to-rotate-secrets) which describes the process for rotation."
+                Consult [this documentation](https://user-guide.modernisation-platform.service.justice.gov.uk/runbooks/rotating-secrets.html#how-to-rotate-secrets) which describes the process for rotation."
                 else 
                 echo "The $secret secret has not been identified for rotation (age: $((age / (24 * 60 * 60))) days)"
                 fi

--- a/.github/workflows/secrets-rotation-reminder.yml
+++ b/.github/workflows/secrets-rotation-reminder.yml
@@ -47,7 +47,7 @@ jobs:
               secrets=$(aws secretsmanager list-secrets --region $AWS_REGION --query "SecretList[].Name" --output text)
               
               # Remove secrets from list that are exempt from rotation
-              delete=("environment_management" "nuke_account_ids" "nuke_account_blocklist" "mod-platform-circleci")
+              delete=("environment_management" "nuke_account_ids" "nuke_account_blocklist" "mod-platform-circleci" "pagerduty_integration_keys")
               for del in ${delete[@]}
               do
                 secrets=("${secrets[@]/$del}")

--- a/.github/workflows/secrets-rotation-reminder.yml
+++ b/.github/workflows/secrets-rotation-reminder.yml
@@ -80,7 +80,7 @@ jobs:
                 echo "Creating GitHub Issue to rotate $secret"
                 # gh issue create --title "Rotate $secret Credential" --label security --body "The secrets-rotation-reminder workflow ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} has identified that the $secret credential requires rotation as it is close to or exceeding the threshold of 180 days. For more information see https://user-guide.modernisation-platform.service.justice.gov.uk/runbooks/rotating-secrets.html#how-to-rotate-secrets"
                 else 
-                echo "The $secret secret has not been identified for rotation"
+                echo "The $secret secret has not been identified for rotation (age: $((age / (24 * 60 * 60))) days)"
                 fi
 
               done

--- a/.github/workflows/secrets-rotation-reminder.yml
+++ b/.github/workflows/secrets-rotation-reminder.yml
@@ -12,6 +12,9 @@ on:
 env:
     AWS_REGION: "eu-west-2"
     ENVIRONMENT_MANAGEMENT: ${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENTS }}
+    SECRET: ${{ secrets.GITHUB_TOKEN }}
+    GITHUB_REPOSITORY: ${{ secrets.GITHUB_REPOSITORY }}
+    GH_TOKEN: ${{ github.token }}
     
 permissions:
     id-token: write # This is required for requesting the JWT
@@ -82,9 +85,4 @@ jobs:
                 echo "The $secret secret has not been identified for rotation (age: $((age / (24 * 60 * 60))) days)"
                 fi
 
-              done
-
-            env:
-              SECRET: ${{ secrets.GITHUB_TOKEN }}
-              GITHUB_REPOSITORY: ${{ secrets.GITHUB_REPOSITORY }}
-              GH_TOKEN: ${{ github.token }}
+              done              

--- a/.github/workflows/secrets-rotation-reminder.yml
+++ b/.github/workflows/secrets-rotation-reminder.yml
@@ -47,7 +47,6 @@ jobs:
               secrets=$(aws secretsmanager list-secrets --region $AWS_REGION --query "SecretList[].Name" --output text)
               
               # Remove secrets from list that are exempt from rotation
-              
               delete=("environment_management" "nuke_account_ids" "nuke_account_blocklist" "mod-platform-circleci")
               for del in ${delete[@]}
               do
@@ -56,12 +55,11 @@ jobs:
               
               # Define the threshold in seconds (180 days)
               threshold=$((180 * 24 * 60 * 60))
-              ten_day_warning=$((170 * 24 * 60 * 60))
               
               # Get the current timestamp in seconds
               current_timestamp=$(date +%s)
               
-              # Loop through each secret and check its last changed date
+              # Loop through each secret,  check its last changed date and raise issue if required
               for secret in $secrets; do
                 last_changed=$(aws secretsmanager describe-secret --secret-id $secret --region $AWS_REGION --query "LastChangedDate" --output text | sort -r | head -n 1)
                 
@@ -72,29 +70,21 @@ jobs:
               
                 # Calculate the age of the secret in seconds
                 age=$((current_timestamp - $(date -d "$last_changed" +%s)))
+
+                # Check if there is an existing open issue to rotate the secret
+                open_issue=$(gh issue list -R ministryofjustice/modernisation-platform --search "Rotate $secret in:title" --state open)
               
-                # Check if the secret is older than the threshold
-                if [ $age -gt $threshold ]; then
-                SLACK_PAYLOAD=$(echo "$secret secret is older than 180 days (age: $((age / (24 * 60 * 60))) days)")
+                # Check if the secret is older than the threshold and if there is an existing open issue to rotate it, if required raise a new issue
+                if [ $age -gt $threshold ] && [ -z "$open_issue" ]; then
+                echo "$secret secret is older than 180 days (age: $((age / (24 * 60 * 60))) days)"
+                echo "Creating GitHub Issue to rotate $secret"
+                # gh issue create --title "Rotate $secret Credential" --label security --body "The secrets-rotation-reminder workflow ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} has identified that the $secret credential requires rotation as it is close to or exceeding the threshold of 180 days. For more information see https://user-guide.modernisation-platform.service.justice.gov.uk/runbooks/rotating-secrets.html#how-to-rotate-secrets"
+                else 
+                echo "The $secret secret has not been identified for rotation"
                 fi
 
-                # Check if secret is nearing expiry
-                if [ $age -gt $ten_day_warning ] && [ $age -lt $threshold ]; then
-                  echo "$secret secret will expire within the next 10 days (age: $((age / (24 * 60 * 60))) days)"
-                fi
               done
 
             env:
               SECRET: ${{ secrets.GITHUB_TOKEN }}
               GITHUB_REPOSITORY: ${{ secrets.GITHUB_REPOSITORY }}
-              SLACK_PAYLOAD: ''
-
-          # - name: Slack Notification
-          #   uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0
-          #   with:
-          #     payload: |
-          #       {"blocks":[{"type": "section","text": {"type": "mrkdwn","text": ":no_entry: GitHub Action:"}},{"type": "section","fields":[{"type": "mrkdwn","text": "*Workflow:*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>"},{"type": "mrkdwn","text": "*Job:*\n${{ github.job }}"},{"type": "mrkdwn","text": "*Repo:*\n${{ github.repository }}"}]}]}
-          #   env:
-          #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          #     SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-          #   if: 

--- a/.github/workflows/secrets-rotation-reminder.yml
+++ b/.github/workflows/secrets-rotation-reminder.yml
@@ -45,9 +45,40 @@ jobs:
             run: |
               # Get the list of secret names from AWS Secrets Manager
               secrets=$(aws secretsmanager list-secrets --region $AWS_REGION --query "SecretList[].Name" --output text)
-
-              # Print secret names to logs
-              echo $secrets
+              echo $secrets // debugging
+              
+              # Remove secrets from list that are exempt from rotation
+              
+              delete=("environment_management" "nuke_account_ids" "github_ci_user_password" "nuke_account_blocklist" "mod-platform-circleci")
+              for del in ${delete[@]}
+              do
+                secrets=("${secrets[@]/$del}")
+              done
+              echo "New list:" $secrets // debugging
+              
+              # Define the threshold in seconds (180 days)
+              threshold=$((180 * 24 * 60 * 60))
+              
+              # Get the current timestamp in seconds
+              current_timestamp=$(date +%s)
+              
+              # Loop through each secret and check its last changed date
+              for secret in $secrets; do
+                last_changed=$(aws secretsmanager describe-secret --secret-id $secret --region $AWS_REGION --query "LastChangedDate" --output text | sort -r | head -n 1)
+                
+                # If the secret has never been changed, set the last_changed date to 0
+                if [ -z "$last_changed" ]; then
+                  last_changed=0
+                fi
+              
+                # Calculate the age of the secret in seconds
+                age=$((current_timestamp - $(date -d "$last_changed" +%s)))
+              
+                # Check if the secret is older than the threshold
+                if [ $age -gt $threshold ]; then
+                  echo "$secret secret is older than 180 days (age: $((age / (24 * 60 * 60))) days)"
+                fi
+              done
 
             env:
               SECRET: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/5548

## How does this PR fix the problem?

I've written a GH Action that queries the age of the secrets held in the Mod Platform account. Currently it is scheduled to run at **9:30 am daily** (this could be altered as necessary). It will check to see if the secrets are over 180 days old and also whether an existing issue is open to rotate the secret. If necessary it will raise a new issue to rotate the secret.

It will not raise an issue for the secrets we have deemed unnecessary to rotate in the [docs](https://user-guide.modernisation-platform.service.justice.gov.uk/runbooks/rotating-secrets.html).

## How has this been tested?

I've run the [workflow](https://github.com/ministryofjustice/modernisation-platform/actions/workflows/secrets-rotation-reminder.yml) on my branch but have commented out the issue creation steps so as not to spam our issues list.

I tested out raising issues in my own repo to check the logic and formatting, [here](https://github.com/richgreen-moj/test-github-actions/issues/24) is an example of the kind of issue that will be created.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

