### PR TITLE
Break glass access for Ewa

### DIFF
--- a/terraform/modernisation-platform-account/locals.tf
+++ b/terraform/modernisation-platform-account/locals.tf
@@ -7,6 +7,7 @@ locals {
   root_users_with_state_access = [ # also includes the organisationsl GHA Role
     "arn:aws:iam::${local.root_account.master_account_id}:user/ModernisationPlatformOrganisationManagement",
     "arn:aws:iam::${local.root_account.master_account_id}:user/DavidElliott",
+    "arn:aws:iam::${local.root_account.master_account_id}:user/EwaStempel",
     "arn:aws:iam::${local.root_account.master_account_id}:role/ModernisationPlatformGithubActionsRole" # Role with the same permissions as ModernisationPlatformOrganisationManagement for Github OIDC
   ]
 


### PR DESCRIPTION
## A reference to the issue / Description of it

This is to allow Ewa to run terraform against the root account locally.

## How does this PR fix the problem?

It gives access to the tf state s3 bucket.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

It's been run locally already, when fixing an issue earlier on.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
