### PR TITLE
Added SSO permission sets for fleet-manager role

### DIFF
--- a/terraform/single-sign-on/outputs.tf
+++ b/terraform/single-sign-on/outputs.tf
@@ -30,6 +30,10 @@ output "powerbi_user" {
   value = aws_ssoadmin_permission_set.modernisation_platform_powerbi_user.arn
 }
 
+output "instance_management" {
+  value = aws_ssoadmin_permission_set.modernisation_platform_fleet_manager.arn
+}
+
 # Data outputs
 output "administrator" {
   value = data.aws_ssoadmin_permission_set.administrator.arn

--- a/terraform/single-sign-on/outputs.tf
+++ b/terraform/single-sign-on/outputs.tf
@@ -30,7 +30,7 @@ output "powerbi_user" {
   value = aws_ssoadmin_permission_set.modernisation_platform_powerbi_user.arn
 }
 
-output "instance_management" {
+output "fleet_manager" {
   value = aws_ssoadmin_permission_set.modernisation_platform_fleet_manager.arn
 }
 

--- a/terraform/single-sign-on/sso-permission-sets.tf
+++ b/terraform/single-sign-on/sso-permission-sets.tf
@@ -251,3 +251,30 @@ resource "aws_ssoadmin_customer_managed_policy_attachment" "modernisation_platfo
     path = "/"
   }
 }
+
+# Modernisation Platform fleet-manager role
+resource "aws_ssoadmin_permission_set" "modernisation_platform_fleet_manager" {
+  provider         = aws.sso-management
+  name             = "mp-fleet-manager"
+  description      = "Modernisation Platform: fleet-manager"
+  instance_arn     = local.sso_admin_instance_arn
+  session_duration = "PT8H"
+  tags             = {}
+}
+
+resource "aws_ssoadmin_managed_policy_attachment" "modernisation_platform_fleet_manager" {
+  provider           = aws.sso-management
+  instance_arn       = local.sso_admin_instance_arn
+  managed_policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+  permission_set_arn = aws_ssoadmin_permission_set.modernisation_platform_fleet_manager.arn
+}
+
+resource "aws_ssoadmin_customer_managed_policy_attachment" "modernisation_platform_fleet_manager" {
+  provider           = aws.sso-management
+  instance_arn       = local.sso_admin_instance_arn
+  permission_set_arn = aws_ssoadmin_permission_set.modernisation_platform_fleet_manager.arn
+  customer_managed_policy_reference {
+    name = "fleet_manager_policy"
+    path = "/"
+  }
+}


### PR DESCRIPTION
## A reference to the issue / Description of it

This PR addresses the need to provide SSO permission sets for the fleet manager role. Previously, fleet managers lacked the necessary permissions to access certain environments. By adding SSO permission sets, we aim to grant them appropriate access

## How does this PR fix the problem?

This PR resolves the issue by adding SSO permission sets specifically tailored for the fleet manager role. With these permissions in place, fleet managers can now access the required environments without encountering access restrictions.