### PR TITLE
Add 6-month ignore for SCA alert

### DIFF
--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -4,6 +4,9 @@ vulnerabilities:
   - id: CVE-2019-11253
   - id: CVE-2020-8558
   - id: CVE-2020-10675
+  - id: CVE-2020-15114
+    expired_at: 2024-08-20
+    statement: "Review in 6 months"
   - id: CVE-2020-26160
   - id: CVE-2020-35381
   - id: CVE-2021-25741


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/actions/runs/7969650566/job/21755824207

## How does this PR fix the problem?

Adds an ignore for a Golang vulnerability that we don't think is relevant to our use.

## How has this been tested?

It hasn't

## Deployment Plan / Instructions

SCA runs will pick up this new ignore

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
