### PR TITLE
Adds firehose resources to core-vpc-development for hmpps only.

### DIFF
--- a/terraform/environments/core-vpc/locals.tf
+++ b/terraform/environments/core-vpc/locals.tf
@@ -8,7 +8,7 @@ locals {
   application_name           = "core-vpc"
   environment_management     = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
   pagerduty_integration_keys = jsondecode(data.aws_secretsmanager_secret_version.pagerduty_integration_keys.secret_string)
-  firehose_preprod_network_secret = tostring(jsondecode(data.aws_secretsmanager_secret_version.preprod_network_secret_arn_version.secret_string["second_key"]))
+  firehose_preprod_network_secret = tostring(jsondecode(data.aws_secretsmanager_secret_version.preprod_network_secret_arn_version.secret_string["xsiam_preprod_network_secret"]))
 
   # This takes the name of the Terraform workspace (e.g. core-vpc-production), strips out the application name (e.g. core-vpc), and checks if
   # the string leftover is `-production`, if it isn't (e.g. core-vpc-non-production => -non-production) then it sets the var to false.

--- a/terraform/environments/core-vpc/locals.tf
+++ b/terraform/environments/core-vpc/locals.tf
@@ -8,7 +8,7 @@ locals {
   application_name           = "core-vpc"
   environment_management     = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
   pagerduty_integration_keys = jsondecode(data.aws_secretsmanager_secret_version.pagerduty_integration_keys.secret_string)
-  firehose_preprod_network_secret = tostring(jsondecode(data.aws_secretsmanager_secret_version.preprod_network_secret_arn_version.secret_string["xsiam_preprod_network_secret"]))
+  firehose_preprod_network_secret = jsondecode(data.aws_secretsmanager_secret_version.preprod_network_secret_arn_version.secret_string)
 
   # This takes the name of the Terraform workspace (e.g. core-vpc-production), strips out the application name (e.g. core-vpc), and checks if
   # the string leftover is `-production`, if it isn't (e.g. core-vpc-non-production => -non-production) then it sets the var to false.

--- a/terraform/environments/core-vpc/locals.tf
+++ b/terraform/environments/core-vpc/locals.tf
@@ -14,6 +14,11 @@ locals {
   is-production = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-production"
   is-live_data  = (substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-production") || (substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-preproduction")
 
+  # This applies the same logic as above but to determine whether the environment is development. Required for firehose resources.
+  is-development = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-development"
+
+  endpoint_url = "https://api-justiceukpreprod.xdr.uk.paloaltonetworks.com/logs/v1/aws"
+
   tags = {
     business-unit = "Platforms"
     application   = "Modernisation Platform: core-vpc"

--- a/terraform/environments/core-vpc/locals.tf
+++ b/terraform/environments/core-vpc/locals.tf
@@ -8,7 +8,7 @@ locals {
   application_name           = "core-vpc"
   environment_management     = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
   pagerduty_integration_keys = jsondecode(data.aws_secretsmanager_secret_version.pagerduty_integration_keys.secret_string)
-  firehose_preprod_network_secret = tostring(jsondecode(data.aws_secretsmanager_secret_version.preprod_network_secret_arn_version.secret_string))
+  firehose_preprod_network_secret = tostring(jsondecode(data.aws_secretsmanager_secret_version.preprod_network_secret_arn_version.secret_string["Secret value"]))
 
   # This takes the name of the Terraform workspace (e.g. core-vpc-production), strips out the application name (e.g. core-vpc), and checks if
   # the string leftover is `-production`, if it isn't (e.g. core-vpc-non-production => -non-production) then it sets the var to false.

--- a/terraform/environments/core-vpc/locals.tf
+++ b/terraform/environments/core-vpc/locals.tf
@@ -8,7 +8,7 @@ locals {
   application_name           = "core-vpc"
   environment_management     = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
   pagerduty_integration_keys = jsondecode(data.aws_secretsmanager_secret_version.pagerduty_integration_keys.secret_string)
-  firehose_preprod_network_secret = tostring(jsondecode(data.aws_secretsmanager_secret_version.preprod_network_secret_arn_version.secret_string[1]))
+  firehose_preprod_network_secret = tostring(jsondecode(data.aws_secretsmanager_secret_version.preprod_network_secret_arn_version.secret_string["second_key"]))
 
   # This takes the name of the Terraform workspace (e.g. core-vpc-production), strips out the application name (e.g. core-vpc), and checks if
   # the string leftover is `-production`, if it isn't (e.g. core-vpc-non-production => -non-production) then it sets the var to false.

--- a/terraform/environments/core-vpc/locals.tf
+++ b/terraform/environments/core-vpc/locals.tf
@@ -8,7 +8,7 @@ locals {
   application_name           = "core-vpc"
   environment_management     = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
   pagerduty_integration_keys = jsondecode(data.aws_secretsmanager_secret_version.pagerduty_integration_keys.secret_string)
-  secret_string                = jsondecode(data.aws_secretsmanager_secret_version.secret_arn_version.secret_string)
+  firehose_preprod_network_secret = tostring(jsondecode(data.aws_secretsmanager_secret_version.preprod_network_secret_arn_version.secret_string))
 
   # This takes the name of the Terraform workspace (e.g. core-vpc-production), strips out the application name (e.g. core-vpc), and checks if
   # the string leftover is `-production`, if it isn't (e.g. core-vpc-non-production => -non-production) then it sets the var to false.

--- a/terraform/environments/core-vpc/locals.tf
+++ b/terraform/environments/core-vpc/locals.tf
@@ -8,7 +8,7 @@ locals {
   application_name           = "core-vpc"
   environment_management     = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
   pagerduty_integration_keys = jsondecode(data.aws_secretsmanager_secret_version.pagerduty_integration_keys.secret_string)
-  firehose_preprod_network_secret = tostring(jsondecode(data.aws_secretsmanager_secret_version.preprod_network_secret_arn_version.secret_string["Secret value"]))
+  firehose_preprod_network_secret = tostring(jsondecode(data.aws_secretsmanager_secret_version.preprod_network_secret_arn_version.secret_string[1]))
 
   # This takes the name of the Terraform workspace (e.g. core-vpc-production), strips out the application name (e.g. core-vpc), and checks if
   # the string leftover is `-production`, if it isn't (e.g. core-vpc-non-production => -non-production) then it sets the var to false.

--- a/terraform/environments/core-vpc/locals.tf
+++ b/terraform/environments/core-vpc/locals.tf
@@ -8,6 +8,7 @@ locals {
   application_name           = "core-vpc"
   environment_management     = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
   pagerduty_integration_keys = jsondecode(data.aws_secretsmanager_secret_version.pagerduty_integration_keys.secret_string)
+  secret_string                = jsondecode(data.aws_secretsmanager_secret_version.secret_arn_version.secret_string)
 
   # This takes the name of the Terraform workspace (e.g. core-vpc-production), strips out the application name (e.g. core-vpc), and checks if
   # the string leftover is `-production`, if it isn't (e.g. core-vpc-non-production => -non-production) then it sets the var to false.

--- a/terraform/environments/core-vpc/secrets.tf
+++ b/terraform/environments/core-vpc/secrets.tf
@@ -23,13 +23,13 @@ data "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {
 
 
 # For the Firehose Endpoints - More will be added for the other endpoints
-data "aws_secretsmanager_secret" "secret_arn" {
+data "aws_secretsmanager_secret" "preprod_network_secret_arn" {
   provider = aws.modernisation-platform
   name     = "xsiam_preprod_network_secret"
 }
 
-data "aws_secretsmanager_secret_version" "secret_arn_version" {
+data "aws_secretsmanager_secret_version" "preprod_network_secret_arn_version" {
   provider = aws.modernisation-platform
-  secret_id = data.aws_secretsmanager_secret.secret_arn.id
+  secret_id = data.aws_secretsmanager_secret.preprod_network_secret_arn.id
 }
 

--- a/terraform/environments/core-vpc/secrets.tf
+++ b/terraform/environments/core-vpc/secrets.tf
@@ -20,3 +20,16 @@ data "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {
   provider  = aws.modernisation-platform
   secret_id = data.aws_secretsmanager_secret.pagerduty_integration_keys.id
 }
+
+
+# For the Firehose Endpoints - More will be added for the other endpoints
+data "aws_secretsmanager_secret" "secret_arn" {
+  provider = aws.modernisation-platform
+  name     = "xsiam_preprod_network_secret"
+}
+
+data "aws_secretsmanager_secret_version" "secret_arn_version" {
+  provider = aws.modernisation-platform
+  secret_id = data.aws_secretsmanager_secret.secret_arn.id
+}
+

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -85,7 +85,7 @@ locals {
 module "vpc" {
   for_each = local.vpcs[terraform.workspace]
 
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-member-vpc?ref=46e8738d3237dc8a887f9178c7f831676d6f595d" # See branch add-aws-firehose
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-member-vpc?ref=93ecac996b01626cd262a13f4972b520b33d05ee" # See branch add-aws-firehose
 
   subnet_sets = { for key, subnet in each.value.cidr.subnet_sets : key => subnet.cidr }
 
@@ -107,6 +107,7 @@ module "vpc" {
   # build_firehose = anytrue([local.is-development, local.is-production]) 
 
   build_firehose = (local.is-development == true && each.key == "hmpps-development")
+  
   # Tags
   tags_common = local.tags
   tags_prefix = each.key

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -104,9 +104,9 @@ module "vpc" {
 
   environment = substr(terraform.workspace, length(local.application_name) + 1, length(terraform.workspace))
 
-  # build_firehose = anytrue([local.is-development, local.is-production]) 
+  build_firehose = anytrue([local.is-development, local.is-production]) 
 
-  build_firehose = (local.is-development == true && each.key == "hmpps") || (local.is-production == true && each.key == "hmpps")
+  # build_firehose = (local.is-development == true && each.key == "hmpps") || (local.is-production == true && each.key == "hmpps")
 
   # Tags
   tags_common = local.tags

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -106,8 +106,7 @@ module "vpc" {
 
   # build_firehose = anytrue([local.is-development, local.is-production]) 
 
-  build_firehose = (local.is-development == true && each.key == "hmpps-development") || (local.is-production == true && each.key == "hmpps-production")
-
+  build_firehose = (local.is-development == true && each.key == "hmpps-development")
   # Tags
   tags_common = local.tags
   tags_prefix = each.key

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -104,9 +104,9 @@ module "vpc" {
 
   environment = substr(terraform.workspace, length(local.application_name) + 1, length(terraform.workspace))
 
-  build_firehose = anytrue([local.is-development, local.is-production]) 
+  # build_firehose = anytrue([local.is-development, local.is-production]) 
 
-  # build_firehose = (local.is-development == true && each.key == "hmpps") || (local.is-production == true && each.key == "hmpps")
+  build_firehose = (local.is-development == true && each.key == "hmpps-development") || (local.is-production == true && each.key == "hmpps-production")
 
   # Tags
   tags_common = local.tags

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -85,13 +85,22 @@ locals {
 module "vpc" {
   for_each = local.vpcs[terraform.workspace]
 
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-member-vpc?ref=e8447fc0906270e0e67bf329e8355cd306ef9fef" #v2.2.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-member-vpc?ref=fd28014d7f7ccdc7def154a9ebef8c3a0a41596a" # See branch add-aws-firehose
 
   subnet_sets = { for key, subnet in each.value.cidr.subnet_sets : key => subnet.cidr }
 
   additional_endpoints = each.value.options.additional_endpoints
 
   transit_gateway_id = data.aws_ec2_transit_gateway.transit-gateway.id
+
+  environment = substr(terraform.workspace, length(local.application_name) + 1, length(terraform.workspace))
+
+  build_firehose = local.is_development == "-development" || local.is_production == "-production" ? true : false
+
+  endpoint_url = local.endpoint_url
+
+
+
 
   # VPC Flow Logs
   vpc_flow_log_iam_role = data.aws_iam_role.vpc-flow-log.arn

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -96,7 +96,7 @@ module "vpc" {
   # VPC Flow Logs
   vpc_flow_log_iam_role = data.aws_iam_role.vpc-flow-log.arn
 
-  secret_string = local.secret_string
+  secret_string = local.firehose_preprod_network_endpoint_secret_string
 
   endpoint_url = local.endpoint_url
 

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -85,7 +85,7 @@ locals {
 module "vpc" {
   for_each = local.vpcs[terraform.workspace]
 
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-member-vpc?ref=3f65805e95b401cb1005290495a26fac0be5371e" # See branch add-aws-firehose
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-member-vpc?ref=cd05ddf6f897245baf5b43daf7a2e3339a6386f1" # See branch add-aws-firehose
 
   subnet_sets = { for key, subnet in each.value.cidr.subnet_sets : key => subnet.cidr }
 

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -85,7 +85,7 @@ locals {
 module "vpc" {
   for_each = local.vpcs[terraform.workspace]
 
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-member-vpc?ref=fd28014d7f7ccdc7def154a9ebef8c3a0a41596a" # See branch add-aws-firehose
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-member-vpc?ref=5271710c8973d219deb9f889743e8dbfaaf12114" # See branch add-aws-firehose
 
   subnet_sets = { for key, subnet in each.value.cidr.subnet_sets : key => subnet.cidr }
 

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -104,7 +104,7 @@ module "vpc" {
 
   environment = substr(terraform.workspace, length(local.application_name) + 1, length(terraform.workspace))
 
-  build_firehose = local.is-development == true || local.is-production == true ? true : false
+  build_firehose = anytrue([local.is-development, local.is-production, each.key == "hmpps"])
 
   # Tags
   tags_common = local.tags

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -102,7 +102,7 @@ module "vpc" {
 
   environment = substr(terraform.workspace, length(local.application_name) + 1, length(terraform.workspace))
 
-  build_firehose = local.is_development == "-development" || local.is_production == "-production" ? true : false
+  build_firehose = local.is-development == "-development" || local.is-production == "-production" ? true : false
 
   # Tags
   tags_common = local.tags

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -96,7 +96,7 @@ module "vpc" {
   # VPC Flow Logs
   vpc_flow_log_iam_role = data.aws_iam_role.vpc-flow-log.arn
 
-  secret_string = local.firehose_preprod_network_endpoint_secret_string
+  secret_string = local.firehose_preprod_network_secret
 
   endpoint_url = local.endpoint_url
 

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -93,17 +93,16 @@ module "vpc" {
 
   transit_gateway_id = data.aws_ec2_transit_gateway.transit-gateway.id
 
-  environment = substr(terraform.workspace, length(local.application_name) + 1, length(terraform.workspace))
+  # VPC Flow Logs
+  vpc_flow_log_iam_role = data.aws_iam_role.vpc-flow-log.arn
 
-  build_firehose = local.is_development == "-development" || local.is_production == "-production" ? true : false
+  secret_string = local.secret_string
 
   endpoint_url = local.endpoint_url
 
+  environment = substr(terraform.workspace, length(local.application_name) + 1, length(terraform.workspace))
 
-
-
-  # VPC Flow Logs
-  vpc_flow_log_iam_role = data.aws_iam_role.vpc-flow-log.arn
+  build_firehose = local.is_development == "-development" || local.is_production == "-production" ? true : false
 
   # Tags
   tags_common = local.tags

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -96,7 +96,9 @@ module "vpc" {
   # VPC Flow Logs
   vpc_flow_log_iam_role = data.aws_iam_role.vpc-flow-log.arn
 
-  secret_string = local.firehose_preprod_network_secret
+  # Variables required for Firehose integration
+
+  secret_string = tostring(local.firehose_preprod_network_secret["xsiam_preprod_network_secret"])
 
   endpoint_url = local.endpoint_url
 

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -85,7 +85,7 @@ locals {
 module "vpc" {
   for_each = local.vpcs[terraform.workspace]
 
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-member-vpc?ref=5271710c8973d219deb9f889743e8dbfaaf12114" # See branch add-aws-firehose
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-member-vpc?ref=3f65805e95b401cb1005290495a26fac0be5371e" # See branch add-aws-firehose
 
   subnet_sets = { for key, subnet in each.value.cidr.subnet_sets : key => subnet.cidr }
 

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -104,7 +104,7 @@ module "vpc" {
 
   environment = substr(terraform.workspace, length(local.application_name) + 1, length(terraform.workspace))
 
-  build_firehose = local.is-development == "-development" || local.is-production == "-production" ? true : false
+  build_firehose = local.is-development == true || local.is-production == true ? true : false
 
   # Tags
   tags_common = local.tags

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -104,7 +104,9 @@ module "vpc" {
 
   environment = substr(terraform.workspace, length(local.application_name) + 1, length(terraform.workspace))
 
-  build_firehose = anytrue([local.is-development, local.is-production, each.key == "hmpps"])
+  # build_firehose = anytrue([local.is-development, local.is-production]) 
+
+  build_firehose = (local.is-development == true && each.key == "hmpps") || (local.is-production == true && each.key == "hmpps")
 
   # Tags
   tags_common = local.tags

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -85,7 +85,7 @@ locals {
 module "vpc" {
   for_each = local.vpcs[terraform.workspace]
 
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-member-vpc?ref=cd05ddf6f897245baf5b43daf7a2e3339a6386f1" # See branch add-aws-firehose
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-member-vpc?ref=46e8738d3237dc8a887f9178c7f831676d6f595d" # See branch add-aws-firehose
 
   subnet_sets = { for key, subnet in each.value.cidr.subnet_sets : key => subnet.cidr }
 


### PR DESCRIPTION
## A reference to the issue / Description of it

As per ticket https://github.com/ministryofjustice/modernisation-platform/issues/6163, this covers the initial build of the firehose resources for just one business unit so that we can test the build and confirm with SecOps that the solution is working. It uses a non-production version of the VPC module as a new release for that will not be created until testing is complete.

The firehose resources themselves have been added to the vpc module and are based on a rewrite of this module - https://github.com/ministryofjustice/network-access-control-infrastructure/tree/main/modules/kinesis_firehose_xsiam

The commit of the VPC module that this change uses is - https://github.com/ministryofjustice/modernisation-platform-terraform-member-vpc/tree/93ecac996b01626cd262a13f4972b520b33d05ee

## How does this PR fix the problem?

See ticket link for details.

## How has this been tested?

To date testing has been confirmed to the terraform plan. This will be the first build test.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

To be deployed into core-vpc-development only. The plan does not delete nor force the recreation of any existing resources. E.g.

https://github.com/ministryofjustice/modernisation-platform/actions/runs/8139550048/job/22242989997


## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

This PR is to gather comments on the source.