### PR TITLE
Added fleet-manager role to sprinkler

### DIFF
--- a/environments/sprinkler.json
+++ b/environments/sprinkler.json
@@ -13,6 +13,11 @@
           "github_slug": "modernisation-platform-security",
           "level": "instance-management",
           "nuke": "rebuild"
+        },
+        {
+          "github_slug": "modernisation-platform-security",
+          "level": "fleet-manager",
+          "nuke": "rebuild"
         }
       ],
       "additional_reviewers": ["astrobinson"]

--- a/policies/environments/environment-definitions.rego
+++ b/policies/environments/environment-definitions.rego
@@ -25,7 +25,8 @@ allowed_access := [
   "sandbox",
   "security-audit",
   "view-only",
-  "powerbi-user"
+  "powerbi-user",
+  "fleet-manager"
 ]
 
 allowed_nuke := [


### PR DESCRIPTION
## A reference to the issue / Description of it

This PR aims to facilitate testing of the fleet-manager role deployed to the Sprinkler environment. Currently, there's a need to verify the functionality and permissions associated with this role.

## How does this PR fix the problem?

This PR addresses the problem by providing the necessary access and permissions to test the fleet-manager role deployed on the Sprinkler environment. By doing so, it allows for thorough testing and validation of the role's functionality