### PR TITLE
Added kms secrets_key_multi_region

### DIFF
--- a/terraform/modernisation-platform-account/secrets.tf
+++ b/terraform/modernisation-platform-account/secrets.tf
@@ -13,6 +13,19 @@ resource "aws_kms_alias" "secrets_key" {
   target_key_id = aws_kms_key.secrets_key.id
 }
 
+resource "aws_kms_key" "secrets_key_multi_region" {
+  description             = "AWS Secretsmanager CMK"
+  policy                  = data.aws_iam_policy_document.kms_secrets_key.json
+  enable_key_rotation     = true
+  deletion_window_in_days = 30
+  multi_region            = true
+}
+
+resource "aws_kms_alias" "secrets_key_multi_region" {
+  name          = "alias/secrets-key-multi-region"
+  target_key_id = aws_kms_key.secrets_key_multi_region.id
+}
+
 data "aws_iam_policy_document" "kms_secrets_key" {
   #cannot reference secret in resources for statement as this causes cyclic error
   #checkov:skip=CKV_AWS_108: Cannot set resource as not known at time document is created, causing a cyclic error


### PR DESCRIPTION
## A reference to the issue / Description of it
https://github.com/ministryofjustice/modernisation-platform/issues/5635

## How does this PR fix the problem?
Added multi-Region KMS keys for DR replication because existing KMS keys are all single-Region and cannot be converted to multi-Region

## How has this been tested?
Created and tested primary multi_region KMS key and it's replica in eu-west-1 in sprinkler account

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
