### PR TITLE
Equip PowerBi Firewall FQDN Rule

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/fqdn_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/fqdn_rules.json
@@ -5,7 +5,7 @@
     ".docker.io",
     ".download.windowsupdate.com",
     ".ghcr.io",
-    ".servicebus.windows.net"
+    ".servicebus.windows.net",
     ".ubuntu.com",
     ".update.microsoft.com",
     ".windowsupdate.com",

--- a/terraform/environments/core-network-services/firewall-rules/fqdn_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/fqdn_rules.json
@@ -1,21 +1,22 @@
 {
   "fw_allowed_domains": [
-    "microsoft.com",
-    "tlu.dl.delivery.mp.microsoft.com",
-    "onegetcdn.azureedge.net",
-    ".windowsupdate.microsoft.com",
+    ".amazontrust.com",
+    ".docker.com",
+    ".docker.io",
+    ".download.windowsupdate.com",
+    ".ghcr.io",
+    ".servicebus.windows.net"
+    ".ubuntu.com",
     ".update.microsoft.com",
     ".windowsupdate.com",
-    ".download.windowsupdate.com",
-    "wustat.windows.com",
+    ".windowsupdate.microsoft.com",
+    "microsoft.com",
     "ntservicepack.microsoft.com",
-    "stats.microsoft.com",
+    "onegetcdn.azureedge.net",
     "saas40.kaseya.net",
-    ".ubuntu.com",
-    ".docker.io",
-    ".docker.com",
-    ".ghcr.io",
-    ".amazontrust.com"
+    "stats.microsoft.com",
+    "tlu.dl.delivery.mp.microsoft.com",
+    "wustat.windows.com"
   ],
   "fw_home_net_ips": ["10.26.0.0/16", "10.27.0.0/16"]
 }


### PR DESCRIPTION
As part of the current Equip upgrade work including a new power bi server, this PR adds a fqdn firewall rule for `.servicebus.windows.net` as per requirements detailed here https://learn.microsoft.com/en-us/data-integration/gateway/service-gateway-communication#ports

I have also sorted the list alphabetically 

TLDR: add servicebus.windows.net to fqdn rules and sort alphabetically.