### PR TITLE
Update accessing-ec2s.html.md.erb: filter to running instances

### DIFF
--- a/source/user-guide/accessing-ec2s.html.md.erb
+++ b/source/user-guide/accessing-ec2s.html.md.erb
@@ -66,7 +66,7 @@ Host glados-test-bastion
      LogLevel QUIET
      IdentityFile ~/.ssh/id_rsa
      User jane
-     ProxyCommand sh -c "aws ssm start-session --target $(aws ec2 describe-instances --no-cli-pager --filters "Name=tag:Name,Values=bastion_linux" --query 'Reservations[0].Instances[0].InstanceId' --profile glados-test-developer | tr -d '"') --document-name AWS-StartSSHSession --parameters 'portNumber=%p' --profile glados-test-developer --region eu-west-2"
+     ProxyCommand sh -c "aws ssm start-session --target $(aws ec2 describe-instances --no-cli-pager --filter "Name=tag:Name,Values=bastion_linux" --filter "Name=instance-state-code,Values=16" --query 'Reservations[0].Instances[0].InstanceId' --profile glados-test-developer | tr -d '"') --document-name AWS-StartSSHSession --parameters 'portNumber=%p' --profile glados-test-developer --region eu-west-2"
 ```
 
 >Note: The bastion server is re-created on daily basis which causes the host identification to change. When the user connects to the bastion using SSH, the SSH client warns about the host identification change. In the above, the configuration `StrictHostKeyChecking no`, `UserKnownHostsFile /dev/null` and `LogLevel QUIET` is added to prevent the `WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!` by the SSH client. If we didn't add the above, the user would have to manually remove the old host key from `~/.ssh/known_hosts` on daily basis, which could be annoying.


### PR DESCRIPTION
## A reference to the issue / Description of it

Hit a strange edge case tonight where after manually editing the ASG for the linux_bastion to bring an instance back online after 9pm, even though the old instance was instance state Terminated, the aws cli was still returning it (and it was visible in the console). 

The current proxy command grabs the first instance only

## How does this PR fix the problem?

Adding a second filter to find instances with status code 16 means only "running" instances will be returned

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Tested the output of the command manually and have updated my bastion configuration already.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
