### PR TITLE
Adding data engineering access level to AP-DEV account.

### DIFF
--- a/environments/analytical-platform.json
+++ b/environments/analytical-platform.json
@@ -11,6 +11,10 @@
         {
           "github_slug": "data-platform-audit-and-security",
           "level": "security-audit"
+        },
+        {
+          "github_slug": "analytical-platform-data-development-data-engineer",
+          "level": "data-engineer"
         }
       ]
     },


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/data-platform/issues/2452

We need to add this level of access to perform end to end testing with data engineers.

## How does this PR fix the problem?

Provides the needed access

## How has this been tested?

Code review only.


## Deployment Plan / Instructions

This is a pre-existing unconstrained access level that is already active in other AP accounts so should not cause any additional issues.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

