### PR TITLE
Update documentation and templates for state locking

### DIFF
--- a/source/user-guide/running-terraform-plan-locally.html.md.erb
+++ b/source/user-guide/running-terraform-plan-locally.html.md.erb
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#modernisation-platform"
 title: Running Terraform Plan Locally
-last_reviewed_on: 2023-10-17
+last_reviewed_on: 2023-12-11
 review_in: 6 months
 ---
 
@@ -23,7 +23,7 @@ Follow the instructions [here](https://learn.hashicorp.com/tutorials/terraform/i
 ## Run Terraform plan
 
 1. Navigate to your application infrastructure code - `cd modernisation-platform-environments/terraform/environments/my-application`
-1. Run a Terraform init - `terraform init`
+1. Run a Terraform init that assumes the backend role in the Modernisation Platform account- `terraform init -backend-config="assume_role.role_arn=arn:aws:iam::000000000000:role/modernisation-account-terraform-state-member-access"`
 1. View the workspaces (you have different workspaces for your different environment accounts) - `terraform workspace list`
 1. Select the required workspace - `terraform workspace select my-application-development`
 1. Run a Terraform plan - `terraform plan`

--- a/terraform/templates/modernisation-platform-environments/platform_backend.tf
+++ b/terraform/templates/modernisation-platform-environments/platform_backend.tf
@@ -5,6 +5,7 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
+    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/5534

## How does this PR fix the problem?

Updates documentation for customers, and templates for new Modernisation Platform Environments customers.

## How has this been tested?

Changes to `platform_backend.tf` are identical to those in my test PR and full PR in the Modernisation Platform Environments repository

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

Corresponds with https://github.com/ministryofjustice/modernisation-platform-environments/pull/4254
