### PR TITLE
Code Scanning Alert- pin dependency by hash

### DIFF
--- a/.github/workflows/notify-user-new-environment-created.yml
+++ b/.github/workflows/notify-user-new-environment-created.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4.0.1
         with:
           node-version: 20
       - name: Send message to user on onboarding issue close


### PR DESCRIPTION
## A reference to the issue / Description of it

[Pinned-Dependency](https://github.com/ministryofjustice/modernisation-platform/security/code-scanning/1053)
#4998 

## How does this PR fix the problem?

Pins each Action to an immutable checksum as recommended by GitHub's Security Hardening guide.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
