### PR TITLE
Terraform Static Code Analysis - fix commit hash

### DIFF
--- a/.github/workflows/terraform-static-analysis.yml
+++ b/.github/workflows/terraform-static-analysis.yml
@@ -67,7 +67,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Run Analysis
-      uses: ministryofjustice/github-actions/terraform-static-analysis@7433c75e44be4eabb0a6ca573951090b9da4901cf # v15.1.0
+      uses: ministryofjustice/github-actions/terraform-static-analysis@433c75e44be4eabb0a6ca573951090b9da4901cf # v15.1.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -476,7 +476,7 @@ data "aws_iam_policy_document" "policy" {
 # MemberInfrastructureBedrockEuCentral
 module "member-access-eu-central" {
   count                  = local.account_data.account-type == "member" && terraform.workspace != "testing-test" ? 1 : 0
-  source                 = "github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access?ref=v2.3.0"
+  source                 = "github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access?ref=6819b090bce6d3068d55c7c7b9b3fd18c9dca648" #v3.0.0
   account_id             = local.modernisation_platform_account.id
   additional_trust_roles = [one(data.aws_iam_roles.github_actions_role.arns), one(data.aws_iam_roles.member-sso-admin-access.arns)]
   policy_arn             = aws_iam_policy.member-access-us-east[0].id


### PR DESCRIPTION
Currently the TSA (Terraform Static Code Analysis) workflow is failing due to an incorrect commit hash, this PR updates the commit hash to the correct value. 

failing workflow: https://github.com/ministryofjustice/modernisation-platform/actions/runs/7383085655
error: `Unable to resolve action ministryofjustice/github-actions@7433c75e44be4eabb0a6ca573951090b9da4901cf, unable to find version 7433c75e44be4eabb0a6ca573951090b9da4901cf`