### PR TITLE
Revert back to v3 of upload-artifact

### DIFF
--- a/.github/workflows/publish-gh-pages.yml
+++ b/.github/workflows/publish-gh-pages.yml
@@ -32,9 +32,9 @@ jobs:
         run: |
           /scripts/compile-and-create-artifact.sh
       - name: Upload artifact to be published
-        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.0
         with:
-          name: github-pages-${{ github.run_id }}-${{ github.run_attempt }}
+          name: github-pages
           path: artifact.tar
           retention-days: 1
       - name: Slack failure notification
@@ -59,8 +59,6 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@13b55b33dd8996121833dbc1db458c793a334630 # v3.0.1
-        with:
-          artifact_name: github-pages-${{ github.run_id }}-${{ github.run_attempt }}
       - name: Slack failure notification
         uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0
         with:


### PR DESCRIPTION
## A reference to the issue / Description of it

This is to Revert the change of upload-artifact back to V3 as currently V4 is not working correctly in our workflows

## How does this PR fix the problem?

version change

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
