### PR TITLE
add mojo to prod csr firewall rules

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/production_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/production_rules.json
@@ -404,5 +404,54 @@
     "destination_ip": "${hmpps-production-general-private-subnets}",
     "destination_port": "1434",
     "protocol": "UDP"
+  },
+  "mojo_to_csr_production_http": {
+    "action": "PASS",
+    "source_ip": "10.0.0.0/8",
+    "destination_ip": "${ hmpps-production-general-private-subnets}",
+    "destination_port": "80",
+    "protocol": "TCP"
+  },
+  "mojo_to_csr_production_app_core_7770": {
+    "action": "PASS",
+    "source_ip": "10.0.0.0/8",
+    "destination_ip": "${ hmpps-production-general-private-subnets}",
+    "destination_port": "7770",
+    "protocol": "TCP"
+  },
+  "mojo_to_csr_production_app_core_7771": {
+    "action": "PASS",
+    "source_ip": "10.0.0.0/8",
+    "destination_ip": "${ hmpps-production-general-private-subnets}",
+    "destination_port": "7771",
+    "protocol": "TCP"
+  },
+  "mojo_to_csr_production_app_custom_7780": {
+    "action": "PASS",
+    "source_ip": "10.0.0.0/8",
+    "destination_ip": "${ hmpps-production-general-private-subnets}",
+    "destination_port": "7780",
+    "protocol": "TCP"
+  },
+  "mojo_to_csr_production_app_custom_7781": {
+    "action": "PASS",
+    "source_ip": "10.0.0.0/8",
+    "destination_ip": "${ hmpps-production-general-private-subnets}",
+    "destination_port": "7781",
+    "protocol": "TCP"
+  },
+  "mojo_to_csr_production_2109": {
+    "action": "PASS",
+    "source_ip": "10.0.0.0/8",
+    "destination_ip": "${ hmpps-production-general-private-subnets}",
+    "destination_port": "2109",
+    "protocol": "TCP"
+  },
+  "mojo_to_csr_production_45054": {
+    "action": "PASS",
+    "source_ip": "10.0.0.0/8",
+    "destination_ip": "${ hmpps-production-general-private-subnets}",
+    "destination_port": "45054",
+    "protocol": "TCP"
   }
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

Open firewall for MoJo devices -> CSR prod as per pre-production rules (which work)

## How does this PR fix the problem?

Allows traffic to CSR subnets in AWS

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Pre-Prod version works, prod environment currently blocking everything 👎 

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

Only positively

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

NA
