### PR TITLE
Move SSM parameters from delegate to member bootstrap access

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -20,34 +20,6 @@ module "cross-account-access" {
   additional_trust_roles = terraform.workspace == "testing-test" ? ["arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:user/testing-ci"] : []
 }
 
-# Create a parameter for the modernisation platform environment management secret ARN that can be used to gain
-# access to the environments parameter when running a tf plan locally
-
-resource "aws_ssm_parameter" "environment_management_arn" {
-  #checkov:skip=CKV_AWS_337: Standard key is fine here
-  provider = aws.workspace
-
-  name  = "environment_management_arn"
-  type  = "SecureString"
-  value = data.aws_secretsmanager_secret.environment_management.arn
-
-  tags = local.environments
-}
-
-# Create a parameter for the modernisation platform account id that can be used
-# by providers in member accounts to assume a role in MP
-
-resource "aws_ssm_parameter" "modernisation_platform_account_id" {
-  #checkov:skip=CKV_AWS_337: Standard key is fine here
-  provider = aws.workspace
-
-  name  = "modernisation_platform_account_id"
-  type  = "SecureString"
-  value = local.environment_management.modernisation_platform_account_id
-
-  tags = local.environments
-}
-
 # AWS Shield Advanced SRT (Shield Response Team) support role
 module "shield_response_team_role" {
   # checkov:skip=CKV_TF_1:

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -572,10 +572,11 @@ resource "aws_iam_policy" "member-access-eu-central" {
 
 resource "aws_ssm_parameter" "environment_management_arn" {
   #checkov:skip=CKV_AWS_337: Standard key is fine here
+  count = local.account_data.account-type == "member" ? 1 : 0
   name  = "environment_management_arn"
   type  = "SecureString"
   value = data.aws_secretsmanager_secret.environment_management.arn
-  tags = local.tags
+  tags  = local.tags
 }
 
 # Create a parameter for the modernisation platform account id that can be used
@@ -583,8 +584,9 @@ resource "aws_ssm_parameter" "environment_management_arn" {
 
 resource "aws_ssm_parameter" "modernisation_platform_account_id" {
   #checkov:skip=CKV_AWS_337: Standard key is fine here
+  count = local.account_data.account-type == "member" ? 1 : 0
   name  = "modernisation_platform_account_id"
   type  = "SecureString"
   value = local.environment_management.modernisation_platform_account_id
-  tags = local.tags
+  tags  = local.tags
 }

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -572,7 +572,6 @@ resource "aws_iam_policy" "member-access-eu-central" {
 
 resource "aws_ssm_parameter" "environment_management_arn" {
   #checkov:skip=CKV_AWS_337: Standard key is fine here
-  count = local.account_data.account-type == "member" ? 1 : 0
   name  = "environment_management_arn"
   type  = "SecureString"
   value = data.aws_secretsmanager_secret.environment_management.arn
@@ -584,7 +583,6 @@ resource "aws_ssm_parameter" "environment_management_arn" {
 
 resource "aws_ssm_parameter" "modernisation_platform_account_id" {
   #checkov:skip=CKV_AWS_337: Standard key is fine here
-  count = local.account_data.account-type == "member" ? 1 : 0
   name  = "modernisation_platform_account_id"
   type  = "SecureString"
   value = local.environment_management.modernisation_platform_account_id

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -572,6 +572,7 @@ resource "aws_iam_policy" "member-access-eu-central" {
 
 resource "aws_ssm_parameter" "environment_management_arn" {
   #checkov:skip=CKV_AWS_337: Standard key is fine here
+  count = local.account_data.account-type == "member" ? 1 : 0
   name  = "environment_management_arn"
   type  = "SecureString"
   value = data.aws_secretsmanager_secret.environment_management.arn
@@ -583,6 +584,7 @@ resource "aws_ssm_parameter" "environment_management_arn" {
 
 resource "aws_ssm_parameter" "modernisation_platform_account_id" {
   #checkov:skip=CKV_AWS_337: Standard key is fine here
+  count = local.account_data.account-type == "member" ? 1 : 0
   name  = "modernisation_platform_account_id"
   type  = "SecureString"
   value = local.environment_management.modernisation_platform_account_id

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -566,3 +566,25 @@ resource "aws_iam_policy" "member-access-eu-central" {
   description = "Restricted policy for US East usage"
   policy      = data.aws_iam_policy_document.member-access-eu-central.json
 }
+
+# Create a parameter for the modernisation platform environment management secret ARN that can be used to gain
+# access to the environments parameter when running a tf plan locally
+
+resource "aws_ssm_parameter" "environment_management_arn" {
+  #checkov:skip=CKV_AWS_337: Standard key is fine here
+  name  = "environment_management_arn"
+  type  = "SecureString"
+  value = data.aws_secretsmanager_secret.environment_management.arn
+  tags = local.tags
+}
+
+# Create a parameter for the modernisation platform account id that can be used
+# by providers in member accounts to assume a role in MP
+
+resource "aws_ssm_parameter" "modernisation_platform_account_id" {
+  #checkov:skip=CKV_AWS_337: Standard key is fine here
+  name  = "modernisation_platform_account_id"
+  type  = "SecureString"
+  value = local.environment_management.modernisation_platform_account_id
+  tags = local.tags
+}


### PR DESCRIPTION
## A reference to the issue / Description of it

#3053 

## How does this PR fix the problem?

This PR moves SSM parameters from delegate to member bootstrap access by deleting the SSM parameters from delegate access and recreating them in the member bootstrap access. 

## How has this been tested?

deployed to the sprinkler