### PR TITLE
🔨  FIX TSA Warnings

### DIFF
--- a/.github/workflows/terraform-static-analysis.yml
+++ b/.github/workflows/terraform-static-analysis.yml
@@ -31,8 +31,7 @@ jobs:
       with:
         scan_type: changed
         trivy_severity: HIGH,CRITICAL
-     #   tfsec_exclude: aws-ssm-secret-use-customer-key,github-repositories-private,aws-vpc-no-excessive-port-access,github-repositories-require-signed-commits
-        trivy_exclude: aws-ssm-secret-use-customer-key,github-repositories-private,aws-vpc-no-excessive-port-access,github-repositories-require-signed-commits
+        tfsec_exclude: aws-ssm-secret-use-customer-key,github-repositories-private,aws-vpc-no-excessive-port-access,github-repositories-require-signed-commits
         checkov_exclude: CKV_GIT_1,CKV_AWS_126,CKV2_AWS_38,CKV2_AWS_39
         tflint_exclude: terraform_unused_declarations
         tflint_call_module_type: none

--- a/terraform/environments/bootstrap/delegate-access/policies.tf
+++ b/terraform/environments/bootstrap/delegate-access/policies.tf
@@ -818,6 +818,8 @@ resource "aws_iam_policy" "fleet-manager-policy" {
 
 
 data "aws_iam_policy_document" "fleet-manager-document" {
+  #checkov:skip=CKV_AWS_111
+  #checkov:skip=CKV_AWS_356: Needs to access multiple resources
   override_policy_documents = [data.aws_iam_policy_document.common_statements.json]
   statement {
     sid    = "FleetManagerAllow"


### PR DESCRIPTION
TSA checks currently failing on new policy and an invalid input for trivy (have changed back to 'tfsec_exclude' but this might require further investigation... 

`Warning: Unexpected input(s) 'trivy_exclude', valid inputs are ['entryPoint', 'args', 'scan_type', 'comment_on_pr', 'terraform_working_dir', 'tfsec_exclude', 'checkov_exclude', 'checkov_external_modules', 'tflint_exclude', 'tflint_config', 'tflint_call_module_type', 'tfsec_version', 'tfsec_output_format', 'tfsec_output_file', 'trivy_severity', 'trivy_version', 'tfsec_trivy']`