### PR TITLE
Removed fleet-manager sso account assignment

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/main.tf
+++ b/terraform/environments/bootstrap/single-sign-on/main.tf
@@ -354,26 +354,3 @@ resource "aws_ssoadmin_account_assignment" "powerbi_user" {
   target_id   = local.environment_management.account_ids[terraform.workspace]
   target_type = "AWS_ACCOUNT"
 }
-
-resource "aws_ssoadmin_account_assignment" "fleet_manager" {
-
-  for_each = {
-
-    for sso_assignment in local.sso_data[local.env_name][*] :
-
-    "${sso_assignment.github_slug}-${sso_assignment.level}" => sso_assignment
-
-    if(sso_assignment.level == "fleet-manager")
-  }
-
-  provider = aws.sso-management
-
-  instance_arn       = local.sso_instance_arn
-  permission_set_arn = data.terraform_remote_state.mp-sso-permissions-sets.outputs.fleet_manager
-
-  principal_id   = data.aws_identitystore_group.member[each.value.github_slug].group_id
-  principal_type = "GROUP"
-
-  target_id   = local.environment_management.account_ids[terraform.workspace]
-  target_type = "AWS_ACCOUNT"
-}


### PR DESCRIPTION
## A reference to the issue / Description of it

This PR aims to address the testing of the removal of entities from the fleet_manager_policy.

## How does this PR fix the problem?

To test the removal of entities from the fleet_manager_policy, this PR proposes removing the accounts assigned to the fleet manager SSO permission set. This action will allow for testing whether the removal of entities from the policy is functioning as expected.