### PR TITLE
bump terraform baseline module to 6.4.0

### DIFF
--- a/terraform/environments/bootstrap/secure-baselines/main.tf
+++ b/terraform/environments/bootstrap/secure-baselines/main.tf
@@ -5,7 +5,7 @@ data "aws_kms_key" "cloudtrail_key" {
 }
 
 module "baselines" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=8997b02fdc5a1f151a6e285c33fd17d5a946389e" # v6.3.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=e8a385de54111b6030f768fb3421f03d7fd53ab6" # v6.4.0
 
   providers = {
     # Default and replication regions

--- a/terraform/modernisation-platform-account/baselines.tf
+++ b/terraform/modernisation-platform-account/baselines.tf
@@ -16,7 +16,7 @@ locals {
 
 # Secure baselines (GuardDuty, Config, SecurityHub, etc)
 module "baselines-modernisation-platform" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=8997b02fdc5a1f151a6e285c33fd17d5a946389e" # v6.3.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=e8a385de54111b6030f768fb3421f03d7fd53ab6" # v6.4.0
   providers = {
     # Default and replication regions
     aws                    = aws.modernisation-platform-eu-west-2


### PR DESCRIPTION
bump terraform baseline module to 6.4.0 to fix S3 backup failures. 