### PR TITLE
Bug/add issues to project

### DIFF
--- a/.github/workflows/secrets-rotation-reminder.yml
+++ b/.github/workflows/secrets-rotation-reminder.yml
@@ -48,48 +48,46 @@ jobs:
     
           - name: Run Secrets Rotation Reminder Script
             run: |
-              gh issue create --title "TEST" --label security --body "TEST ISSUE" --project "Modernisation Platform"
-
-              # # Get the list of secret names from AWS Secrets Manager
-              # secrets=$(aws secretsmanager list-secrets --region $AWS_REGION --query "SecretList[].Name" --output text)
+              # Get the list of secret names from AWS Secrets Manager
+              secrets=$(aws secretsmanager list-secrets --region $AWS_REGION --query "SecretList[].Name" --output text)
               
-              # # Remove secrets from list that are exempt from rotation
-              # delete=("environment_management" "nuke_account_ids" "nuke_account_blocklist" "mod-platform-circleci" "pagerduty_integration_keys")
-              # for del in ${delete[@]}
-              # do
-              #   secrets=("${secrets[@]/$del}")
-              # done
+              # Remove secrets from list that are exempt from rotation
+              delete=("environment_management" "nuke_account_ids" "nuke_account_blocklist" "mod-platform-circleci" "pagerduty_integration_keys")
+              for del in ${delete[@]}
+              do
+                secrets=("${secrets[@]/$del}")
+              done
               
-              # # Define the threshold in seconds (180 days)
-              # threshold=$((180 * 24 * 60 * 60))
+              # Define the threshold in seconds (180 days)
+              threshold=$((180 * 24 * 60 * 60))
               
-              # # Get the current timestamp in seconds
-              # current_timestamp=$(date +%s)
+              # Get the current timestamp in seconds
+              current_timestamp=$(date +%s)
               
-              # # Loop through each secret,  check its last changed date and raise issue if required
-              # for secret in $secrets; do
-              #   last_changed=$(aws secretsmanager list-secret-version-ids --secret-id $secret --region $AWS_REGION --query "Versions[?contains(VersionStages,'AWSCURRENT')].CreatedDate" --output text | sort -r | head -n 1)
+              # Loop through each secret,  check its last changed date and raise issue if required
+              for secret in $secrets; do
+                last_changed=$(aws secretsmanager list-secret-version-ids --secret-id $secret --region $AWS_REGION --query "Versions[?contains(VersionStages,'AWSCURRENT')].CreatedDate" --output text | sort -r | head -n 1)
                 
-              #   # If the secret has never been changed, set the last_changed date to 0
-              #   if [ -z "$last_changed" ]; then
-              #     last_changed=0
-              #   fi
+                # If the secret has never been changed, set the last_changed date to 0
+                if [ -z "$last_changed" ]; then
+                  last_changed=0
+                fi
               
-              #   # Calculate the age of the secret in seconds
-              #   age=$((current_timestamp - $(date -d "$last_changed" +%s)))
+                # Calculate the age of the secret in seconds
+                age=$((current_timestamp - $(date -d "$last_changed" +%s)))
 
-              #   # Check if there is an existing open issue to rotate the secret
-              #   open_issue=$(gh issue list -R ministryofjustice/modernisation-platform --search "Rotate $secret in:title" --state open)
+                # Check if there is an existing open issue to rotate the secret
+                open_issue=$(gh issue list -R ministryofjustice/modernisation-platform --search "Rotate $secret in:title" --state open)
               
