### PR TITLE
replacecd <owner-name> with \<owner-name\> to prevent missing item in documentation

### DIFF
--- a/source/runbooks/creating-accounts-for-end-users.html.md.erb
+++ b/source/runbooks/creating-accounts-for-end-users.html.md.erb
@@ -38,7 +38,7 @@ By default the codeowners for the application teams folder in the `modernisation
 
 You can over write this by defining codeowners as an attribute for that application.
 
-'"codeowners": ["<owner-name>"],'  Replace <owner-name> with a GitHub team such as `modernisation-platform`.
+`"codeowners": ["\owner-name\"],`  Replace \owner-name\ with a GitHub team such as `modernisation-platform`.
 
 This will restrict code approval to only the GitHub team slugs listed in the 'cdeowners' attribute.
 

--- a/source/runbooks/creating-accounts-for-end-users.html.md.erb
+++ b/source/runbooks/creating-accounts-for-end-users.html.md.erb
@@ -38,7 +38,7 @@ By default the codeowners for the application teams folder in the `modernisation
 
 You can over write this by defining codeowners as an attribute for that application.
 
-`"codeowners": ["\owner-name\"],`  Replace \owner-name\ with a GitHub team such as `modernisation-platform`.
+`"codeowners": ["\<owner-name\>"],`  Replace \<owner-name\> with a GitHub team such as `modernisation-platform`.
 
 This will restrict code approval to only the GitHub team slugs listed in the 'cdeowners' attribute.
 


### PR DESCRIPTION
Fixed an issue with <owner-name" showing as a blank in the documentation. 