### PR TITLE
Add Dependency Between Jobs in Bootstrap-Sprinkler Workflow

### DIFF
--- a/.github/workflows/bootstrap-sprinkler.yml
+++ b/.github/workflows/bootstrap-sprinkler.yml
@@ -46,6 +46,7 @@ jobs:
 
   secure-baselines-plan:
     runs-on: ubuntu-latest
+    needs: delegate-access-plan
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Set Account Number
@@ -66,6 +67,7 @@ jobs:
 
   single-sign-on-plan:
     runs-on: ubuntu-latest
+    needs: delegate-access-plan
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Set Account Number
@@ -86,6 +88,7 @@ jobs:
 
   member-bootstrap-plan:
     runs-on: ubuntu-latest
+    needs: single-sign-on-plan
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Set Account Number
@@ -126,6 +129,7 @@ jobs:
 
   secure-baselines-apply:
     runs-on: ubuntu-latest
+    needs: delegate-access-apply
     environment: production
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -147,6 +151,7 @@ jobs:
 
   single-sign-on-apply:
     runs-on: ubuntu-latest
+    needs: delegate-access-apply
     environment: production
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -168,6 +173,7 @@ jobs:
 
   member-bootstrap-apply:
     runs-on: ubuntu-latest
+    needs: single-sign-on-apply
     environment: production
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1


### PR DESCRIPTION
## A reference to the issue / Description of it

There was an issue identified in the bootstrap-sprinkler workflow where all the jobs were running in parallel, causing potential conflicts and inefficiencies. This issue was impacting the reliability and performance of our workflow execution.

## How does this PR fix the problem?

this PR modifies the workflow to incorporate dependencies between jobs. By adding dependencies, we ensure that certain jobs wait for others to complete before starting, thus preventing parallel execution where it's not desired. This ensures that the workflow runs smoothly and consistently, resolving the problem of parallel execution and improving overall efficiency.
