### PR TITLE
CC-2295: Allow Cloud Platform communication on database port 1522 to …

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
@@ -446,5 +446,12 @@
     "destination_ip": "${hmpps-preproduction-general-private-subnets}",
     "destination_port": "7073",
     "protocol": "TCP"
+  },
+  "cp_to_mp_laa_preproduction": {
+    "action": "PASS",
+    "source_ip": "${cloud-platform}",
+    "destination_ip": "${laa-preproduction}",
+    "destination_port": "1522",
+    "protocol": "TCP"
   }
 }


### PR DESCRIPTION
…PreProduction LAA

## A reference to the issue / Description of it

Allow Cloud Platform communication on database port 1522 to PreProduction LAA

## How does this PR fix the problem?

Allows Cloud Platform app to communicate with our services

## How has this been tested?

Similar rules were set up in DEV and TEST


## Deployment Plan / Instructions

Once deployed will allow communication on that port between CP and LAA on PreProduction


## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [X] All checks have passed
- [X] I have made corresponding changes to the documentation
- [X] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

Production not needed yet but will do in the future and will create a separate PR when needed
