### PR TITLE
Setting data engineering policy as a base for powerbi role.

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -544,7 +544,7 @@ data "aws_iam_policy_document" "powerbi_user_additional" {
   #checkov:skip=CKV_AWS_109
   #checkov:skip=CKV_AWS_110
   #checkov:skip=CKV_AWS_356: Needs to access multiple resources
-  override_policy_documents = [data.aws_iam_policy_document.common_statements.json]
+  override_policy_documents = [data.aws_iam_policy_document.data_engineering_additional.json]
   statement {
     actions = [
       "s3:ListBucket",


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/data-platform/issues/1916 in Analytical Platform backlog

## How does this PR fix the problem?

PowerBI user needs athena and glue access so amending the policy to include them without resorting to  blanket permissions

## How has this been tested?
We will be testing this out with users. Aside from that, a self-review



## Deployment Plan / Instructions

Should not do. This is a standalone policy only applicable to AP accounts


## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
