### PR TITLE
encrypt pagerduty secrets with pagerduty kms key

### DIFF
--- a/terraform/pagerduty/aws.tf
+++ b/terraform/pagerduty/aws.tf
@@ -68,10 +68,10 @@ resource "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {
 # Required for Terraform to make api calls to pagerduty, set in the console, new tokens available from #ops-engineering
 #tfsec:ignore:aws-ssm-secret-use-customer-key
 resource "aws_secretsmanager_secret" "pagerduty_token" {
-  # checkov:skip=CKV_AWS_149:No requirement currently to encrypt this secret with customer-managed KMS key
   # checkov:skip=CKV2_AWS_57:Auto rotation not possible
   name        = "pagerduty_token"
   description = "PagerDuty api token, used by PagerDuty Terraform to manage most PagerDuty resources"
+  kms_key_id  = aws_kms_key.pagerduty.id
   tags        = local.tags
   replica {
     region = local.replica_region
@@ -82,9 +82,9 @@ resource "aws_secretsmanager_secret" "pagerduty_token" {
 # Required for Terraform to make api calls to pagerduty, set in the console, new tokens available from #ops-engineering
 #tfsec:ignore:aws-ssm-secret-use-customer-key
 resource "aws_secretsmanager_secret" "pagerduty_user_token" {
-  # checkov:skip=CKV_AWS_149:No requirement currently to encrypt this secret with customer-managed KMS key
   # checkov:skip=CKV2_AWS_57:Auto rotation not possible
   name        = "pagerduty_userapi_token"
+  kms_key_id  = aws_kms_key.pagerduty.id
   description = "PagerDuty api user level token, used to link services to Slack channels.  A valid PD and Slack user needed (to authorise against a slack user), needed in addition to the org level token"
   tags        = local.tags
   replica {


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/4999

## How does this PR fix the problem?

Addresses the encryption of PagerDuty secrets

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

No

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)
