### PR TITLE
NIT-1042 allow traffic to legacy ad

### DIFF
--- a/terraform/environments/core-network-services/cidr-ranges.tf
+++ b/terraform/environments/core-network-services/cidr-ranges.tf
@@ -54,15 +54,17 @@ locals {
     moj-smtp-relay2                = "10.180.105.100/32"
 
     # hmpps aws cidr ranges
-    delius-eng-dev  = "10.161.98.0/25"
-    delius-eng-prod = "10.160.98.0/25"
-    delius-core-dev = "10.161.20.0/22"
-    delius-mis-dev  = "10.162.32.0/20"
-    delius-test     = "10.162.0.0/20"
-    delius-stage    = "10.160.32.0/20"
-    delius-pre-prod = "10.160.0.0/20"
-    delius-training = "10.162.96.0/20"
-    delius-prod     = "10.160.16.0/20"
+    delius-eng-dev                    = "10.161.98.0/25"
+    delius-eng-prod                   = "10.160.98.0/25"
+    delius-mis-dev                    = "10.162.32.0/20"
+    delius-mis-dev-private-eu-west-2a = "10.162.32.0/22"
+    delius-mis-dev-private-eu-west-2b = "10.162.36.0/22"
+    delius-mis-dev-private-eu-west-2c = "10.162.40.0/22"
+    delius-test                       = "10.162.0.0/20"
+    delius-stage                      = "10.160.32.0/20"
+    delius-pre-prod                   = "10.160.0.0/20"
+    delius-training                   = "10.162.96.0/20"
+    delius-prod                       = "10.160.16.0/20"
 
     # laa landing zone cidr ranges
     laa-lz-development             = "10.202.0.0/20"

--- a/terraform/environments/core-network-services/firewall-rules/development_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/development_rules.json
@@ -272,53 +272,25 @@
     "destination_port": "1521",
     "protocol": "TCP"
   },
-  "hmpps_development_to_delius-mis-dev_ad_tcp_53": {
+  "hmpps_development_to_delius-mis-dev-2a_ad_all": {
     "action": "PASS",
     "source_ip": "${hmpps-development}",
-    "destination_ip": "${delius-mis-dev}",
-    "destination_port": "53",
+    "destination_ip": "${delius-mis-dev-private-eu-west-2a}",
+    "destination_port": "ANY",
     "protocol": "TCP"
   },
-  "hmpps_development_to_delius-mis-dev_ad_tcp_88": {
+  "hmpps_development_to_delius-mis-dev-2b_ad_all": {
     "action": "PASS",
     "source_ip": "${hmpps-development}",
-    "destination_ip": "${delius-mis-dev}",
-    "destination_port": "88",
+    "destination_ip": "${delius-mis-dev-private-eu-west-2b}",
+    "destination_port": "ANY",
     "protocol": "TCP"
   },
-  "hmpps_development_to_delius-mis-dev_ad_tcp_135": {
+  "hmpps_development_to_delius-mis-dev-2c_ad_all": {
     "action": "PASS",
     "source_ip": "${hmpps-development}",
-    "destination_ip": "${delius-mis-dev}",
-    "destination_port": "135",
-    "protocol": "TCP"
-  },
-  "hmpps_development_to_delius-mis-dev_ad_tcp_389": {
-    "action": "PASS",
-    "source_ip": "${hmpps-development}",
-    "destination_ip": "${delius-mis-dev}",
-    "destination_port": "389",
-    "protocol": "TCP"
-  },
-  "hmpps_development_to_delius-mis-dev_ad_tcp_445": {
-    "action": "PASS",
-    "source_ip": "${hmpps-development}",
-    "destination_ip": "${delius-mis-dev}",
-    "destination_port": "445",
-    "protocol": "TCP"
-  },
-  "hmpps_development_to_delius-mis-dev_ad_tcp_464": {
-    "action": "PASS",
-    "source_ip": "${hmpps-development}",
-    "destination_ip": "${delius-mis-dev}",
-    "destination_port": "464",
-    "protocol": "TCP"
-  },
-  "hmpps_development_to_delius-mis-dev_ad_tcp_636": {
-    "action": "PASS",
-    "source_ip": "${hmpps-development}",
-    "destination_ip": "${delius-mis-dev}",
-    "destination_port": "636",
+    "destination_ip": "${delius-mis-dev-private-eu-west-2c}",
+    "destination_port": "ANY",
     "protocol": "TCP"
   },
   "hmpps_development_to_delius-mis-dev_ad_udp_53": {


### PR DESCRIPTION
Ephemeral TCP ports are required

## A reference to the issue / Description of it

delius-mis machines need temporary access to legacy AD while we migrate resources to MP

## How does this PR fix the problem?

This PR allows TCP traffic to legacy AD on ephemeral ports

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

N/A

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No impact anticipated

## Checklist (check `x` in `[ ]` of list items)

- [ x ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

N/A
