### PR TITLE
🛂 Add S3 Storage Lens permissions

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/policies.tf
+++ b/terraform/environments/bootstrap/delegate-access/policies.tf
@@ -231,6 +231,7 @@ data "aws_iam_policy_document" "developer_additional" {
       "s3:DeleteObject",
       "s3:DeleteObjectVersion",
       "s3:RestoreObject",
+      "s3:*StorageLens*",
       "secretsmanager:GetResourcePolicy",
       "secretsmanager:GetSecretValue",
       "secretsmanager:DescribeSecret",


### PR DESCRIPTION
## A reference to the issue / Description of it

This pull request adds S3 Storage Lens permissions to the developer policy

## How does this PR fix the problem?

It's not a problem, but an additional set of features

## How has this been tested?

It hasn't

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

It will extend the current developer policy

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

https://aws.amazon.com/s3/storage-lens/

https://docs.aws.amazon.com/AmazonS3/latest/userguide/storage_lens_iam_permissions.html#storage_lens_iam_permissions_account
