### PR TITLE
add vpc endpoint create/delete permissions

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -76,6 +76,8 @@ data "aws_iam_policy_document" "member-access" {
       "ds:Update*",
       "dynamodb:*",
       "ebs:*",
+      "ec2:CreateVpcEndpoint",
+      "ec2:DeleteVpcEndpoints",
       "ec2:CreateVpcEndpointServiceConfiguration",
       "ec2:DeleteVpcEndpointServiceConfigurations",
       "ec2:ModifyVpcEndpointServiceConfiguration",


### PR DESCRIPTION
## A reference to the issue / Description of it

Relates to [this query](https://github.com/ministryofjustice/modernisation-platform-environments/actions/runs/7501579296/job/20422527745?pr=4503 ) from Electronic Monitoring Data team regarding the lack of permissions for creation of an aws transfer server 

## How does this PR fix the problem?

This gives the `member-access` role the ability to **create** and **delete** ec2 vpc endpoints as listed as min pre reqs in creation of aws transfer servers [here](https://docs.aws.amazon.com/transfer/latest/userguide/getting-started.html)

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

This will be tested by EMD team when permissions are added by re-running their workflow.

## Additional comments (if any)

As this will allow members to create/destroy vpc endpoints (something we don't usually want them to do) there is a corresponding PR https://github.com/ministryofjustice/modernisation-platform-environments/pull/4541 for adding a check to any PRs raised by members in the MP Environments repo if any aws transfer server or vpc endpoints are being managed ensuring that these changes must be reviewed by MP team.

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [X] All checks have passed

