### PR TITLE
Create environment secret for backend state locking

### DIFF
--- a/terraform/github/repositories.tf
+++ b/terraform/github/repositories.tf
@@ -274,6 +274,7 @@ module "modernisation-platform-environments" {
     # Terraform GitHub token for the CI/CD user
     TERRAFORM_GITHUB_TOKEN                               = data.aws_secretsmanager_secret_version.github_ci_user_token.secret_string
     MODERNISATION_PLATFORM_CI_USER_ENVIRONMENTS_REPO_PAT = data.aws_secretsmanager_secret_version.github_ci_user_environments_repo_pat_token.secret_string
+    MODERNISATION_PLATFORM_ACCOUNT_ID                    = local.modernisation_platform_account.id
     TESTING_AWS_ACCESS_KEY_ID                            = local.testing_ci_iam_user_keys.AWS_ACCESS_KEY_ID
     TESTING_AWS_SECRET_ACCESS_KEY                        = local.testing_ci_iam_user_keys.AWS_SECRET_ACCESS_KEY
   }


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/5534

## How does this PR fix the problem?

This PR creates a GitHub secret, managed in code, that can be consumed through a GitHub action like so:

```
steps:
  - shell: bash
    env:
      MP_ACCOUNT_ID: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_ID }}
    run: |
      terraform init -backend-config=assume_role={role_arn=\"arn:aws:iam::$MP_ACCOUNT_ID:role/modernisation-account-terraform-state-member-access\"}

## How has this been tested?

Ran `terraform plan` locally, ran `terraform apply --refresh-only` locally, confirmed local value returns correct account number


## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
