### PR TITLE
dom 1 domain controller FW rules

### DIFF
--- a/terraform/environments/core-network-services/cidr-ranges.tf
+++ b/terraform/environments/core-network-services/cidr-ranges.tf
@@ -77,6 +77,7 @@ locals {
     hmpps-production-general-private-subnets    = "10.27.10.0/22"
 
     mojo-end-user-devices = "10.0.0.0/8"
+    outbound-to-all       = "0.0.0.0/0"
   }
 
   all_cidr_ranges = merge(

--- a/terraform/environments/core-network-services/cidr-ranges.tf
+++ b/terraform/environments/core-network-services/cidr-ranges.tf
@@ -77,7 +77,6 @@ locals {
     hmpps-production-general-private-subnets    = "10.27.10.0/22"
 
     mojo-end-user-devices = "10.0.0.0/8"
-    outbound-to-all       = "0.0.0.0/0"
   }
 
   all_cidr_ranges = merge(

--- a/terraform/environments/core-network-services/cidr-ranges.tf
+++ b/terraform/environments/core-network-services/cidr-ranges.tf
@@ -77,6 +77,7 @@ locals {
     hmpps-production-general-private-subnets    = "10.27.10.0/22"
 
     mojo-end-user-devices = "10.0.0.0/8"
+    dom1-dcs              = "10.0.0.0/8"
   }
 
   all_cidr_ranges = merge(

--- a/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
@@ -565,12 +565,5 @@
     "destination_ip": "${dom1-dcs}",
     "destination_port": "9389",
     "protocol": "TCP"
-  },
-  "dom1_dcs_to_planetfm_preproduction_49152_RPC_TCP": {
-    "action": "PASS",
-    "source_ip": "${hmpps-preproduction-general-private-subnets}",
-    "destination_ip": "${dom1-dcs}",
-    "destination_port": "49152-65535",
-    "protocol": "TCP"
   }
 }

--- a/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
@@ -454,6 +454,41 @@
     "destination_port": "1522",
     "protocol": "TCP"
   },
+  "dom1_dcs_to_planetfm_preproduction_53_DNS_TCP": {
+    "action": "PASS",
+    "source_ip": "${hmpps-preproduction-general-private-subnets}",
+    "destination_ip": "${mojo-end-user-devices}",
+    "destination_port": "53",
+    "protocol": "TCP"
+  },
+  "dom1_dcs_to_planetfm_preproduction_53_DNS_UDP": {
+    "action": "PASS",
+    "source_ip": "${hmpps-preproduction-general-private-subnets}",
+    "destination_ip": "${mojo-end-user-devices}",
+    "destination_port": "53",
+    "protocol": "UDP"
+  },
+  "dom1_dcs_to_planetfm_preproduction_88_Kerberos_TCP": {
+    "action": "PASS",
+    "source_ip": "${hmpps-preproduction-general-private-subnets}",
+    "destination_ip": "${mojo-end-user-devices}",
+    "destination_port": "88",
+    "protocol": "TCP"
+  },
+  "dom1_dcs_to_planetfm_preproduction_88_Kerberos_UDP": {
+    "action": "PASS",
+    "source_ip": "${hmpps-preproduction-general-private-subnets}",
+    "destination_ip": "${mojo-end-user-devices}",
+    "destination_port": "88",
+    "protocol": "UDP"
+  },
+  "dom1_dcs_to_planetfm_preproduction_123_NTP_UDP": {
+    "action": "PASS",
+    "source_ip": "${hmpps-preproduction-general-private-subnets}",
+    "destination_ip": "${mojo-end-user-devices}",
+    "destination_port": "123",
+    "protocol": "UDP"
+  },
   "dom1_dcs_to_planetfm_preproduction_135_MS_RPC_TCP": {
     "action": "PASS",
     "source_ip": "${hmpps-preproduction-general-private-subnets}",
@@ -461,11 +496,11 @@
     "destination_port": "135",
     "protocol": "TCP"
   },
