### PR TITLE
Firewall rule: allow cloud platform to hmpps-preprod for Oracle DB port

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
@@ -216,6 +216,13 @@
     "destination_port": "5721",
     "protocol": "UDP"
   },
+  "cp_to_mp_hmpps_preproduction_oracledb": {
+    "action": "PASS",
+    "source_ip": "${cloud-platform}",
+    "destination_ip": "${hmpps-preproduction}",
+    "destination_port": "1521",
+    "protocol": "TCP"
+  },
   "cp_to_mp_hmpps_preproduction_jdbc": {
     "action": "PASS",
     "source_ip": "${cloud-platform}",


### PR DESCRIPTION
## A reference to the issue / Description of it

Cloud platform unable to connect to preprod nomis DB in hmpps-preproduction. This is to facilitate migration of container app from Azure to Cloud Platform.

## How does this PR fix the problem?

Adds required firewall rule

## How has this been tested?

N/A

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)


