### PR TITLE
Give hmpps-dba access to OEM and remove sandbox from dev

### DIFF
--- a/environments/hmpps-oem.json
+++ b/environments/hmpps-oem.json
@@ -6,11 +6,15 @@
       "access": [
         {
           "github_slug": "studio-webops",
-          "level": "sandbox"
+          "level": "developer"
         },
         {
           "github_slug": "hmpps-migration",
-          "level": "sandbox"
+          "level": "developer"
+        },
+        {
+          "github_slug": "hmpps-dba",
+          "level": "developer"
         }
       ]
     },
@@ -23,6 +27,10 @@
         },
         {
           "github_slug": "hmpps-migration",
+          "level": "developer"
+        },
+        {
+          "github_slug": "hmpps-dba",
           "level": "developer"
         }
       ]
@@ -37,6 +45,10 @@
         {
           "github_slug": "hmpps-migration",
           "level": "developer"
+        },
+        {
+          "github_slug": "hmpps-dba",
+          "level": "developer"
         }
       ]
     },
@@ -49,6 +61,10 @@
         },
         {
           "github_slug": "hmpps-migration",
+          "level": "developer"
+        },
+        {
+          "github_slug": "hmpps-dba",
           "level": "developer"
         }
       ]


### PR DESCRIPTION
## A reference to the issue / Description of it

Probation WebOps need access to shared Oracle Enterprise Management solution.
In addition, we don't need sandbox functionality/nuking in the development environment

## How does this PR fix the problem?

It gives DBAs access and removes sandbox permissions

## How has this been tested?

n/a

## Deployment Plan / Instructions

n/a

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

n/a

## Additional comments (if any)

{Please write here}
