### PR TITLE
Addressing checkov failures

### DIFF
--- a/terraform/environments/core-shared-services/instance-scheduler-lambda-function.tf
+++ b/terraform/environments/core-shared-services/instance-scheduler-lambda-function.tf
@@ -81,10 +81,12 @@ resource "aws_cloudwatch_event_target" "instance_scheduler_weekly_start_in_the_m
 
 # sns topics that are the instance scheduler lambda function's destination configuration
 resource "aws_sns_topic" "on_failure" {
+  #checkov:skip=CKV_AWS_26:"encrypted topics do not work with pagerduty subscription"
   name = "instance-scheduler-event-notification-topic-on-failure"
 }
 
 resource "aws_sns_topic" "on_success" {
+  #checkov:skip=CKV_AWS_26:"encrypted topics do not work with pagerduty subscription"
   name = "instance-scheduler-event-notification-topic-on-success"
 }
 
@@ -93,7 +95,7 @@ module "pagerduty_core_alerts" {
   depends_on = [
     aws_sns_topic.on_failure, aws_sns_topic.on_success
   ]
-  source                    = "github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration?ref=v2.0.0"
+  source                    = "github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration?ref=0179859e6fafc567843cd55c0b05d325d5012dc4" # v2.0.0
   sns_topics                = [aws_sns_topic.on_failure.name, aws_sns_topic.on_success.name]
   pagerduty_integration_key = local.pagerduty_integration_keys["core_alerts_cloudwatch"]
 }

--- a/terraform/environments/core-shared-services/instance-scheduler-lambda-function.tf
+++ b/terraform/environments/core-shared-services/instance-scheduler-lambda-function.tf
@@ -9,6 +9,7 @@ module "instance_scheduler" {
   description                    = "Lambda to automatically start and stop instances on member accounts"
   role_name                      = "InstanceSchedulerLambdaFunctionPolicy"
   policy_json                    = data.aws_iam_policy_document.instance-scheduler-lambda-function-policy.json
+  policy_json_attached           = true
   function_name                  = "instance-scheduler-lambda-function"
   create_role                    = true
   reserved_concurrent_executions = 1


### PR DESCRIPTION
## A reference to the issue / Description of it

Addressing SCA failures in https://github.com/ministryofjustice/modernisation-platform/actions/runs/7109130936
and adding the policy back to the instance scheduler role, which has been removed in the merge yesterday.
 
## How does this PR fix the problem?

Adding hash for PD integration and suppressing SNS topic error, as encryption is not possible with PD integration.

Also, the lambda function has changed between the merge commit yesterday and the version that has been used in the past, the logic has changed and when using the module, it was missing on var that is used in the conditional that would either create that policy or not…so because it wasn’t meeting that conditional’s requirements, it would delete the policy from the role. This fix is to add the permissions back to the role.

## How has this been tested?

Checks should pass now and it has been applied and re-tested with tests in the pipeline.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No and it has been applied already in order for the tests to be able to run (it needed permissions to run the tests, chicken and egg situation).

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
