### PR TITLE
Updates ref of the superadmins module to use v2.0.2 of the module.

### DIFF
--- a/terraform/modernisation-platform-account/iam.tf
+++ b/terraform/modernisation-platform-account/iam.tf
@@ -1,7 +1,7 @@
 #tfsec:ignore:aws-iam-no-policy-wildcards
 #tfsec:ignore:aws-iam-enforce-mfa
 module "iam" {
-  source        = "github.com/ministryofjustice/modernisation-platform-terraform-iam-superadmins?ref=2390874e4b8f1d01fd21c342d253345ec8a5b708" # v2.0.1
+  source        = "github.com/ministryofjustice/modernisation-platform-terraform-iam-superadmins?ref=180803bb2f1f9e08bb2653b40e52744126472dce" # v2.0.2
   account_alias = "moj-modernisation-platform"
 }
 


### PR DESCRIPTION
## A reference to the issue / Description of it

Updates the ref to the superadmins module to references v2.0.2

## How does this PR fix the problem?

As per issue 5830.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Tests undertaken as per doc - https://user-guide.modernisation-platform.service.justice.gov.uk/runbooks/adding-a-new-team-member.html#adding-them-as-a-superadmin-in-our-aws-landing-zone

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

Not according to the documentation.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
