### PR TITLE
ELM-1447 give pen tester read access via collaborators.json

### DIFF
--- a/collaborators.json
+++ b/collaborators.json
@@ -555,6 +555,16 @@
           "access": "developer"
         }
       ]
+    },
+    {
+      "username": "william.gould",
+      "github-username": "W-GOULD",
+      "accounts": [
+        {
+          "account-name": "electronic-monitoring-data-production",
+          "access": "read-only"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

[ELM-1447](https://dsdmoj.atlassian.net/browse/ELM-1447)

## How does this PR fix the problem?

`electronic-monitoring-data` env is undergoing a penetration test and has asked to have access to the AWS console to look at the vpc configuration for the sftp servers we're running, as well as the buckets we're exposing.

## How has this been tested?

N/A

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

It will give read access to the prod environment, access will be revoked after the pen test.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
