### PR TITLE
allow directory management permission set to start SSM connections

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/policies.tf
+++ b/terraform/environments/bootstrap/delegate-access/policies.tf
@@ -828,6 +828,7 @@ data "aws_iam_policy_document" "directory-management-document" {
       "ec2:AuthorizeSecurityGroupIngress",
       "ec2:AuthorizeSecurityGroupEgress",
       "ec2:CreateTags",
+      "ssm:*",
       "ssm-guiconnect:*Connection"
     ]
     resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097


### PR DESCRIPTION
## A reference to the issue / Description of it

Users who make use of the directory management role need SSM permissions to connect to a directory service management instance.

## How does this PR fix the problem?

Adds `ssm:*` to permissions for role policy.

## How has this been tested?

Observed failure when attempting to connect to management instance:
```
An error occurred while calling the StartConnection API operation. AccessDeniedException: An error occurred (AccessDeniedException) when calling the StartSession operation: User: arn:aws:sts::000000000000:assumed-role/AWSReservedSSO_mp-active-directory-management_93c9c1890364ab9b/user@digital.justice.gov.uk is not authorized to perform: ssm:StartSession on resource: arn:aws:ec2:eu-west-2:000000000000:instance/i-028fd3a3be2530136 because no identity-based policy allows the ssm:StartSession action
```

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

Deploy through GitHub Actions scheduled baseline

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
