### PR TITLE
Added the error (AVD-GIT-0001) to the .trivyignore.yaml file.

### DIFF
--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -29,8 +29,8 @@ misconfigurations:
   - id: AVD-AWS-0031
   - id: AVD-AWS-0057
   - id: AVD-AWS-0039
+  - id: AVD-GIT-0001
 
 secrets:
-
 
 licenses:


### PR DESCRIPTION
## A reference to the issue / Description of it

See #6158 . Trivy reporting errors that github is not private. All of our are public so it should be ignored.

## How does this PR fix the problem?

Added the error to .trivyignore.yaml which should ensure it is no longer considered.

## How has this been tested?

Impossible to test with a plan due to a different error that pops up.

## Deployment Plan / Instructions

Approve the import and apply the change.

## Checklist (check `x` in `[ ]` of list items)

- [x ] I have performed a self-review of my own code
- [x ] Plan and discussed how it should be deployed to PROD (If needed)

