### PR TITLE
Add github_action_reviewers option from PR #6338 to the account request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-environment.yml
+++ b/.github/ISSUE_TEMPLATE/new-environment.yml
@@ -45,6 +45,14 @@ body:
       value:
     validations:
       required: false
+  - type: input
+    id: github_action_reviewers
+    attributes:
+      label: GitHub actions reviewer team slug
+      description: By default members of the github team/s specified can both access the aws environments and approve Github action runs. If you would like to seperate the permissions so that a different github team can review these, then specify this here.
+      value:
+    validations:
+      required: false
   - type: checkboxes
     id: environment
     attributes:


### PR DESCRIPTION
## A reference to the issue / Description of it

See #6338 for context - This PR adds the new `github_action_reviewers` option into the environment request template.

## How does this PR fix the problem?



## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.



## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?



## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)