-  "dom1_dcs_to_planetfm_preproduction_137_NetBios_TCP": {
+  "dom1_dcs_to_planetfm_preproduction_139_NetBios_TCP": {
     "action": "PASS",
     "source_ip": "${hmpps-preproduction-general-private-subnets}",
     "destination_ip": "${mojo-end-user-devices}",
-    "destination_port": "137",
+    "destination_port": "139",
     "protocol": "TCP"
   },
   "dom1_dcs_to_planetfm_preproduction_389_LDAP_TCP": {
@@ -475,11 +510,67 @@
     "destination_port": "389",
     "protocol": "TCP"
   },
+  "dom1_dcs_to_planetfm_preproduction_389_LDAP_UDP": {
+    "action": "PASS",
+    "source_ip": "${hmpps-preproduction-general-private-subnets}",
+    "destination_ip": "${mojo-end-user-devices}",
+    "destination_port": "389",
+    "protocol": "UDP"
+  },
   "dom1_dcs_to_planetfm_preproduction_445_SMB_TCP": {
     "action": "PASS",
     "source_ip": "${hmpps-preproduction-general-private-subnets}",
     "destination_ip": "${mojo-end-user-devices}",
     "destination_port": "445",
+    "protocol": "TCP"
+  },
+  "dom1_dcs_to_planetfm_preproduction_464_Kerberos_TCP": {
+    "action": "PASS",
+    "source_ip": "${hmpps-preproduction-general-private-subnets}",
+    "destination_ip": "${mojo-end-user-devices}",
+    "destination_port": "464",
+    "protocol": "UDP"
+  },
+  "dom1_dcs_to_planetfm_preproduction_464_Kerberos_UDP": {
+    "action": "PASS",
+    "source_ip": "${hmpps-preproduction-general-private-subnets}",
+    "destination_ip": "${mojo-end-user-devices}",
+    "destination_port": "464",
+    "protocol": "UDP"
+  },
+  "dom1_dcs_to_planetfm_preproduction_636_Kerberos_TCP": {
+    "action": "PASS",
+    "source_ip": "${hmpps-preproduction-general-private-subnets}",
+    "destination_ip": "${mojo-end-user-devices}",
+    "destination_port": "636",
+    "protocol": "TCP"
+  },
+  "dom1_dcs_to_planetfm_preproduction_3268_LDAP_glocal_catalogue_TCP": {
+    "action": "PASS",
+    "source_ip": "${hmpps-preproduction-general-private-subnets}",
+    "destination_ip": "${mojo-end-user-devices}",
+    "destination_port": "3268",
+    "protocol": "TCP"
+  },
+  "dom1_dcs_to_planetfm_preproduction_3269_LDAPS_TCP": {
+    "action": "PASS",
+    "source_ip": "${hmpps-preproduction-general-private-subnets}",
+    "destination_ip": "${mojo-end-user-devices}",
+    "destination_port": "3269",
+    "protocol": "TCP"
+  },
+  "dom1_dcs_to_planetfm_preproduction_9389_LDAPS_TCP": {
+    "action": "PASS",
+    "source_ip": "${hmpps-preproduction-general-private-subnets}",
+    "destination_ip": "${mojo-end-user-devices}",
+    "destination_port": "3269",
+    "protocol": "TCP"
+  },
+  "dom1_dcs_to_planetfm_preproduction_49152_RPC_TCP": {
+    "action": "PASS",
+    "source_ip": "${hmpps-preproduction-general-private-subnets}",
+    "destination_ip": "${mojo-end-user-devices}",
+    "destination_port": "49152",
     "protocol": "TCP"
   }
 }

--- a/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
@@ -454,11 +454,32 @@
     "destination_port": "1522",
     "protocol": "TCP"
   },
