### PR TITLE
Resolve failure to retag RAM shared subnets

### DIFF
--- a/scripts/member-account-ram-association.sh
+++ b/scripts/member-account-ram-association.sh
@@ -22,7 +22,9 @@ setup_ram_share_association() {
     
     if [[ $select_workspace ]]; then
 
-      # Run terraform apply
+      # Run terraform apply to get subnet info
+      ./scripts/terraform-apply.sh $basedir/$application -target=module.ram-ec2-retagging[0].data.aws_subnets.associated
+      # Run the full terraform apply
       ./scripts/terraform-apply.sh $basedir/$application
     fi
     echo "Finished running ram share association for application: ${application}"


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/6048

## How does this PR fix the problem?

When we run the `./member-account-ram-association.sh` script, we encounter a problem where we want to apply tags to the RAM shared objects corresponding to VPC subnets.

To add the tags we need a full list of subnet IDs, but this isn't available when we run a Terraform plan. To get this list of subnet IDs we either need to use a statically defined map, or we need to run Terraform in a targeted fashion to get those subnet IDs.

This PR amends the `./member-account-ram-association.sh` script so that it first runs a targeted apply, then a full apply.

## How has this been tested?

Tested locally

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No, but there could be unexpected behaviour in a situation where `networking.auto.tfvars` is unpopulated.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

I'm still not convinced this is the right way to go, but without reworking how we retag the shared subnets - for example, passing the subnet information into the module and refactoring the templates - this is the lightest touch solution.
