### PR TITLE
DSOS-2537: give csr app support team access to hmpps domain services

### DIFF
--- a/environments/hmpps-domain-services.json
+++ b/environments/hmpps-domain-services.json
@@ -6,7 +6,12 @@
       "access": [
         {
           "github_slug": "studio-webops",
-          "level": "sandbox"
+          "level": "sandbox",
+          "nuke": "exclude"
+        },
+        {
+          "github_slug": "csr-application-support",
+          "level": "instance-management"
         }
       ]
     },
@@ -16,6 +21,10 @@
         {
           "github_slug": "studio-webops",
           "level": "developer"
+        },
+        {
+          "github_slug": "csr-application-support",
+          "level": "instance-management"
         }
       ]
     },
@@ -25,6 +34,10 @@
         {
           "github_slug": "studio-webops",
           "level": "developer"
+        },
+        {
+          "github_slug": "csr-application-support",
+          "level": "instance-management"
         }
       ]
     },
@@ -34,6 +47,10 @@
         {
           "github_slug": "studio-webops",
           "level": "developer"
+        },
+        {
+          "github_slug": "csr-application-support",
+          "level": "instance-management"
         }
       ]
     }


### PR DESCRIPTION
## A reference to the issue / Description of it

Update account settings to hmpps-domain-services in prep for some shared remote desktop resources.
Give CSR app support team access to the account - so they can logon to the servers using FleetManager if needed.
Remove nuke to ensure some core resources don't get deleted at the weekend (e.g. aws_autoscaling_group and aws_launch_template)

## How does this PR fix the problem?

Updates json file accordingly

## How has this been tested?

Mod platform pipelines

## Deployment Plan / Instructions

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)