### PR TITLE
Add Cognito to allow MemberInfrastructureAccess permissions

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -49,6 +49,7 @@ data "aws_iam_policy_document" "member-access" {
       "codebuild:*",
       "codedeploy:*",
       "codepipeline:*",
+      "cognito:*",
       "datasync:*",
       "dbqms:*",
       "dlm:*",


### PR DESCRIPTION
## A reference to the issue / Description of it

As per this [Slack request](https://mojdt.slack.com/archives/C01A7QK5VM1/p1705313573903589) I've added `cognito:*` to the MemberInfrastructureAccess permissions

## How does this PR fix the problem?

Allows GitHub automation to create and delete `cognito` resources

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Yes, we've done this for many other permissions

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)


