### PR TITLE
Persisting the state when tf errors out

### DIFF
--- a/scripts/terraform-apply.sh
+++ b/scripts/terraform-apply.sh
@@ -24,3 +24,7 @@ if [ ! -z "$2" ]; then
 else
   terraform -chdir="$1" apply -input=false -no-color -auto-approve | ./scripts/redact-output.sh  
 fi
+
+if [ -f "$1/errored.tfstate" ]; then
+  terraform -chdir="$1" state push errored.tfstate | ./scripts/redact-output.sh
+fi


### PR DESCRIPTION
## A reference to the issue / Description of it

This is to fix https://github.com/ministryofjustice/modernisation-platform/issues/5859

## How does this PR fix the problem?

`terraform state push errored.tfstate ` is run, when the pipeline fails with the error below and writes a `errored.tfstate` file:

```
Error: Failed to save state

Error saving state: failed to upload state: operation error S3: PutObject,
failed to rewind transport stream for retry, request stream is not seekable

Error: Failed to persist state to backend

The error shown above has prevented Terraform from writing the updated state
to the configured backend. To allow for recovery, the state has been written
to the file "errored.tfstate" in the current working directory.

Running "terraform apply" again at this point will create a forked state,
making it harder to recover.

To retry writing this state, use the following command:
    terraform state push errored.tfstate
```

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

It was run locally to test the correctness of code when the file exists and when the file does not exist.
The terraform action itself can only be tested live, when a pipeline fails for that error and generates `errored.tfstate` file.
The correctness of the terraform command was also tested locally (with a fake empty `errored.tfstate` file).

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

The change is done in a bash script of the `terraform apply` script and it will be enrolled to all pipelines in the `modernisation-platform` that run `scripts\terraform-apply.sh` script.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
