### PR TITLE
DSOS-2635: add permissions for assuming ad-fixngo-ec2-access role

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -77,6 +77,7 @@ data "aws_iam_policy_document" "common_statements" {
       "arn:aws:iam::*:role/read-log-records",
       "arn:aws:iam::*:role/member-delegation-read-only",
       "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/member-shared-services",
+      "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/ad-fixngo-ec2-access",
       "arn:aws:iam::${local.modernisation_platform_account.id}:role/modernisation-account-limited-read-member-access",
       "arn:aws:iam::${local.modernisation_platform_account.id}:role/modernisation-account-terraform-state-member-access"
     ]

--- a/terraform/environments/core-shared-services/ad-fixngo.tf
+++ b/terraform/environments/core-shared-services/ad-fixngo.tf
@@ -4,6 +4,9 @@
 # - https://dsdmoj.atlassian.net/wiki/x/3oCKGAE
 # Managed by DSO team, slack: #ask-digital-studio-ops 
 
+# NOTE: remember to remove ad-fixngo-ec2-access from
+# terraform/environments/bootstrap/single-sign-on/policies.tf when this is no longer required
+
 module "ad_fixngo_ip_addresses" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   source = "github.com/ministryofjustice/modernisation-platform-environments//terraform/modules/ip_addresses?ref=373164d50013894187bc4fdba80a066ec136c90f"


### PR DESCRIPTION
## A reference to the issue / Description of it

Please see https://github.com/ministryofjustice/modernisation-platform/issues/5970 and https://github.com/ministryofjustice/modernisation-platform/pull/6359

Added policy to allow SSO users ability to assume the core-shared-services-production "ad-fixngo-ec2-access".  This gives access to the FixNGo Domain Controller EC2s via FleetManager console.

## How does this PR fix the problem?

Allows role to be assumed by Mod Platform SSO user and therefore EC2s to be accessed.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Not possible to test, other than the role policy does give the required permissions.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

Alternatively, could add the additional permissions into member-shared-services role.  Just wanted to keep everything to do with these DCs in one place so it can be easily tidied up afterwards.
