### PR TITLE
New firewall rules to allow access  to Nomis

### DIFF
--- a/terraform/environments/core-network-services/cidr-ranges.tf
+++ b/terraform/environments/core-network-services/cidr-ranges.tf
@@ -44,6 +44,8 @@ locals {
     nomisapi-t3-root-vnet          = "10.47.0.0/26"
     nomisapi-preprod-root-vnet     = "10.47.0.64/26"
     nomisapi-prod-root-vnet        = "10.47.0.128/26"
+    nomis-SMTP-Relay1              = "10.180.104.100"
+    nomis-SMTP-Relay2              = "10.180.105.100"
 
     # hmpps aws cidr ranges
     delius-eng-dev  = "10.161.98.0/25"

--- a/terraform/environments/core-network-services/cidr-ranges.tf
+++ b/terraform/environments/core-network-services/cidr-ranges.tf
@@ -44,8 +44,8 @@ locals {
     nomisapi-t3-root-vnet          = "10.47.0.0/26"
     nomisapi-preprod-root-vnet     = "10.47.0.64/26"
     nomisapi-prod-root-vnet        = "10.47.0.128/26"
-    nomis-smtp-relay1              = "10.180.104.100"
-    nomis-smtp-relay2              = "10.180.105.100"
+    moj-smtp-relay1              = "10.180.104.100"
+    moj-smtp-relay2              = "10.180.105.100"
 
     # hmpps aws cidr ranges
     delius-eng-dev  = "10.161.98.0/25"

--- a/terraform/environments/core-network-services/cidr-ranges.tf
+++ b/terraform/environments/core-network-services/cidr-ranges.tf
@@ -44,8 +44,8 @@ locals {
     nomisapi-t3-root-vnet          = "10.47.0.0/26"
     nomisapi-preprod-root-vnet     = "10.47.0.64/26"
     nomisapi-prod-root-vnet        = "10.47.0.128/26"
-    nomis-SMTP-Relay1              = "10.180.104.100"
-    nomis-SMTP-Relay2              = "10.180.105.100"
+    nomis-smtp-relay1              = "10.180.104.100"
+    nomis-smtp-relay2              = "10.180.105.100"
 
     # hmpps aws cidr ranges
     delius-eng-dev  = "10.161.98.0/25"

--- a/terraform/environments/core-network-services/cidr-ranges.tf
+++ b/terraform/environments/core-network-services/cidr-ranges.tf
@@ -44,8 +44,8 @@ locals {
     nomisapi-t3-root-vnet          = "10.47.0.0/26"
     nomisapi-preprod-root-vnet     = "10.47.0.64/26"
     nomisapi-prod-root-vnet        = "10.47.0.128/26"
-    moj-smtp-relay1              = "10.180.104.100"
-    moj-smtp-relay2              = "10.180.105.100"
+    moj-smtp-relay1              = "10.180.104.100/32"
+    moj-smtp-relay2              = "10.180.105.100/32"
 
     # hmpps aws cidr ranges
     delius-eng-dev  = "10.161.98.0/25"

--- a/terraform/environments/core-network-services/firewall-rules/development_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/development_rules.json
@@ -369,5 +369,33 @@
     "destination_ip": "10.172.68.0/23",
     "destination_port": "389",
     "protocol": "TCP"
+  },
+  "mp-dev-test_to_moj-smtp-relay-1": {
+    "action": "PASS",
+    "source_ip": "10.26.0.0/16",
+    "destination_ip": "10.180.104.100",
+    "destination_port": "25",
+    "protocol": "TCP"
+  },
+  "mp-dev-test_to_moj-smtp-relay-2": {
+    "action": "PASS",
+    "source_ip": "10.26.0.0/16",
+    "destination_ip": "10.180.105.100",
+    "destination_port": "25",
+    "protocol": "TCP"
+  },
+  "mp-dev-test_secure_to_moj-smtp-relay-1": {
+    "action": "PASS",
+    "source_ip": "10.26.0.0/16",
+    "destination_ip": "10.180.104.100",
+    "destination_port": "587",
+    "protocol": "TCP"
+  },
+  "mp-dev-test_secure_to_moj-smtp-relay-2": {
+    "action": "PASS",
+    "source_ip": "10.26.0.0/16",
+    "destination_ip": "10.180.105.100",
+    "destination_port": "587",
+    "protocol": "TCP"
   }
 }

--- a/terraform/environments/core-network-services/firewall-rules/development_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/development_rules.json
@@ -373,28 +373,28 @@
   "mp-dev-test_to_moj-smtp-relay-1": {
     "action": "PASS",
     "source_ip": "${mp-development-test}",
-    "destination_ip": "${nomis-SMTP-Relay1}",
+    "destination_ip": "${nomis-smtp-relay1}",
     "destination_port": "25",
     "protocol": "TCP"
   },
   "mp-dev-test_to_moj-smtp-relay-2": {
     "action": "PASS",
     "source_ip": "${mp-development-test}",
-    "destination_ip": "${nomis-SMTP-Relay2}",
+    "destination_ip": "${nomis-smtp-relay2}",
     "destination_port": "25",
     "protocol": "TCP"
   },
   "mp-dev-test_secure_to_moj-smtp-relay-1": {
     "action": "PASS",
-    "source_ip": "${mp-development-test",
-    "destination_ip": "${nomis-SMTP-Relay1}",
+    "source_ip": "${mp-development-test}",
+    "destination_ip": "${nomis-smtp-relay1}",
     "destination_port": "587",
     "protocol": "TCP"
   },
   "mp-dev-test_secure_to_moj-smtp-relay-2": {
     "action": "PASS",
     "source_ip": "${mp-development-test}",
-    "destination_ip": "${nomis-SMTP-Relay2}",
+    "destination_ip": "${nomis-smtp-relay2}",
     "destination_port": "587",
     "protocol": "TCP"
   }

--- a/terraform/environments/core-network-services/firewall-rules/development_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/development_rules.json
@@ -373,28 +373,28 @@
   "mp-dev-test_to_moj-smtp-relay-1": {
     "action": "PASS",
     "source_ip": "${mp-development-test}",
-    "destination_ip": "${nomis-smtp-relay1}",
+    "destination_ip": "${moj-smtp-relay1}",
     "destination_port": "25",
     "protocol": "TCP"
   },
   "mp-dev-test_to_moj-smtp-relay-2": {
     "action": "PASS",
     "source_ip": "${mp-development-test}",
-    "destination_ip": "${nomis-smtp-relay2}",
+    "destination_ip": "${moj-smtp-relay2}",
     "destination_port": "25",
     "protocol": "TCP"
   },
   "mp-dev-test_secure_to_moj-smtp-relay-1": {
     "action": "PASS",
     "source_ip": "${mp-development-test}",
-    "destination_ip": "${nomis-smtp-relay1}",
+    "destination_ip": "${moj-smtp-relay1}",
     "destination_port": "587",
     "protocol": "TCP"
   },
   "mp-dev-test_secure_to_moj-smtp-relay-2": {
     "action": "PASS",
     "source_ip": "${mp-development-test}",
-    "destination_ip": "${nomis-smtp-relay2}",
+    "destination_ip": "${moj-smtp-relay2}",
     "destination_port": "587",
     "protocol": "TCP"
   }

--- a/terraform/environments/core-network-services/firewall-rules/development_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/development_rules.json
@@ -372,29 +372,29 @@
   },
   "mp-dev-test_to_moj-smtp-relay-1": {
     "action": "PASS",
-    "source_ip": "10.26.0.0/16",
-    "destination_ip": "10.180.104.100",
+    "source_ip": "${mp-development-test}",
+    "destination_ip": "${nomis-SMTP-Relay1}",
     "destination_port": "25",
     "protocol": "TCP"
   },
   "mp-dev-test_to_moj-smtp-relay-2": {
     "action": "PASS",
-    "source_ip": "10.26.0.0/16",
-    "destination_ip": "10.180.105.100",
+    "source_ip": "${mp-development-test}",
+    "destination_ip": "${nomis-SMTP-Relay2}",
     "destination_port": "25",
     "protocol": "TCP"
   },
   "mp-dev-test_secure_to_moj-smtp-relay-1": {
     "action": "PASS",
-    "source_ip": "10.26.0.0/16",
-    "destination_ip": "10.180.104.100",
+    "source_ip": "${mp-development-test",
+    "destination_ip": "${nomis-SMTP-Relay1}",
     "destination_port": "587",
     "protocol": "TCP"
   },
   "mp-dev-test_secure_to_moj-smtp-relay-2": {
     "action": "PASS",
-    "source_ip": "10.26.0.0/16",
-    "destination_ip": "10.180.105.100",
+    "source_ip": "${mp-development-test}",
+    "destination_ip": "${nomis-SMTP-Relay2}",
     "destination_port": "587",
     "protocol": "TCP"
   }

--- a/terraform/environments/core-network-services/firewall-rules/production_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/production_rules.json
@@ -457,28 +457,28 @@
   "mp-prod-preprod_to_moj-smtp-relay-1": {
     "action": "PASS",
     "source_ip": "${mp-preproduction-production}",
-    "destination_ip": "${nomis-SMTP-Relay1}",
+    "destination_ip": "${nomis-smtp-relay1}",
     "destination_port": "25",
     "protocol": "TCP"
   },
   "mp-prod-preprod_to_moj-smtp-relay-2": {
     "action": "PASS",
     "source_ip": "${mp-preproduction-production}",
-    "destination_ip": "${nomis-SMTP-Relay2}",
+    "destination_ip": "${nomis-smtp-relay2}",
     "destination_port": "25",
     "protocol": "TCP"
   },
   "mp-prod-preprod_secure_to_moj-smtp-relay-1": {
     "action": "PASS",
     "source_ip": "${mp-preproduction-production}",
-    "destination_ip": "${nomis-SMTP-Relay1}",
+    "destination_ip": "${nomis-smtp-relay1}",
     "destination_port": "587",
     "protocol": "TCP"
   },
   "mp-prod-preprod_secure_to_moj-smtp-relay-2": {
     "action": "PASS",
     "source_ip": "${mp-preproduction-production}",
-    "destination_ip": "${nomis-SMTP-Relay2}",
+    "destination_ip": "${nomis-smtp-relay2}",
     "destination_port": "587",
     "protocol": "TCP"
   }

--- a/terraform/environments/core-network-services/firewall-rules/production_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/production_rules.json
@@ -453,5 +453,33 @@
     "destination_ip": "${ hmpps-production-general-private-subnets}",
     "destination_port": "45054",
     "protocol": "TCP"
+  },
+  "mp-prod-preprod_to_moj-smtp-relay-1": {
+    "action": "PASS",
+    "source_ip": "10.27.0.0/16",
+    "destination_ip": "10.180.104.100",
+    "destination_port": "25",
+    "protocol": "TCP"
+  },
+  "mp-prod-preprod_to_moj-smtp-relay-2": {
+    "action": "PASS",
+    "source_ip": "10.27.0.0/16",
+    "destination_ip": "10.180.105.100",
+    "destination_port": "25",
+    "protocol": "TCP"
+  },
+  "mp-prod-preprod_secure_to_moj-smtp-relay-1": {
+    "action": "PASS",
+    "source_ip": "10.27.0.0/16",
+    "destination_ip": "10.180.104.100",
+    "destination_port": "587",
+    "protocol": "TCP"
+  },
+  "mp-prod-preprod_secure_to_moj-smtp-relay-2": {
+    "action": "PASS",
+    "source_ip": "10.27.0.0/16",
+    "destination_ip": "10.180.105.100",
+    "destination_port": "587",
+    "protocol": "TCP"
   }
 }

