### PR TITLE
additional permissions to run cur reports

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/policies.tf
+++ b/terraform/environments/bootstrap/delegate-access/policies.tf
@@ -183,6 +183,7 @@ data "aws_iam_policy_document" "developer_additional" {
       "cloudwatch:ListTagsForResource",
       "codebuild:ImportSourceCredentials",
       "codebuild:PersistOAuthToken",
+      "cur:DescribeReportDefinitions",
       "ds:*Tags*",
       "ds:*Snapshot*",
       "ds:ResetUserPassword",


### PR DESCRIPTION
## A reference to the issue / Description of it

run plans, apply CUR reports as a module in modernisation-platform-environments/baseline

## How does this PR fix the problem?

permission needed to deploy

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

error describes 

```
│ Error: reading Cost And Usage Report Definition (planetfm-development-cost-usage-report): AccessDeniedException: User: arn:aws:sts::326533041175:assumed-role/AWSReservedSSO_modernisation-platform-sandbox_82845f23a0bbb190/robertsweetman@digital.justice.gov.uk is not authorized to perform: cur:DescribeReportDefinitions on resource: arn:aws:cur:us-east-1:326533041175:definition/ because no identity-based policy allows the cur:DescribeReportDefinitions action
```

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

nope

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