-  "dom1_dcs_to_planetfm_preproduction_9389_tcp": {
+  "dom1_dcs_to_planetfm_preproduction_135_MS_RPC_TCP": {
     "action": "PASS",
     "source_ip": "${hmpps-preproduction-general-private-subnets}",
-    "destination_ip": "${dom1-domain-controllers}",
-    "destination_port": "9389",
+    "destination_ip": "${outbound-to-all}",
+    "destination_port": "135",
+    "protocol": "TCP"
+  },
+  "dom1_dcs_to_planetfm_preproduction_137_NetBios_TCP": {
+    "action": "PASS",
+    "source_ip": "${hmpps-preproduction-general-private-subnets}",
+    "destination_ip": "${outbound-to-all}",
+    "destination_port": "137",
+    "protocol": "TCP"
+  },
+  "dom1_dcs_to_planetfm_preproduction_389_LDAP_TCP": {
+    "action": "PASS",
+    "source_ip": "${hmpps-preproduction-general-private-subnets}",
+    "destination_ip": "${outbound-to-all}",
+    "destination_port": "389",
+    "protocol": "TCP"
+  },
+  "dom1_dcs_to_planetfm_preproduction_445_SMB_TCP": {
+    "action": "PASS",
+    "source_ip": "${hmpps-preproduction-general-private-subnets}",
+    "destination_ip": "${outbound-to-all}",
+    "destination_port": "445",
     "protocol": "TCP"
   }
 }

--- a/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
@@ -457,120 +457,120 @@
   "dom1_dcs_to_planetfm_preproduction_53_DNS_TCP": {
     "action": "PASS",
     "source_ip": "${hmpps-preproduction-general-private-subnets}",
-    "destination_ip": "${mojo-end-user-devices}",
+    "destination_ip": "${dom1-dcs}",
     "destination_port": "53",
     "protocol": "TCP"
   },
   "dom1_dcs_to_planetfm_preproduction_53_DNS_UDP": {
     "action": "PASS",
     "source_ip": "${hmpps-preproduction-general-private-subnets}",
-    "destination_ip": "${mojo-end-user-devices}",
+    "destination_ip": "${dom1-dcs}",
     "destination_port": "53",
     "protocol": "UDP"
   },
   "dom1_dcs_to_planetfm_preproduction_88_Kerberos_TCP": {
     "action": "PASS",
     "source_ip": "${hmpps-preproduction-general-private-subnets}",
-    "destination_ip": "${mojo-end-user-devices}",
+    "destination_ip": "${dom1-dcs}",
     "destination_port": "88",
     "protocol": "TCP"
   },
   "dom1_dcs_to_planetfm_preproduction_88_Kerberos_UDP": {
     "action": "PASS",
     "source_ip": "${hmpps-preproduction-general-private-subnets}",
-    "destination_ip": "${mojo-end-user-devices}",
+    "destination_ip": "${dom1-dcs}",
     "destination_port": "88",
     "protocol": "UDP"
   },
   "dom1_dcs_to_planetfm_preproduction_123_NTP_UDP": {
     "action": "PASS",
     "source_ip": "${hmpps-preproduction-general-private-subnets}",
-    "destination_ip": "${mojo-end-user-devices}",
+    "destination_ip": "${dom1-dcs}",
     "destination_port": "123",
     "protocol": "UDP"
   },
   "dom1_dcs_to_planetfm_preproduction_135_MS_RPC_TCP": {
     "action": "PASS",
     "source_ip": "${hmpps-preproduction-general-private-subnets}",
-    "destination_ip": "${mojo-end-user-devices}",
+    "destination_ip": "${dom1-dcs}",
     "destination_port": "135",
     "protocol": "TCP"
   },
   "dom1_dcs_to_planetfm_preproduction_139_NetBios_TCP": {
     "action": "PASS",
     "source_ip": "${hmpps-preproduction-general-private-subnets}",
-    "destination_ip": "${mojo-end-user-devices}",
+    "destination_ip": "${dom1-dcs}",
     "destination_port": "139",
     "protocol": "TCP"
   },
   "dom1_dcs_to_planetfm_preproduction_389_LDAP_TCP": {
     "action": "PASS",
     "source_ip": "${hmpps-preproduction-general-private-subnets}",
-    "destination_ip": "${mojo-end-user-devices}",
+    "destination_ip": "${dom1-dcs}",
     "destination_port": "389",
     "protocol": "TCP"
   },
   "dom1_dcs_to_planetfm_preproduction_389_LDAP_UDP": {
     "action": "PASS",
     "source_ip": "${hmpps-preproduction-general-private-subnets}",
-    "destination_ip": "${mojo-end-user-devices}",
+    "destination_ip": "${dom1-dcs}",
     "destination_port": "389",
     "protocol": "UDP"
   },
   "dom1_dcs_to_planetfm_preproduction_445_SMB_TCP": {
     "action": "PASS",
     "source_ip": "${hmpps-preproduction-general-private-subnets}",
-    "destination_ip": "${mojo-end-user-devices}",
+    "destination_ip": "${dom1-dcs}",
     "destination_port": "445",
     "protocol": "TCP"
   },
   "dom1_dcs_to_planetfm_preproduction_464_Kerberos_TCP": {
     "action": "PASS",
     "source_ip": "${hmpps-preproduction-general-private-subnets}",
-    "destination_ip": "${mojo-end-user-devices}",
+    "destination_ip": "${dom1-dcs}",
     "destination_port": "464",
     "protocol": "UDP"
   },
   "dom1_dcs_to_planetfm_preproduction_464_Kerberos_UDP": {
     "action": "PASS",
     "source_ip": "${hmpps-preproduction-general-private-subnets}",
-    "destination_ip": "${mojo-end-user-devices}",
+    "destination_ip": "${dom1-dcs}",
     "destination_port": "464",
     "protocol": "UDP"
   },
