### PR TITLE
add git codeowner option to new env issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-environment.yml
+++ b/.github/ISSUE_TEMPLATE/new-environment.yml
@@ -40,8 +40,8 @@ body:
   - type: input
     id: codeowners
     attributes:
-      label: GitHub "codeowner" team slug
-      description: By default members of the github team/s specified can both access the aws environments and approve pull requests to release changes. If you would like to seperate the permissions so that a different github team acts as a "codeowner" to review changes before they are released then specify this here.
+      label: GitHub code owner team slug
+      description: By default members of the github team/s specified can both access the aws environments and approve pull requests to release changes. If you would like to seperate the permissions so that a different github team acts as a code owner to review changes before they are released then specify this here.
       value:
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/new-environment.yml
+++ b/.github/ISSUE_TEMPLATE/new-environment.yml
@@ -37,6 +37,14 @@ body:
       value:
     validations:
       required: true
+  - type: input
+    id: codeowners
+    attributes:
+      label: GitHub "codeowner" team slug
+      description: By default all members of the github team specified can access the environments and approve pull requests/merge in to production. If you would like to seperate the permissions so that a different github team acts as a "codeowner" then specify this here.
+      value:
+    validations:
+      required: false
   - type: checkboxes
     id: environment
     attributes:

--- a/.github/ISSUE_TEMPLATE/new-environment.yml
+++ b/.github/ISSUE_TEMPLATE/new-environment.yml
@@ -41,7 +41,7 @@ body:
     id: codeowners
     attributes:
       label: GitHub "codeowner" team slug
-      description: By default all members of the github team specified can both access the aws environments and approve pull requests to release changes. If you would like to seperate the permissions so that a different github team acts as a "codeowner" to review changes before they are released then specify this here.
+      description: By default members of the github team/s specified can both access the aws environments and approve pull requests to release changes. If you would like to seperate the permissions so that a different github team acts as a "codeowner" to review changes before they are released then specify this here.
       value:
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/new-environment.yml
+++ b/.github/ISSUE_TEMPLATE/new-environment.yml
@@ -41,7 +41,7 @@ body:
     id: codeowners
     attributes:
       label: GitHub "codeowner" team slug
-      description: By default all members of the github team specified can access the environments and approve pull requests/merge in to production. If you would like to seperate the permissions so that a different github team acts as a "codeowner" then specify this here.
+      description: By default all members of the github team specified can both access the aws environments and approve pull requests to release changes. If you would like to seperate the permissions so that a different github team acts as a "codeowner" to review changes before they are released then specify this here.
       value:
     validations:
       required: false

--- a/source/user-guide/creating-environments.html.md.erb
+++ b/source/user-guide/creating-environments.html.md.erb
@@ -174,7 +174,7 @@ Here are some examples of the environments JSON file that the Modernisation Plat
 ### Schema
 - `account-type` determines if this is a core modernisation platform account or a user member account
 - `environments` should be an array of objects for environments required. If the environment is `production`, retention periods, backup frequency, and similar will be different compared to non-production environments
