### PR TITLE
add fw rules for planetfm endusers access

### DIFF
--- a/terraform/environments/core-network-services/cidr-ranges.tf
+++ b/terraform/environments/core-network-services/cidr-ranges.tf
@@ -73,6 +73,8 @@ locals {
 
     hmpps-preproduction-general-private-subnets = "10.27.0.0/22"
     hmpps-production-general-private-subnets    = "10.27.10.0/22"
+
+    mojo-end-user-devices = "10.0.0.0/8"
   }
 
   all_cidr_ranges = merge(

--- a/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
@@ -351,49 +351,49 @@
   },
   "mojo_to_csr_preproduction_http": {
     "action": "PASS",
-    "source_ip": "10.0.0.0/8",
+    "source_ip": "${mojo-end-user-devices}",
     "destination_ip": "${ hmpps-preproduction-general-private-subnets}",
     "destination_port": "80",
     "protocol": "TCP"
   },
   "mojo_to_csr_preproduction_app_core_7770": {
     "action": "PASS",
-    "source_ip": "10.0.0.0/8",
+    "source_ip": "${mojo-end-user-devices}",
     "destination_ip": "${ hmpps-preproduction-general-private-subnets}",
     "destination_port": "7770",
     "protocol": "TCP"
   },
   "mojo_to_csr_preproduction_app_core_7771": {
     "action": "PASS",
-    "source_ip": "10.0.0.0/8",
+    "source_ip": "${mojo-end-user-devices}",
     "destination_ip": "${ hmpps-preproduction-general-private-subnets}",
     "destination_port": "7771",
     "protocol": "TCP"
   },
   "mojo_to_csr_preproduction_app_custom_7780": {
     "action": "PASS",
-    "source_ip": "10.0.0.0/8",
+    "source_ip": "${mojo-end-user-devices}",
     "destination_ip": "${ hmpps-preproduction-general-private-subnets}",
     "destination_port": "7780",
     "protocol": "TCP"
   },
   "mojo_to_csr_preproduction_app_custom_7781": {
     "action": "PASS",
-    "source_ip": "10.0.0.0/8",
+    "source_ip": "${mojo-end-user-devices}",
     "destination_ip": "${ hmpps-preproduction-general-private-subnets}",
     "destination_port": "7781",
     "protocol": "TCP"
   },
   "mojo_to_csr_preproduction_2109": {
     "action": "PASS",
-    "source_ip": "10.0.0.0/8",
+    "source_ip": "${mojo-end-user-devices}",
     "destination_ip": "${ hmpps-preproduction-general-private-subnets}",
     "destination_port": "2109",
     "protocol": "TCP"
   },
   "mojo_to_csr_preproduction_45054": {
     "action": "PASS",
-    "source_ip": "10.0.0.0/8",
+    "source_ip": "${mojo-end-user-devices}",
     "destination_ip": "${ hmpps-preproduction-general-private-subnets}",
     "destination_port": "45054",
     "protocol": "TCP"
@@ -405,44 +405,44 @@
     "destination_port": "1434",
     "protocol": "UDP"
   },