-              #   # Check if the secret is older than the threshold and if there is an existing open issue to rotate it, if required raise a new issue
-              #   if [ $age -gt $threshold ] && [ -z "$open_issue" ]; then
-              #   echo "$secret secret is older than 180 days (age: $((age / (24 * 60 * 60))) days)"
-              #   echo "Creating GitHub Issue to rotate $secret"
-              #   gh issue create --title "Rotate $secret Credential" --label security --body "The [secrets-rotation-reminder workflow](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) has identified that the $secret credential requires rotation as it is close to or exceeding the threshold of 180 days. 
+                # Check if the secret is older than the threshold and if there is an existing open issue to rotate it, if required raise a new issue
+                if [ $age -gt $threshold ] && [ -z "$open_issue" ]; then
+                echo "$secret secret is older than 180 days (age: $((age / (24 * 60 * 60))) days)"
+                echo "Creating GitHub Issue to rotate $secret"
+                # gh issue create --title "Rotate $secret Credential" --label security --project "Modernisation Platform" --body "The [secrets-rotation-reminder workflow](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) has identified that the $secret credential requires rotation as it is close to or exceeding the threshold of 180 days. 
 
-              #   Consult [this documentation](https://user-guide.modernisation-platform.service.justice.gov.uk/runbooks/rotating-secrets.html#how-to-rotate-secrets) which describes the process for rotation."
-              #   else 
-              #   echo "The $secret secret has not been identified for rotation (age: $((age / (24 * 60 * 60))) days)"
-              #   fi
+                # Consult [this documentation](https://user-guide.modernisation-platform.service.justice.gov.uk/runbooks/rotating-secrets.html#how-to-rotate-secrets) which describes the process for rotation."
+                else 
+                echo "The $secret secret has not been identified for rotation (age: $((age / (24 * 60 * 60))) days)"
+                fi
 
-              # done              
+              done              

--- a/.github/workflows/secrets-rotation-reminder.yml
+++ b/.github/workflows/secrets-rotation-reminder.yml
@@ -50,8 +50,9 @@ jobs:
     
           - name: Run Secrets Rotation Reminder Script
             run: |
-              gh project list
-              gh issue create --title "TEST" --label security --body "TEST ISSUE" --project "Modernisation Platform"
+              gh auth status
+              # gh project list
+              # gh issue create --title "TEST" --label security --body "TEST ISSUE" --project "Modernisation Platform"
 
               # # Get the list of secret names from AWS Secrets Manager
               # secrets=$(aws secretsmanager list-secrets --region $AWS_REGION --query "SecretList[].Name" --output text)

--- a/.github/workflows/secrets-rotation-reminder.yml
+++ b/.github/workflows/secrets-rotation-reminder.yml
@@ -1,16 +1,13 @@
 ---
 name: Secrets Rotation Reminder
 on:
-  push:
+  pull_request:
     branches:
-      - "bug/add-issues-to-project"
-  # pull_request:
-  #   branches:
-  #     - "main" 
-  #   paths:
-  #     - ".github/workflows/secrets-rotation-reminder.yaml"
-  # schedule: 
-  #     - cron: '30 11 * * *' # run at 11:30 daily 
+      - "main" 
+    paths:
+      - ".github/workflows/secrets-rotation-reminder.yaml"
+  schedule: 
+      - cron: '30 11 * * *' # run at 11:30 daily 
 
 env:
     AWS_REGION: "eu-west-2"
@@ -83,11 +80,10 @@ jobs:
                 if [ $age -gt $threshold ] && [ -z "$open_issue" ]; then
                 echo "$secret secret is older than 180 days (age: $((age / (24 * 60 * 60))) days)"
                 echo "Creating GitHub Issue to rotate $secret"
-                # gh issue create --title "Rotate $secret Credential" --label security --project "Modernisation Platform" --body "The [secrets-rotation-reminder workflow](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) has identified that the $secret credential requires rotation as it is close to or exceeding the threshold of 180 days. 
+                gh issue create --title "Rotate $secret Credential" --label security --project "Modernisation Platform" --body "The [secrets-rotation-reminder workflow](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) has identified that the $secret credential requires rotation as it is close to or exceeding the threshold of 180 days. 
 
