### PR TITLE
Add infrastructure-support tag in cica-copilot.json

### DIFF
--- a/environments/cica-copilot.json
+++ b/environments/cica-copilot.json
@@ -14,6 +14,7 @@
     "tags": {
       "application": "cica-copilot",
       "business-unit": "CICA",
+      "infrastructure-support": "infrastructure@cica.gov.uk",
       "owner": "CICA: infrastructure@cica.gov.uk"
     },
     "github-oidc-team-repositories": [""],


### PR DESCRIPTION
## A reference to the issue / Description of it

member-bootstrap job failed due to infrastructure-support tag is missing in cica-copilot.json

## How does this PR fix the problem?

Added infrastructure-support tag in cica-copilot.json inorder to run the member-bootstrap job