### PR TITLE
🛂 Update CODEOWNERS template

### DIFF
--- a/scripts/provision-member-directories.sh
+++ b/scripts/provision-member-directories.sh
@@ -149,6 +149,7 @@ EOL
 **/networking.auto.tfvars.json @ministryofjustice/modernisation-platform
 **/platform_*.tf @ministryofjustice/modernisation-platform
 /terraform/modules
+.devcontainer @ministryofjustice/devcontainer-community
 EOL
 
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

This pull request is part of https://github.com/ministryofjustice/modernisation-platform-environments/pull/4937

It adds @ministryofjustice/devcontainer-community as a code owner for `.devcontainer`

## How does this PR fix the problem?

N/A

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

It hasn't

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

It shouldn't impact tenants

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
