### PR TITLE
Add details for further syslog senders

### DIFF
--- a/terraform/environments/core-network-services/cidr-ranges.tf
+++ b/terraform/environments/core-network-services/cidr-ranges.tf
@@ -15,6 +15,7 @@ locals {
   }
 
   other_cidr_ranges = {
+    pettyfrance-mgmt                 = "10.38.0.0/16"
     analytical-platform-airflow-dev  = "10.200.0.0/16"
     analytical-platform-airflow-prod = "10.201.0.0/16"
     atos_arkc_ras                    = "10.175.0.0/16" # for DOM1 devices connected to Cisco RAS VPN

--- a/terraform/environments/core-network-services/firewall-rules/development_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/development_rules.json
@@ -523,5 +523,19 @@
     "destination_ip": "${hq-development}",
     "destination_port": "6514",
     "protocol": "TCP"
+  },
+  "pf-mgmt-syslog_to_hq-development-1": {
+    "action": "PASS",
+    "source_ip": "${pettyfrance-mgmt}",
+    "destination_ip": "${hq-development}",
+    "destination_port": "514",
+    "protocol": "UDP"
+  },
+  "pf-mgmt-syslog_to_hq-development-2": {
+    "action": "PASS",
+    "source_ip": "${pettyfrance-mgmt}",
+    "destination_ip": "${hq-development}",
+    "destination_port": "6514",
+    "protocol": "TCP"
   }
 }

--- a/terraform/environments/core-network-services/firewall-rules/production_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/production_rules.json
@@ -636,16 +636,30 @@
     "destination_port": "49152:65535",
     "protocol": "TCP"
   },
-  "arkf-syslog_to_hq-development-1": {
+  "arkf-syslog_to_hq-production-1": {
     "action": "PASS",
     "source_ip": "${arkf_anyconnect_transit}",
     "destination_ip": "${hq-production}",
     "destination_port": "514",
     "protocol": "UDP"
   },
-  "arkf-syslog_to_hq-development-2": {
+  "arkf-syslog_to_hq-production-2": {
     "action": "PASS",
     "source_ip": "${arkf_anyconnect_transit}",
+    "destination_ip": "${hq-production}",
+    "destination_port": "6514",
+    "protocol": "TCP"
+  },
+  "pf-mgmt-syslog_to_hq-production-1": {
+    "action": "PASS",
+    "source_ip": "${pettyfrance-mgmt}",
+    "destination_ip": "${hq-production}",
+    "destination_port": "514",
+    "protocol": "UDP"
+  },
+  "pf-mgmt-syslog_to_hq-production-2": {
+    "action": "PASS",
+    "source_ip": "${pettyfrance-mgmt}",
     "destination_ip": "${hq-production}",
     "destination_port": "6514",
     "protocol": "TCP"


### PR DESCRIPTION
## A reference to the issue / Description of it

#6157 relies on further network ranges to send syslogs into MP

## How does this PR fix the problem?

Adds firewall rules

## How has this been tested?

Tested with a local Terraform plan

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
