### PR TITLE
Add directory management for sprinkler

### DIFF
--- a/environments/sprinkler.json
+++ b/environments/sprinkler.json
@@ -8,6 +8,14 @@
           "github_slug": "modernisation-platform",
           "level": "sandbox",
           "nuke": "rebuild"
+        },
+        {
+          "github_slug": "modernisation-platform",
+          "level": "active-directory-management"
+        },
+        {
+          "github_slug": "studio-webops",
+          "level": "active-directory-management"
         }
       ],
       "additional_reviewers": ["astrobinson"]

--- a/policies/environments/environment-definitions.rego
+++ b/policies/environments/environment-definitions.rego
@@ -14,17 +14,18 @@ allowed_business_units := [
 ]
 
 allowed_access := [
-  "view-only",
-  "developer",
-  "sandbox",
+  "active-directory-management",
   "administrator",
-  "migration",
-  "instance-management",
-  "read-only",
-  "security-audit",
   "data-engineer",
+  "developer",
+  "instance-management",
+  "migration",
+  "mwaa-user",
+  "read-only",
   "reporting-operations",
-  "mwaa-user"
+  "sandbox",
+  "security-audit",
+  "view-only",
 ]
 
 allowed_nuke := [

--- a/policies/environments/environment-definitions_test.rego
+++ b/policies/environments/environment-definitions_test.rego
@@ -41,7 +41,7 @@ test_business_units_character{
 }
 
 test_unexpected_access {
-  deny["`example.json` uses an unexpected access level: got `incorrect-access`, expected one of: view-only, developer, sandbox, administrator, migration, instance-management, read-only, security-audit, data-engineer, reporting-operations, mwaa-user"] with input as { "filename": "example.json", "environments": [{"access": [{"level": "incorrect-access"}]}]}
+  deny["`example.json` uses an unexpected access level: got `incorrect-access`, expected one of: view-only, developer, sandbox, administrator, migration, instance-management, read-only, security-audit, data-engineer, reporting-operations, mwaa-user", "active-directory-management"] with input as { "filename": "example.json", "environments": [{"access": [{"level": "incorrect-access"}]}]}
 }
 
 test_unexpected_nuke {

--- a/policies/environments/environment-definitions_test.rego
+++ b/policies/environments/environment-definitions_test.rego
@@ -41,7 +41,7 @@ test_business_units_character{
 }
 
 test_unexpected_access {
-  deny["`example.json` uses an unexpected access level: got `incorrect-access`, expected one of: view-only, developer, sandbox, administrator, migration, instance-management, read-only, security-audit, data-engineer, reporting-operations, mwaa-user", "active-directory-management"] with input as { "filename": "example.json", "environments": [{"access": [{"level": "incorrect-access"}]}]}
+  deny["`example.json` uses an unexpected access level: got `incorrect-access`, expected one of: view-only, developer, sandbox, administrator, migration, instance-management, read-only, security-audit, data-engineer, reporting-operations, mwaa-user, active-directory-management"] with input as { "filename": "example.json", "environments": [{"access": [{"level": "incorrect-access"}]}]}
 }
 
 test_unexpected_nuke {


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/5810

## How does this PR fix the problem?

If we build an AWS Managed Microsoft Active Directory cluster in `sprinkler` for testing purposes, we need to also test the role to manage it.

Also I've alphabetised the list of roles checked in the OPA policy.

## How has this been tested?


## Deployment Plan / Instructions


## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