-  "dom1_dcs_to_planetfm_preproduction_636_Kerberos_TCP": {
+  "dom1_dcs_to_planetfm_preproduction_636_LDAPS_TCP": {
     "action": "PASS",
     "source_ip": "${hmpps-preproduction-general-private-subnets}",
-    "destination_ip": "${mojo-end-user-devices}",
+    "destination_ip": "${dom1-dcs}",
     "destination_port": "636",
     "protocol": "TCP"
   },
   "dom1_dcs_to_planetfm_preproduction_3268_LDAP_glocal_catalogue_TCP": {
     "action": "PASS",
     "source_ip": "${hmpps-preproduction-general-private-subnets}",
-    "destination_ip": "${mojo-end-user-devices}",
+    "destination_ip": "${dom1-dcs}",
     "destination_port": "3268",
     "protocol": "TCP"
   },
   "dom1_dcs_to_planetfm_preproduction_3269_LDAPS_TCP": {
     "action": "PASS",
     "source_ip": "${hmpps-preproduction-general-private-subnets}",
-    "destination_ip": "${mojo-end-user-devices}",
+    "destination_ip": "${dom1-dcs}",
     "destination_port": "3269",
     "protocol": "TCP"
   },
-  "dom1_dcs_to_planetfm_preproduction_9389_LDAPS_TCP": {
+  "dom1_dcs_to_planetfm_preproduction_9389_ADWS_TCP": {
     "action": "PASS",
     "source_ip": "${hmpps-preproduction-general-private-subnets}",
-    "destination_ip": "${mojo-end-user-devices}",
-    "destination_port": "3269",
+    "destination_ip": "${dom1-dcs}",
+    "destination_port": "9389",
     "protocol": "TCP"
   },
   "dom1_dcs_to_planetfm_preproduction_49152_RPC_TCP": {
     "action": "PASS",
     "source_ip": "${hmpps-preproduction-general-private-subnets}",
-    "destination_ip": "${mojo-end-user-devices}",
-    "destination_port": "49152",
+    "destination_ip": "${dom1-dcs}",
+    "destination_port": "49152-65535",
     "protocol": "TCP"
   }
 }

--- a/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
@@ -457,28 +457,28 @@
   "dom1_dcs_to_planetfm_preproduction_135_MS_RPC_TCP": {
     "action": "PASS",
     "source_ip": "${hmpps-preproduction-general-private-subnets}",
-    "destination_ip": "${outbound-to-all}",
+    "destination_ip": "${mojo-end-user-devices}",
     "destination_port": "135",
     "protocol": "TCP"
   },
   "dom1_dcs_to_planetfm_preproduction_137_NetBios_TCP": {
     "action": "PASS",
     "source_ip": "${hmpps-preproduction-general-private-subnets}",
-    "destination_ip": "${outbound-to-all}",
+    "destination_ip": "${mojo-end-user-devices}",
     "destination_port": "137",
     "protocol": "TCP"
   },
   "dom1_dcs_to_planetfm_preproduction_389_LDAP_TCP": {
     "action": "PASS",
     "source_ip": "${hmpps-preproduction-general-private-subnets}",
-    "destination_ip": "${outbound-to-all}",
+    "destination_ip": "${mojo-end-user-devices}",
     "destination_port": "389",
     "protocol": "TCP"
   },
   "dom1_dcs_to_planetfm_preproduction_445_SMB_TCP": {
     "action": "PASS",
     "source_ip": "${hmpps-preproduction-general-private-subnets}",
-    "destination_ip": "${outbound-to-all}",
+    "destination_ip": "${mojo-end-user-devices}",
     "destination_port": "445",
     "protocol": "TCP"
   }

--- a/terraform/environments/core-network-services/firewall-rules/production_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/production_rules.json
@@ -520,120 +520,120 @@
   "dom1_dcs_to_planetfm_production_53_DNS_TCP": {
     "action": "PASS",
     "source_ip": "${hmpps-production-general-private-subnets}",
-    "destination_ip": "${mojo-end-user-devices}",
+    "destination_ip": "${dom1-dcs}",
     "destination_port": "53",
     "protocol": "TCP"
   },
   "dom1_dcs_to_planetfm_production_53_DNS_UDP": {
     "action": "PASS",
     "source_ip": "${hmpps-production-general-private-subnets}",
-    "destination_ip": "${mojo-end-user-devices}",
+    "destination_ip": "${dom1-dcs}",
     "destination_port": "53",
     "protocol": "UDP"
   },
   "dom1_dcs_to_planetfm_production_88_Kerberos_TCP": {
     "action": "PASS",
     "source_ip": "${hmpps-production-general-private-subnets}",
-    "destination_ip": "${mojo-end-user-devices}",
+    "destination_ip": "${dom1-dcs}",
     "destination_port": "88",
     "protocol": "TCP"
   },
   "dom1_dcs_to_planetfm_production_88_Kerberos_UDP": {
     "action": "PASS",
     "source_ip": "${hmpps-production-general-private-subnets}",
-    "destination_ip": "${mojo-end-user-devices}",
+    "destination_ip": "${dom1-dcs}",
     "destination_port": "88",
     "protocol": "UDP"
   },
   "dom1_dcs_to_planetfm_production_123_NTP_UDP": {
     "action": "PASS",
     "source_ip": "${hmpps-production-general-private-subnets}",
-    "destination_ip": "${mojo-end-user-devices}",
+    "destination_ip": "${dom1-dcs}",
     "destination_port": "123",
     "protocol": "UDP"
   },
   "dom1_dcs_to_planetfm_production_135_MS_RPC_TCP": {
     "action": "PASS",
     "source_ip": "${hmpps-production-general-private-subnets}",
-    "destination_ip": "${mojo-end-user-devices}",
+    "destination_ip": "${dom1-dcs}",
     "destination_port": "135",
     "protocol": "TCP"
   },
   "dom1_dcs_to_planetfm_production_139_NetBios_TCP": {
     "action": "PASS",
     "source_ip": "${hmpps-production-general-private-subnets}",
-    "destination_ip": "${mojo-end-user-devices}",
+    "destination_ip": "${dom1-dcs}",
     "destination_port": "139",
     "protocol": "TCP"
   },
   "dom1_dcs_to_planetfm_production_389_LDAP_TCP": {
     "action": "PASS",
     "source_ip": "${hmpps-production-general-private-subnets}",
-    "destination_ip": "${mojo-end-user-devices}",
+    "destination_ip": "${dom1-dcs}",
     "destination_port": "389",
     "protocol": "TCP"
   },
   "dom1_dcs_to_planetfm_production_389_LDAP_UDP": {
     "action": "PASS",
     "source_ip": "${hmpps-production-general-private-subnets}",
-    "destination_ip": "${mojo-end-user-devices}",
+    "destination_ip": "${dom1-dcs}",
     "destination_port": "389",
     "protocol": "UDP"
   },
   "dom1_dcs_to_planetfm_production_445_SMB_TCP": {
     "action": "PASS",
     "source_ip": "${hmpps-production-general-private-subnets}",
-    "destination_ip": "${mojo-end-user-devices}",
+    "destination_ip": "${dom1-dcs}",
     "destination_port": "445",
     "protocol": "TCP"
   },
   "dom1_dcs_to_planetfm_production_464_Kerberos_TCP": {
     "action": "PASS",
     "source_ip": "${hmpps-production-general-private-subnets}",
-    "destination_ip": "${mojo-end-user-devices}",
+    "destination_ip": "${dom1-dcs}",
     "destination_port": "464",
     "protocol": "TCP"
   },
   "dom1_dcs_to_planetfm_production_464_Kerberos_UDP": {
     "action": "PASS",
     "source_ip": "${hmpps-production-general-private-subnets}",
-    "destination_ip": "${mojo-end-user-devices}",
+    "destination_ip": "${dom1-dcs}",
     "destination_port": "464",
     "protocol": "UDP"
   },
-  "dom1_dcs_to_planetfm_production_636_Kerberos_TCP": {
+  "dom1_dcs_to_planetfm_production_636_LDAPS_TCP": {
     "action": "PASS",
     "source_ip": "${hmpps-production-general-private-subnets}",
-    "destination_ip": "${mojo-end-user-devices}",
+    "destination_ip": "${dom1-dcs}",
     "destination_port": "636",
     "protocol": "TCP"
   },
   "dom1_dcs_to_planetfm_production_3268_LDAP_glocal_catalogue_TCP": {
     "action": "PASS",
     "source_ip": "${hmpps-production-general-private-subnets}",
-    "destination_ip": "${mojo-end-user-devices}",
+    "destination_ip": "${dom1-dcs}",
     "destination_port": "3268",
     "protocol": "TCP"
   },
   "dom1_dcs_to_planetfm_production_3269_LDAPS_TCP": {
     "action": "PASS",
     "source_ip": "${hmpps-production-general-private-subnets}",
-    "destination_ip": "${mojo-end-user-devices}",
+    "destination_ip": "${dom1-dcs}",
     "destination_port": "3269",
     "protocol": "TCP"
   },
-  "dom1_dcs_to_planetfm_production_9389_LDAPS_TCP": {
+  "dom1_dcs_to_planetfm_production_9389_ADWS_TCP": {
     "action": "PASS",
     "source_ip": "${hmpps-production-general-private-subnets}",
-    "destination_ip": "${mojo-end-user-devices}",
-    "destination_port": "3269",
+    "destination_ip": "${dom1-dcs}",
+    "destination_port": "9389",
     "protocol": "TCP"
   },
   "dom1_dcs_to_planetfm_production_49152_RPC_TCP": {
     "action": "PASS",
     "source_ip": "${hmpps-production-general-private-subnets}",
-    "destination_ip": "${mojo-end-user-devices}",
-    "destination_port": "49152",
+    "destination_ip": "${dom1-dcs}",
+    "destination_port": "49152-65535",
     "protocol": "TCP"
   }
 }

--- a/terraform/environments/core-network-services/firewall-rules/production_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/production_rules.json
@@ -520,28 +520,28 @@
   "dom1_dcs_to_planetfm_production_135_MS_RPC_TCP": {
     "action": "PASS",
     "source_ip": "${hmpps-production-general-private-subnets}",
-    "destination_ip": "${outbound-to-all}",
+    "destination_ip": "${mojo-end-user-devices}",
     "destination_port": "135",
     "protocol": "TCP"
   },
   "dom1_dcs_to_planetfm_production_137_NetBios_TCP": {
     "action": "PASS",
     "source_ip": "${hmpps-production-general-private-subnets}",
-    "destination_ip": "${outbound-to-all}",
+    "destination_ip": "${mojo-end-user-devices}",
     "destination_port": "137",
     "protocol": "TCP"
   },
   "dom1_dcs_to_planetfm_production_389_LDAP_TCP": {
     "action": "PASS",
     "source_ip": "${hmpps-production-general-private-subnets}",
-    "destination_ip": "${outbound-to-all}",
+    "destination_ip": "${mojo-end-user-devices}",
     "destination_port": "389",
     "protocol": "TCP"
   },
   "dom1_dcs_to_planetfm_production_445_SMB_TCP": {
     "action": "PASS",
     "source_ip": "${hmpps-production-general-private-subnets}",
-    "destination_ip": "${outbound-to-all}",
+    "destination_ip": "${mojo-end-user-devices}",
     "destination_port": "445",
     "protocol": "TCP"
   }

--- a/terraform/environments/core-network-services/firewall-rules/production_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/production_rules.json
@@ -628,12 +628,5 @@
     "destination_ip": "${dom1-dcs}",
     "destination_port": "9389",
     "protocol": "TCP"
-  },
-  "dom1_dcs_to_planetfm_production_49152_RPC_TCP": {
-    "action": "PASS",
-    "source_ip": "${hmpps-production-general-private-subnets}",
-    "destination_ip": "${dom1-dcs}",
-    "destination_port": "49152-65535",
-    "protocol": "TCP"
   }
 }

