### PR TITLE
Removed the item that was causing an error on run.

### DIFF
--- a/.github/workflows/email-requester-onboarding-close.yml
+++ b/.github/workflows/email-requester-onboarding-close.yml
@@ -4,7 +4,6 @@ on:
   issues:
     types:
       - closed
-
 jobs:
   send-message:
     runs-on: ubuntu-latest
@@ -17,31 +16,29 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-
-      - name: Install dependencies
-        run: npm install github-actions-toolkit
-
       - name: Send message to user on onboarding issue close
         if: contains(github.event.issue.labels.*.name, 'onboarding') && github.event.issue.state == 'closed'
         run: |
           const { GitHub, context } = require('github-actions-toolkit');
 
+
           const github = new GitHub();
 
           const issue = context.payload.issue;
+
 
           // Get the user who opened the issue
           const user = issue.user.login;
 
           // Send a message as a comment when the onboarding issue is closed
-          const message = `Hello @${user}! 
-          Welcome to the Modernisation Platform! Your new accounts have now been created. Please see the user guidance for details on how to build and access infrastructure in the 
-          Modernisation Platform - https://user-guide.modernisation-platform.service.justice.gov.uk/#getting-started
+            const message = `Hello @${user}! 
+            Welcome to the Modernisation Platform! Your new accounts have now been created. Please see the user guidance for details on how to build and access infrastructure in the 
+            Modernisation Platform - https://user-guide.modernisation-platform.service.justice.gov.uk/#getting-started
 
-          If you need any help or assistance please contact us in the [#ask-modernisation-platform](https://moj.enterprise.slack.com/archives/C01A7QK5VM1)`;
-          github.issues.createComment({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            issue_number: issue.number,
-            body: message,
+            If you need any help or assistance please contact us in the [#ask-modernisation-platform](https://moj.enterprise.slack.com/archives/C01A7QK5VM1)`;
+            github.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              body: message,
           });

--- a/.github/workflows/notify-user-new-environment-created.yml
+++ b/.github/workflows/notify-user-new-environment-created.yml
@@ -19,26 +19,22 @@ jobs:
       - name: Send message to user on onboarding issue close
         if: contains(github.event.issue.labels.*.name, 'onboarding') && github.event.issue.state == 'closed'
         run: |
-          const { GitHub, context } = require('github-actions-toolkit');
-
-
           const github = new GitHub();
 
-          const issue = context.payload.issue;
-
+          const issue = context.payload.i
 
           // Get the user who opened the issue
           const user = issue.user.login;
 
           // Send a message as a comment when the onboarding issue is closed
-            const message = `Hello @${user}! 
+          const message = `Hello @${user}! 
             Welcome to the Modernisation Platform! Your new accounts have now been created. Please see the user guidance for details on how to build and access infrastructure in the 
             Modernisation Platform - https://user-guide.modernisation-platform.service.justice.gov.uk/#getting-started
 
             If you need any help or assistance please contact us in the [#ask-modernisation-platform](https://moj.enterprise.slack.com/archives/C01A7QK5VM1)`;
-            github.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: issue.number,
-              body: message,
+          github.issues.createComment({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: issue.number,
+            body: message,
           });

--- a/.github/workflows/notify-user-new-environment-created.yml
+++ b/.github/workflows/notify-user-new-environment-created.yml
@@ -21,8 +21,6 @@ jobs:
         run: |
           const github = new GitHub();
 
-          const issue = context.payload.i
-
           // Get the user who opened the issue
           const user = issue.user.login;
 


### PR DESCRIPTION
## A reference to the issue / Description of it

#3451 

## How does this PR fix the problem?

Automatically generates the email on closing the onboarders release

## How has this been tested?

Used act (act -W 'email-requester-onboarding-close.yml') to test and further tests require the release to be posted.

## Deployment Plan / Instructions

Does not impact any other services

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed

## Additional comments (if any)
It will be tested using a dummy onboarders call which will be closed to cause the yml to run
