### PR TITLE
Using the latest lambda function in instance scheduler

### DIFF
--- a/terraform/environments/core-shared-services/instance-scheduler-lambda-function.tf
+++ b/terraform/environments/core-shared-services/instance-scheduler-lambda-function.tf
@@ -3,7 +3,7 @@ module "instance_scheduler" {
   #checkov:skip=CKV_AWS_117
   #checkov:skip=CKV_AWS_272 "Code signing not required"
   #checkov:skip=CKV_AWS_173 "These lambda envvars aren't sensitive and don't need a cmk. Default AWS KMS key is sufficient"
-  source                         = "github.com/ministryofjustice/modernisation-platform-terraform-lambda-function?ref=20e0d9e27402d1e012159a41b474da908d74941b" #v2.0.0
+  source                         = "github.com/ministryofjustice/modernisation-platform-terraform-lambda-function?ref=5a3c02a071519986a0ae415168fb4f9d3fb7970f" #v2.0.0
   application_name               = local.application_name
   tags                           = local.tags
   description                    = "Lambda to automatically start and stop instances on member accounts"
@@ -31,6 +31,9 @@ module "instance_scheduler" {
       source_arn = aws_cloudwatch_event_rule.instance_scheduler_weekly_start_in_the_morning.arn
     }
   }
+
+  sns_topic_on_failure = aws_sns_topic.on_failure.arn
+  sns_topic_on_success = aws_sns_topic.on_success.arn
 
 }
 


### PR DESCRIPTION
## A reference to the issue / Description of it

This PR is to further implement https://github.com/ministryofjustice/modernisation-platform/issues/2722
This change will use the latest version of the lambda function to allow passing of SNS topics as lambda's destination.

## How does this PR fix the problem?

SNS topics are specified to enable alerting with PD/slack.

## How has this been tested?

This plans out OK locally. This will be further tested when the scheduler runs.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

This should not impact the instance scheduling, but it should create alerts, which then will need tuning.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
