### PR TITLE
added KMS encryption to eventbridge schedule

### DIFF
--- a/terraform/environments/core-shared-services/data.tf
+++ b/terraform/environments/core-shared-services/data.tf
@@ -1,2 +1,6 @@
 # Discover current region name - used when setting up vpc endpoints
 data "aws_region" "current_region" {}
+
+data "aws_kms_key" "general_shared" {
+  key_id = "arn:aws:kms:eu-west-2:${local.environment_management.account_ids["core-shared-services-production"]}:alias/general-${lower(local.tags.business-unit)}"
+}

--- a/terraform/environments/core-shared-services/instance-scheduler-lambda-function.tf
+++ b/terraform/environments/core-shared-services/instance-scheduler-lambda-function.tf
@@ -36,6 +36,7 @@ resource "aws_scheduler_schedule" "instance_scheduler_weekly_stop_at_night" {
   flexible_time_window {
     mode = "OFF"
   }
+  kms_key_arn = data.aws_kms_key.general_shared.arn
   schedule_expression          = "cron(0 21 ? * MON-FRI *)"
   schedule_expression_timezone = "Europe/London"
   target {
@@ -60,6 +61,7 @@ resource "aws_scheduler_schedule" "instance_scheduler_weekly_start_in_the_mornin
   flexible_time_window {
     mode = "OFF"
   }
+  kms_key_arn = data.aws_kms_key.general_shared.arn
   schedule_expression          = "cron(0 6 ? * MON-FRI *)"
   schedule_expression_timezone = "Europe/London"
   target {


### PR DESCRIPTION
## A reference to the issue / Description of it

Adds KMS encryption to address a secure code analysis failure [here](https://github.com/ministryofjustice/modernisation-platform/actions/runs/7705153518/job/20998642358).

## How does this PR fix the problem?

Creates a data call, then uses the content of that data call to supply a KMS ARN used to encrypt the resource.

## How has this been tested?

Ran `checkov` locally to confirm the issue had been addressed

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

I couldn't seem to get Terraform to correctly reference the content of the module directly, so I created a data call.

I could see that `terraform state show show module.kms["platforms"].aws_kms_alias.general` returned information in the statefile about the resource, but trying to directly retrieve it through the console for confirmation was unsuccessful like so: 
```
module.kms
{}

module.kms["platforms"].aws_kms_alias.general.arn
╷
│ Error: Invalid index
│ 
│   on <console-input> line 1:
│   (source code not available)
│ 
│ The given key does not identify an element in this collection value.
```