### PR TITLE
Additional CircleCI Role Permissions

### DIFF
--- a/terraform/environments/digital-prison-reporting/iam.tf
+++ b/terraform/environments/digital-prison-reporting/iam.tf
@@ -31,8 +31,8 @@ data "aws_iam_policy_document" "circleci_iam_policy" {
       "ec2:TerminateInstances",
       "ec2:CreateTags",
       "s3:PutObject",
-      "s3:GetObject",
       "s3:ListBucket",
+      "s3:*Object",
       "iam:PassRole",
       "elasticbeanstalk:*",
       "rds:*",
@@ -44,7 +44,9 @@ data "aws_iam_policy_document" "circleci_iam_policy" {
       "logs:PutLogEvents",
       "elasticache:*",
       "kms:Decrypt*",
-      "kms:GenerateDataKey"
+      "kms:GenerateDataKey",
+      "dms:*",
+      "glue:*"
     ]
     resources = ["*"]
   }

--- a/terraform/environments/digital-prison-reporting/iam.tf
+++ b/terraform/environments/digital-prison-reporting/iam.tf
@@ -30,7 +30,6 @@ data "aws_iam_policy_document" "circleci_iam_policy" {
       "ec2:DescribeInstances",
       "ec2:TerminateInstances",
       "ec2:CreateTags",
-      "s3:PutObject",
       "s3:ListBucket",
       "s3:*Object",
       "iam:PassRole",


### PR DESCRIPTION
Additional CircleCI Role Permissions

## A reference to the issue / Description of it

Additional CircleCI Role Permissions

## How does this PR fix the problem?

Additional CircleCI Role Permissions will allow DPR Specific Pipelines to manage the AWS resources, currently we are unable to manage the DMS/Glue and S3 resources as per our requirements

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Tested on Sandbox Dev

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

N/A

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
