### PR TITLE
adding in preprod and prod rules from planet FM

### DIFF
--- a/terraform/environments/core-network-services/cidr-ranges.tf
+++ b/terraform/environments/core-network-services/cidr-ranges.tf
@@ -20,6 +20,7 @@ locals {
     atos_arkc_ras                    = "10.175.0.0/16" # for DOM1 devices connected to Cisco RAS VPN
     atos_arkf_ras                    = "10.176.0.0/16" # for DOM1 devices connected to Cisco RAS VPN
     cloud-platform                   = "172.20.0.0/16"
+    dom1-domain-controllers          = "10.172.68.146/29"
     global-protect                   = "10.184.0.0/16"
     i2n                              = "10.110.0.0/16"
     moj-core-azure-1                 = "10.50.25.0/27"

--- a/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
@@ -456,8 +456,8 @@
   },
   "dom1_dcs_to_planetfm_preproduction_9389_tcp": {
     "action": "PASS",
-    "source_ip": "${dom1-domain-controllers}",
-    "destination_ip": "${hmpps-preproduction-general-private-subnets}",
+    "source_ip": "${hmpps-preproduction-general-private-subnets}",
+    "destination_ip": "${dom1-domain-controllers}",
     "destination_port": "9389",
     "protocol": "TCP"
   }

--- a/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
@@ -405,13 +405,6 @@
     "destination_port": "1434",
     "protocol": "UDP"
   },
-  "dom1_dcs_to_planetfm_preproduction_9389_tcp": {
-    "action": "PASS",
-    "source_ip": "${dom1-domain-controllers}",
-    "destination_ip": "${hmpps-preproduction-general-private-subnets}",
-    "destination_port": "9389",
-    "protocol": "TCP"
-  },
   "mojo_to_planetfm_preproduction_netbios_137_udp": {
     "action": "PASS",
     "source_ip": "${mojo-end-user-devices}",
@@ -459,6 +452,13 @@
     "source_ip": "${cloud-platform}",
     "destination_ip": "${laa-preproduction}",
     "destination_port": "1522",
+    "protocol": "TCP"
+  },
+  "dom1_dcs_to_planetfm_preproduction_9389_tcp": {
+    "action": "PASS",
+    "source_ip": "${dom1-domain-controllers}",
+    "destination_ip": "${hmpps-preproduction-general-private-subnets}",
+    "destination_port": "9389",
     "protocol": "TCP"
   }
 }

--- a/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
@@ -405,6 +405,13 @@
     "destination_port": "1434",
     "protocol": "UDP"
   },
+  "dom1_dcs_to_planetfm_preproduction_9389_tcp": {
+    "action": "PASS",
+    "source_ip": "${dom1-domain-controllers}",
+    "destination_ip": "${hmpps-preproduction-general-private-subnets}",
+    "destination_port": "9389",
+    "protocol": "TCP"
+  },
   "mojo_to_planetfm_preproduction_netbios_137_udp": {
     "action": "PASS",
     "source_ip": "${mojo-end-user-devices}",

--- a/terraform/environments/core-network-services/firewall-rules/production_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/production_rules.json
@@ -398,6 +398,13 @@
     "destination_port": "1434",
     "protocol": "UDP"
   },
+  "dom1_dcs_to_planetfm_production_9389_tcp": {
+    "action": "PASS",
+    "source_ip": "${dom1-domain-controllers}",
+    "destination_ip": "${hmpps-production-general-private-subnets}",
+    "destination_port": "9389",
+    "protocol": "TCP"
+  },
   "mojo_to_csr_production_http": {
     "action": "PASS",
     "source_ip": "${mojo-end-user-devices}",

--- a/terraform/environments/core-network-services/firewall-rules/production_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/production_rules.json
@@ -398,13 +398,6 @@
     "destination_port": "1434",
     "protocol": "UDP"
   },
-  "dom1_dcs_to_planetfm_production_9389_tcp": {
-    "action": "PASS",
-    "source_ip": "${dom1-domain-controllers}",
-    "destination_ip": "${hmpps-production-general-private-subnets}",
-    "destination_port": "9389",
-    "protocol": "TCP"
-  },
   "mojo_to_csr_production_http": {
     "action": "PASS",
     "source_ip": "${mojo-end-user-devices}",
@@ -522,6 +515,13 @@
     "source_ip": "${mojo-end-user-devices}",
     "destination_ip": "${hmpps-production-general-private-subnets}",
     "destination_port": "7073",
+    "protocol": "TCP"
+  },
+  "dom1_dcs_to_planetfm_production_9389_tcp": {
+    "action": "PASS",
+    "source_ip": "${dom1-domain-controllers}",
+    "destination_ip": "${hmpps-production-general-private-subnets}",
+    "destination_port": "9389",
     "protocol": "TCP"
   }
 }

--- a/terraform/environments/core-network-services/firewall-rules/production_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/production_rules.json
@@ -519,8 +519,8 @@
   },
   "dom1_dcs_to_planetfm_production_9389_tcp": {
     "action": "PASS",
-    "source_ip": "${dom1-domain-controllers}",
-    "destination_ip": "${hmpps-production-general-private-subnets}",
+    "source_ip": "${hmpps-production-general-private-subnets}",
+    "destination_ip": "${dom1-domain-controllers}",
     "destination_port": "9389",
     "protocol": "TCP"
   }


### PR DESCRIPTION
## A reference to the issue / Description of it

Including a FW rule that allows traffic from DOM1 domain controllers (10.172.68.146/29) on port 9389 to private subnets, specifically for Planet FM preprod and prod. 

## How does this PR fix the problem?

New Preprod and Prod firewall rule, with domain-controller cidr range

## How has this been tested?

Firewall logs indicate that this traffic is currently blocked, will re-test by running connection tests from prod / preprod planet servers.

## Deployment Plan / Instructions

It will add an additional allow rule to the MP firewall

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
