### PR TITLE
Issue #5012

### DIFF
--- a/terraform/environments/bootstrap/secure-baselines/main.tf
+++ b/terraform/environments/bootstrap/secure-baselines/main.tf
@@ -5,7 +5,7 @@ data "aws_kms_key" "cloudtrail_key" {
 }
 
 module "baselines" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=2f01841c0a3a3b9894cdd7bc6999802a5dc81c01" # v6.2.1
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=8011886209e43f22489429e3573aa14a5cc4a359" # v6.2.2
 
   providers = {
     # Default and replication regions

--- a/terraform/modernisation-platform-account/baselines.tf
+++ b/terraform/modernisation-platform-account/baselines.tf
@@ -16,7 +16,7 @@ locals {
 
 # Secure baselines (GuardDuty, Config, SecurityHub, etc)
 module "baselines-modernisation-platform" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=98bf536ee2c66b268dfb7670f416fc1103935212" # v6.1.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=8011886209e43f22489429e3573aa14a5cc4a359" # v6.2.2
   providers = {
     # Default and replication regions
     aws                    = aws.modernisation-platform-eu-west-2


### PR DESCRIPTION
Updates references for module "modernisation-platform-terraform-baselines" to 6.2.2 (8011886209e43f22489429e3573aa14a5cc4a359) as per issue #5012

## A reference to the issue / Description of it

Issue Ref #5012. Updates the references to module "modernisation-platform-terraform-baselines" which includes a resource that blocks public access to AMIs if that account already has publicly-shared AMIs. 

## How does this PR fix the problem?

By default, public sharing of AMIs is blocked. However for accounts that already have shared AMIs this way, this resource needs to be applied to enable it. 

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

Changes to sprinkler have applied without error.

Also note the outcome of action - https://github.com/ministryofjustice/modernisation-platform/actions/runs/7695516096/job/20968555950 which looks to recreate the resource "aws_backup_selection.production" across a number of regions.
