### PR TITLE
Switch local to data rather than secret

### DIFF
--- a/terraform/environments/environments.tf
+++ b/terraform/environments/environments.tf
@@ -1,6 +1,6 @@
 module "environments" {
   source                             = "github.com/ministryofjustice/modernisation-platform-terraform-environments?ref=b17ca8d6c23a2c22d2efc6c5116a1328492c32bd" # v6.0.0
   environment_directory              = "../../environments"
-  environment_parent_organisation_id = local.environment_management.modernisation_platform_organisation_unit_id
+  environment_parent_organisation_id = local.modernisation_platform_ou_id
   environment_prefix                 = "modernisation-platform"
 }


### PR DESCRIPTION
If the secret is cleared for any reason this terraform won't run as it's needed currently to get the modernisation platform ou id.  By getting this from a data look up it means that we are not dependant on the secret.