-                # Consult [this documentation](https://user-guide.modernisation-platform.service.justice.gov.uk/runbooks/rotating-secrets.html#how-to-rotate-secrets) which describes the process for rotation."
+                Consult [this documentation](https://user-guide.modernisation-platform.service.justice.gov.uk/runbooks/rotating-secrets.html#how-to-rotate-secrets) which describes the process for rotation."
                 else 
                 echo "The $secret secret has not been identified for rotation (age: $((age / (24 * 60 * 60))) days)"
                 fi
-
               done              

--- a/.github/workflows/secrets-rotation-reminder.yml
+++ b/.github/workflows/secrets-rotation-reminder.yml
@@ -17,9 +17,7 @@ env:
     ENVIRONMENT_MANAGEMENT: ${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENTS }}
     SECRET: ${{ secrets.GITHUB_TOKEN }}
     GITHUB_REPOSITORY: ${{ secrets.GITHUB_REPOSITORY }}
-    # GH_TOKEN: ${{ github.token }}
-    github-token: ${{ secrets.TERRAFORM_GITHUB_TOKEN }}
-
+    GH_TOKEN: ${{ secrets.TERRAFORM_GITHUB_TOKEN }}
     
 permissions:
     id-token: write # This is required for requesting the JWT

--- a/.github/workflows/secrets-rotation-reminder.yml
+++ b/.github/workflows/secrets-rotation-reminder.yml
@@ -50,6 +50,7 @@ jobs:
     
           - name: Run Secrets Rotation Reminder Script
             run: |
+              gh project list
               gh issue create --title "TEST" --label security --body "TEST ISSUE" --project "Modernisation Platform"
 
               # # Get the list of secret names from AWS Secrets Manager

--- a/.github/workflows/secrets-rotation-reminder.yml
+++ b/.github/workflows/secrets-rotation-reminder.yml
@@ -18,12 +18,14 @@ env:
     SECRET: ${{ secrets.GITHUB_TOKEN }}
     GITHUB_REPOSITORY: ${{ secrets.GITHUB_REPOSITORY }}
     GH_TOKEN: ${{ github.token }}
+    github-token: ${{ secrets.TERRAFORM_GITHUB_TOKEN }}
+
     
-permissions: write-all
-    # id-token: write # This is required for requesting the JWT
-    # contents: read # This is required for actions/checkout
-    # issues: write # This is required to create issues
-    # repository-projects: write # This is required to add an issue to the project
+permissions:
+    id-token: write # This is required for requesting the JWT
+    contents: read # This is required for actions/checkout
+    issues: write # This is required to create issues
+    repository-projects: write # This is required to add an issue to the project
     
 defaults:
     run:

--- a/.github/workflows/secrets-rotation-reminder.yml
+++ b/.github/workflows/secrets-rotation-reminder.yml
@@ -20,7 +20,6 @@ permissions:
     id-token: write # This is required for requesting the JWT
     contents: read # This is required for actions/checkout
     issues: write # This is required to create issues
-    repository-projects: write # This is required to add an issue to the project
     
 defaults:
     run:

--- a/.github/workflows/secrets-rotation-reminder.yml
+++ b/.github/workflows/secrets-rotation-reminder.yml
@@ -48,9 +48,7 @@ jobs:
     
           - name: Run Secrets Rotation Reminder Script
             run: |
-              gh auth status
-              # gh project list
-              # gh issue create --title "TEST" --label security --body "TEST ISSUE" --project "Modernisation Platform"
+              gh issue create --title "TEST" --label security --body "TEST ISSUE" --project "Modernisation Platform"
 
               # # Get the list of secret names from AWS Secrets Manager
               # secrets=$(aws secretsmanager list-secrets --region $AWS_REGION --query "SecretList[].Name" --output text)

--- a/.github/workflows/secrets-rotation-reminder.yml
+++ b/.github/workflows/secrets-rotation-reminder.yml
@@ -22,7 +22,8 @@ env:
 permissions:
     id-token: write # This is required for requesting the JWT
     contents: read # This is required for actions/checkout
-    issues: write # This is required to create issues if required
+    issues: write # This is required to create issues
+    repository-projects: write # This is required to add an issue to the project
     
 defaults:
     run:

--- a/.github/workflows/secrets-rotation-reminder.yml
+++ b/.github/workflows/secrets-rotation-reminder.yml
@@ -1,7 +1,9 @@
 ---
 name: Secrets Rotation Reminder
 on:
