### PR TITLE
Add gha_reviewers option to environments file

### DIFF
--- a/environments/delius-core.json
+++ b/environments/delius-core.json
@@ -1,6 +1,11 @@
 {
   "account-type": "member",
-  "codeowners": ["hmpps-migration"],
+  "codeowners": [
+    "hmpps-migration"
+  ],
+  "gha_reviewers": [
+    "hmpps-migration"
+  ],
   "environments": [
     {
       "name": "development",

--- a/scripts/git-create-environments.sh
+++ b/scripts/git-create-environments.sh
@@ -161,8 +161,17 @@ main() {
       account_type=$(jq -r '."account-type"' ${json_file})
       if [ "${account_type}" = "member" ]
       then
-        # Get environment GitHub team slugs
-        teams=$(jq -r --arg e "${env}" '.environments[] | select( .name == $e ) | .access[].github_slug' $json_file)
+        
+        # Get environment GitHub team slugs from gha_reviewers array
+        gha_reviewers=$(jq -r 'try (.gha_reviewers[])' $json_file)
+        # If gha_reviewers is not empty, use it as the teams
+         if ([ ${#gha_reviewers[@]} -gt 0 ] && [ -n "$gha_reviewers" ]); then
+          teams=$gha_reviewers
+        else
+          # Get environment GitHub team slugs from member access array
+          teams=$(jq -r --arg e "${env}" '.environments[] | select( .name == $e ) | .access[].github_slug' $json_file)
+        fi
+
         echo "Teams for $environment: $teams"
         # Check if environment exists and that if has a team associated with it
         environment_exists="false"

--- a/scripts/provision-member-directories.sh
+++ b/scripts/provision-member-directories.sh
@@ -125,7 +125,7 @@ EOL
     application_name=$(basename "$file" .json)
     directory=/terraform/environments/$application_name
     account_type=$(jq -r '."account-type"' ${environment_json_dir}/${application_name}.json)
-    codeowners=$(jq -r '.codeowners[] | "@ministryofjustice/" + .' ${environment_json_dir}/${application_name}.json | sort | uniq | tr '\n' ' ')
+    codeowners=$(jq -r 'try (.codeowners[] | "@ministryofjustice/" + .) ' ${environment_json_dir}/${application_name}.json | sort | uniq | tr '\n' ' ')
     github_slugs=$(jq -r '.environments[].access[].github_slug | "@ministryofjustice/" + .' ${environment_json_dir}/${application_name}.json | sort | uniq | tr '\n' ' ')
 
     if [ "$account_type" = "member" ]; then


### PR DESCRIPTION
## A reference to the issue / Description of it

This follows on from the recent addition of the `codeowners` option and aims to achieve a similar goal, but with GHA/GH Env reviewers. 

## How does this PR fix the problem?

Allows members to add a `gha_reviewers` key at the top level of their environment.json which can be used to explicitly specify GH Teams as reviews. If it is left blank, or not included then the default behaviour remains the same - pulling the teams out of the AWS Member access array(s).

## How has this been tested?

I have tested the bash logic locally to confirm that the output from the new `jq` call is the same format as the existing. The logic for converting the gh team slugs into their team id's is untouched, this just changes the list provided to the loop calling `get_github_team_id` if the `gha_reviewers` key is included.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ X ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
