### PR TITLE
Added fleet-manager permission set

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/main.tf
+++ b/terraform/environments/bootstrap/single-sign-on/main.tf
@@ -354,3 +354,26 @@ resource "aws_ssoadmin_account_assignment" "powerbi_user" {
   target_id   = local.environment_management.account_ids[terraform.workspace]
   target_type = "AWS_ACCOUNT"
 }
+
+resource "aws_ssoadmin_account_assignment" "fleet_manager" {
+
+  for_each = {
+
+    for sso_assignment in local.sso_data[local.env_name][*] :
+
+    "${sso_assignment.github_slug}-${sso_assignment.level}" => sso_assignment
+
+    if(sso_assignment.level == "fleet-manager")
+  }
+
+  provider = aws.sso-management
+
+  instance_arn       = local.sso_instance_arn
+  permission_set_arn = data.terraform_remote_state.mp-sso-permissions-sets.outputs.fleet_manager
+
+  principal_id   = data.aws_identitystore_group.member[each.value.github_slug].group_id
+  principal_type = "GROUP"
+
+  target_id   = local.environment_management.account_ids[terraform.workspace]
+  target_type = "AWS_ACCOUNT"
+}


### PR DESCRIPTION
## A reference to the issue / Description of it

This PR addresses the need to provide SSO permission sets for the fleet manager role. Previously, fleet managers lacked the necessary permissions to access certain environments. By adding SSO permission sets, we aim to grant them appropriate access

## How does this PR fix the problem?

This PR resolves the issue by adding SSO permission sets specifically tailored for the fleet manager role. With these permissions in place, fleet managers can now access the required environments without encountering access restrictions.