### PR TITLE
add cur:DescribeReportDefinitions permissions to sandbox role

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/policies.tf
+++ b/terraform/environments/bootstrap/delegate-access/policies.tf
@@ -423,6 +423,7 @@ data "aws_iam_policy_document" "sandbox_additional" {
       "codebuild:PersistOAuthToken",
       "cognito-identity:*",
       "cognito-idp:*",
+      "cur:DescribeReportDefinitions",
       "datasync:*",
       "dbqms:*",
       "dlm:*",


### PR DESCRIPTION
## A reference to the issue / Description of it

missed off "cur:DescribeReportDefinitions", needs to be added to sandbox also

## How does this PR fix the problem?

sorts out permissions error

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

previous error still exists, was added to 'developer' role only

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

nope

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
