### PR TITLE
Add transfer.server endpoint  to hmpps

### DIFF
--- a/environments-networks/hmpps-development.json
+++ b/environments-networks/hmpps-development.json
@@ -33,7 +33,8 @@
       "com.amazonaws.eu-west-2.email-smtp",
       "com.amazonaws.eu-west-2.execute-api",
       "com.amazonaws.eu-west-2.kinesis-streams",
-      "com.amazonaws.eu-west-2.secretsmanager"
+      "com.amazonaws.eu-west-2.secretsmanager",
+      "com.amazonaws.eu-west-2.transfer.server"
     ],
     "additional_private_zones": [],
     "additional_vpcs": [],

--- a/environments-networks/hmpps-preproduction.json
+++ b/environments-networks/hmpps-preproduction.json
@@ -29,7 +29,8 @@
       "com.amazonaws.eu-west-2.email-smtp",
       "com.amazonaws.eu-west-2.execute-api",
       "com.amazonaws.eu-west-2.kinesis-streams",
-      "com.amazonaws.eu-west-2.secretsmanager"
+      "com.amazonaws.eu-west-2.secretsmanager",
+      "com.amazonaws.eu-west-2.transfer.server"
     ],
     "additional_private_zones": [],
     "additional_vpcs": [],

--- a/environments-networks/hmpps-production.json
+++ b/environments-networks/hmpps-production.json
@@ -31,7 +31,8 @@
       "com.amazonaws.eu-west-2.email-smtp",
       "com.amazonaws.eu-west-2.execute-api",
       "com.amazonaws.eu-west-2.kinesis-streams",
-      "com.amazonaws.eu-west-2.secretsmanager"
+      "com.amazonaws.eu-west-2.secretsmanager",
+      "com.amazonaws.eu-west-2.transfer.server"
     ],
     "additional_private_zones": [],
     "additional_vpcs": [],


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform-environments/pull/4503 is building an SFTP server for external access but requires additional permissions so that a transfer server can be created.

See [here](https://github.com/terraform-aws-modules/terraform-aws-vpc/issues/334) for difference between `transfer` and `transfer.server`

## How does this PR fix the problem?

Adds `transfer.server` endpoint for HMPPS domain

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

n/a

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

Required to be able to deploy the sftp server.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
