### PR TITLE
NIT-1038 allow traffic between MP hmpps and legacy delius networks

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/development_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/development_rules.json
@@ -230,19 +230,145 @@
     "destination_port": "1521",
     "protocol": "TCP"
   },
-  "delius_core_dev_to_hmpps_development_ldap": {
-    "action": "PASS",
-    "source_ip": "${delius-core-dev}",
-    "destination_ip": "${hmpps-development}",
-    "destination_port": "389",
-    "protocol": "TCP"
-  },
   "delius_mis_dev_to_hmpps_development_ldap": {
     "action": "PASS",
     "source_ip": "${delius-mis-dev}",
     "destination_ip": "${hmpps-development}",
     "destination_port": "389",
     "protocol": "TCP"
+  },
+  "delius_mis_dev_to_hmpps_development_icmp": {
+    "action": "PASS",
+    "source_ip": "${delius-mis-dev}",
+    "destination_ip": "${hmpps-development}",
+    "destination_port": "ANY",
+    "protocol": "ICMP"
+  },
+  "hmpps_development_to_delius-mis-dev_icmp": {
+    "action": "PASS",
+    "source_ip": "${hmpps-development}",
+    "destination_ip": "${delius-mis-dev}",
+    "destination_port": "ANY",
+    "protocol": "ICMP"
+  },
+  "hmpps_development_to_delius-mis-dev_http": {
+    "action": "PASS",
+    "source_ip": "${hmpps-development}",
+    "destination_ip": "${delius-mis-dev}",
+    "destination_port": "80",
+    "protocol": "TCP"
+  },
+  "hmpps_development_to_delius-mis-dev_https": {
+    "action": "PASS",
+    "source_ip": "${hmpps-development}",
+    "destination_ip": "${delius-mis-dev}",
+    "destination_port": "443",
+    "protocol": "TCP"
+  },
+  "hmpps_development_to_delius-mis-dev_oracledb": {
+    "action": "PASS",
+    "source_ip": "${hmpps-development}",
+    "destination_ip": "${delius-mis-dev}",
+    "destination_port": "1521",
+    "protocol": "TCP"
+  },
+  "hmpps_development_to_delius-mis-dev_ad_tcp_53": {
+    "action": "PASS",
+    "source_ip": "${hmpps-development}",
+    "destination_ip": "${delius-mis-dev}",
+    "destination_port": "53",
+    "protocol": "TCP"
+  },
+  "hmpps_development_to_delius-mis-dev_ad_tcp_88": {
+    "action": "PASS",
+    "source_ip": "${hmpps-development}",
+    "destination_ip": "${delius-mis-dev}",
+    "destination_port": "88",
+    "protocol": "TCP"
+  },
+  "hmpps_development_to_delius-mis-dev_ad_tcp_135": {
+    "action": "PASS",
+    "source_ip": "${hmpps-development}",
+    "destination_ip": "${delius-mis-dev}",
+    "destination_port": "135",
+    "protocol": "TCP"
+  },
+  "hmpps_development_to_delius-mis-dev_ad_tcp_389": {
+    "action": "PASS",
+    "source_ip": "${hmpps-development}",
+    "destination_ip": "${delius-mis-dev}",
+    "destination_port": "389",
+    "protocol": "TCP"
+  },
+  "hmpps_development_to_delius-mis-dev_ad_tcp_445": {
+    "action": "PASS",
+    "source_ip": "${hmpps-development}",
+    "destination_ip": "${delius-mis-dev}",
+    "destination_port": "445",
+    "protocol": "TCP"
+  },
+  "hmpps_development_to_delius-mis-dev_ad_tcp_464": {
+    "action": "PASS",
+    "source_ip": "${hmpps-development}",
+    "destination_ip": "${delius-mis-dev}",
+    "destination_port": "464",
+    "protocol": "TCP"
+  },
+  "hmpps_development_to_delius-mis-dev_ad_tcp_636": {
+    "action": "PASS",
+    "source_ip": "${hmpps-development}",
+    "destination_ip": "${delius-mis-dev}",
+    "destination_port": "636",
+    "protocol": "TCP"
+  },
+  "hmpps_development_to_delius-mis-dev_ad_udp_53": {
+    "action": "PASS",
+    "source_ip": "${hmpps-development}",
+    "destination_ip": "${delius-mis-dev}",
+    "destination_port": "53",
+    "protocol": "UDP"
+  },
+  "hmpps_development_to_delius-mis-dev_ad_udp_88": {
+    "action": "PASS",
+    "source_ip": "${hmpps-development}",
+    "destination_ip": "${delius-mis-dev}",
+    "destination_port": "88",
+    "protocol": "UDP"
+  },
+  "hmpps_development_to_delius-mis-dev_ad_udp_123": {
+    "action": "PASS",
+    "source_ip": "${hmpps-development}",
+    "destination_ip": "${delius-mis-dev}",
+    "destination_port": "123",
+    "protocol": "UDP"
+  },
+  "hmpps_development_to_delius-mis-dev_ad_udp_138": {
+    "action": "PASS",
+    "source_ip": "${hmpps-development}",
+    "destination_ip": "${delius-mis-dev}",
+    "destination_port": "138",
+    "protocol": "UDP"
+  },
+  "hmpps_development_to_delius-mis-dev_ad_udp_389": {
+    "action": "PASS",
+    "source_ip": "${hmpps-development}",
+    "destination_ip": "${delius-mis-dev}",
+    "destination_port": "389",
+    "protocol": "UDP"
+  },
+  "hmpps_development_to_delius-mis-dev_ad_udp_445": {
+    "action": "PASS",
+    "source_ip": "${hmpps-development}",
+    "destination_ip": "${delius-mis-dev}",
+    "destination_port": "445",
+    "protocol": "UDP"
+  },
+  "hmpps_development_to_delius-mis-dev_ad_udp_464": {
+    "action": "PASS",
+    "source_ip": "${hmpps-development}",
+    "destination_ip": "${delius-mis-dev}",
+    "destination_port": "464",
+    "protocol": "UDP"
   },
   "global-protect_to_data-insights-hub_development_redshift": {
     "action": "PASS",


### PR DESCRIPTION
## A reference to the issue / Description of it

We need to allow more bi-directional traffic between hmpps networks/environments and their legacy delius counterparts.

## How does this PR fix the problem?

This PR will allow traffic to flow through the central firewall.

## How has this been tested?

No testing performed yet. This PR is a prerequisite to further work.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No negative impact expected

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

Not aware of any MP docs that need updating due to this change. Is anybody able to point me to relevant pages so I can update?