--- a/terraform/environments/core-network-services/firewall-rules/production_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/production_rules.json
@@ -517,11 +517,32 @@
     "destination_port": "7073",
     "protocol": "TCP"
   },
-  "dom1_dcs_to_planetfm_production_9389_tcp": {
+  "dom1_dcs_to_planetfm_production_135_MS_RPC_TCP": {
     "action": "PASS",
     "source_ip": "${hmpps-production-general-private-subnets}",
-    "destination_ip": "${dom1-domain-controllers}",
-    "destination_port": "9389",
+    "destination_ip": "${outbound-to-all}",
+    "destination_port": "135",
+    "protocol": "TCP"
+  },
+  "dom1_dcs_to_planetfm_production_137_NetBios_TCP": {
+    "action": "PASS",
+    "source_ip": "${hmpps-production-general-private-subnets}",
+    "destination_ip": "${outbound-to-all}",
+    "destination_port": "137",
+    "protocol": "TCP"
+  },
+  "dom1_dcs_to_planetfm_production_389_LDAP_TCP": {
+    "action": "PASS",
+    "source_ip": "${hmpps-production-general-private-subnets}",
+    "destination_ip": "${outbound-to-all}",
+    "destination_port": "389",
+    "protocol": "TCP"
+  },
+  "dom1_dcs_to_planetfm_production_445_SMB_TCP": {
+    "action": "PASS",
+    "source_ip": "${hmpps-production-general-private-subnets}",
+    "destination_ip": "${outbound-to-all}",
+    "destination_port": "445",
     "protocol": "TCP"
   }
 }

