### PR TITLE
removed invalid `path` declaration

### DIFF
--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -34,6 +34,3 @@ misconfigurations:
 secrets:
 
 licenses:
-
-# Ignore all directories named "test" and their contents
-**/test/**


### PR DESCRIPTION
Fixes https://github.com/ministryofjustice/modernisation-platform/actions/runs/7882878946

Paths are supported in trivyignore, but are done per vulnerability at present.