### PR TITLE
Docs/5646 rotate GitHub ci user pat

### DIFF
--- a/source/runbooks/rotating-secrets.html.md.erb
+++ b/source/runbooks/rotating-secrets.html.md.erb
@@ -29,3 +29,16 @@ This guide advises where secrets are stored and how to rotate them.
 | Circle CI ID                                      | mod-platform-circleci                | CircleCI organisation ID for ministryofjustice, used for OIDC IAM policies                                                                                                                                                               | AWS Secrets Manager     | Not really a secret, should not be rotated                                                                    | N/A |
 | ModernisationPlatformOrganisationManagement IAM user in MoJ root account | N/A           | Used to perform limited activities in the root account. No longer used as replaced by OIDC but user kept for breakglass purposes.                                                                                                        | Not stored              | No active access keys, if keys or password needed contact Operations Engineering                              | N/A |
 | Modernisation Platform Account Root User Password | N/A                                  | Only used during initial platform set up, log in prevented via SCP and no password or keys set                                                                                                                                           | Not stored              | Disable or move account to a non SCP protected OU and follow the password reset steps                         | N/A |
+
+## Rotating Secret Runbooks
+
+### GitHub MP CI User PAT 
+
+1. Retrieve the MP GitHub credentials by logging in to the [Modernisation Platform account](https://moj.awsapps.com/start#/) with **AdministratorAccess**
+2. Navigate to the [Secrets Manager github_ci_user_password secret](https://eu-west-2.console.aws.amazon.com/secretsmanager/secret?name=github_ci_user_password&region=eu-west-2) and click `Retrieve secret value``
+3. Use the Username and Password details to log in to [GitHub](https://github.com)
+4. Use the Oath command provided to generate a OTP. (NB: you may need to install [oath-toolkit](https://formulae.brew.sh/formula/oath-toolkit) on your Mac )
+5. Once logged in to GitHub click on the profile icon and then **Settings > Developer settings > Personal access tokens > Tokens (classic) > Generate new token (classic)**
+6. Fill out the details: 
+    * In the **Note** field give the token a descriptive name e.g. `"Modernisation Platform GitHub Terraform"`
+    * Set **Expiration** value to `'No Expiration'`

--- a/source/runbooks/rotating-secrets.html.md.erb
+++ b/source/runbooks/rotating-secrets.html.md.erb
@@ -32,7 +32,9 @@ This guide advises where secrets are stored and how to rotate them.
 
 ## Runbooks
 
-### GitHub MP CI User PAT 
+### GitHub MP CI User PAT
+
+This runbook describes the process for rotating the **github_ci_user_pat** secret.
 
 1. Retrieve the MP GitHub credentials by logging in to the AWS [Modernisation Platform account](https://moj.awsapps.com/start#/) with **AdministratorAccess**
 2. Navigate to the Secrets Manager [github_ci_user_password](https://eu-west-2.console.aws.amazon.com/secretsmanager/secret?name=github_ci_user_password&region=eu-west-2) secret and click `Retrieve secret value`

--- a/source/runbooks/rotating-secrets.html.md.erb
+++ b/source/runbooks/rotating-secrets.html.md.erb
@@ -46,9 +46,9 @@ This guide advises where secrets are stored and how to rotate them.
         * admin:org (write:org | read:org | manage_runners:org)
         * user:email
         * project (read:project)
-6. Click Generate token and then copy the token to your clipboard
+6. Click `Generate token` and then copy the token to your clipboard
 7. Navigate to the Secrets Manager [github_ci_user_pat](https://eu-west-2.console.aws.amazon.com/secretsmanager/secret?name=github_ci_user_pat&region=eu-west-2) secret and click `Retrieve secret value`
 8. Click `Edit` and replace the token with the new one and click `Save`
 9. Run the [Github resources Workflow](https://github.com/ministryofjustice/modernisation-platform/actions/workflows/terraform-github.yml) manually on the main branch. This will populate the GH secret with the value that you have just updated in AWS Secrets Manager.
-10. Wait for another workflow to run which uses the secret to confirm that the new token has taken effect successfully 
+10. Wait for another workflow to run which uses the secret to confirm that the new token has taken effect successfully. (The secrets status will show as *"Last used within the last week"*)
 11. When you are confident the new secret is working successfully you can delete the old PAT token in GitHub

--- a/source/runbooks/rotating-secrets.html.md.erb
+++ b/source/runbooks/rotating-secrets.html.md.erb
@@ -36,18 +36,19 @@ This guide advises where secrets are stored and how to rotate them.
 
 1. Retrieve the MP GitHub credentials by logging in to the AWS [Modernisation Platform account](https://moj.awsapps.com/start#/) with **AdministratorAccess**
 2. Navigate to the Secrets Manager [github_ci_user_password](https://eu-west-2.console.aws.amazon.com/secretsmanager/secret?name=github_ci_user_password&region=eu-west-2) secret and click `Retrieve secret value`
-3. Use the Username and Password details to log in to [GitHub](https://github.com)
-4. Use the Oath command provided to generate a OTP. (NB: you may need to install [oath-toolkit](https://formulae.brew.sh/formula/oath-toolkit) on your Mac )
-5. Once logged in to GitHub click on the profile icon and then **Settings > Developer settings > Personal access tokens > Tokens (classic) > Generate new token (classic)**
-6. Fill out the details: 
+3. Use the credentials provided to log in to [GitHub](https://github.com)
+4. Once logged in click on the profile icon and then **Settings > Developer settings > Personal access tokens > Tokens (classic) > Generate new token (classic)**
+5. Fill out the details: 
     * In the **Note** field give the token a descriptive name e.g. `"Modernisation Platform GitHub Terraform"`
-    * Set **Expiration** value to `'No Expiration'`
+    * Set **Expiration** value to `"No Expiration"`
     * Set Scopes by ticking the following boxes:
         * workflow
         * admin:org (write:org | read:org | manage_runners:org)
         * user:email
         * project (read:project)
-7. Click Generate token and then copy the token to your clipboard
-8. Navigate to the Secrets Manager [github_ci_user_pat](https://eu-west-2.console.aws.amazon.com/secretsmanager/secret?name=github_ci_user_pat&region=eu-west-2) secret and click `Retrieve secret value`
-9. Click `Edit` and replace the token with the new one and click `Save`
-10. Delete the old pat token in GitHub
+6. Click Generate token and then copy the token to your clipboard
+7. Navigate to the Secrets Manager [github_ci_user_pat](https://eu-west-2.console.aws.amazon.com/secretsmanager/secret?name=github_ci_user_pat&region=eu-west-2) secret and click `Retrieve secret value`
+8. Click `Edit` and replace the token with the new one and click `Save`
+9. Run the [Github resources Workflow](https://github.com/ministryofjustice/modernisation-platform/actions/workflows/terraform-github.yml) manually on the main branch. This will populate the GH secret with the value that you have just updated in AWS Secrets Manager.
+10. Wait for another workflow to run which uses the secret to confirm that the new token has taken effect successfully 
+11. When you are confident the new secret is working successfully you can delete the old PAT token in GitHub

--- a/source/runbooks/rotating-secrets.html.md.erb
+++ b/source/runbooks/rotating-secrets.html.md.erb
@@ -20,7 +20,7 @@ This guide advises where secrets are stored and how to rotate them.
 | PagerDuty Integration Keys                        | pagerduty_integration_keys           | Map of integration keys generated and updated by Terraform PagerDuty integration resources when users create services, used to push alerts to those services                                                                             | AWS Secrets Manager     | Destroy and recreate the PagerDuty integration resource in Terraform                                          | 180 |
 | PagerDuty Modernisation Platform Team user        | N/A                                  | Used for dead-end notifications as all schedules need a user                                                                                                                                                                             | Not stored              | Use password reset process if needed                                                                          | N/A |
 | Slack Webhook URL                                 | slack_webhook_url                    | Used to post alarms to Slack                                                                                                                                                                                                             | AWS Secrets Manager     | Contact Operations Engineeering to issue a new incoming webhook for the `Modernisation Platform Alerts` custom Slack application.  Revoke the old incoming webhook and update the secret. | 180 |
-| GitHub MP CI User PAT                             | github_ci_user_pat                   | Used to create PRs etc in GitHub actions and deploy GitHub resources via Terraform                                                                                                                                                       | AWS Secrets Manager     | Log in as the Modernisation Platform CI User and generate a new PAT, revoke the old one and update the secret.| 180 |
+| GitHub MP CI User PAT                             | github_ci_user_pat                   | Used to create PRs etc in GitHub actions and deploy GitHub resources via Terraform                                                                                                                                                       | AWS Secrets Manager     | Use this [runbook](https://user-guide.modernisation-platform.service.justice.gov.uk/runbooks/rotating-secrets.html#github-mp-ci-user-pat) to rotate the secret| 180 |
 | GitHub MP CI User Environments Repo PAT           | github_ci_user_environments_repo_pat | Used in reusable pipelines of the modernisation-platform-environments repository. This is so that the CI user can post comments in PRs, e.g. tf plan/apply output.                                                                       | AWS Secrets Manager     | Log in as the Modernisation Platform CI User and generate a new PAT, revoke the old one and update the secret.| 180 |
 | GitHub MP CI User Password                        | github_ci_user_password              | Used to log in and set the PAT                                                                                                                                                                                                           | AWS Secrets Manager     | Log in to GitHub as the user and reset the password, update the secret                                        | 180 |
 | Environment Management                            | environment_management               | A Map of account names to IDs, and data for environment management, such as organizational unit IDs                                                                                                                                      | AWS Secrets Manager     | Does not need rotating, not really a secret and regenerated on each account creation                          | N/A |
@@ -30,15 +30,24 @@ This guide advises where secrets are stored and how to rotate them.
 | ModernisationPlatformOrganisationManagement IAM user in MoJ root account | N/A           | Used to perform limited activities in the root account. No longer used as replaced by OIDC but user kept for breakglass purposes.                                                                                                        | Not stored              | No active access keys, if keys or password needed contact Operations Engineering                              | N/A |
 | Modernisation Platform Account Root User Password | N/A                                  | Only used during initial platform set up, log in prevented via SCP and no password or keys set                                                                                                                                           | Not stored              | Disable or move account to a non SCP protected OU and follow the password reset steps                         | N/A |
 
-## Rotating Secret Runbooks
+## Runbooks
 
 ### GitHub MP CI User PAT 
 
-1. Retrieve the MP GitHub credentials by logging in to the [Modernisation Platform account](https://moj.awsapps.com/start#/) with **AdministratorAccess**
-2. Navigate to the [Secrets Manager github_ci_user_password secret](https://eu-west-2.console.aws.amazon.com/secretsmanager/secret?name=github_ci_user_password&region=eu-west-2) and click `Retrieve secret value``
+1. Retrieve the MP GitHub credentials by logging in to the AWS [Modernisation Platform account](https://moj.awsapps.com/start#/) with **AdministratorAccess**
+2. Navigate to the Secrets Manager [github_ci_user_password](https://eu-west-2.console.aws.amazon.com/secretsmanager/secret?name=github_ci_user_password&region=eu-west-2) secret and click `Retrieve secret value`
 3. Use the Username and Password details to log in to [GitHub](https://github.com)
 4. Use the Oath command provided to generate a OTP. (NB: you may need to install [oath-toolkit](https://formulae.brew.sh/formula/oath-toolkit) on your Mac )
 5. Once logged in to GitHub click on the profile icon and then **Settings > Developer settings > Personal access tokens > Tokens (classic) > Generate new token (classic)**
 6. Fill out the details: 
     * In the **Note** field give the token a descriptive name e.g. `"Modernisation Platform GitHub Terraform"`
     * Set **Expiration** value to `'No Expiration'`
+    * Set Scopes by ticking the following boxes:
+        * workflow
+        * admin:org (write:org | read:org | manage_runners:org)
+        * user:email
+        * project (read:project)
+7. Click Generate token and then copy the token to your clipboard
+8. Navigate to the Secrets Manager [github_ci_user_pat](https://eu-west-2.console.aws.amazon.com/secretsmanager/secret?name=github_ci_user_pat&region=eu-west-2) secret and click `Retrieve secret value`
+9. Click `Edit` and replace the token with the new one and click `Save`
+10. Delete the old pat token in GitHub


### PR DESCRIPTION
## A reference to the issue / Description of it
https://github.com/ministryofjustice/modernisation-platform/issues/5646

## How does this PR fix the problem?

I've rotated the secret and have added some documentation on the process for it in case that would be of use in future. The GitHub Resources workflow step in particular was a part where I wasn't aware that needed to happen.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

I have run the [GitHub resources](https://github.com/ministryofjustice/modernisation-platform/actions/runs/7250267742) job to import the new secrets from AWS Secrets Manager and subsequent workflows have successfully used the new secret. The status in Github shows that the new secret has been "Used within the last week".

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

Not if done correctly! 

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [x] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

As a side note it raised some questions:
1. Should we be using the new 'Fine grained tokens' in future? (expiration date is mandatory)
2. Should we automate further the rotation process e.g. using GitHub API to generate new tokens and updating the secrets in AWS etc. ?