-  "endusers_to_planetfm_preproduction_netbios_137_udp": {
+  "mojo_to_planetfm_preproduction_netbios_137_udp": {
     "action": "PASS",
-    "source_ip": "10.0.0.0/8",
+    "source_ip": "${mojo-end-user-devices}",
     "destination_ip": "${hmpps-preproduction-general-private-subnets}",
     "destination_port": "137",
     "protocol": "UDP"
   },
-  "endusers_to_planetfm_preproduction_smb_445_tcp": {
+  "mojo_to_planetfm_preproduction_smb_445_tcp": {
     "action": "PASS",
-    "source_ip": "10.0.0.0/8",
+    "source_ip": "${mojo-end-user-devices}",
     "destination_ip": "${hmpps-preproduction-general-private-subnets}",
     "destination_port": "445",
     "protocol": "TCP"
   },
-  "endusers_to_planetfm_preproduction_sql_1433_tcp": {
+  "mojo_to_planetfm_preproduction_sql_1433_tcp": {
     "action": "PASS",
-    "source_ip": "10.0.0.0/8",
+    "source_ip": "${mojo-end-user-devices}",
     "destination_ip": "${hmpps-preproduction-general-private-subnets}",
     "destination_port": "1433",
     "protocol": "TCP"
   },
-  "endusers_to_planetfm_preproduction_sql_1434_udp": {
+  "mojo_to_planetfm_preproduction_sql_1434_udp": {
     "action": "PASS",
-    "source_ip": "10.0.0.0/8",
+    "source_ip": "${mojo-end-user-devices}",
     "destination_ip": "${hmpps-preproduction-general-private-subnets}",
     "destination_port": "1434",
     "protocol": "UDP"
   },
-  "endusers_to_planetfm_preproduction_cfam_scheduling_7071_tcp": {
+  "mojo_to_planetfm_preproduction_cfam_scheduling_7071_tcp": {
     "action": "PASS",
-    "source_ip": "10.0.0.0/8",
+    "source_ip": "${mojo-end-user-devices}",
     "destination_ip": "${hmpps-preproduction-general-private-subnets}",
     "destination_port": "7071",
     "protocol": "TCP"
   },
-  "endusers_to_planetfm_preproduction_cafm_licensing_7073_tcp": {
+  "mojo_to_planetfm_preproduction_cafm_licensing_7073_tcp": {
     "action": "PASS",
-    "source_ip": "10.0.0.0/8",
+    "source_ip": "${mojo-end-user-devices}",
     "destination_ip": "${hmpps-preproduction-general-private-subnets}",
     "destination_port": "7073",
     "protocol": "TCP"

--- a/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
@@ -404,5 +404,47 @@
     "destination_ip": "${hmpps-preproduction-general-private-subnets}",
     "destination_port": "1434",
     "protocol": "UDP"
+  },
+  "endusers_to_planetfm_preproduction_netbios_137_udp": {
+    "action": "PASS",
+    "source_ip": "10.0.0.0/8",
+    "destination_ip": "${hmpps-preproduction-general-private-subnets}",
+    "destination_port": "137",
+    "protocol": "UDP"
+  },
+  "endusers_to_planetfm_preproduction_smb_445_tcp": {
+    "action": "PASS",
+    "source_ip": "10.0.0.0/8",
+    "destination_ip": "${hmpps-preproduction-general-private-subnets}",
+    "destination_port": "445",
+    "protocol": "TCP"
+  },
+  "endusers_to_planetfm_preproduction_sql_1433_tcp": {
+    "action": "PASS",
+    "source_ip": "10.0.0.0/8",
+    "destination_ip": "${hmpps-preproduction-general-private-subnets}",
+    "destination_port": "1433",
+    "protocol": "TCP"
+  },
+  "endusers_to_planetfm_preproduction_sql_1434_udp": {
+    "action": "PASS",
+    "source_ip": "10.0.0.0/8",
+    "destination_ip": "${hmpps-preproduction-general-private-subnets}",
+    "destination_port": "1434",
+    "protocol": "UDP"
+  },
+  "endusers_to_planetfm_preproduction_cfam_scheduling_7071_tcp": {
+    "action": "PASS",
+    "source_ip": "10.0.0.0/8",
+    "destination_ip": "${hmpps-preproduction-general-private-subnets}",
+    "destination_port": "7071",
+    "protocol": "TCP"
+  },
+  "endusers_to_planetfm_preproduction_cafm_licensing_7073_tcp": {
+    "action": "PASS",
+    "source_ip": "10.0.0.0/8",
+    "destination_ip": "${hmpps-preproduction-general-private-subnets}",
+    "destination_port": "7073",
+    "protocol": "TCP"
   }
 }

--- a/terraform/environments/core-network-services/firewall-rules/production_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/production_rules.json
@@ -474,5 +474,47 @@
     "destination_ip": "${moj-smtp-relay2}",
     "destination_port": "587",
     "protocol": "TCP"
+  },
+  "endusers_to_planetfm_production_netbios_137_udp": {
+    "action": "PASS",
+    "source_ip": "10.0.0.0/8",
+    "destination_ip": "${hmpps-production-general-private-subnets}",
+    "destination_port": "137",
+    "protocol": "UDP"
+  },
+  "endusers_to_planetfm_production_smb_445_tcp": {
+    "action": "PASS",
+    "source_ip": "10.0.0.0/8",
+    "destination_ip": "${hmpps-production-general-private-subnets}",
+    "destination_port": "445",
+    "protocol": "TCP"
+  },
+  "endusers_to_planetfm_production_sql_1433_tcp": {
+    "action": "PASS",
+    "source_ip": "10.0.0.0/8",
+    "destination_ip": "${hmpps-production-general-private-subnets}",
+    "destination_port": "1433",
+    "protocol": "TCP"
+  },
+  "endusers_to_planetfm_production_sql_1434_udp": {
+    "action": "PASS",
+    "source_ip": "10.0.0.0/8",
+    "destination_ip": "${hmpps-production-general-private-subnets}",
+    "destination_port": "1434",
+    "protocol": "UDP"
+  },
+  "endusers_to_planetfm_production_cfam_scheduling_7071_tcp": {
+    "action": "PASS",
+    "source_ip": "10.0.0.0/8",
+    "destination_ip": "${hmpps-production-general-private-subnets}",
+    "destination_port": "7071",
+    "protocol": "TCP"
+  },
+  "endusers_to_planetfm_production_cafm_licensing_7073_tcp": {
+    "action": "PASS",
+    "source_ip": "10.0.0.0/8",
+    "destination_ip": "${hmpps-production-general-private-subnets}",
+    "destination_port": "7073",
+    "protocol": "TCP"
   }
 }

--- a/terraform/environments/core-network-services/firewall-rules/production_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/production_rules.json
@@ -400,49 +400,49 @@
   },
   "mojo_to_csr_production_http": {
     "action": "PASS",
-    "source_ip": "10.0.0.0/8",
+    "source_ip": "${mojo-end-user-devices}",
     "destination_ip": "${ hmpps-production-general-private-subnets}",
     "destination_port": "80",
     "protocol": "TCP"
   },
   "mojo_to_csr_production_app_core_7770": {
     "action": "PASS",
-    "source_ip": "10.0.0.0/8",
+    "source_ip": "${mojo-end-user-devices}",
     "destination_ip": "${ hmpps-production-general-private-subnets}",
     "destination_port": "7770",
     "protocol": "TCP"
   },
   "mojo_to_csr_production_app_core_7771": {
     "action": "PASS",
-    "source_ip": "10.0.0.0/8",
+    "source_ip": "${mojo-end-user-devices}",
     "destination_ip": "${ hmpps-production-general-private-subnets}",
     "destination_port": "7771",
     "protocol": "TCP"
   },
   "mojo_to_csr_production_app_custom_7780": {
     "action": "PASS",
-    "source_ip": "10.0.0.0/8",
+    "source_ip": "${mojo-end-user-devices}",
     "destination_ip": "${ hmpps-production-general-private-subnets}",
     "destination_port": "7780",
     "protocol": "TCP"
   },
   "mojo_to_csr_production_app_custom_7781": {
     "action": "PASS",
-    "source_ip": "10.0.0.0/8",
+    "source_ip": "${mojo-end-user-devices}",
     "destination_ip": "${ hmpps-production-general-private-subnets}",
     "destination_port": "7781",
     "protocol": "TCP"
   },
   "mojo_to_csr_production_2109": {
     "action": "PASS",
-    "source_ip": "10.0.0.0/8",
+    "source_ip": "${mojo-end-user-devices}",
     "destination_ip": "${ hmpps-production-general-private-subnets}",
     "destination_port": "2109",
     "protocol": "TCP"
   },
   "mojo_to_csr_production_45054": {
     "action": "PASS",
-    "source_ip": "10.0.0.0/8",
+    "source_ip": "${mojo-end-user-devices}",
     "destination_ip": "${ hmpps-production-general-private-subnets}",
     "destination_port": "45054",
     "protocol": "TCP"
@@ -475,44 +475,44 @@
     "destination_port": "587",
     "protocol": "TCP"
   },
-  "endusers_to_planetfm_production_netbios_137_udp": {
+  "mojo_to_planetfm_production_netbios_137_udp": {
     "action": "PASS",
-    "source_ip": "10.0.0.0/8",
+    "source_ip": "${mojo-end-user-devices}",
     "destination_ip": "${hmpps-production-general-private-subnets}",
     "destination_port": "137",
     "protocol": "UDP"
   },
-  "endusers_to_planetfm_production_smb_445_tcp": {
+  "mojo_to_planetfm_production_smb_445_tcp": {
     "action": "PASS",
-    "source_ip": "10.0.0.0/8",
+    "source_ip": "${mojo-end-user-devices}",
     "destination_ip": "${hmpps-production-general-private-subnets}",
     "destination_port": "445",
     "protocol": "TCP"
   },
-  "endusers_to_planetfm_production_sql_1433_tcp": {
+  "mojo_to_planetfm_production_sql_1433_tcp": {
     "action": "PASS",
-    "source_ip": "10.0.0.0/8",
+    "source_ip": "${mojo-end-user-devices}",
     "destination_ip": "${hmpps-production-general-private-subnets}",
     "destination_port": "1433",
     "protocol": "TCP"
   },
-  "endusers_to_planetfm_production_sql_1434_udp": {
+  "mojo_to_planetfm_production_sql_1434_udp": {
     "action": "PASS",
-    "source_ip": "10.0.0.0/8",
+    "source_ip": "${mojo-end-user-devices}",
     "destination_ip": "${hmpps-production-general-private-subnets}",
     "destination_port": "1434",
     "protocol": "UDP"
   },
-  "endusers_to_planetfm_production_cfam_scheduling_7071_tcp": {
+  "mojo_to_planetfm_production_cfam_scheduling_7071_tcp": {
     "action": "PASS",
-    "source_ip": "10.0.0.0/8",
+    "source_ip": "${mojo-end-user-devices}",
     "destination_ip": "${hmpps-production-general-private-subnets}",
     "destination_port": "7071",
     "protocol": "TCP"
   },
-  "endusers_to_planetfm_production_cafm_licensing_7073_tcp": {
+  "mojo_to_planetfm_production_cafm_licensing_7073_tcp": {
     "action": "PASS",
-    "source_ip": "10.0.0.0/8",
+    "source_ip": "${mojo-end-user-devices}",
     "destination_ip": "${hmpps-production-general-private-subnets}",
     "destination_port": "7073",
     "protocol": "TCP"


### PR DESCRIPTION
## A reference to the issue / Description of it

PlanetFM enduser client access is currently blocked by these FW rules

## How does this PR fix the problem?

Adds access to private subnets for PlanetFM end users

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

We can see traffic being blocked and the underlying SG's are correct

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

Will allow currently ongoing connectivity testing to proceed. 

Delays in local testing will impact UAT test schedule (which we really don't want)

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

Similar exercise already been carried out for CSR