### PR TITLE
Add runbook of how to rotate MP CI User Environments Repo PAT

### DIFF
--- a/source/runbooks/rotating-secrets.html.md.erb
+++ b/source/runbooks/rotating-secrets.html.md.erb
@@ -54,3 +54,19 @@ This runbook describes the process for rotating the **github_ci_user_pat** secre
 9. Run the [Github resources Workflow](https://github.com/ministryofjustice/modernisation-platform/actions/workflows/terraform-github.yml) manually on the main branch. This will populate the GH secret with the value that you have just updated in AWS Secrets Manager.
 10. Wait for another workflow to run which uses the secret to confirm that the new token has taken effect successfully. (The secrets status will show as *"Last used within the last week"*)
 11. When you are confident the new secret is working successfully you can delete the old PAT token in GitHub
+
+### GitHub MP CI User Environments Repo PAT
+
+This runbook describes the process for rotating the **github_ci_user_environments_repo_pat** secret.
+
+1. Retrieve the MP GitHub credentials by logging in to the AWS [Modernisation Platform account](https://moj.awsapps.com/start#/) with **AdministratorAccess**
+2. Navigate to the Secrets Manager [github_ci_user_password](https://eu-west-2.console.aws.amazon.com/secretsmanager/secret?name=github_ci_user_password&region=eu-west-2) secret and click `Retrieve secret value`
+3. Use the credentials provided to log in to [GitHub](https://github.com)
+4. Once logged in click on the profile icon and then **Settings > Developer settings > Personal access tokens > Tokens (Fine-grained tokens) > GITHUB_CI_USER_ENVIRONMENTS_REPO_PAT**
+5. Click `Regenerate token` and then copy the token to your clipboard
+6. Navigate to the Secrets Manager [github_ci_user_environments_repo_pat](https://eu-west-2.console.aws.amazon.com/secretsmanager/secret?name=github_ci_user_environments_repo_pat&region=eu-west-2) secret and click `Retrieve secret value`
+7. Click `Edit` and replace the token with the new one and click `Save`
+8. Run the [Github resources Workflow](https://github.com/ministryofjustice/modernisation-platform/actions/workflows/terraform-github.yml) manually on the main branch. This will populate the GH secret with the value that you have just updated in AWS Secrets Manager. 
+9. Wait for another workflow to run which uses the secret to confirm that the new token has taken effect successfully. (The secrets status will show as *"Last used within the last week"*)
+
+


### PR DESCRIPTION
## A reference to the issue / Description of it

While working on https://github.com/ministryofjustice/modernisation-platform/issues/5648, I noticed there was no guidance on how to rotate a fine-grained personal access token.

## How does this PR fix the problem?

Adds a runbook.

## How has this been tested?

I documented the steps I followed to rotate the credential.

## Deployment Plan / Instructions

N/A

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [x] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
