### PR TITLE
ec2:ModifyInstanceAttribute Permission for Instance-Management

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -600,6 +600,7 @@ data "aws_iam_policy_document" "instance-management-document" {
       "ec2:StopInstances",
       "ec2:RebootInstances",
       "ec2:ModifyImageAttribute",
+      "ec2:ModifyInstanceAttribute",
       "ec2:ModifySnapshotAttribute",
       "ec2:CopyImage",
       "ec2:CreateImage",
@@ -668,20 +669,6 @@ data "aws_iam_policy_document" "instance-management-document" {
       test     = "Bool"
       variable = "kms:GrantIsForAWSResource"
       values   = ["true"]
-    }
-  }
-
-  statement {
-    sid    = "AllowDisableApiStop"
-    effect = "Allow"
-    actions = [
-      "ec2:ModifyInstanceAttribute"
-    ]
-    resources = ["*"]
-    condition {
-      test     = "StringEquals"
-      variable = "ec2:ModifyInstanceAttribute"
-      values   = ["disableApiStop"]
     }
   }
 }


### PR DESCRIPTION
Following on from the permission issue raised in ask channel (https://mojdt.slack.com/archives/C01A7QK5VM1/p1708342824264679) 

This PR removes the condition statement and adds the `ec2:ModifyInstanceAttribute` permission to the `instance-management-document`