### PR TITLE
Reduce ECR delete scope

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/policies.tf
+++ b/terraform/environments/bootstrap/delegate-access/policies.tf
@@ -203,7 +203,7 @@ data "aws_iam_policy_document" "developer_additional" {
       "ec2:DescribeInstances",
       "ec2:DescribeInstanceTypes",
       "ec2-instance-connect:SendSerialConsoleSSHPublicKey",
-      "ecr:DeleteRepository",
+      "ecr:BatchDeleteImage",
       "ecs:StartTask",
       "ecs:StopTask",
       "ecs:ListTagsForResource",


### PR DESCRIPTION

## A reference to the issue / Description of it

Wrong permissions for deleting ECR images

## How does this PR fix the problem?

This should be to allow users to delete images, rather than repositories.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

TF Plan

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No (unless people are manually deleting ECR repos which they shouldn't be)

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
