### PR TITLE
Bump provider version

### DIFF
--- a/terraform/github/versions.tf
+++ b/terraform/github/versions.tf
@@ -6,7 +6,7 @@ terraform {
       source  = "hashicorp/aws"
     }
     github = {
-      version = "~> 5.2"
+      version = "~> 6.0"
       source  = "integrations/github"
     }
     time = {


### PR DESCRIPTION
## A reference to the issue / Description of it

GitHub actions terraform runs have been failing due to a mismatch in allowed provider versions

## How does this PR fix the problem?

Sets a consistent floor for the GitHub provider

## How has this been tested?

Test locally

## Deployment Plan / Instructions

CI run will use new version successfully.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
