### PR TITLE
Separating GitHub codeowners and aws access #5908

### DIFF
--- a/scripts/provision-member-directories.sh
+++ b/scripts/provision-member-directories.sh
@@ -125,7 +125,7 @@ EOL
     application_name=$(basename "$file" .json)
     directory=/terraform/environments/$application_name
     account_type=$(jq -r '."account-type"' ${environment_json_dir}/${application_name}.json)
-    codeowners=$(jq -r '.codeowners[] | "@ministryofjustice/" + .' delius-core.json | sort | uniq | tr '\n' ' ')
+    codeowners=$(jq -r '.codeowners[] | "@ministryofjustice/" + .' ${environment_json_dir}/${application_name}.json | sort | uniq | tr '\n' ' ')
     github_slugs=$(jq -r '.environments[].access[].github_slug | "@ministryofjustice/" + .' ${environment_json_dir}/${application_name}.json | sort | uniq | tr '\n' ' ')
 
     if [ "$account_type" = "member" ]; then

--- a/scripts/provision-member-directories.sh
+++ b/scripts/provision-member-directories.sh
@@ -125,11 +125,19 @@ EOL
     application_name=$(basename "$file" .json)
     directory=/terraform/environments/$application_name
     account_type=$(jq -r '."account-type"' ${environment_json_dir}/${application_name}.json)
+    codeowners=$(jq -r '.codeowners[] | "@ministryofjustice/" + .' delius-core.json | sort | uniq | tr '\n' ' ')
     github_slugs=$(jq -r '.environments[].access[].github_slug | "@ministryofjustice/" + .' ${environment_json_dir}/${application_name}.json | sort | uniq | tr '\n' ' ')
 
     if [ "$account_type" = "member" ]; then
-      echo "Adding $directory $github_slugs@modernisation-platform to codeowners"
-      echo "$directory $github_slugs@ministryofjustice/modernisation-platform" >> $codeowners_file
+      # if codeowners array has been defined in the json file, use that
+      if [ -n "$codeowners" ]; then
+        echo "Adding $directory $codeowners@ministryofjustice/modernisation-platform  to codeowners"
+        echo "$directory $codeowners@ministryofjustice/modernisation-platform" >> $codeowners_file
+      # otherwise, use the github_slugs array
+      else
+        echo "Adding $directory $github_slugs@ministryofjustice/modernisation-platform to codeowners"
+        echo "$directory $github_slugs@ministryofjustice/modernisation-platform" >> $codeowners_file
+      fi
     fi
 
   done


### PR DESCRIPTION
## A reference to the issue / Description of it

See #5908 

## How does this PR fix the problem?

Allows specifying a top level array containing github_slugs to be considered as `codeowners`. If you have not provided a `codeowners` key, then the existing method of considering all `github_slugs` with member access as codeowners is still used.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

I have tested the bash locally using an example `${environment_json_dir}/${application_name}.json` file. 

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
