### PR TITLE
Removing more data calls from SSO

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/main.tf
+++ b/terraform/environments/bootstrap/single-sign-on/main.tf
@@ -1,12 +1,6 @@
-# # Get AWS SSO instances. Note that this returns a list,
-# # although AWS SSO only supports singular SSO instances.
-data "aws_ssoadmin_instances" "default" {
-  provider = aws.sso-management
-}
-
 locals {
-  sso_instance_arn      = coalesce(data.aws_ssoadmin_instances.default.arns...)
-  sso_identity_store_id = coalesce(data.aws_ssoadmin_instances.default.identity_store_ids...)
+  sso_instance_arn      = coalesce(data.terraform_remote_state.mp-sso-permissions-sets.outputs.ssoadmin_instances.arns...)
+  sso_identity_store_id = coalesce(data.terraform_remote_state.mp-sso-permissions-sets.outputs.ssoadmin_instances.identity_store_ids...)
 
 }
 
@@ -22,48 +16,7 @@ data "terraform_remote_state" "mp-sso-permissions-sets" {
     encrypt = "true"
   }
 }
-# Get AWS SSO permission sets
-data "aws_ssoadmin_permission_set" "administrator" {
-  provider = aws.sso-management
 
-  instance_arn = local.sso_instance_arn
-  name         = "AdministratorAccess"
-}
-
-data "aws_ssoadmin_permission_set" "view-only" {
-  provider = aws.sso-management
-
-  instance_arn = local.sso_instance_arn
-  name         = "ViewOnlyAccess"
-}
-
-data "aws_ssoadmin_permission_set" "developer" {
-  provider = aws.sso-management
-
-  instance_arn = local.sso_instance_arn
-  name         = "modernisation-platform-developer"
-}
-
-data "aws_ssoadmin_permission_set" "platform_engineer" {
-  provider = aws.sso-management
-
-  instance_arn = local.sso_instance_arn
-  name         = "ModernisationPlatformEngineer"
-}
-
-data "aws_ssoadmin_permission_set" "security_audit" {
-  provider = aws.sso-management
-
-  instance_arn = local.sso_instance_arn
-  name         = "SecurityAudit"
-}
-
-data "aws_ssoadmin_permission_set" "read_only" {
-  provider = aws.sso-management
-
-  instance_arn = local.sso_instance_arn
-  name         = "ReadOnlyAccess"
-}
 
 # Get Identity Store groups
 data "aws_identitystore_group" "platform_admin" {
@@ -102,7 +55,7 @@ resource "aws_ssoadmin_account_assignment" "platform_admin" {
   provider = aws.sso-management
 
   instance_arn       = local.sso_instance_arn
-  permission_set_arn = data.aws_ssoadmin_permission_set.administrator.arn
+  permission_set_arn = data.terraform_remote_state.mp-sso-permissions-sets.outputs.administrator
 
   principal_id   = data.aws_identitystore_group.platform_admin.group_id
   principal_type = "GROUP"
@@ -116,7 +69,7 @@ resource "aws_ssoadmin_account_assignment" "platform_engineer" {
   provider = aws.sso-management
 
   instance_arn       = local.sso_instance_arn
-  permission_set_arn = data.aws_ssoadmin_permission_set.platform_engineer.arn
+  permission_set_arn = data.terraform_remote_state.mp-sso-permissions-sets.outputs.platform_engineer
 
   principal_id   = data.aws_identitystore_group.platform_admin.group_id
   principal_type = "GROUP"
@@ -139,7 +92,7 @@ resource "aws_ssoadmin_account_assignment" "view_only" {
   provider = aws.sso-management
 
   instance_arn       = local.sso_instance_arn
-  permission_set_arn = data.aws_ssoadmin_permission_set.view-only.arn
+  permission_set_arn = data.terraform_remote_state.mp-sso-permissions-sets.outputs.view-only
 
   principal_id   = data.aws_identitystore_group.member[each.value.github_slug].group_id
   principal_type = "GROUP"
@@ -162,7 +115,7 @@ resource "aws_ssoadmin_account_assignment" "developer" {
   provider = aws.sso-management
 
   instance_arn       = local.sso_instance_arn
-  permission_set_arn = data.aws_ssoadmin_permission_set.developer.arn
+  permission_set_arn = data.terraform_remote_state.mp-sso-permissions-sets.outputs.developer
 
   principal_id   = data.aws_identitystore_group.member[each.value.github_slug].group_id
   principal_type = "GROUP"
@@ -232,7 +185,7 @@ resource "aws_ssoadmin_account_assignment" "administator" {
   provider = aws.sso-management
 
   instance_arn       = local.sso_instance_arn
-  permission_set_arn = data.aws_ssoadmin_permission_set.administrator.arn
+  permission_set_arn = data.terraform_remote_state.mp-sso-permissions-sets.outputs.administrator
 
   principal_id   = data.aws_identitystore_group.member[each.value.github_slug].group_id
   principal_type = "GROUP"
@@ -278,7 +231,7 @@ resource "aws_ssoadmin_account_assignment" "security_audit" {
   provider = aws.sso-management
 
   instance_arn       = local.sso_instance_arn
-  permission_set_arn = data.aws_ssoadmin_permission_set.security_audit.arn
+  permission_set_arn = data.terraform_remote_state.mp-sso-permissions-sets.outputs.security_audit
 
   principal_id   = data.aws_identitystore_group.member[each.value.github_slug].group_id
   principal_type = "GROUP"
@@ -301,7 +254,7 @@ resource "aws_ssoadmin_account_assignment" "read_only" {
   provider = aws.sso-management
 
   instance_arn       = local.sso_instance_arn
-  permission_set_arn = data.aws_ssoadmin_permission_set.read_only.arn
+  permission_set_arn = data.terraform_remote_state.mp-sso-permissions-sets.outputs.read_only
 
   principal_id   = data.aws_identitystore_group.member[each.value.github_slug].group_id
   principal_type = "GROUP"

--- a/terraform/single-sign-on/data.tf
+++ b/terraform/single-sign-on/data.tf
@@ -13,3 +13,46 @@ data "aws_secretsmanager_secret" "environment_management" {
 data "aws_secretsmanager_secret_version" "environment_management" {
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+
+# Get AWS SSO permission sets
+data "aws_ssoadmin_permission_set" "administrator" {
+  provider = aws.sso-management
+
+  instance_arn = local.sso_instance_arn
+  name         = "AdministratorAccess"
+}
+
+data "aws_ssoadmin_permission_set" "view-only" {
+  provider = aws.sso-management
+
+  instance_arn = local.sso_instance_arn
+  name         = "ViewOnlyAccess"
+}
+
+data "aws_ssoadmin_permission_set" "developer" {
+  provider = aws.sso-management
+
+  instance_arn = local.sso_instance_arn
+  name         = "modernisation-platform-developer"
+}
+
+data "aws_ssoadmin_permission_set" "platform_engineer" {
+  provider = aws.sso-management
+
+  instance_arn = local.sso_instance_arn
+  name         = "ModernisationPlatformEngineer"
+}
+
+data "aws_ssoadmin_permission_set" "security_audit" {
+  provider = aws.sso-management
+
+  instance_arn = local.sso_instance_arn
+  name         = "SecurityAudit"
+}
+
+data "aws_ssoadmin_permission_set" "read_only" {
+  provider = aws.sso-management
+
+  instance_arn = local.sso_instance_arn
+  name         = "ReadOnlyAccess"
+}

--- a/terraform/single-sign-on/outputs.tf
+++ b/terraform/single-sign-on/outputs.tf
@@ -21,3 +21,31 @@ output "reporting_operations" {
 output "mwaa_user" {
     value = aws_ssoadmin_permission_set.modernisation_platform_data_mwaa_user.arn
 }
+
+# Data outputs
+output "administrator" {
+    value = data.aws_ssoadmin_permission_set.administrator.arn
+}
+output "view-only" {
+    value = data.aws_ssoadmin_permission_set.view-only.arn
+}
+
+output "developer" {
+    value = data.aws_ssoadmin_permission_set.developer.arn
+}
+
+output "platform_engineer" {
+    value = data.aws_ssoadmin_permission_set.platform_engineer.arn
+}
+
+output "security_audit" {
+    value = data.aws_ssoadmin_permission_set.security_audit.arn
+}
+
+output "read_only" {
+    value = data.aws_ssoadmin_permission_set.read_only.arn
+}
+
+output "ssoadmin_instances" {
+    value = data.aws_ssoadmin_instances.default
+}


### PR DESCRIPTION
## A reference to the issue / Description of it

We are still hitting API limits with the number of data calls we are making. 

## How does this PR fix the problem?

Moving the maximum amount of data calls we can realistically move out and storing them in tf state for the platform wide single-sign-on terraform to be queried from here as an output.

## How has this been tested?

Tested locally on a member account, no changes.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No changes operation, no impact.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
