### PR TITLE
Creating SNS topics and updating IAM policy for instance scheduler

### DIFF
--- a/terraform/environments/core-shared-services/iam.tf
+++ b/terraform/environments/core-shared-services/iam.tf
@@ -161,6 +161,17 @@ data "aws_iam_policy_document" "instance-scheduler-lambda-function-policy" {
     resources = ["*"]
     actions   = ["kms:Decrypt"]
   }
+  statement {
+    sid    = "AllowLambdaToPublishToSNSTopics"
+    effect = "Allow"
+    actions = [
+      "sns:Publish"
+    ]
+    resources = [
+      aws_sns_topic.on_success.arn,
+      aws_sns_topic.on_failure.arn
+    ]
+  }
 }
 
 ## END: IAM for Instance Scheduler Lambda Function


### PR DESCRIPTION
## A reference to the issue / Description of it

This PR partially implements [the issue 2722](https://github.com/ministryofjustice/modernisation-platform/issues/2722).
This is to allow the instance scheduler lambda function to publish to SNS topics and to create topics that the lambda is going to use as the destination config. This is also integrating with an existing pagerduty service.

## How does this PR fix the problem?

This is to enable alerts when the instance scheduler fails/succeeds.

## How has this been tested?

Run the tf plan locally and it works as expected for the added functionality, but it fails for a transit gateway policy saying it needs an apply. Not end-to-end tested yet, as the lambda terraform module needs updating first.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

The instance scheduler IAM policy may be impacted if configured incorrectly.
SNS topics and the pagerduty integration are new resources, so it does not break the existing functionality.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
