### PR TITLE
Vulnerability patch for CVE-2024-22048

### DIFF
--- a/.github/workflows/publish-gh-pages.yml
+++ b/.github/workflows/publish-gh-pages.yml
@@ -24,7 +24,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: ministryofjustice/tech-docs-github-pages-publisher:v2
+      image: ministryofjustice/tech-docs-github-pages-publisher:v3.0.1
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1


### PR DESCRIPTION
As per the vulnerability identified in [CVE-2024-22048](https://github.com/advisories/GHSA-x2xw-hw8g-6773)

This PR updates to the latest version as recommended.
(https://mojdt.slack.com/archives/C02D2NEF9CJ/p1706096643823459)