### PR TITLE
add firewall rule for RPC to dom1 domain controllers

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
@@ -565,5 +565,12 @@
     "destination_ip": "${dom1-dcs}",
     "destination_port": "9389",
     "protocol": "TCP"
+  },
+  "dom1_dcs_to_planetfm_preproduction_49152_65535_RPC_TCP": {
+    "action": "PASS",
+    "source_ip": "${hmpps-preproduction-general-private-subnets}",
+    "destination_ip": "${dom1-dcs}",
+    "destination_port": "49152:65535",
+    "protocol": "TCP"
   }
 }

--- a/terraform/environments/core-network-services/firewall-rules/production_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/production_rules.json
@@ -628,5 +628,12 @@
     "destination_ip": "${dom1-dcs}",
     "destination_port": "9389",
     "protocol": "TCP"
+  },
+  "dom1_dcs_to_planetfm_production_49152_65535_RPC_TCP": {
+    "action": "PASS",
+    "source_ip": "${hmpps-production-general-private-subnets}",
+    "destination_ip": "${dom1-dcs}",
+    "destination_port": "49152:65535",
+    "protocol": "TCP"
   }
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

Adjust the firewall rules to allow RPC connections to Dom1 domain controller - required for the PlanetFM application and Dom1 device connectivity

## How does this PR fix the problem?

Allows outbound traffic in port range 49152:65535

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Running Test-NetConnection from the (windows) source to the target works with other opened firewall rules ports. Trying anything in this range fails.  

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

Nope, other than allowing them to work

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
