### PR TITLE
Updated powerbi_user_additional policy

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/policies.tf
+++ b/terraform/environments/bootstrap/delegate-access/policies.tf
@@ -820,7 +820,6 @@ data "aws_iam_policy_document" "powerbi_user_additional" {
   override_policy_documents = [data.aws_iam_policy_document.common_statements.json]
   statement {
     effect = "Allow"
-
     resources = [
       "arn:aws:s3:::alpha-everyone/*",
       "arn:aws:s3:::alpha-postcodes/database/postcodes/*",
@@ -829,17 +828,21 @@ data "aws_iam_policy_document" "powerbi_user_additional" {
       "arn:aws:s3:::mojap-derived-tables/dev/models/*",
       "arn:aws:s3:::mojap-derived-tables/seeds/*",
     ]
-
     actions = [
       "s3:GetObject",
       "s3:GetObjectAcl",
       "s3:GetObjectVersion",
     ]
+    sid = "s3readonly"
   }
 
   statement {
+    actions = [
+      "s3:ListBucket",
+      "s3:ListAllMyBuckets",
+      "s3:GetBucketLocation"
+    ]
     effect = "Allow"
-
     resources = [
       "arn:aws:s3:::alpha-everyone",
       "arn:aws:s3:::alpha-postcodes",
@@ -847,56 +850,44 @@ data "aws_iam_policy_document" "powerbi_user_additional" {
       "arn:aws:s3:::mojap-derived-tables",
       "arn:aws:s3:::alpha-athena-query-dump",
       "arn:aws:s3:::mojap-athena-query-dump",
+      "arn:aws:s3:::alpha-everyone/*",
+      "arn:aws:s3:::alpha-postcodes/database/postcodes/*",
+      "arn:aws:s3:::alpha-postcodes/database/names/*",
+      "arn:aws:s3:::mojap-derived-tables/prod/models/*",
+      "arn:aws:s3:::mojap-derived-tables/dev/models/*",
+      "arn:aws:s3:::mojap-derived-tables/seeds/*",
     ]
-
-    actions = [
-      "s3:ListBucket",
-    ]
-  }
-
-  statement {
-    effect    = "Allow"
-    resources = ["*"]
-
-    actions = [
-      "s3:ListAllMyBuckets",
-      "s3:ListAccessPoints",
-      "s3:GetAccountPublicAccessBlock",
-      "s3:GetBucketLocation",
-      "s3:ListAllMyBuckets",
-    ]
+    sid = "List"
   }
 
   statement {
     effect    = "Allow"
     resources = ["arn:aws:s3:::aws-athena-query-results-*"]
-
     actions = [
       "s3:GetObject",
       "s3:PutObject",
     ]
+    sid = "ReadWriteQueryResults"
   }
 
   statement {
     effect = "Allow"
-
     resources = [
       "arn:aws:s3:::alpha-athena-query-dump/$${aws:userid}/*",
       "arn:aws:s3:::mojap-athena-query-dump/$${aws:userid}/*",
     ]
-
     actions = [
       "s3:GetObject",
       "s3:PutObject",
       "s3:DeleteObject",
     ]
+    sid = "ReadWriteQueryDump"
   }
 
   statement {
     sid       = "AllowReadAthenaGlue"
     effect    = "Allow"
     resources = ["*"]
-
     actions = [
       "athena:BatchGetNamedQuery",
       "athena:BatchGetQueryExecution",
@@ -932,35 +923,9 @@ data "aws_iam_policy_document" "powerbi_user_additional" {
   }
 
   statement {
-    sid       = "AllowWriteAthenaGlue"
-    effect    = "Allow"
-    resources = ["*"]
-
-    actions = [
-      "athena:DeleteNamedQuery",
-      "glue:BatchCreatePartition",
-      "glue:BatchDeletePartition",
-      "glue:BatchDeleteTable",
-      "glue:CreateDatabase",
-      "glue:CreatePartition",
-      "glue:CreateTable",
-      "glue:DeleteDatabase",
-      "glue:DeletePartition",
-      "glue:DeleteTable",
-      "glue:UpdateDatabase",
-      "glue:UpdatePartition",
-      "glue:UpdateTable",
-      "glue:CreateUserDefinedFunction",
-      "glue:DeleteUserDefinedFunction",
-      "glue:UpdateUserDefinedFunction",
-    ]
-  }
-
-  statement {
     sid       = "AllowGetPutObject"
     effect    = "Allow"
     resources = ["arn:aws:s3:::aws-athena-query-results-593291632749-eu-west-1/*"]
-
     actions = [
       "s3:GetObject",
       "s3:PutObject",

--- a/terraform/environments/bootstrap/delegate-access/policies.tf
+++ b/terraform/environments/bootstrap/delegate-access/policies.tf
@@ -819,110 +819,154 @@ data "aws_iam_policy_document" "powerbi_user_additional" {
   #checkov:skip=CKV_AWS_356: Needs to access multiple resources
   override_policy_documents = [data.aws_iam_policy_document.common_statements.json]
   statement {
-    actions = [
-      "s3:ListBucket",
-      "s3:ListAllMyBuckets",
-      "s3:GetBucketLocation"
-    ]
     effect = "Allow"
+
     resources = [
-      "arn:aws:s3:::mojap-derived-tables/dev/run_artefacts/*",
-      "arn:aws:s3:::mojap-derived-tables/dev/models/domain_name=risk/*",
-      "arn:aws:s3:::mojap-derived-tables/seeds/*",
       "arn:aws:s3:::alpha-everyone/*",
-      "arn:aws:s3:::dbt-query-dump/*",
-      "arn:aws:s3:::mojap-manage-offences/ho-offence-codes/dev/*",
-      "arn:aws:s3:::mojap-derived-tables/dev/models/domain_name=general/*",
-      "arn:aws:s3:::mojap-derived-tables/*__dbt_tmp/*",
       "arn:aws:s3:::alpha-postcodes/database/postcodes/*",
-      "arn:aws:s3:::alpha-lookup-cjsq/lookup_offence_raw/*",
-      "arn:aws:s3:::mojap-derived-tables/prod/models/domain_name=general/*",
-      "arn:aws:s3:::moj-reg-dev-curated/hmpps-assess-risks-and-needs-dev/data/*",
-      "arn:aws:s3:::alpha-data-linking/v4/products/internal/*",
-      "arn:aws:s3:::moj-reg-dev-curated/data-eng-uploader-dev/data/*",
-      "arn:aws:s3:::alpha-cjsm-logs-data/api_test/production/processed/pass/*",
       "arn:aws:s3:::alpha-postcodes/database/names/*",
-      "arn:aws:s3:::mojap-derived-tables/prod/run_artefacts/*",
-      "arn:aws:s3:::moj-reg-dev-curated/hmpps-interventions-dev/data/*",
-      "arn:aws:s3:::alpha-lookup-cjsq/lookup_offence/*",
-      "arn:aws:s3:::alpha-lookup-cjsq/lookup_court_disposals/*",
-      "arn:aws:s3:::alpha-data-linking-anonymised/v4/products/internal/*",
-      "arn:aws:s3:::mojap-derived-tables/prod/models/domain_name=risk/*",
-      "arn:aws:s3:::alpha-psr-discovery-work/*",
-      "arn:aws:s3:::alpha-interventions-discovery-ds/*",
-      "arn:aws:s3:::alpha-segmentation-adhoc/*",
-      "arn:aws:s3:::alpha-app-commuter-sandbox/*",
-      "arn:aws:s3:::alpha-app-interventions/*",
-      "arn:aws:s3:::alpha-segmentation/*",
-      "arn:aws:s3:::alpha-segmentation-2020alpha-segmentation-2020/restricted_share//*",
-      "arn:aws:s3:::alpha-segmentation-2020restricted_share//*",
-      "arn:aws:s3:::alpha-segmentation-2020restricted_share/*/*",
-      "arn:aws:s3:::alpha-segmentation-2020restricted_share/*",
-      "arn:aws:s3:::alpha-segmentation-2020/*",
-      "arn:aws:s3:::alpha-nextgenaccreditedevaluation/*",
-      "arn:aws:s3:::alpha-app-occupeye-automation/*",
-      "arn:aws:s3:::alpha-app-matrixbooking/*",
-      "arn:aws:s3:::alpha-dag-matrix/*",
-      "arn:aws:s3:::alpha-dag-occupeye/*",
-      "arn:aws:s3:::alpha-data-science-risk/*",
-      "arn:aws:s3:::alpha--people-survey/*",
-      "arn:aws:s3:::alpha-accredited-programmes-review-2021/*",
-      "arn:aws:s3:::alpha-probation-data-room/*",
-      "arn:aws:s3:::alpha-app-segmentation-tool-probation/*",
-      "arn:aws:s3:::alpha-hr-dataproject/Input Data/Pay Element Lists/*",
-      "arn:aws:s3:::alpha-hr-dataproject/Input Data/Remuneration Data/Remuneration Tool Data/*"
+      "arn:aws:s3:::mojap-derived-tables/prod/models/*",
+      "arn:aws:s3:::mojap-derived-tables/dev/models/*",
+      "arn:aws:s3:::mojap-derived-tables/seeds/*",
     ]
-    sid = "readonly"
-  }
-  statement {
+
     actions = [
-      "s3:ListBucket",
-      "s3:ListAllMyBuckets",
-      "s3:GetBucketLocation"
+      "s3:GetObject",
+      "s3:GetObjectAcl",
+      "s3:GetObjectVersion",
     ]
+  }
+
+  statement {
     effect = "Allow"
+
     resources = [
-      "arn:aws:s3:::alpha-cjsm-logs-data",
-      "arn:aws:s3:::alpha-data-linking",
-      "arn:aws:s3:::alpha-data-linking-anonymised",
       "arn:aws:s3:::alpha-everyone",
-      "arn:aws:s3:::alpha-lookup-cjsq",
       "arn:aws:s3:::alpha-postcodes",
       "arn:aws:s3:::dbt-query-dump",
-      "arn:aws:s3:::moj-reg-dev-curated",
       "arn:aws:s3:::mojap-derived-tables",
-      "arn:aws:s3:::mojap-manage-offences",
-      "arn:aws:s3:::alpha-probation-data-room",
-      "arn:aws:s3:::alpha-psr-discovery-work",
-      "arn:aws:s3:::alpha-interventions-discovery-ds",
-      "arn:aws:s3:::alpha-segmentation-adhoc",
-      "arn:aws:s3:::alpha-app-commuter-sandbox",
-      "arn:aws:s3:::alpha-app-segmentation-tool-probation",
-      "arn:aws:s3:::alpha-app-interventions",
-      "arn:aws:s3:::alpha-segmentation",
-      "arn:aws:s3:::alpha-segmentation-2020",
-      "arn:aws:s3:::alpha-nextgenaccreditedevaluation",
-      "arn:aws:s3:::alpha-app-occupeye-automation",
-      "arn:aws:s3:::alpha-app-matrixbooking",
-      "arn:aws:s3:::alpha-dag-matrix",
-      "arn:aws:s3:::alpha-dag-occupeye",
-      "arn:aws:s3:::alpha-data-science-risk",
-      "arn:aws:s3:::alpha--people-survey",
-      "arn:aws:s3:::alpha-hr-dataproject",
-      "arn:aws:s3:::alpha-accredited-programmes-review-2021",
       "arn:aws:s3:::alpha-athena-query-dump",
-      "arn:aws:s3:::mojap-athena-query-dump"
+      "arn:aws:s3:::mojap-athena-query-dump",
     ]
-    sid = "list"
-  }
-  statement {
-    sid       = "ssm"
-    resources = ["*"]
-    effect    = "Allow"
+
     actions = [
-      "ssm:*"
+      "s3:ListBucket",
     ]
   }
+
+  statement {
+    effect    = "Allow"
+    resources = ["*"]
+
+    actions = [
+      "s3:ListAllMyBuckets",
+      "s3:ListAccessPoints",
+      "s3:GetAccountPublicAccessBlock",
+      "s3:GetBucketLocation",
+      "s3:ListAllMyBuckets",
+    ]
+  }
+
+  statement {
+    effect    = "Allow"
+    resources = ["arn:aws:s3:::aws-athena-query-results-*"]
+
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+
+    resources = [
+      "arn:aws:s3:::alpha-athena-query-dump/$${aws:userid}/*",
+      "arn:aws:s3:::mojap-athena-query-dump/$${aws:userid}/*",
+    ]
+
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:DeleteObject",
+    ]
+  }
+
+  statement {
+    sid       = "AllowReadAthenaGlue"
+    effect    = "Allow"
+    resources = ["*"]
+
+    actions = [
+      "athena:BatchGetNamedQuery",
+      "athena:BatchGetQueryExecution",
+      "athena:GetNamedQuery",
+      "athena:GetQueryExecution",
+      "athena:GetQueryResults",
+      "athena:GetQueryResultsStream",
+      "athena:GetWorkGroup",
+      "athena:ListNamedQueries",
+      "athena:ListWorkGroups",
+      "athena:StartQueryExecution",
+      "athena:StopQueryExecution",
+      "athena:CancelQueryExecution",
+      "athena:GetCatalogs",
+      "athena:GetExecutionEngine",
+      "athena:GetExecutionEngines",
+      "athena:GetNamespace",
+      "athena:GetNamespaces",
+      "athena:GetTable",
+      "athena:GetTables",
+      "athena:RunQuery",
+      "glue:GetDatabase",
+      "glue:GetDatabases",
+      "glue:GetTable",
+      "glue:GetTables",
+      "glue:GetPartition",
+      "glue:GetPartitions",
+      "glue:BatchGetPartition",
+      "glue:GetCatalogImportStatus",
+      "glue:GetUserDefinedFunction",
+      "glue:GetUserDefinedFunctions",
+    ]
+  }
+
+  statement {
+    sid       = "AllowWriteAthenaGlue"
+    effect    = "Allow"
+    resources = ["*"]
+
+    actions = [
+      "athena:DeleteNamedQuery",
+      "glue:BatchCreatePartition",
+      "glue:BatchDeletePartition",
+      "glue:BatchDeleteTable",
+      "glue:CreateDatabase",
+      "glue:CreatePartition",
+      "glue:CreateTable",
+      "glue:DeleteDatabase",
+      "glue:DeletePartition",
+      "glue:DeleteTable",
+      "glue:UpdateDatabase",
+      "glue:UpdatePartition",
+      "glue:UpdateTable",
+      "glue:CreateUserDefinedFunction",
+      "glue:DeleteUserDefinedFunction",
+      "glue:UpdateUserDefinedFunction",
+    ]
+  }
+
+  statement {
+    sid       = "AllowGetPutObject"
+    effect    = "Allow"
+    resources = ["arn:aws:s3:::aws-athena-query-results-593291632749-eu-west-1/*"]
+
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+    ]
+  }
+
 }
 
 resource "aws_iam_policy" "powerbi_user" {

--- a/terraform/environments/bootstrap/delegate-access/policies.tf
+++ b/terraform/environments/bootstrap/delegate-access/policies.tf
@@ -833,7 +833,7 @@ data "aws_iam_policy_document" "powerbi_user_additional" {
       "s3:GetObjectAcl",
       "s3:GetObjectVersion",
     ]
-    sid = "S3Readnly"
+    sid = "S3ReadOnly"
   }
 
   statement {

--- a/terraform/environments/bootstrap/delegate-access/policies.tf
+++ b/terraform/environments/bootstrap/delegate-access/policies.tf
@@ -826,12 +826,12 @@ data "aws_iam_policy_document" "powerbi_user_additional" {
       "arn:aws:s3:::alpha-postcodes/database/names/*",
       "arn:aws:s3:::mojap-derived-tables/prod/models/*",
       "arn:aws:s3:::mojap-derived-tables/dev/models/*",
-      "arn:aws:s3:::mojap-derived-tables/seeds/*",
+      "arn:aws:s3:::mojap-derived-tables/seeds/*"
     ]
     actions = [
       "s3:GetObject",
       "s3:GetObjectAcl",
-      "s3:GetObjectVersion",
+      "s3:GetObjectVersion"
     ]
     sid = "S3ReadOnly"
   }
@@ -840,7 +840,7 @@ data "aws_iam_policy_document" "powerbi_user_additional" {
     actions = [
       "s3:ListBucket",
       "s3:ListAllMyBuckets",
-      "s3:GetBucketLocation",
+      "s3:GetBucketLocation"
     ]
     effect = "Allow"
     resources = [
@@ -855,7 +855,7 @@ data "aws_iam_policy_document" "powerbi_user_additional" {
       "arn:aws:s3:::alpha-postcodes/database/names/*",
       "arn:aws:s3:::mojap-derived-tables/prod/models/*",
       "arn:aws:s3:::mojap-derived-tables/dev/models/*",
-      "arn:aws:s3:::mojap-derived-tables/seeds/*",
+      "arn:aws:s3:::mojap-derived-tables/seeds/*"
     ]
     sid = "List"
   }
@@ -865,7 +865,7 @@ data "aws_iam_policy_document" "powerbi_user_additional" {
     resources = ["arn:aws:s3:::aws-athena-query-results-*"]
     actions = [
       "s3:GetObject",
-      "s3:PutObject",
+      "s3:PutObject"
     ]
     sid = "ReadWriteQueryResults"
   }
@@ -874,12 +874,12 @@ data "aws_iam_policy_document" "powerbi_user_additional" {
     effect = "Allow"
     resources = [
       "arn:aws:s3:::alpha-athena-query-dump/$${aws:userid}/*",
-      "arn:aws:s3:::mojap-athena-query-dump/$${aws:userid}/*",
+      "arn:aws:s3:::mojap-athena-query-dump/$${aws:userid}/*"
     ]
     actions = [
       "s3:GetObject",
       "s3:PutObject",
-      "s3:DeleteObject",
+      "s3:DeleteObject"
     ]
     sid = "ReadWriteQueryDump"
   }
@@ -918,7 +918,7 @@ data "aws_iam_policy_document" "powerbi_user_additional" {
       "glue:BatchGetPartition",
       "glue:GetCatalogImportStatus",
       "glue:GetUserDefinedFunction",
-      "glue:GetUserDefinedFunctions",
+      "glue:GetUserDefinedFunctions"
     ]
   }
 
@@ -928,7 +928,7 @@ data "aws_iam_policy_document" "powerbi_user_additional" {
     resources = ["arn:aws:s3:::aws-athena-query-results-593291632749-eu-west-1/*"]
     actions = [
       "s3:GetObject",
-      "s3:PutObject",
+      "s3:PutObject"
     ]
   }
 

--- a/terraform/environments/bootstrap/delegate-access/policies.tf
+++ b/terraform/environments/bootstrap/delegate-access/policies.tf
@@ -833,12 +833,14 @@ data "aws_iam_policy_document" "powerbi_user_additional" {
       "s3:GetObjectAcl",
       "s3:GetObjectVersion",
     ]
-    sid = "S3ReadOnly"
+    sid = "S3Readnly"
   }
 
   statement {
     actions = [
       "s3:ListBucket",
+      "s3:ListAllMyBuckets",
+      "s3:GetBucketLocation",
     ]
     effect = "Allow"
     resources = [

--- a/terraform/environments/bootstrap/delegate-access/policies.tf
+++ b/terraform/environments/bootstrap/delegate-access/policies.tf
@@ -833,14 +833,12 @@ data "aws_iam_policy_document" "powerbi_user_additional" {
       "s3:GetObjectAcl",
       "s3:GetObjectVersion",
     ]
-    sid = "s3readonly"
+    sid = "S3ReadOnly"
   }
 
   statement {
     actions = [
       "s3:ListBucket",
-      "s3:ListAllMyBuckets",
-      "s3:GetBucketLocation"
     ]
     effect = "Allow"
     resources = [
@@ -929,6 +927,14 @@ data "aws_iam_policy_document" "powerbi_user_additional" {
     actions = [
       "s3:GetObject",
       "s3:PutObject",
+    ]
+  }
+
+  statement {
+    effect    = "Allow"
+    resources = ["*"]
+    actions = [
+      "ssm:*"
     ]
   }
 


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/data-platform/issues/1916 in Analytical Platform backlog

## How does this PR fix the problem?

PowerBI user needs athena and glue access so amending the policy to include them without resorting to blanket permissions

## How has this been tested?

We will be testing this out with users. Aside from that, a self-review

## Deployment Plan / Instructions

Should not do. This is a standalone policy only applicable to AP accounts

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)
