### PR TITLE
Removing Jake from pagerduty and team page

### DIFF
--- a/source/runbooks/removing-a-team-member.html.md.erb
+++ b/source/runbooks/removing-a-team-member.html.md.erb
@@ -14,3 +14,4 @@ Along with the standard [leavers form](https://leavers.form.service.justice.gov.
 1. Remove them as a superadmin to our AWS landing zone [superadmins/main.tf](https://github.com/ministryofjustice/modernisation-platform-terraform-iam-superadmins/blob/main/main.tf#L5)
 1. Run the modernisation-platform account Terraform for the above code change locally as a superuser (the CI user does not have permissions to delete users)
 1. Remove them from the Modernisation Platform Google Group and Slack teams.
+1. Remove them from pagerduty [terraform/pagerduty/locals.tf](https://github.com/ministryofjustice/modernisation-platform/blob/main/terraform/pagerduty/locals.tf)

--- a/source/team/team.html.md.erb
+++ b/source/team/team.html.md.erb
@@ -12,7 +12,6 @@ We are currently made up of 16 members:
 - Karen Botsh, Senior Delivery Manager
 - David Elliott, Technical Architect
 - Stephen Linden, WebOps Engineer
-- Jake Mulley, Lead Technical Architect
 - David Sibley, WebOps Engineer
 - Katie Watson, User Researcher
 - Edward Proctor, WebOps Engineer

--- a/terraform/pagerduty/locals.tf
+++ b/terraform/pagerduty/locals.tf
@@ -41,7 +41,6 @@ locals {
 
   existing_users = {
     karen_botsh    = data.pagerduty_user.karen_botsh,
-    jake_mulley    = data.pagerduty_user.jake_mulley,
     stephen_linden = data.pagerduty_user.stephen_linden,
     simon_pledger  = data.pagerduty_user.simon_pledger,
     mark_roberts   = data.pagerduty_user.mark_roberts,
@@ -77,10 +76,6 @@ data "pagerduty_user" "stephen_linden" {
 
 data "pagerduty_user" "karen_botsh" {
   email = "karen.botsh${local.digital_email_suffix}"
-}
-
-data "pagerduty_user" "jake_mulley" {
-  email = "jake.mulley${local.digital_email_suffix}"
 }
 
 data "pagerduty_user" "simon_pledger" {


### PR DESCRIPTION
Removing Jake as pagerduty terraform was failing (and he has now left): https://github.com/ministryofjustice/modernisation-platform/actions/runs/7826944229/job/21353765269#step:7:173


