### PR TITLE
Exiting with 0 after tf state push

### DIFF
--- a/scripts/terraform-apply-and-state-push.sh
+++ b/scripts/terraform-apply-and-state-push.sh
@@ -22,11 +22,15 @@ if [ ! -z "$2" ]; then
   options="$2"
   terraform -chdir="$1" apply -input=false -no-color -auto-approve $options | ./scripts/redact-output.sh
   if [ -f "$1/errored.tfstate" ]; then
+    echo "Running 'terraform -chdir="$1" state push errored.tfstate' ..."
     terraform -chdir="$1" state push errored.tfstate | ./scripts/redact-output.sh
+    exit 0
   fi
 else
   terraform -chdir="$1" apply -input=false -no-color -auto-approve | ./scripts/redact-output.sh
   if [ -f "$1/errored.tfstate" ]; then
+    echo "Running 'terraform -chdir="$1" state push errored.tfstate' ..."
     terraform -chdir="$1" state push errored.tfstate | ./scripts/redact-output.sh
+    exit 0
   fi
 fi


### PR DESCRIPTION
## A reference to the issue / Description of it

This is to implement further fix for the https://github.com/ministryofjustice/modernisation-platform/issues/5859 by letting the code exit with 0 after the errored tf state is pushed to the state file.

This means, that when the tf fails to save the state, it will try (once) to push the errored state to the state file, then it will exit with 0 regardless of whether the push command itself has failed or not.

The echo commands has also been added for easier debugging. 

## How does this PR fix the problem?

Evidence of a successful tf state push is here: https://github.com/ministryofjustice/modernisation-platform/actions/runs/7434337243/job/20229028807

Note, the pipeline files (exit 1) due to the original error. This change is to let it exit with 0, after the tf state push is run.

## How has this been tested?

Run locally to test the correctness of the code and see the above comment for an example of a successful tf state push.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

This is currently rolled out only to the scheduled baseline pipeline.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
