### PR TITLE
Update terraform-static-analysis.yml

### DIFF
--- a/.github/workflows/terraform-static-analysis.yml
+++ b/.github/workflows/terraform-static-analysis.yml
@@ -25,7 +25,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Run Analysis
-      uses: ministryofjustice/github-actions/terraform-static-analysis@d7b58ea1d0fee51b12a8138907cd4e7b5e173045 # v15.4.0
+      uses: ministryofjustice/github-actions/terraform-static-analysis@e7d9a2ab238d4757c2e8902dddf79266e08e59fb # v15.4.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
@@ -52,7 +52,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Run Analysis
-      uses: ministryofjustice/github-actions/terraform-static-analysis@d7b58ea1d0fee51b12a8138907cd4e7b5e173045 # v15.4.0
+      uses: ministryofjustice/github-actions/terraform-static-analysis@e7d9a2ab238d4757c2e8902dddf79266e08e59fb # v15.4.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
@@ -82,7 +82,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Run Analysis
-      uses: ministryofjustice/github-actions/terraform-static-analysis@d7b58ea1d0fee51b12a8138907cd4e7b5e173045 # v15.4.0
+      uses: ministryofjustice/github-actions/terraform-static-analysis@e7d9a2ab238d4757c2e8902dddf79266e08e59fb # v15.4.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:


### PR DESCRIPTION
Updated to github actions version hash 15.4

## A reference to the issue / Description of it

dependabot synced to the wrong hash

## How does this PR fix the problem?

manually updated the has to the one that coresponds to version 15.4.0

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
