### PR TITLE
Add domain admin to sso

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/main.tf
+++ b/terraform/environments/bootstrap/single-sign-on/main.tf
@@ -95,6 +95,14 @@ data "aws_ssoadmin_permission_set" "mwaa_user" {
   name         = "modernisation-platform-mwaa-user"
 }
 
+data "aws_ssoadmin_permission_set" "active_directory_management" {
+  provider = aws.sso-management
+
+  instance_arn = local.sso_instance_arn
+  name         = "mp-active-directory-management"
+}
+
+
 # Get Identity Store groups
 data "aws_identitystore_group" "platform_admin" {
   provider = aws.sso-management
@@ -395,6 +403,29 @@ resource "aws_ssoadmin_account_assignment" "mwaa_user" {
     "${sso_assignment.github_slug}-${sso_assignment.level}" => sso_assignment
 
     if(sso_assignment.level == "mwaa-user")
+  }
+
+  provider = aws.sso-management
+
+  instance_arn       = local.sso_instance_arn
+  permission_set_arn = data.aws_ssoadmin_permission_set.mwaa_user.arn
+
+  principal_id   = data.aws_identitystore_group.member[each.value.github_slug].group_id
+  principal_type = "GROUP"
+
+  target_id   = local.environment_management.account_ids[terraform.workspace]
+  target_type = "AWS_ACCOUNT"
+}
+
+resource "aws_ssoadmin_account_assignment" "active_directory_management" {
+
+  for_each = {
+
+    for sso_assignment in local.sso_data[local.env_name][*] :
+
+    "${sso_assignment.github_slug}-${sso_assignment.level}" => sso_assignment
+
+    if(sso_assignment.level == "active-directory-management")
   }
 
   provider = aws.sso-management

--- a/terraform/environments/bootstrap/single-sign-on/main.tf
+++ b/terraform/environments/bootstrap/single-sign-on/main.tf
@@ -431,7 +431,7 @@ resource "aws_ssoadmin_account_assignment" "active_directory_management" {
   provider = aws.sso-management
 
   instance_arn       = local.sso_instance_arn
-  permission_set_arn = data.aws_ssoadmin_permission_set.mwaa_user.arn
+  permission_set_arn = data.aws_ssoadmin_permission_set.active_directory_management.arn
 
   principal_id   = data.aws_identitystore_group.member[each.value.github_slug].group_id
   principal_type = "GROUP"


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/5810

## How does this PR fix the problem?

This PR should allow us to assign an access level of `active-directory-management` through the `environments/$application.json` files

## How has this been tested?

No

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

It shouldn't.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

See these related PRs:

https://github.com/ministryofjustice/modernisation-platform/pull/5821
https://github.com/ministryofjustice/aws-root-account/pull/843