### PR TITLE
Fix breaking changes in tech-docs-github-pages-publisher v3

### DIFF
--- a/.github/workflows/publish-gh-pages.yml
+++ b/.github/workflows/publish-gh-pages.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Compile Markdown to HTML and create artifact
         run: |
-          /scripts/compile-and-create-artifact.sh
+          /scripts/deploy.sh
       - name: Upload artifact to be published
         uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v3.1.0
         with:


### PR DESCRIPTION
following the version upgrade from v2 > v3 this PR uses the new 'deploy' script rather than the 'compile-and-create-artifact.sh' script.