### PR TITLE
Fix for Terraform Static Code Analysis Error. 

### DIFF
--- a/terraform/environments/core-shared-services/ad-fixngo.tf
+++ b/terraform/environments/core-shared-services/ad-fixngo.tf
@@ -5,6 +5,7 @@
 # Managed by DSO team, slack: #ask-digital-studio-ops 
 
 module "ad_fixngo_ip_addresses" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   source = "github.com/ministryofjustice/modernisation-platform-environments//terraform/modules/ip_addresses"
 }
 


### PR DESCRIPTION
Adds skill commit hash error check as the module it is referencing is one of those owned by Modernisation Platform.

Fixes failed run - https://github.com/ministryofjustice/modernisation-platform/actions/runs/7927178027/job/21643126838

## A reference to the issue / Description of it

See above

## How does this PR fix the problem?

See above

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
