### PR TITLE
Updated role and policy resource arn

### DIFF
--- a/terraform/environments/core-shared-services/iam.tf
+++ b/terraform/environments/core-shared-services/iam.tf
@@ -272,7 +272,7 @@ resource "aws_iam_policy" "lambda_invoke_policy" {
       {
         Action   = ["lambda:InvokeFunction"]
         Effect   = "Allow"
-        Resource = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:root"
+        Resource = "arn:aws:lambda:eu-west-2:${local.environment_management.account_ids["core-shared-services-production"]}:function:*"
       }
     ]
   })
@@ -287,7 +287,7 @@ resource "aws_iam_role" "lambda_invoke_role_policy" {
       {
         "Effect" : "Allow",
         "Principal" : {
-          "AWS" : "arn:aws:lambda:eu-west-2:${local.environment_management.account_ids["core-shared-services-production"]}:function:*"
+          "AWS" : "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:root"
         },
         "Action" : "sts:AssumeRole"
       }


### PR DESCRIPTION
## A reference to the issue / Description of it

Resolved `invalid principal in policy` error by updating the principal ARN in Terraform configuration #5449 

## How does this PR fix the problem?

This PR addresses the issue by correcting the principal ARN, ensuring the Terraform apply process now functions without `invalid principal in policy` error