### PR TITLE
Amended code to include limiting change approvals

### DIFF
--- a/source/runbooks/creating-accounts-for-end-users.html.md.erb
+++ b/source/runbooks/creating-accounts-for-end-users.html.md.erb
@@ -33,11 +33,13 @@ Customers will fill out the new-environment template via our public repository [
 See an example file [here](https://user-guide.modernisation-platform.service.justice.gov.uk/user-guide/creating-environments.html#example-json-files).
 
 > Note - If you are adding an environment to an existing application you can add the new environment block to this file, you do not need to create another. Creating multiple environments in bulk is supported, but creating multiple application accounts is not.
+
 There is also a facility to list only the account which will have approval rights on the accounts. To add this limitation you will need to include the line belo immediately after the "account-type" line.
 
-"codeowners": ["hmpps-migration"],
+'"codeowners": ["<owner-name>"],'  Replace <owner-name> with a team such as modernisation-platform. for example. 
 
-This will enable this account to be limited to approval so any others created will not be able to approve their own code. The code in provision-member-directories.sh was amended to limit access.
+This will restrict code approval to only the GitHub team slugs listed in the 'cdeowners' block.. The code in provision-member-directories.sh was amended to limit access.
+
 See [#5957] (https://github.com/ministryofjustice/modernisation-platform/pull/5957) for an example of the change required.
 
 #### 2. Update the `expected.rego`

--- a/source/runbooks/creating-accounts-for-end-users.html.md.erb
+++ b/source/runbooks/creating-accounts-for-end-users.html.md.erb
@@ -33,6 +33,12 @@ Customers will fill out the new-environment template via our public repository [
 See an example file [here](https://user-guide.modernisation-platform.service.justice.gov.uk/user-guide/creating-environments.html#example-json-files).
 
 > Note - If you are adding an environment to an existing application you can add the new environment block to this file, you do not need to create another. Creating multiple environments in bulk is supported, but creating multiple application accounts is not.
+There is also a facility to list only the account which will have approval rights on the accounts. To add this limitation you will need to include the line belo immediately after the "account-type" line.
+
+"codeowners": ["hmpps-migration"],
+
+This will enable this account to be limited to approval so any others created will not be able to approve their own code. The code in provision-member-directories.sh was amended to limit access.
+See [#5957] (https://github.com/ministryofjustice/modernisation-platform/pull/5957) for an example of the change required.
 
 #### 2. Update the `expected.rego`
 

--- a/source/runbooks/creating-accounts-for-end-users.html.md.erb
+++ b/source/runbooks/creating-accounts-for-end-users.html.md.erb
@@ -38,7 +38,7 @@ By default the codeowners for the application teams folder in the `modernisation
 
 You can over write this by defining codeowners as an attribute for that application.
 
-'"codeowners": ["<owner-name>"],'  Replace <owner-name> with a team such as modernisation-platform. for example. 
+'"codeowners": ["<owner-name>"],'  Replace <owner-name> with a GitHub team such as `modernisation-platform`.
 
 This will restrict code approval to only the GitHub team slugs listed in the 'cdeowners' attribute.
 

--- a/source/runbooks/creating-accounts-for-end-users.html.md.erb
+++ b/source/runbooks/creating-accounts-for-end-users.html.md.erb
@@ -38,7 +38,7 @@ There is also a facility to list only the account which will have approval right
 
 '"codeowners": ["<owner-name>"],'  Replace <owner-name> with a team such as modernisation-platform. for example. 
 
-This will restrict code approval to only the GitHub team slugs listed in the 'cdeowners' block.. The code in provision-member-directories.sh was amended to limit access.
+This will restrict code approval to only the GitHub team slugs listed in the 'cdeowners' attribute.
 
 See [#5957] (https://github.com/ministryofjustice/modernisation-platform/pull/5957) for an example of the change required.
 

--- a/source/runbooks/creating-accounts-for-end-users.html.md.erb
+++ b/source/runbooks/creating-accounts-for-end-users.html.md.erb
@@ -34,7 +34,9 @@ See an example file [here](https://user-guide.modernisation-platform.service.jus
 
 > Note - If you are adding an environment to an existing application you can add the new environment block to this file, you do not need to create another. Creating multiple environments in bulk is supported, but creating multiple application accounts is not.
 
-There is also a facility to list only the account which will have approval rights on the accounts. To add this limitation you will need to include the line belo immediately after the "account-type" line.
+By default the codeowners for the application teams folder in the `modernisation-platform-environments` repository will be the GitHub teams defined in the access block.
+
+You can over write this by defining codeowners as an attribute for that application.
 
 '"codeowners": ["<owner-name>"],'  Replace <owner-name> with a team such as modernisation-platform. for example. 
 


### PR DESCRIPTION
## A reference to the issue / Description of it

Information about the change to allow limitation of approvals to account PRs

## How does this PR fix the problem?

Stops other teams/members from approving PRs. It must be done by the owner.

## How has this been tested?

Code was used to make sure only one account can approve PRs

## Deployment Plan / Instructions

Just a change to the documentation to reflect new approach.

## Checklist (check `x` in `[ ]` of list items)

- [x ] I have performed a self-review of my own code
- [ x] I have made corresponding changes to the documentation
- [ x] Plan and discussed how it should be deployed to PROD (If needed)

I expect some comments on the quality of the language in the code.