### PR TITLE
Added fleet-manager role to sprinkler

### DIFF
--- a/environments/sprinkler.json
+++ b/environments/sprinkler.json
@@ -15,7 +15,7 @@
           "nuke": "rebuild"
         },
         {
-          "github_slug": "modernisation-platform-security",
+          "github_slug": "modernisation-platform",
           "level": "fleet-manager",
           "nuke": "rebuild"
         }


### PR DESCRIPTION
## A reference to the issue / Description of it

#6165

## How does this PR fix the problem?

The fleet manager role was not previously applied to the sprinkler environment due to an error in the previous PR action, causing it to not be applied. This PR will create a new role to the sprinkler environment