### PR TITLE
Route traffic for sandbox VPCs back to TGW

### DIFF
--- a/terraform/environments/core-network-services/cidr-ranges.tf
+++ b/terraform/environments/core-network-services/cidr-ranges.tf
@@ -3,6 +3,7 @@ locals {
     mp-core                     = "10.20.0.0/16"
     mp-development-test         = "10.26.0.0/16"
     mp-preproduction-production = "10.27.0.0/16"
+    mp-sandbox                  = "10.231.0.0/20"
     mp-sandbox-garden           = "10.231.0.0/21"
     mp-sandbox-house            = "10.231.8.0/21"
   }

--- a/terraform/environments/core-network-services/firewall-rules/inline_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/inline_rules.json
@@ -22,7 +22,7 @@
   },
   "mp_sandboxes_to_internet_https": {
     "action": "PASS",
-    "source_ip": "10.231.0.0/20",
+    "source_ip": "${mp-sandbox}",
     "destination_ip": "0.0.0.0/0",
     "destination_port": "443",
     "protocol": "TCP"

--- a/terraform/modules/vpc-inspection/main.tf
+++ b/terraform/modules/vpc-inspection/main.tf
@@ -136,6 +136,13 @@ resource "aws_route" "transit-gateway-10-27-0-0" {
   transit_gateway_id     = var.transit_gateway_id
 }
 
+resource "aws_route" "transit-gateway-10-231-0-0" {
+  for_each               = aws_route_table.transit-gateway
+  destination_cidr_block = "10.231.0.0/20"
+  route_table_id         = each.value.id
+  transit_gateway_id     = var.transit_gateway_id
+}
+
 resource "aws_network_acl" "transit-gateway" {
   vpc_id     = aws_vpc.main.id
   subnet_ids = [for subnet in aws_subnet.transit-gateway : subnet.id]
@@ -218,6 +225,13 @@ resource "aws_route" "inspection-10-26-0-0" {
 resource "aws_route" "inspection-10-27-0-0" {
   for_each               = aws_route_table.inspection
   destination_cidr_block = "10.27.0.0/16"
+  route_table_id         = each.value.id
+  transit_gateway_id     = var.transit_gateway_id
+}
+
+resource "aws_route" "inspection-10-231-0-0" {
+  for_each               = aws_route_table.inspection
+  destination_cidr_block = "10.231.0.0/20"
   route_table_id         = each.value.id
   transit_gateway_id     = var.transit_gateway_id
 }
@@ -310,6 +324,13 @@ resource "aws_route" "public-10-27-0-0" {
   route_table_id         = each.value.id
   vpc_endpoint_id        = local.firewall_endpoint_map[aws_subnet.public[each.key].availability_zone]
 }
+
+resource "aws_route" "public-10-231-0-0" {
+  depends_on             = [aws_networkfirewall_firewall.inline_inspection]
+  for_each               = aws_route_table.public
+  destination_cidr_block = "10.231.0.0/20"
+  route_table_id         = each.value.id
+  vpc_endpoint_id        = local.firewall_endpoint_map[aws_subnet.public[each.key].availability_zone]
 
 resource "aws_network_acl" "public" {
   vpc_id     = aws_vpc.main.id

--- a/terraform/modules/vpc-inspection/main.tf
+++ b/terraform/modules/vpc-inspection/main.tf
@@ -331,6 +331,7 @@ resource "aws_route" "public-10-231-0-0" {
   destination_cidr_block = "10.231.0.0/20"
   route_table_id         = each.value.id
   vpc_endpoint_id        = local.firewall_endpoint_map[aws_subnet.public[each.key].availability_zone]
+}
 
 resource "aws_network_acl" "public" {
   vpc_id     = aws_vpc.main.id


### PR DESCRIPTION
## A reference to the issue / Description of it

Traffic from Sandbox VPCs to the internet does not return to the source host

## How does this PR fix the problem?

This PR adds routes back to the TGW for traffic from Sandbox VPCs

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Observed traffic reaching inline NWFW endpoints in egress VPCs, but no return traffic seen on source host.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

Routes should be added by GitHub action