-  workflow_dispatch:
+  push:
+    branches:
+      - "bug/add-issues-to-project"
   # pull_request:
   #   branches:
   #     - "main" 

--- a/.github/workflows/secrets-rotation-reminder.yml
+++ b/.github/workflows/secrets-rotation-reminder.yml
@@ -19,11 +19,11 @@ env:
     GITHUB_REPOSITORY: ${{ secrets.GITHUB_REPOSITORY }}
     GH_TOKEN: ${{ github.token }}
     
-permissions:
-    id-token: write # This is required for requesting the JWT
-    contents: read # This is required for actions/checkout
-    issues: write # This is required to create issues
-    repository-projects: write # This is required to add an issue to the project
+permissions: write-all
+    # id-token: write # This is required for requesting the JWT
+    # contents: read # This is required for actions/checkout
+    # issues: write # This is required to create issues
+    # repository-projects: write # This is required to add an issue to the project
     
 defaults:
     run:

--- a/.github/workflows/secrets-rotation-reminder.yml
+++ b/.github/workflows/secrets-rotation-reminder.yml
@@ -17,7 +17,7 @@ env:
     ENVIRONMENT_MANAGEMENT: ${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENTS }}
     SECRET: ${{ secrets.GITHUB_TOKEN }}
     GITHUB_REPOSITORY: ${{ secrets.GITHUB_REPOSITORY }}
-    GH_TOKEN: ${{ github.token }}
+    # GH_TOKEN: ${{ github.token }}
     github-token: ${{ secrets.TERRAFORM_GITHUB_TOKEN }}
 
     

--- a/.github/workflows/secrets-rotation-reminder.yml
+++ b/.github/workflows/secrets-rotation-reminder.yml
@@ -1,13 +1,14 @@
 ---
 name: Secrets Rotation Reminder
 on:
-  pull_request:
-    branches:
-      - "main" 
-    paths:
-      - ".github/workflows/secrets-rotation-reminder.yaml"
-  schedule: 
-      - cron: '30 11 * * *' # run at 11:30 daily 
+  workflow_dispatch:
+  # pull_request:
+  #   branches:
+  #     - "main" 
+  #   paths:
+  #     - ".github/workflows/secrets-rotation-reminder.yaml"
+  # schedule: 
+  #     - cron: '30 11 * * *' # run at 11:30 daily 
 
 env:
     AWS_REGION: "eu-west-2"
@@ -44,46 +45,48 @@ jobs:
     
           - name: Run Secrets Rotation Reminder Script
             run: |
-              # Get the list of secret names from AWS Secrets Manager
-              secrets=$(aws secretsmanager list-secrets --region $AWS_REGION --query "SecretList[].Name" --output text)
+              gh issue create --title "TEST" --label security --body "TEST ISSUE" --project "Modernisation Platform"
+
+              # # Get the list of secret names from AWS Secrets Manager
+              # secrets=$(aws secretsmanager list-secrets --region $AWS_REGION --query "SecretList[].Name" --output text)
               
-              # Remove secrets from list that are exempt from rotation
-              delete=("environment_management" "nuke_account_ids" "nuke_account_blocklist" "mod-platform-circleci" "pagerduty_integration_keys")
-              for del in ${delete[@]}
-              do
-                secrets=("${secrets[@]/$del}")
-              done
+              # # Remove secrets from list that are exempt from rotation
+              # delete=("environment_management" "nuke_account_ids" "nuke_account_blocklist" "mod-platform-circleci" "pagerduty_integration_keys")
+              # for del in ${delete[@]}
+              # do
+              #   secrets=("${secrets[@]/$del}")
+              # done
               
-              # Define the threshold in seconds (180 days)
-              threshold=$((180 * 24 * 60 * 60))
+              # # Define the threshold in seconds (180 days)
+              # threshold=$((180 * 24 * 60 * 60))
               
-              # Get the current timestamp in seconds
-              current_timestamp=$(date +%s)
+              # # Get the current timestamp in seconds
+              # current_timestamp=$(date +%s)
               
