### PR TITLE
Fix EventBridge Scheduler issue with customer-managed KMS key

### DIFF
--- a/terraform/environments/core-shared-services/iam.tf
+++ b/terraform/environments/core-shared-services/iam.tf
@@ -270,9 +270,16 @@ resource "aws_iam_policy" "lambda_invoke_policy" {
     Version = "2012-10-17"
     Statement = [
       {
-        Action   = ["lambda:InvokeFunction"]
-        Effect   = "Allow"
-        Resource = "arn:aws:lambda:${data.aws_region.current_region.name}:${local.environment_management.account_ids["core-shared-services-production"]}:function:*"
+        Action = [
+          "lambda:InvokeFunction",
+          "kms:GenerateDataKey",
+          "kms:Decrypt"
+        ]
+        Effect = "Allow"
+        Resource = [
+          "arn:aws:lambda:${data.aws_region.current_region.name}:${local.environment_management.account_ids["core-shared-services-production"]}:function:*",
+          "arn:aws:kms:${data.aws_region.current_region.name}:${local.environment_management.account_ids["core-shared-services-production"]}:key/*"
+        ]
       }
     ]
   })

--- a/terraform/environments/core-shared-services/instance-scheduler-lambda-function.tf
+++ b/terraform/environments/core-shared-services/instance-scheduler-lambda-function.tf
@@ -30,13 +30,14 @@ module "instance_scheduler" {
 ## BEGIN: Stop trigger for Instance Scheduler Lambda Function
 
 resource "aws_scheduler_schedule" "instance_scheduler_weekly_stop_at_night" {
-  #checkov:skip=CKV_AWS_297 "KMS encryption not required at present"
+  #checkov:skip=CKV_AWS_297 "EventBridge Scheduler Schedule uses Customer Managed KMS Key"
   name        = "instance_scheduler_weekly_stop_at_night"
   description = "Call Instance Scheduler with Stop action at 9:00 pm (BST) every Monday through Friday"
   group_name  = "default"
   flexible_time_window {
     mode = "OFF"
   }
+  kms_key_arn                  = data.aws_kms_key.general_shared.arn
   schedule_expression          = "cron(0 21 ? * MON-FRI *)"
   schedule_expression_timezone = "Europe/London"
   target {
@@ -55,13 +56,14 @@ resource "aws_scheduler_schedule" "instance_scheduler_weekly_stop_at_night" {
 ## BEGIN: Start trigger for Instance Scheduler Lambda Function
 
 resource "aws_scheduler_schedule" "instance_scheduler_weekly_start_in_the_morning" {
-  #checkov:skip=CKV_AWS_297 "KMS encryption not required at present"
+  #checkov:skip=CKV_AWS_297 "EventBridge Scheduler Schedule uses Customer Managed KMS Key"
   name        = "instance_scheduler_weekly_start_in_the_morning"
   description = "Call Instance Scheduler with Start action at 6:00 am (BST) every Monday through Friday"
   group_name  = "default"
   flexible_time_window {
     mode = "OFF"
   }
+  kms_key_arn                  = data.aws_kms_key.general_shared.arn
   schedule_expression          = "cron(0 6 ? * MON-FRI *)"
   schedule_expression_timezone = "Europe/London"
   target {


### PR DESCRIPTION
## A reference to the issue / Description of it

This PR addresses an issue where the EventBridge scheduler was unable to trigger the lambda function due to missing permissions for the KMS key used for encryption

## How does this PR fix the problem?

This PR updates the EventBridge scheduler role policy to explicitly grant the permission. This allow the scheduler to decrypt encrypted events and invoke the Lambda function as intended 


## How has this been tested?

Tested this on sprinkler