### PR TITLE
added pagerduty kms multi-region

### DIFF
--- a/terraform/environments/secrets.tf
+++ b/terraform/environments/secrets.tf
@@ -65,6 +65,22 @@ resource "aws_kms_alias" "environment_management" {
   target_key_id = aws_kms_key.environment_management.id
 }
 
+# Environment secret KMS key multi-Region
+resource "aws_kms_key" "environment_management_multi_region" {
+  provider                = aws.modernisation-platform
+  description             = "environment-management-multi-region"
+  policy                  = data.aws_iam_policy_document.kms_environment_management.json
+  enable_key_rotation     = true
+  deletion_window_in_days = 30
+  multi_region            = true
+}
+
+resource "aws_kms_alias" "environment_management_multi_region" {
+  provider      = aws.modernisation-platform
+  name          = "alias/environment-management-multi-region"
+  target_key_id = aws_kms_key.environment_management_multi_region.id
+}
+
 data "aws_iam_policy_document" "kms_environment_management" {
 
   # checkov:skip=CKV_AWS_111: "policy is directly related to the resource"

--- a/terraform/modernisation-platform-account/dynamodb.tf
+++ b/terraform/modernisation-platform-account/dynamodb.tf
@@ -15,6 +15,23 @@ resource "aws_kms_alias" "dynamo_encryption" {
   target_key_id = aws_kms_key.dynamo_encryption.id
 }
 
+resource "aws_kms_key" "dynamo_encryption_multi_region" {
+  enable_key_rotation = true
+  policy              = data.aws_iam_policy_document.dynamo_encryption.json
+  multi_region        = true
+  tags = merge(
+  local.tags,
+  {
+    Name = "dynamo_encryption_multi_region"
+  }
+  )
+}
+
+resource "aws_kms_alias" "dynamo_encryption_multi_region" {
+  name          = "alias/dynamodb-state-lock-multi-region"
+  target_key_id = aws_kms_key.dynamo_encryption_multi_region.id
+}
+
 data "aws_iam_policy_document" "dynamo_encryption" {
 
   # checkov:skip=CKV_AWS_109: "Key policy requires asterisk resource"

--- a/terraform/modernisation-platform-account/s3.tf
+++ b/terraform/modernisation-platform-account/s3.tf
@@ -11,6 +11,20 @@ resource "aws_kms_alias" "s3_state_bucket" {
   target_key_id = aws_kms_key.s3_state_bucket.id
 }
 
+# State bucket KMS multi-Region
+resource "aws_kms_key" "s3_state_bucket_multi_region" {
+  description             = "s3-state-bucket-multi-region"
+  policy                  = data.aws_iam_policy_document.kms_state_bucket.json
+  enable_key_rotation     = true
+  deletion_window_in_days = 30
+  multi_region            = true
+}
+
+resource "aws_kms_alias" "s3_state_bucket_multi_region" {
+  name          = "alias/s3-state-bucket-multi-region"
+  target_key_id = aws_kms_key.s3_state_bucket_multi_region.id
+}
+
 data "aws_iam_policy_document" "kms_state_bucket" {
   # checkov:skip=CKV_AWS_111: "policy is directly related to the resource"
   # checkov:skip=CKV_AWS_356: "policy is directly related to the resource"

--- a/terraform/pagerduty/kms.tf
+++ b/terraform/pagerduty/kms.tf
@@ -8,3 +8,15 @@ resource "aws_kms_alias" "pagerduty" {
   name          = "alias/pagerduty-secret"
   target_key_id = aws_kms_key.pagerduty.id
 }
+
+resource "aws_kms_key" "pagerduty_multi_region" {
+  enable_key_rotation = true
+  policy              = data.aws_iam_policy_document.pagerduty_kms.json
+  multi_region        = true
+  tags                = local.tags
+}
+
+resource "aws_kms_alias" "pagerduty_multi_region" {
+  name          = "alias/pagerduty-secret-multi-region"
+  target_key_id = aws_kms_key.pagerduty_multi_region.id
+}


### PR DESCRIPTION
## A reference to the issue / Description of it
https://github.com/ministryofjustice/modernisation-platform/issues/5635

## How does this PR fix the problem?
Added multi-Region KMS keys for DR replication because existing KMS keys are all single-Region and cannot be converted to multi-Region

## How has this been tested?
Created and tested primary multi_region KMS key and it's replica in eu-west-1 in sprinkler account

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