--- a/terraform/environments/core-network-services/firewall-rules/production_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/production_rules.json
@@ -456,29 +456,29 @@
   },
   "mp-prod-preprod_to_moj-smtp-relay-1": {
     "action": "PASS",
-    "source_ip": "10.27.0.0/16",
-    "destination_ip": "10.180.104.100",
+    "source_ip": "${mp-preproduction-production}",
+    "destination_ip": "${nomis-SMTP-Relay1}",
     "destination_port": "25",
     "protocol": "TCP"
   },
   "mp-prod-preprod_to_moj-smtp-relay-2": {
     "action": "PASS",
-    "source_ip": "10.27.0.0/16",
-    "destination_ip": "10.180.105.100",
+    "source_ip": "${mp-preproduction-production}",
+    "destination_ip": "${nomis-SMTP-Relay2}",
     "destination_port": "25",
     "protocol": "TCP"
   },
   "mp-prod-preprod_secure_to_moj-smtp-relay-1": {
     "action": "PASS",
-    "source_ip": "10.27.0.0/16",
-    "destination_ip": "10.180.104.100",
+    "source_ip": "${mp-preproduction-production}",
+    "destination_ip": "${nomis-SMTP-Relay1}",
     "destination_port": "587",
     "protocol": "TCP"
   },
   "mp-prod-preprod_secure_to_moj-smtp-relay-2": {
     "action": "PASS",
-    "source_ip": "10.27.0.0/16",
-    "destination_ip": "10.180.105.100",
+    "source_ip": "${mp-preproduction-production}",
+    "destination_ip": "${nomis-SMTP-Relay2}",
     "destination_port": "587",
     "protocol": "TCP"
   }

