### PR TITLE
removing dns records that are no longer required

### DIFF
--- a/terraform/environments/core-network-services/route53.tf
+++ b/terraform/environments/core-network-services/route53.tf
@@ -82,35 +82,6 @@ resource "aws_shield_protection" "application_public_hosted_zone" {
   tags = local.tags
 }
 
-# Remote Supervision NS delegation
-resource "aws_route53_record" "remote-supervision-production" {
-  allow_overwrite = true
-  name            = "rs-production.${local.modernisation-platform-domain}"
-  ttl             = 30
-  type            = "NS"
-  zone_id         = aws_route53_zone.modernisation-platform.zone_id
-  records = [
-    "ns-1009.awsdns-62.net.",
-    "ns-1104.awsdns-10.org.",
-    "ns-316.awsdns-39.com.",
-    "ns-1876.awsdns-42.co.uk"
-  ]
-}
-
-resource "aws_route53_record" "remote-supervision-non-production" {
-  allow_overwrite = true
-  name            = "rs-non-production.${local.modernisation-platform-domain}"
-  ttl             = 30
-  type            = "NS"
-  zone_id         = aws_route53_zone.modernisation-platform.zone_id
-  records = [
-    "ns-897.awsdns-48.net.",
-    "ns-1217.awsdns-24.org.",
-    "ns-77.awsdns-09.com.",
-    "ns-1636.awsdns-12.co.uk."
-  ]
-}
-
 # Bichard7 NS delegation
 resource "aws_route53_record" "bichard7" {
   allow_overwrite = true


### PR DESCRIPTION
## A reference to the issue / Description of it

We’re contacting you from the [Domain Management team](https://www.gov.uk/government/groups/domain-management-team) at the Central Digital & Data Office (CDDO). We help to secure public sector domains.
We've noticed some inconsistencies with subdomains under [modernisation-platform.service.justice.gov.uk](http://modernisation-platform.service.justice.gov.uk/)
These are the subdomains that we have identified:
[rs-non-production.modernisation-platform.service.justice.gov.uk](http://rs-non-production.modernisation-platform.service.justice.gov.uk/)
[rs-production.modernisation-platform.service.justice.gov.uk](http://rs-production.modernisation-platform.service.justice.gov.uk/)
[video.rs-production.modernisation-platform.service.justice.gov.uk](http://video.rs-production.modernisation-platform.service.justice.gov.uk/)
For example, the nameserver(s) for the following subdomain return a SERVFAIL error. You can see the configuration error below:
; <<>> DiG 9.10.6 <<>> [rs-non-production.modernisation-platform.service.justice.gov.uk](http://rs-non-production.modernisation-platform.service.justice.gov.uk/)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: SERVFAIL, id: 44219
;; flags: qr rd ra; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 1

## How does this PR fix the problem?

After looking around i found that the account that these ns record relate to has been removed this PR now removes the ns records as they are no longer needed


## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
