### PR TITLE
Add routes for sandbox VPCs to non_live_data TGW route table

### DIFF
--- a/terraform/environments/core-network-services/transit_gateway_connections.tf
+++ b/terraform/environments/core-network-services/transit_gateway_connections.tf
@@ -84,6 +84,7 @@ locals {
   tgw_non_live_data_attachments = {
     for k, v in data.aws_ec2_transit_gateway_vpc_attachment.transit_gateway_all : k => v.tags.Name if(
       length(regexall("(?:development-attachment)", v.tags.Name)) > 0 ||
+      length(regexall("(?:sandbox-attachment)", v.tags.Name)) > 0 ||
       length(regexall("(?:test-attachment)", v.tags.Name)) > 0 ||
       length(regexall("(?:-non_live_data-attachment)", v.tags.Name)) > 0
     )


### PR DESCRIPTION

## A reference to the issue / Description of it

Traffic to the internet does not return to sandbox VPCs

## How does this PR fix the problem?

Because return traffic flows back to the TGW and the non_live_data route table, propagations are required to return internet traffic to sandbox VPCs

## How has this been tested?

Added manual propagation, confirmed that host in garden-sandbox could curl an internet endpoint successfully

## Deployment Plan / Instructions

Deploy through GitHub Actions

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

I've checked that this won't inadvertently allow east-west traffic between Sandbox VPCs and Development / Test VPCs. The NACLs in place at present will allow traffic in from a sandbox, but returning traffic to the sandbox will be dropped by the NACLs so flows will not establish.
