### PR TITLE
Setting tflint_call_module_type to none

### DIFF
--- a/.github/workflows/terraform-static-analysis.yml
+++ b/.github/workflows/terraform-static-analysis.yml
@@ -25,7 +25,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Run Analysis
-      uses: ministryofjustice/github-actions/terraform-static-analysis@7c689fe2de15e1692f5cceceb132919ab854081c # v14
+      uses: ministryofjustice/github-actions/terraform-static-analysis@433c75e44be4eabb0a6ca573951090b9da4901cf # v15.1.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
@@ -33,6 +33,7 @@ jobs:
         tfsec_exclude: aws-ssm-secret-use-customer-key,github-repositories-private,aws-vpc-no-excessive-port-access,github-repositories-require-signed-commits
         checkov_exclude: CKV_GIT_1,CKV_AWS_126,CKV2_AWS_38,CKV2_AWS_39
         tflint_exclude: terraform_unused_declarations
+        tflint_call_module_type: none
 
   terraform-static-analysis-full-scan:
     permissions:
@@ -46,7 +47,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Run Analysis
-      uses: ministryofjustice/github-actions/terraform-static-analysis@7c689fe2de15e1692f5cceceb132919ab854081c # v14
+      uses: ministryofjustice/github-actions/terraform-static-analysis@433c75e44be4eabb0a6ca573951090b9da4901cf # v15.1.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
@@ -54,6 +55,7 @@ jobs:
         tfsec_exclude: aws-ssm-secret-use-customer-key,github-repositories-private,aws-vpc-no-excessive-port-access,github-repositories-require-signed-commits
         checkov_exclude: CKV_GIT_1,CKV_AWS_126,CKV2_AWS_38,CKV2_AWS_39
         tflint_exclude: terraform_unused_declarations
+        tflint_call_module_type: none
 
   terraform-static-analysis-scheduled-scan:
     name: Terraform Static Analysis - scheduled scan of all directories
@@ -65,7 +67,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Run Analysis
-      uses: ministryofjustice/github-actions/terraform-static-analysis@7c689fe2de15e1692f5cceceb132919ab854081c
+      uses: ministryofjustice/github-actions/terraform-static-analysis@7433c75e44be4eabb0a6ca573951090b9da4901cf # v15.1.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
@@ -73,6 +75,7 @@ jobs:
         tfsec_exclude: aws-ssm-secret-use-customer-key,github-repositories-private,aws-vpc-no-excessive-port-access,github-repositories-require-signed-commits
         checkov_exclude: CKV_GIT_1,CKV_AWS_126,CKV2_AWS_38,CKV2_AWS_39
         tflint_exclude: terraform_unused_declarations
+        tflint_call_module_type: none
     - name: Slack failure notification
       uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0
       with:


### PR DESCRIPTION
## A reference to the issue / Description of it

This PR is to fix [this issues](https://github.com/ministryofjustice/modernisation-platform/issues/5890) and to test [this change](https://github.com/ministryofjustice/github-actions/pull/226/).

## How does this PR fix the problem?

By setting tflint_call_module_type to none to skip tf module scanning with tflint.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Locally in a dockerfile, but not in action yet.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
