### PR TITLE
Aggregating lambda cloudwatch alarms for instance-scheduler

### DIFF
--- a/terraform/environments/core-shared-services/instance-scheduler-lambda-function.tf
+++ b/terraform/environments/core-shared-services/instance-scheduler-lambda-function.tf
@@ -117,6 +117,10 @@ resource "aws_cloudwatch_metric_alarm" "instance_scheduler_has_errors" {
   threshold           = "1"
   treat_missing_data  = "notBreaching"
 
+  dimensions = {
+    FunctionName = "instance-scheduler-lambda-function"
+  }
+  
   tags = local.tags
 }
 
@@ -133,6 +137,10 @@ resource "aws_cloudwatch_metric_alarm" "instance_scheduler_was_throttled" {
   statistic           = "Sum"
   threshold           = "1"
   treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    FunctionName = "instance-scheduler-lambda-function"
+  }
 
   tags = local.tags
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

This is to finish the https://github.com/ministryofjustice/modernisation-platform/issues/2722 issue implementation.

## How does this PR fix the problem?

It aggregates lambda cloud watch alarms to narrow it down to the instance-scheduler lambda function only.

## How has this been tested?

Tested manually in the console and local terraform plan. The checks should pass as well.


## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No impact on the platform/services.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
