### PR TITLE
Add sandbox permissions to LAA OEM development environment

### DIFF
--- a/environments/laa-oem.json
+++ b/environments/laa-oem.json
@@ -6,7 +6,8 @@
       "access": [
         {
           "github_slug": "laa-ccms-migration-team",
-          "level": "developer"
+          "level": "sandbox",
+          "nuke": "exclude"
         }
       ]
     },


### PR DESCRIPTION
As per slack request in the ask channel [here](https://mojdt.slack.com/archives/C01A7QK5VM1/p1708099283581729) this PR updates the LAA OEM development environment with sandbox permissions. 