### PR TITLE
Make name of artifact unique based on GitHub action run

### DIFF
--- a/.github/workflows/publish-gh-pages.yml
+++ b/.github/workflows/publish-gh-pages.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Upload artifact to be published
         uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
         with:
-          name: github-pages
+          name: github-pages-${{ github.run_id }}-${{ github.run_attempt }}
           path: artifact.tar
           retention-days: 1
       - name: Slack failure notification


### PR DESCRIPTION
## A reference to the issue / Description of it

Deploy GitHub Pages action is broken. We believe this is due to how the `upload-artifact/v4` action requires unique names.

## How does this PR fix the problem?

Appends the `run_id` and `run_attempt` to the archive name

## How has this been tested?

It will be tested when this workflow is created by using `workflow_dispatch`

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
