### PR TITLE
Update test_rules.json for delius test ldap traffic

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/test_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/test_rules.json
@@ -300,7 +300,7 @@
     "destination_port": "ANY",
     "protocol": "ICMP"
   },
-  "hmpps_test_to_delius_test_icmp": {
+  "delius_test_icmp_toThmpps_test": {
     "action": "PASS",
     "source_ip": "${hmpps-test}",
     "destination_ip": "${delius-test}",

--- a/terraform/environments/core-network-services/firewall-rules/test_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/test_rules.json
@@ -300,11 +300,18 @@
     "destination_port": "ANY",
     "protocol": "ICMP"
   },
-  "delius_test_icmp_toThmpps_test": {
+  "delius_test_icmp_to_hmpps_test": {
     "action": "PASS",
     "source_ip": "${hmpps-test}",
     "destination_ip": "${delius-test}",
     "destination_port": "ANY",
     "protocol": "ICMP"
+  },
+    "cp_to_mp_hmpps_test_ldap": {
+    "action": "PASS",
+    "source_ip": "${cloud-platform}",
+    "destination_ip": "${hmpps-test}",
+    "destination_port": "389",
+    "protocol": "TCP"
   },
 }

--- a/terraform/environments/core-network-services/firewall-rules/test_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/test_rules.json
@@ -286,13 +286,6 @@
     "destination_port": "1522",
     "protocol": "TCP"
   },
-  "delius_test_to_hmpps_test_ldap": {
-    "action": "PASS",
-    "source_ip": "${delius-test}",
-    "destination_ip": "${hmpps-test}",
-    "destination_port": "389",
-    "protocol": "TCP"
-  },
   "delius_test_to_hmpps_test_icmp": {
     "action": "PASS",
     "source_ip": "${delius-test}",

--- a/terraform/environments/core-network-services/firewall-rules/test_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/test_rules.json
@@ -286,7 +286,7 @@
     "destination_port": "1522",
     "protocol": "TCP"
   },
-    "delius_test_to_hmpps_test_ldap": {
+  "delius_test_to_hmpps_test_ldap": {
     "action": "PASS",
     "source_ip": "${delius-test}",
     "destination_ip": "${hmpps-test}",
@@ -313,5 +313,5 @@
     "destination_ip": "${hmpps-test}",
     "destination_port": "389",
     "protocol": "TCP"
-  },
+  }
 }

--- a/terraform/environments/core-network-services/firewall-rules/test_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/test_rules.json
@@ -285,5 +285,26 @@
     "destination_ip": "${laa-test}",
     "destination_port": "1522",
     "protocol": "TCP"
-  }
+  },
+    "delius_test_to_hmpps_test_ldap": {
+    "action": "PASS",
+    "source_ip": "${delius-test}",
+    "destination_ip": "${hmpps-test}",
+    "destination_port": "389",
+    "protocol": "TCP"
+  },
+  "delius_test_to_hmpps_test_icmp": {
+    "action": "PASS",
+    "source_ip": "${delius-test}",
+    "destination_ip": "${hmpps-test}",
+    "destination_port": "ANY",
+    "protocol": "ICMP"
+  },
+  "hmpps_test_to_delius_test_icmp": {
+    "action": "PASS",
+    "source_ip": "${hmpps-test}",
+    "destination_ip": "${delius-test}",
+    "destination_port": "ANY",
+    "protocol": "ICMP"
+  },
 }


### PR DESCRIPTION
Allow traffic to/from delius-test and hmpps-test vpc