-- `codeowners` is an optional list of github slugs if you want specific teams to review code changes before they are released to environments 
+- `codeowners` is an optional list of github slugs if you want specific teams to review code changes before they are released into environments 
 - the `name` key and `access` object are required, see: [Another example](#another-example)
 - the `nuke` key is optional and is only read if the `access.level` is `sandbox`
 - `tags` should be an object of the mandatory tags defined in the MoJ [Tagging Guidance](https://ministryofjustice.github.io/technical-guidance/documentation/standards/documenting-infrastructure-owners.html#tagging-your-infrastructure). You can omit `is-production` as we infer this from the environment name

--- a/source/user-guide/creating-environments.html.md.erb
+++ b/source/user-guide/creating-environments.html.md.erb
@@ -32,6 +32,12 @@ Users who are not part of the MoJ GitHub organisation will need to be added as c
 
 If you wish to add additional deployment reviewers from outside your GitHub team you can specfiy these per an environment in the application.json file (See: "additional_reviewers" in [Another example](#another-example) for an example).
 
+### GitHub "codeowner" team slug
+
+By default members of the github team/s specified can both access the aws environments which are created and approve PRs to release changes in to these environemnts.
+
+If required you can seperate the permissions so that a different github team acts as a "codeowner", this way PRs can require a review from this team before changes are released.
+
 ### Access
 
 This is the level of access for the GitHub team to the Modernisation Platform.
@@ -168,6 +174,7 @@ Here are some examples of the environments JSON file that the Modernisation Plat
 ### Schema
 - `account-type` determines if this is a core modernisation platform account or a user member account
 - `environments` should be an array of objects for environments required. If the environment is `production`, retention periods, backup frequency, and similar will be different compared to non-production environments
+- `codeowners` should be a list of github slugs for teams who will be required to review code changes before they are released to environments
 - the `name` key and `access` object are required, see: [Another example](#another-example)
 - the `nuke` key is optional and is only read if the `access.level` is `sandbox`
 - `tags` should be an object of the mandatory tags defined in the MoJ [Tagging Guidance](https://ministryofjustice.github.io/technical-guidance/documentation/standards/documenting-infrastructure-owners.html#tagging-your-infrastructure). You can omit `is-production` as we infer this from the environment name
@@ -179,6 +186,7 @@ Here are some examples of the environments JSON file that the Modernisation Plat
 ```json
 {
   "account-type": "",
+  "codeowners": [""],
   "environments": [
     {
       "name": ""

--- a/source/user-guide/creating-environments.html.md.erb
+++ b/source/user-guide/creating-environments.html.md.erb
@@ -34,7 +34,7 @@ If you wish to add additional deployment reviewers from outside your GitHub team
 
 ### GitHub "codeowner" team slug
 
-By default members of the github team/s specified can both access the aws environments which are created and approve PRs to release changes in to these environments.
+By default members of the github team/s specified can both access the aws environments and approve pull requests to release changes.
 
 If required you can seperate the permissions so that a different github team acts as a "codeowner", this way PRs will require a review from this team before changes are released.
 

--- a/source/user-guide/creating-environments.html.md.erb
+++ b/source/user-guide/creating-environments.html.md.erb
@@ -174,7 +174,7 @@ Here are some examples of the environments JSON file that the Modernisation Plat
 ### Schema
 - `account-type` determines if this is a core modernisation platform account or a user member account
 - `environments` should be an array of objects for environments required. If the environment is `production`, retention periods, backup frequency, and similar will be different compared to non-production environments
-- `codeowners` should be a list of github slugs for teams who will be required to review code changes before they are released to environments
+- `codeowners` is an optional list of github slugs if you want specific teams to review code changes before they are released to environments 
 - the `name` key and `access` object are required, see: [Another example](#another-example)
 - the `nuke` key is optional and is only read if the `access.level` is `sandbox`
 - `tags` should be an object of the mandatory tags defined in the MoJ [Tagging Guidance](https://ministryofjustice.github.io/technical-guidance/documentation/standards/documenting-infrastructure-owners.html#tagging-your-infrastructure). You can omit `is-production` as we infer this from the environment name

--- a/source/user-guide/creating-environments.html.md.erb
+++ b/source/user-guide/creating-environments.html.md.erb
@@ -34,9 +34,9 @@ If you wish to add additional deployment reviewers from outside your GitHub team
 
 ### GitHub "codeowner" team slug
 
-By default members of the github team/s specified can both access the aws environments which are created and approve PRs to release changes in to these environemnts.
+By default members of the github team/s specified can both access the aws environments which are created and approve PRs to release changes in to these environments.
 
-If required you can seperate the permissions so that a different github team acts as a "codeowner", this way PRs can require a review from this team before changes are released.
+If required you can seperate the permissions so that a different github team acts as a "codeowner", this way PRs will require a review from this team before changes are released.
 
 ### Access
 

--- a/source/user-guide/creating-environments.html.md.erb
+++ b/source/user-guide/creating-environments.html.md.erb
@@ -32,11 +32,11 @@ Users who are not part of the MoJ GitHub organisation will need to be added as c
 
 If you wish to add additional deployment reviewers from outside your GitHub team you can specfiy these per an environment in the application.json file (See: "additional_reviewers" in [Another example](#another-example) for an example).
 
-### GitHub "codeowner" team slug
+### GitHub code owner team slug
 
 By default members of the github team/s specified can both access the aws environments and approve pull requests to release changes.
 
-If required you can seperate the permissions so that a different github team acts as a "codeowner", this way PRs will require a review from this team before changes are released.
+If required you can seperate the permissions so that a different github team acts as a code owner, this way PRs will require a review from this team before changes are released.
 
 ### Access
 


### PR DESCRIPTION
## A reference to the issue / Description of it
This recent feature https://github.com/ministryofjustice/modernisation-platform/pull/5951 enabled members to separate the link between access to environments and who can approve PRs.  

## How does this PR fix the problem?

This PR extends the new environment issue template to add a new field for `Github codeowner team slug` and provides a description of the option.

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [X] All checks have passed
- [X] I have made corresponding changes to the documentation

## Additional comments (if any)

Please feel free to suggest changes to the description to make it more understandable! I think what I've said is correct.