### PR TITLE
Add Permissions to manage DMS Instance

### DIFF
--- a/terraform/environments/digital-prison-reporting/iam.tf
+++ b/terraform/environments/digital-prison-reporting/iam.tf
@@ -56,6 +56,7 @@ data "aws_iam_policy_document" "circleci_iam_policy" {
       "dms:DescribeReplicationTasks",
       "dms:ModifyEndpoint",
       "dms:RemoveTagsFromResource",
+      "dms:ModifyReplicationInstance",
       "dms:TestConnection",
       "dynamodb:GetItem",
       "dynamodb:PutItem",


### PR DESCRIPTION
dms:ModifyReplicationInstance

Add Permissions to manage DMS Instance

## A reference to the issue / Description of it

https://app.circleci.com/pipelines/github/ministryofjustice/digital-prison-reporting-domains/786/workflows/0b766364-5f9e-4e0e-bbc6-06b67154a736/jobs/2192

## How does this PR fix the problem?

Add Permissions to manage DMS Instance, allows devs to manage DMS Configuration through TF Pipeline


## How has this been tested?

Tested all okay on DPR Dev Sandbox Account

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

N/A

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [x ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