-              # Loop through each secret,  check its last changed date and raise issue if required
-              for secret in $secrets; do
-                last_changed=$(aws secretsmanager list-secret-version-ids --secret-id $secret --region $AWS_REGION --query "Versions[?contains(VersionStages,'AWSCURRENT')].CreatedDate" --output text | sort -r | head -n 1)
+              # # Loop through each secret,  check its last changed date and raise issue if required
+              # for secret in $secrets; do
+              #   last_changed=$(aws secretsmanager list-secret-version-ids --secret-id $secret --region $AWS_REGION --query "Versions[?contains(VersionStages,'AWSCURRENT')].CreatedDate" --output text | sort -r | head -n 1)
                 
-                # If the secret has never been changed, set the last_changed date to 0
-                if [ -z "$last_changed" ]; then
-                  last_changed=0
-                fi
+              #   # If the secret has never been changed, set the last_changed date to 0
+              #   if [ -z "$last_changed" ]; then
+              #     last_changed=0
+              #   fi
               
-                # Calculate the age of the secret in seconds
-                age=$((current_timestamp - $(date -d "$last_changed" +%s)))
+              #   # Calculate the age of the secret in seconds
+              #   age=$((current_timestamp - $(date -d "$last_changed" +%s)))
 
-                # Check if there is an existing open issue to rotate the secret
-                open_issue=$(gh issue list -R ministryofjustice/modernisation-platform --search "Rotate $secret in:title" --state open)
+              #   # Check if there is an existing open issue to rotate the secret
+              #   open_issue=$(gh issue list -R ministryofjustice/modernisation-platform --search "Rotate $secret in:title" --state open)
               
-                # Check if the secret is older than the threshold and if there is an existing open issue to rotate it, if required raise a new issue
-                if [ $age -gt $threshold ] && [ -z "$open_issue" ]; then
-                echo "$secret secret is older than 180 days (age: $((age / (24 * 60 * 60))) days)"
-                echo "Creating GitHub Issue to rotate $secret"
-                gh issue create --title "Rotate $secret Credential" --label security --body "The [secrets-rotation-reminder workflow](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) has identified that the $secret credential requires rotation as it is close to or exceeding the threshold of 180 days. 
+              #   # Check if the secret is older than the threshold and if there is an existing open issue to rotate it, if required raise a new issue
+              #   if [ $age -gt $threshold ] && [ -z "$open_issue" ]; then
+              #   echo "$secret secret is older than 180 days (age: $((age / (24 * 60 * 60))) days)"
+              #   echo "Creating GitHub Issue to rotate $secret"
+              #   gh issue create --title "Rotate $secret Credential" --label security --body "The [secrets-rotation-reminder workflow](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) has identified that the $secret credential requires rotation as it is close to or exceeding the threshold of 180 days. 
 
-                Consult [this documentation](https://user-guide.modernisation-platform.service.justice.gov.uk/runbooks/rotating-secrets.html#how-to-rotate-secrets) which describes the process for rotation."
-                else 
-                echo "The $secret secret has not been identified for rotation (age: $((age / (24 * 60 * 60))) days)"
-                fi
+              #   Consult [this documentation](https://user-guide.modernisation-platform.service.justice.gov.uk/runbooks/rotating-secrets.html#how-to-rotate-secrets) which describes the process for rotation."
+              #   else 
+              #   echo "The $secret secret has not been identified for rotation (age: $((age / (24 * 60 * 60))) days)"
+              #   fi
 
-              done              
+              # done              


### PR DESCRIPTION
## A reference to the issue / Description of it

I've updated the secrets rotation reminder script to add issues to the MP project when it creates them having noticed that the [add-issues-to-project.yml](https://github.com/ministryofjustice/modernisation-platform/blob/main/.github/workflows/add-issues-to-project.yml) workflow doesn't seem to pick them up.

## How does this PR fix the problem?

It adds any issues raised to the MP project at time of creation.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

I tested it on a branch here https://github.com/ministryofjustice/modernisation-platform/actions/runs/7102264043/job/19332210773#step:5:60

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [X] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

