### PR TITLE
Amended the delius-code json to add codeowner false to the dba group

### DIFF
--- a/environments/delius-core.json
+++ b/environments/delius-core.json
@@ -12,7 +12,8 @@
         {
           "github_slug": "hmpps-dba",
           "level": "sandbox",
-          "nuke": "exclude"
+          "nuke": "exclude",
+          "codeowner": "false"
         },
         {
           "github_slug": "unilink",

--- a/environments/delius-core.json
+++ b/environments/delius-core.json
@@ -1,5 +1,6 @@
 {
   "account-type": "member",
+  "codeowners" : ["hmpps-migration"],
   "environments": [
     {
       "name": "development",
@@ -12,8 +13,7 @@
         {
           "github_slug": "hmpps-dba",
           "level": "sandbox",
-          "nuke": "exclude",
-          "codeowner": "false"
+          "nuke": "exclude"
         },
         {
           "github_slug": "unilink",


### PR DESCRIPTION
## A reference to the issue / Description of it

As per the request info on #5908 
Additionally another change has been made to the provision-members-directories.sh file too

## How does this PR fix the problem?

Should prevent those with codeowners:false from approving PRs

## How has this been tested?

Difficult to test so will be done by approving this and hoping it runs the above sh

## Checklist (check `x` in `[ ]` of list items)

- [x ] I have performed a self-review of my own code
- [x ] All checks have passed

