### PR TITLE
DSOS-2635: ad fixngo more fixes

### DIFF
--- a/terraform/environments/core-shared-services/ad-fixngo.tf
+++ b/terraform/environments/core-shared-services/ad-fixngo.tf
@@ -883,7 +883,7 @@ resource "aws_instance" "ad_fixngo" {
 
   root_block_device {
     encrypted   = true
-    kms_key_id  = module.kms["hmpps"].key_ids["ebs"]
+    kms_key_id  = module.kms["hmpps"].key_arns["ebs"] # need to specify arn rather than id
     volume_size = 127
     volume_type = "gp3"
 

--- a/terraform/environments/core-shared-services/ad-fixngo.tf
+++ b/terraform/environments/core-shared-services/ad-fixngo.tf
@@ -335,6 +335,7 @@ locals {
       ad_hmpp_route53_resolver_sg = {
         description = "Security group for azure.hmpp.root Route53 Resolver"
         vpc_id      = module.vpc["live_data"].vpc_id
+        ingress     = {}
         egress = {
           dns-tcp = {
             port        = 53
@@ -546,6 +547,7 @@ locals {
       ad_azure_route53_resolver_sg = {
         description = "Security group for azure.noms.root Route53 Resolver"
         vpc_id      = module.vpc["non_live_data"].vpc_id
+        ingress     = {}
         egress = {
           dns-tcp = {
             port        = 53

--- a/terraform/environments/core-shared-services/ad-fixngo.tf
+++ b/terraform/environments/core-shared-services/ad-fixngo.tf
@@ -1025,7 +1025,7 @@ resource "aws_ssm_parameter" "ad_fixngo" {
   for_each = local.ad_fixngo.ssm_parameters
 
   description = each.value.description
-  key_id      = module.kms["hmpps"].key_ids["general"]
+  key_id      = module.kms["hmpps"].key_arns["general"]
   name        = each.key
   type        = "SecureString"
   value       = each.value.value

--- a/terraform/environments/core-shared-services/ad-fixngo.tf
+++ b/terraform/environments/core-shared-services/ad-fixngo.tf
@@ -943,7 +943,7 @@ resource "aws_route53_resolver_rule" "ad_fixngo" {
   name        = each.key
   rule_type   = each.value.rule_type
 
-  resolver_endpoint_id = aws_route53_resolver_endpoint.ad_fixngo[each.value.resolver_name].id
+  resolver_endpoint_id = aws_route53_resolver_endpoint.ad_fixngo[each.value.resolver_endpoint_name].id
 
   dynamic "target_ip" {
     for_each = each.value.target_ips

--- a/terraform/environments/core-shared-services/files/ad-fixngo-ec2-user-data.yaml
+++ b/terraform/environments/core-shared-services/files/ad-fixngo-ec2-user-data.yaml
@@ -40,8 +40,9 @@ tasks:
           $ErrorActionPreference = "Stop"
           Write-Output "Downloading and running Run-GitScript.ps1"
           Set-Location -Path ([System.IO.Path]::GetTempPath())
-          $GitBranch = "DSOS-2581/active-directory-and-rdlicense-pwsh"
+          $GitBranch = "main"
           $Script = "Invoke-UserDataScript.ps1"
           [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 # since powershell 4 uses Tls1 as default
           Invoke-WebRequest "https://raw.githubusercontent.com/ministryofjustice/modernisation-platform-configuration-management/${GitBranch}/powershell/Scripts/Run-GitScript.ps1" -OutFile "Run-GitScript.ps1"
           . ./Run-GitScript.ps1 $Script -GitBranch $GitBranch
+          Exit $LASTEXITCODE


### PR DESCRIPTION
## A reference to the issue / Description of it

Please see https://github.com/ministryofjustice/modernisation-platform/issues/5970

Making progress, we can successfully access the EC2 instances but cannot join to domain as it doesn't resolve.

## How does this PR fix the problem?

Adds resolver rules to live_data and non_live_data VPCs.
Also fixes an issue about automatically provisioning server. Need to add a SSM parameter containing the IDs of the hmpps-domain-services accounts.

## How has this been tested?

Not really possible but the code is similar to what we have in the member accounts and that is working OK

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
