### PR TITLE
fix output reference

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/main.tf
+++ b/terraform/environments/bootstrap/single-sign-on/main.tf
@@ -300,7 +300,7 @@ resource "aws_ssoadmin_account_assignment" "reporting-operations" {
   provider = aws.sso-management
 
   instance_arn       = local.sso_instance_arn
-  permission_set_arn = data.terraform_remote_state.mp-sso-permissions-sets.outputs.reporting-operations
+  permission_set_arn = data.terraform_remote_state.mp-sso-permissions-sets.outputs.reporting_operations
 
   principal_id   = data.aws_identitystore_group.member[each.value.github_slug].group_id
   principal_type = "GROUP"


### PR DESCRIPTION
## A reference to the issue / Description of it
Reference to "reporting operations" output has a typo
https://github.com/ministryofjustice/modernisation-platform/actions/runs/7723959610/job/21055604357#step:7:42


## How does this PR fix the problem?
Changed typo in output reference for the "reporting operations" permission set (underscore instead of hyphen)