### PR TITLE
Changes required to remove Jake Mulley from SuperAdmins & Maintainers list.

### DIFF
--- a/terraform/github/locals.tf
+++ b/terraform/github/locals.tf
@@ -14,7 +14,6 @@ locals {
   # and will attempt to change them from `maintainer` to `member`, so owners should go in here.
   maintainers = [
     "ewastempel",
-    "jakemulley",
     "SteveMarshall",
     "davidkelliott",
     "connormaglynn"
@@ -39,7 +38,6 @@ locals {
   # GitHub usernames for engineers who need full AWS access
   engineers = [
     "davidkelliott",
-    "jakemulley",
     "stevelinden",
     "markgov",
     "dms1981", # David Sibley

--- a/terraform/modernisation-platform-account/iam.tf
+++ b/terraform/modernisation-platform-account/iam.tf
@@ -1,7 +1,7 @@
 #tfsec:ignore:aws-iam-no-policy-wildcards
 #tfsec:ignore:aws-iam-enforce-mfa
 module "iam" {
-  source        = "github.com/ministryofjustice/modernisation-platform-terraform-iam-superadmins?ref=180803bb2f1f9e08bb2653b40e52744126472dce" # v2.0.2
+  source        = "github.com/ministryofjustice/modernisation-platform-terraform-iam-superadmins?ref=403849a8aed2955f15806a2cdb62a9bcce80ad34" # v2.0.3
   account_alias = "moj-modernisation-platform"
 }
 


### PR DESCRIPTION
## A reference to the issue / Description of it

JM is no longer a member of the organisation and as such needs to be removed.

## How does this PR fix the problem?

JM's name remaining causes conflict with Github as he has been removed from the ministryofjustice group.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
