### PR TITLE
Set the max parallel jobs for single sign on

### DIFF
--- a/.github/workflows/scheduled-baseline.yml
+++ b/.github/workflows/scheduled-baseline.yml
@@ -122,7 +122,7 @@ jobs:
 
   single-sign-on:
     strategy:
-      max-parallel: 10
+      max-parallel: 5
       fail-fast: false
       matrix:
         workspaces: ${{ fromJSON(needs.setup-prerequisites.outputs.matrix) }}


### PR DESCRIPTION
## A reference to the issue / Description of it

AWS SSO API limits were being hit, see here - https://github.com/ministryofjustice/modernisation-platform/actions/runs/7058404921/job/19217087981#step:7:120

## How does this PR fix the problem?

Attempting to limit the number of calls to allow the workflow runs to succeed. 10 was still failing, now trying 5.

## How has this been tested?

Not possible to test as needs a matrix to run.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

Fix existing issue.

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
