### PR TITLE
Removed count variable in ssm resources

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -572,7 +572,6 @@ resource "aws_iam_policy" "member-access-eu-central" {
 
 resource "aws_ssm_parameter" "environment_management_arn" {
   #checkov:skip=CKV_AWS_337: Standard key is fine here
-  count = local.account_data.account-type == "member" ? 1 : 0
   name  = "environment_management_arn"
   type  = "SecureString"
   value = data.aws_secretsmanager_secret.environment_management.arn
@@ -584,7 +583,6 @@ resource "aws_ssm_parameter" "environment_management_arn" {
 
 resource "aws_ssm_parameter" "modernisation_platform_account_id" {
   #checkov:skip=CKV_AWS_337: Standard key is fine here
-  count = local.account_data.account-type == "member" ? 1 : 0
   name  = "modernisation_platform_account_id"
   type  = "SecureString"
   value = local.environment_management.modernisation_platform_account_id


### PR DESCRIPTION
## A reference to the issue / Description of it

This PR addresses the issue where two SSM parameters were moved from delegate access to member bootstrap, resulting in deployment solely in member accounts rather than across all accounts. These parameters are crucial for system functionality and need to be deployed universally across all accounts

## How does this PR fix the problem?

This PR removes the count variable responsible for limiting the deployment of SSM parameters to member accounts only. By eliminating this constraint, the parameters will now be deployed in all remaining accounts as intended. 