### PR TITLE
Remove Any from Labeler Config

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,31 +1,26 @@
 onboarding:
-- any:
   - changed-files:
-    - any-glob-to-any-file:
+    - any-glob-to-any-file: 
       - "environments/**"
       - "environments-networks/**"
 
 documentation:
-- any:
   - changed-files:
     - any-glob-to-any-file:
       - "source/**"
       - "architecture-decision-record/**"
 
 dependencies:
-- any:
   - changed-files:
     - any-glob-to-any-file: 
       - "terraform/**/*.lock.hcl"
 
 github-workflow:
-- any:
   - changed-files:
     - any-glob-to-any-file: 
       - "github/workflows/**"
 
 networking:
-- any:
   - changed-files:
     - any-glob-to-any-file: 
       - "terraform/environments/core-vpc/**"
@@ -33,19 +28,16 @@ networking:
       - "cidr-allocation.md"
 
 core:
-- any:
   - changed-files:
     - any-glob-to-any-file: 
       - "terraform/environments/core-*/**"
 
 security:
-- any:
   - changed-files:
     - any-glob-to-any-file:
       - "terraform/environments/core-security/**"
 
 testing:
-- any:
   - changed-files:
     - any-glob-to-any-file:
       - "policies/**"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -18,7 +18,7 @@ dependencies:
 github-workflow:
   - changed-files:
     - any-glob-to-any-file: 
-      - "github/workflows/**"
+      - ".github/workflows/**"
 
 networking:
   - changed-files:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -8,7 +8,6 @@ permissions:
   contents: read
   pull-requests: write
 
-  
 jobs:
   triage:
     runs-on: ubuntu-latest

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -8,6 +8,7 @@ permissions:
   contents: read
   pull-requests: write
 
+  
 jobs:
   triage:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## A reference to the issue / Description of it

Removing '`ANY`' from config as not required, also fixing .github path in config as previous PR did not get labeled with `github-workflow` .

## How does this PR fix the problem?

as per above

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

N/A

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [ X ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
