### PR TITLE
fix permissions & change schedule to 11:30

### DIFF
--- a/.github/workflows/secrets-rotation-reminder.yml
+++ b/.github/workflows/secrets-rotation-reminder.yml
@@ -7,7 +7,7 @@ on:
     paths:
       - ".github/workflows/secrets-rotation-reminder.yaml"
   schedule: 
-      - cron: '30 9 * * *' # run at 9:30 daily 
+      - cron: '30 11 * * *' # run at 11:30 daily 
 
 env:
     AWS_REGION: "eu-west-2"
@@ -18,7 +18,8 @@ env:
     
 permissions:
     id-token: write # This is required for requesting the JWT
-    contents: read # This is required for actions/checkout
+    contents: write # This is required for actions/checkout
+    issues: write # This is required to create issues if required
     
 defaults:
     run:

--- a/.github/workflows/secrets-rotation-reminder.yml
+++ b/.github/workflows/secrets-rotation-reminder.yml
@@ -18,7 +18,7 @@ env:
     
 permissions:
     id-token: write # This is required for requesting the JWT
-    contents: write # This is required for actions/checkout
+    contents: read # This is required for actions/checkout
     issues: write # This is required to create issues if required
     
 defaults:


### PR DESCRIPTION
Unfortunately I had an issue with permissions on the secrets rotation reminder workflow - the only part I hadn't tested on my branch as I didn't want to spam our issues list with my testing but it has come back to bite!

I've also changed the schedule to 11:30 so hopefully I can watch it run in half an hour :)