### PR TITLE
Dsos/firewall rule naming improvements

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/development_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/development_rules.json
@@ -55,7 +55,7 @@
     "destination_port": "ANY",
     "protocol": "IP"
   },
-  "analytical_platform_to_mp_laa_development": {
+  "analytical_platform_to_mp_laa_development_oracledb": {
     "action": "PASS",
     "source_ip": "${analytical-platform-airflow-dev}",
     "destination_ip": "${laa-development}",
@@ -69,14 +69,14 @@
     "destination_port": "ANY",
     "protocol": "TCP"
   },
-  "cp_to_hmpps_development_oracle": {
+  "cp_to_hmpps_development_oracledb": {
     "action": "PASS",
     "source_ip": "${cloud-platform}",
     "destination_ip": "${hmpps-development}",
     "destination_port": "1521",
     "protocol": "TCP"
   },
-  "cp_to_mp_laa_development": {
+  "cp_to_mp_laa_development_oracledb": {
     "action": "PASS",
     "source_ip": "${cloud-platform}",
     "destination_ip": "${laa-development}",
@@ -104,7 +104,7 @@
     "destination_port": "5721",
     "protocol": "UDP"
   },
-  "hmpps_development_to_oracle_tcp": {
+  "hmpps_development_to_cp_oracledb": {
     "action": "PASS",
     "source_ip": "${hmpps-development}",
     "destination_ip": "${cloud-platform}",
@@ -174,7 +174,7 @@
     "destination_port": "ANY",
     "protocol": "TCP"
   },
-  "aks_studio_hosting_dev_1_vnet_to_mp_hmpps_development_db": {
+  "aks_studio_hosting_dev_1_vnet_to_mp_hmpps_development_oracledb": {
     "action": "PASS",
     "source_ip": "${aks-studio-hosting-dev-1-vnet}",
     "destination_ip": "${hmpps-development}",
@@ -186,20 +186,6 @@
     "source_ip": "${aks-studio-hosting-dev-1-vnet}",
     "destination_ip": "${hmpps-development}",
     "destination_port": "443",
-    "protocol": "TCP"
-  },
-  "nomisapi_t2_root_vnet_to_mp_hmpps_development": {
-    "action": "PASS",
-    "source_ip": "${nomisapi-t2-root-vnet}",
-    "destination_ip": "${hmpps-development}",
-    "destination_port": "1521",
-    "protocol": "TCP"
-  },
-  "nomisapi_t3_root_vnet_to_mp_hmpps_development": {
-    "action": "PASS",
-    "source_ip": "${nomisapi-t3-root-vnet}",
-    "destination_ip": "${hmpps-development}",
-    "destination_port": "1521",
     "protocol": "TCP"
   },
   "mp_hmpps_development_to_noms_mgmt_vnet_dns": {

--- a/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
@@ -76,7 +76,7 @@
     "destination_port": "ANY",
     "protocol": "TCP"
   },
-  "nomisapi_preprod_root_to_mp_hmpps_preproduction": {
+  "nomisapi_preprod_root_to_mp_hmpps_preproduction_oracledb": {
     "action": "PASS",
     "source_ip": "${nomisapi-preprod-root-vnet}",
     "destination_ip": "${hmpps-preproduction}",
@@ -139,7 +139,7 @@
     "destination_port": "ANY",
     "protocol": "TCP"
   },
-  "aks_studio_hosting_live_1_to_mp_hmpps_preproduction_db": {
+  "aks_studio_hosting_live_1_to_mp_hmpps_preproduction_oracledb": {
     "action": "PASS",
     "source_ip": "${aks-studio-hosting-live-1-vnet}",
     "destination_ip": "${hmpps-preproduction}",
@@ -153,14 +153,14 @@
     "destination_port": "443",
     "protocol": "TCP"
   },
-  "nomisapi_prod_root_to_mp_hmpps_preproduction": {
+  "nomisapi_prod_root_to_mp_hmpps_preproduction_oracledb": {
     "action": "PASS",
     "source_ip": "${nomisapi-prod-root-vnet}",
     "destination_ip": "${hmpps-preproduction}",
     "destination_port": "1521",
     "protocol": "TCP"
   },
-  "analytical_platform_to_mp_hmpps_preproduction": {
+  "analytical_platform_to_mp_hmpps_preproduction_oracledb": {
     "action": "PASS",
     "source_ip": "${analytical-platform-airflow-prod}",
     "destination_ip": "${hmpps-preproduction}",

--- a/terraform/environments/core-network-services/firewall-rules/production_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/production_rules.json
@@ -160,13 +160,6 @@
     "destination_port": "1521",
     "protocol": "TCP"
   },
-  "nomis_prod_monitoring_to_mp_hmpps_production": {
-    "action": "PASS",
-    "source_ip": "${cloud-platform}",
-    "destination_ip": "${hmpps-production}",
-    "destination_port": "9100",
-    "protocol": "TCP"
-  },
   "psn_to_mp_hmpps_production_https": {
     "action": "PASS",
     "source_ip": "${psn}",

--- a/terraform/environments/core-network-services/firewall-rules/production_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/production_rules.json
@@ -20,14 +20,14 @@
     "destination_port": "443",
     "protocol": "TCP"
   },
-  "azure_noms_to_mp_nomis_production_db": {
+  "azure_noms_to_mp_hmpps_production_oracledb": {
     "action": "PASS",
     "source_ip": "${noms-live-vnet}",
     "destination_ip": "${hmpps-production}",
     "destination_port": "1521",
     "protocol": "TCP"
   },
-  "cp_to_mp_nomis_production_db": {
+  "cp_to_mp_hmpps_production_oracledb": {
     "action": "PASS",
     "source_ip": "${cloud-platform}",
     "destination_ip": "${hmpps-production}",
@@ -118,7 +118,7 @@
     "destination_port": "ANY",
     "protocol": "TCP"
   },
-  "aks_studio_hosting_live_1_to_mp_hmpps_production_db": {
+  "aks_studio_hosting_live_1_to_mp_hmpps_production_oracledb": {
     "action": "PASS",
     "source_ip": "${aks-studio-hosting-live-1-vnet}",
     "destination_ip": "${hmpps-production}",
@@ -132,28 +132,28 @@
     "destination_port": "443",
     "protocol": "TCP"
   },
-  "nomisapi_preprod_root_to_mp_hmpps_production": {
+  "nomisapi_preprod_root_to_mp_hmpps_production_oracledb": {
     "action": "PASS",
     "source_ip": "${nomisapi-preprod-root-vnet}",
     "destination_ip": "${hmpps-production}",
     "destination_port": "1521",
     "protocol": "TCP"
   },
-  "nomisapi_prod_root_vnet_to_mp_hmpps_production": {
+  "nomisapi_prod_root_vnet_to_mp_hmpps_production_oracledb": {
     "action": "PASS",
     "source_ip": "${nomisapi-prod-root-vnet}",
     "destination_ip": "${hmpps-production}",
     "destination_port": "1521",
     "protocol": "TCP"
   },
-  "analytical_platform_to_mp_hmpps_production": {
+  "analytical_platform_to_mp_hmpps_production_oracledb": {
     "action": "PASS",
     "source_ip": "${analytical-platform-airflow-prod}",
     "destination_ip": "${hmpps-production}",
     "destination_port": "1521",
     "protocol": "TCP"
   },
-  "analytical_platform_to_mp_laa_production": {
+  "analytical_platform_to_mp_laa_production_oracledb": {
     "action": "PASS",
     "source_ip": "${analytical-platform-airflow-prod}",
     "destination_ip": "${laa-production}",

--- a/terraform/environments/core-network-services/firewall-rules/test_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/test_rules.json
@@ -13,14 +13,14 @@
     "destination_port": "443",
     "protocol": "TCP"
   },
-  "az_noms_test_to_mp_nomis_test_db": {
+  "az_noms_test_to_mp_hmpps_test_oracledb": {
     "action": "PASS",
     "source_ip": "${noms-test-vnet}",
     "destination_ip": "${hmpps-test}",
     "destination_port": "1521",
     "protocol": "TCP"
   },
-  "cp_to_mp_nomis_test_db": {
+  "cp_to_mp_hmpps_test_oracledb": {
     "action": "PASS",
     "source_ip": "${cloud-platform}",
     "destination_ip": "${hmpps-test}",
@@ -76,7 +76,7 @@
     "destination_port": "ANY",
     "protocol": "TCP"
   },
-  "analytical_platform_airflow_dev_to_mp_dev_test": {
+  "analytical_platform_airflow_dev_to_mp_dev_test_oracledb": {
     "action": "PASS",
     "source_ip": "${analytical-platform-airflow-dev}",
     "destination_ip": "${mp-development-test}",
@@ -111,7 +111,7 @@
     "destination_port": "ANY",
     "protocol": "TCP"
   },
-  "aks_studio_hosting_dev_1_vnet_to_mp_hmpps_test_db": {
+  "aks_studio_hosting_dev_1_vnet_to_mp_hmpps_test_oracledb": {
     "action": "PASS",
     "source_ip": "${aks-studio-hosting-dev-1-vnet}",
     "destination_ip": "${hmpps-test}",
@@ -123,20 +123,6 @@
     "source_ip": "${aks-studio-hosting-dev-1-vnet}",
     "destination_ip": "${hmpps-test}",
     "destination_port": "443",
-    "protocol": "TCP"
-  },
-  "nomisapi_t2_root_vnet_to_mp_hmpps_test": {
-    "action": "PASS",
-    "source_ip": "${nomisapi-t2-root-vnet}",
-    "destination_ip": "${hmpps-test}",
-    "destination_port": "1521",
-    "protocol": "TCP"
-  },
-  "nomisapi_t3_root_vnet_to_mp_hmpps_test": {
-    "action": "PASS",
-    "source_ip": "${nomisapi-t3-root-vnet}",
-    "destination_ip": "${hmpps-test}",
-    "destination_port": "1521",
     "protocol": "TCP"
   },
   "mp_hmpps_test_to_noms_mgmt_vnet_dns": {


### PR DESCRIPTION
## A reference to the issue / Description of it

Inconsistent naming and unused rules make firewall rules harder to manage

## How does this PR fix the problem?

Aligns naming for port 1521 specifically and removes some unused nomis rules (nomisAPI T2 and T3 no longer exist and we no longer use monitoring from cloud platform)

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

N/A

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
