### PR TITLE
add cur permissions to member-access-us-east

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -284,7 +284,11 @@ data "aws_iam_policy_document" "member-access-us-east" {
     actions = ["acm:*",
       "logs:*",
       "waf:*",
-      "wafv2:*"
+      "wafv2:*",
+      "cur:PutReportDefinition", 
+      "cur:DeleteReportDefinition",
+      "cur:ModifyReportDefinition",
+      "cur:DescribeReportDefinitions"
     ]
     resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
   }


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/5924

## How does this PR fix the problem?

This should allow member accounts to build CUR definitions (Cost & Usage Reports) via terraform to a specified s3 bucket.

## How has this been tested?

I'm running TF locally to test in example-development but get the following error when I try to build the CUR definition with the us-east-1 provider...


`User: arn:aws:sts::083957762049:assumed-role/MemberInfrastructureAccessUSEast/aws-go-sdk-1704803134428561000 is not authorized to perform: cur:PutReportDefinition on resource: arn:aws:cur:us-east-1:083957762049:definition/example-cur-report-definition because no identity-based policy allows the cur:PutReportDefinition action`

Once this is merged I will test fully and then look at doing it through the pipeline.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

Adds functionality

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

I'm not sure whether to be prescriptive with the permissions as in this PR or just to go for` "cur:*" `