### PR TITLE
Add Oasys to Oracle license reporting

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/locals.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/locals.tf
@@ -51,6 +51,10 @@ locals {
     "ccms-ebs-test",
     "ccms-ebs-preproduction",
     "ccms-ebs-production",
-    "example-development"
+    "example-development",
+    "oasys-development",
+    "oasys-test",
+    "oasys-preproduction",
+    "oasys-production"
   ]
 }


### PR DESCRIPTION
Allows the oasys accounts to be picked up on Oracle licensing reports.


## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