--- a/terraform/environments/core-network-services/firewall-rules/production_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/production_rules.json
@@ -517,6 +517,41 @@
     "destination_port": "7073",
     "protocol": "TCP"
   },
+  "dom1_dcs_to_planetfm_production_53_DNS_TCP": {
+    "action": "PASS",
+    "source_ip": "${hmpps-production-general-private-subnets}",
+    "destination_ip": "${mojo-end-user-devices}",
+    "destination_port": "53",
+    "protocol": "TCP"
+  },
+  "dom1_dcs_to_planetfm_production_53_DNS_UDP": {
+    "action": "PASS",
+    "source_ip": "${hmpps-production-general-private-subnets}",
+    "destination_ip": "${mojo-end-user-devices}",
+    "destination_port": "53",
+    "protocol": "UDP"
+  },
+  "dom1_dcs_to_planetfm_production_88_Kerberos_TCP": {
+    "action": "PASS",
+    "source_ip": "${hmpps-production-general-private-subnets}",
+    "destination_ip": "${mojo-end-user-devices}",
+    "destination_port": "88",
+    "protocol": "TCP"
+  },
+  "dom1_dcs_to_planetfm_production_88_Kerberos_UDP": {
+    "action": "PASS",
+    "source_ip": "${hmpps-production-general-private-subnets}",
+    "destination_ip": "${mojo-end-user-devices}",
+    "destination_port": "88",
+    "protocol": "UDP"
+  },
+  "dom1_dcs_to_planetfm_production_123_NTP_UDP": {
+    "action": "PASS",
+    "source_ip": "${hmpps-production-general-private-subnets}",
+    "destination_ip": "${mojo-end-user-devices}",
+    "destination_port": "123",
+    "protocol": "UDP"
+  },
   "dom1_dcs_to_planetfm_production_135_MS_RPC_TCP": {
     "action": "PASS",
     "source_ip": "${hmpps-production-general-private-subnets}",
@@ -524,11 +559,11 @@
     "destination_port": "135",
     "protocol": "TCP"
   },
