### PR TITLE
Create policy for Managed AD administrator

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/policies.tf
+++ b/terraform/environments/bootstrap/delegate-access/policies.tf
@@ -822,6 +822,7 @@ data "aws_iam_policy_document" "directory-management-document" {
       "ec2:AuthorizeSecurityGroupEgress",
       "ec2:CreateTags",
     ]
+    resources = ["*"]
   }
   statement {
     sid    = "DirectoryManagementDeny"
@@ -831,5 +832,6 @@ data "aws_iam_policy_document" "directory-management-document" {
       "ds:CreateMicrosoftAD",
       "ds:DeleteDirectory"
     ]
+    resources = ["*"]
   }
 }

--- a/terraform/environments/bootstrap/delegate-access/policies.tf
+++ b/terraform/environments/bootstrap/delegate-access/policies.tf
@@ -807,7 +807,14 @@ resource "aws_iam_policy" "directory-management-policy" {
   policy   = data.aws_iam_policy_document.directory-management-document.json
 }
 
+#tfsec:ignore:aws-iam-no-policy-wildcards
 data "aws_iam_policy_document" "directory-management-document" {
+  #checkov:skip=CKV_AWS_107
+  #checkov:skip=CKV_AWS_108
+  #checkov:skip=CKV_AWS_109
+  #checkov:skip=CKV_AWS_110
+  #checkov:skip=CKV_AWS_111
+  #checkov:skip=CKV_AWS_356
   statement {
     sid    = "DirectoryManagementAllow"
     effect = "Allow"
@@ -822,7 +829,7 @@ data "aws_iam_policy_document" "directory-management-document" {
       "ec2:AuthorizeSecurityGroupEgress",
       "ec2:CreateTags",
     ]
-    resources = ["*"]
+    resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
   }
   statement {
     sid    = "DirectoryManagementDeny"
@@ -832,6 +839,6 @@ data "aws_iam_policy_document" "directory-management-document" {
       "ds:CreateMicrosoftAD",
       "ds:DeleteDirectory"
     ]
-    resources = ["*"]
+    resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
   }
 }

--- a/terraform/environments/bootstrap/delegate-access/policies.tf
+++ b/terraform/environments/bootstrap/delegate-access/policies.tf
@@ -799,3 +799,37 @@ data "aws_iam_policy_document" "reporting-operations" {
     resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
   }
 }
+
+resource "aws_iam_policy" "directory-management-policy" {
+  provider = aws.workspace
+  name     = "directory_management_policy"
+  path     = "/"
+  policy   = data.aws_iam_policy_document.directory-management-document.json
+}
+
+data "aws_iam_policy_document" "directory-management-document" {
+  statement {
+    sid    = "DirectoryManagementAllow"
+    effect = "Allow"
+    actions = [
+      "ds:*",
+      "ec2:DescribeSubnets",
+      "ec2:DescribeVpcs",
+      "ec2:CreateSecurityGroup",
+      "ec2:CreateNetworkInterface",
+      "ec2:DescribeNetworkInterfaces",
+      "ec2:AuthorizeSecurityGroupIngress",
+      "ec2:AuthorizeSecurityGroupEgress",
+      "ec2:CreateTags",
+    ]
+  }
+  statement {
+    sid    = "DirectoryManagementDeny"
+    effect = "Deny"
+    actions = [
+      "ds:CreateDirectory",
+      "ds:CreateMicrosoftAD",
+      "ds:DeleteDirectory"
+    ]
+  }
+}


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/5810

## How does this PR fix the problem?

Creates a permission set that can be used by an SSO role focused on managed AD administration

## How has this been tested?

N/A

## Deployment Plan / Instructions

This will be deployed through the `Terraform: Scheduled baseline` job

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

https://github.com/ministryofjustice/aws-root-account/pull/843