--- a/terraform/environments/core-network-services/firewall-rules/production_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/production_rules.json
@@ -457,28 +457,28 @@
   "mp-prod-preprod_to_moj-smtp-relay-1": {
     "action": "PASS",
     "source_ip": "${mp-preproduction-production}",
-    "destination_ip": "${nomis-smtp-relay1}",
+    "destination_ip": "${moj-smtp-relay1}",
     "destination_port": "25",
     "protocol": "TCP"
   },
   "mp-prod-preprod_to_moj-smtp-relay-2": {
     "action": "PASS",
     "source_ip": "${mp-preproduction-production}",
-    "destination_ip": "${nomis-smtp-relay2}",
+    "destination_ip": "${moj-smtp-relay2}",
     "destination_port": "25",
     "protocol": "TCP"
   },
   "mp-prod-preprod_secure_to_moj-smtp-relay-1": {
     "action": "PASS",
     "source_ip": "${mp-preproduction-production}",
-    "destination_ip": "${nomis-smtp-relay1}",
+    "destination_ip": "${moj-smtp-relay1}",
     "destination_port": "587",
     "protocol": "TCP"
   },
   "mp-prod-preprod_secure_to_moj-smtp-relay-2": {
     "action": "PASS",
     "source_ip": "${mp-preproduction-production}",
-    "destination_ip": "${nomis-smtp-relay2}",
+    "destination_ip": "${moj-smtp-relay2}",
     "destination_port": "587",
     "protocol": "TCP"
   }


### PR DESCRIPTION
## A reference to the issue / Description of it

See #5713 

## How does this PR fix the problem?

Adds the firewalls for when the ports are opened

## How has this been tested?

Not yet testable

## Checklist (check `x` in `[ ]` of list items)

- [ x] I have performed a self-review of my own code
- [ x] All checks have passed