-  "dom1_dcs_to_planetfm_production_137_NetBios_TCP": {
+  "dom1_dcs_to_planetfm_production_139_NetBios_TCP": {
     "action": "PASS",
     "source_ip": "${hmpps-production-general-private-subnets}",
     "destination_ip": "${mojo-end-user-devices}",
-    "destination_port": "137",
+    "destination_port": "139",
     "protocol": "TCP"
   },
   "dom1_dcs_to_planetfm_production_389_LDAP_TCP": {
@@ -538,11 +573,67 @@
     "destination_port": "389",
     "protocol": "TCP"
   },
+  "dom1_dcs_to_planetfm_production_389_LDAP_UDP": {
+    "action": "PASS",
+    "source_ip": "${hmpps-production-general-private-subnets}",
+    "destination_ip": "${mojo-end-user-devices}",
+    "destination_port": "389",
+    "protocol": "UDP"
+  },
   "dom1_dcs_to_planetfm_production_445_SMB_TCP": {
     "action": "PASS",
     "source_ip": "${hmpps-production-general-private-subnets}",
     "destination_ip": "${mojo-end-user-devices}",
     "destination_port": "445",
+    "protocol": "TCP"
+  },
+  "dom1_dcs_to_planetfm_production_464_Kerberos_TCP": {
+    "action": "PASS",
+    "source_ip": "${hmpps-production-general-private-subnets}",
+    "destination_ip": "${mojo-end-user-devices}",
+    "destination_port": "464",
+    "protocol": "TCP"
+  },
+  "dom1_dcs_to_planetfm_production_464_Kerberos_UDP": {
+    "action": "PASS",
+    "source_ip": "${hmpps-production-general-private-subnets}",
+    "destination_ip": "${mojo-end-user-devices}",
+    "destination_port": "464",
+    "protocol": "UDP"
+  },
+  "dom1_dcs_to_planetfm_production_636_Kerberos_TCP": {
+    "action": "PASS",
+    "source_ip": "${hmpps-production-general-private-subnets}",
+    "destination_ip": "${mojo-end-user-devices}",
+    "destination_port": "636",
+    "protocol": "TCP"
+  },
+  "dom1_dcs_to_planetfm_production_3268_LDAP_glocal_catalogue_TCP": {
+    "action": "PASS",
+    "source_ip": "${hmpps-production-general-private-subnets}",
+    "destination_ip": "${mojo-end-user-devices}",
+    "destination_port": "3268",
+    "protocol": "TCP"
+  },
+  "dom1_dcs_to_planetfm_production_3269_LDAPS_TCP": {
+    "action": "PASS",
+    "source_ip": "${hmpps-production-general-private-subnets}",
+    "destination_ip": "${mojo-end-user-devices}",
+    "destination_port": "3269",
+    "protocol": "TCP"
+  },
+  "dom1_dcs_to_planetfm_production_9389_LDAPS_TCP": {
+    "action": "PASS",
+    "source_ip": "${hmpps-production-general-private-subnets}",
+    "destination_ip": "${mojo-end-user-devices}",
+    "destination_port": "3269",
+    "protocol": "TCP"
+  },
+  "dom1_dcs_to_planetfm_production_49152_RPC_TCP": {
+    "action": "PASS",
+    "source_ip": "${hmpps-production-general-private-subnets}",
+    "destination_ip": "${mojo-end-user-devices}",
+    "destination_port": "49152",
     "protocol": "TCP"
   }
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

Opening AD ports to dom 1 domain cotrollers

## How does this PR fix the problem?

Currently blocked traffic to DOM 1 domain controllers preventing fully functioning Planet FM servers

## How has this been tested?

Firewall logs and comparison with Azure networking

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

Will allow traffic from Active Directory ports - should not impact any running services

## Checklist (check `x` in `[ ]` of list items)

- [x ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
