### PR TITLE
Allow developers to assume `ModernisationPlatformSSOReadOnly` role

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -73,6 +73,7 @@ data "aws_iam_policy_document" "common_statements" {
       "sts:AssumeRole"
     ]
     resources = [
+      "arn:aws:iam::*:role/ModernisationPlatformSSOReadOnly",
       "arn:aws:iam::*:role/read-log-records",
       "arn:aws:iam::*:role/member-delegation-read-only",
       "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/member-shared-services",


### PR DESCRIPTION
## A reference to the issue / Description of it

Without this, terraform local plans will fail as a preconfigured terraform provider cannot assume the `ModernisationPlatformSSOReadOnly` role.

## How does this PR fix the problem?

Adds an IAM resource

## How has this been tested?

Tested manually, and with a local apply to `sprinkler-development`

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

Thanks @mikereiddigital for spotting my oversight!
