### PR TITLE
issue-6163

### DIFF
--- a/terraform/environments/core-vpc/locals.tf
+++ b/terraform/environments/core-vpc/locals.tf
@@ -8,11 +8,17 @@ locals {
   application_name           = "core-vpc"
   environment_management     = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
   pagerduty_integration_keys = jsondecode(data.aws_secretsmanager_secret_version.pagerduty_integration_keys.secret_string)
+  firehose_preprod_network_secret = jsondecode(data.aws_secretsmanager_secret_version.preprod_network_secret_arn_version.secret_string)
 
   # This takes the name of the Terraform workspace (e.g. core-vpc-production), strips out the application name (e.g. core-vpc), and checks if
   # the string leftover is `-production`, if it isn't (e.g. core-vpc-non-production => -non-production) then it sets the var to false.
   is-production = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-production"
   is-live_data  = (substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-production") || (substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-preproduction")
+
+  # This applies the same logic as above but to determine whether the environment is development. Required for firehose resources.
+  is-development = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-development"
+
+  endpoint_url = "https://api-justiceukpreprod.xdr.uk.paloaltonetworks.com/logs/v1/aws"
 
   tags = {
     business-unit = "Platforms"

--- a/terraform/environments/core-vpc/locals.tf
+++ b/terraform/environments/core-vpc/locals.tf
@@ -9,6 +9,8 @@ locals {
   environment_management     = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
   pagerduty_integration_keys = jsondecode(data.aws_secretsmanager_secret_version.pagerduty_integration_keys.secret_string)
   firehose_preprod_network_secret = jsondecode(data.aws_secretsmanager_secret_version.kinesis_preprod_network_secret_arn_version.secret_string)
+  firehose_preprod_network_endpoint = jsondecode(data.aws_secretsmanager_secret_version.kinesis_preprod_network_endpoint_arn_version.secret_string)
+  kinesis_endpoint_url = tostring(local.firehose_preprod_network_endpoint["xsiam_preprod_network_endpoint"])
 
   # This takes the name of the Terraform workspace (e.g. core-vpc-production), strips out the application name (e.g. core-vpc), and checks if
   # the string leftover is `-production`, if it isn't (e.g. core-vpc-non-production => -non-production) then it sets the var to false.
@@ -16,10 +18,8 @@ locals {
   is-live_data  = (substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-production") || (substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-preproduction")
 
   # This applies the same logic as above but to determine whether the environment is either sandbox or development. Required for firehose resources.
-  is-sandbox = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-sandbox"
   is-development = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-development"
 
-  kinesis_endpoint_url = "https://api-justiceukpreprod.xdr.uk.paloaltonetworks.com/logs/v1/aws"
 
   tags = {
     business-unit = "Platforms"

--- a/terraform/environments/core-vpc/locals.tf
+++ b/terraform/environments/core-vpc/locals.tf
@@ -15,7 +15,8 @@ locals {
   is-production = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-production"
   is-live_data  = (substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-production") || (substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-preproduction")
 
-  # This applies the same logic as above but to determine whether the environment is development. Required for firehose resources.
+  # This applies the same logic as above but to determine whether the environment is either sandbox or development. Required for firehose resources.
+  is-sandbox = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-sandbox"
   is-development = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-development"
 
   kinesis_endpoint_url = "https://api-justiceukpreprod.xdr.uk.paloaltonetworks.com/logs/v1/aws"

--- a/terraform/environments/core-vpc/locals.tf
+++ b/terraform/environments/core-vpc/locals.tf
@@ -8,7 +8,7 @@ locals {
   application_name           = "core-vpc"
   environment_management     = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
   pagerduty_integration_keys = jsondecode(data.aws_secretsmanager_secret_version.pagerduty_integration_keys.secret_string)
-  firehose_preprod_network_secret = jsondecode(data.aws_secretsmanager_secret_version.preprod_network_secret_arn_version.secret_string)
+  firehose_preprod_network_secret = jsondecode(data.aws_secretsmanager_secret_version.kinesis_preprod_network_secret_arn_version.secret_string)
 
   # This takes the name of the Terraform workspace (e.g. core-vpc-production), strips out the application name (e.g. core-vpc), and checks if
   # the string leftover is `-production`, if it isn't (e.g. core-vpc-non-production => -non-production) then it sets the var to false.

--- a/terraform/environments/core-vpc/locals.tf
+++ b/terraform/environments/core-vpc/locals.tf
@@ -18,7 +18,7 @@ locals {
   # This applies the same logic as above but to determine whether the environment is development. Required for firehose resources.
   is-development = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-development"
 
-  endpoint_url = "https://api-justiceukpreprod.xdr.uk.paloaltonetworks.com/logs/v1/aws"
+  kinesis_endpoint_url = "https://api-justiceukpreprod.xdr.uk.paloaltonetworks.com/logs/v1/aws"
 
   tags = {
     business-unit = "Platforms"

--- a/terraform/environments/core-vpc/secrets.tf
+++ b/terraform/environments/core-vpc/secrets.tf
@@ -20,3 +20,16 @@ data "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {
   provider  = aws.modernisation-platform
   secret_id = data.aws_secretsmanager_secret.pagerduty_integration_keys.id
 }
+
+
+# For the Firehose Endpoints - More will be added for the other endpoints
+data "aws_secretsmanager_secret" "preprod_network_secret_arn" {
+  provider = aws.modernisation-platform
+  name     = "xsiam_preprod_network_secret"
+}
+
+data "aws_secretsmanager_secret_version" "preprod_network_secret_arn_version" {
+  provider = aws.modernisation-platform
+  secret_id = data.aws_secretsmanager_secret.preprod_network_secret_arn.id
+}
+

--- a/terraform/environments/core-vpc/secrets.tf
+++ b/terraform/environments/core-vpc/secrets.tf
@@ -22,7 +22,7 @@ data "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {
 }
 
 
-# For the Firehose Endpoints - More will be added for the other endpoints
+# For the Firehose Endpoint Keys - More will be added for the other endpoints
 data "aws_secretsmanager_secret" "kinesis_preprod_network_secret_arn" {
   provider = aws.modernisation-platform
   name     = "xsiam_preprod_network_secret"
@@ -33,3 +33,13 @@ data "aws_secretsmanager_secret_version" "kinesis_preprod_network_secret_arn_ver
   secret_id = data.aws_secretsmanager_secret.kinesis_preprod_network_secret_arn.id
 }
 
+# For the Firehose Endpoints URLs - More will be added for the other endpoints
+data "aws_secretsmanager_secret" "kinesis_preprod_network_endpoint_arn" {
+  provider = aws.modernisation-platform
+  name     = "xsiam_preprod_network_endpoint"
+}
+
+data "aws_secretsmanager_secret_version" "kinesis_preprod_network_endpoint_arn_version" {
+  provider = aws.modernisation-platform
+  secret_id = data.aws_secretsmanager_secret.kinesis_preprod_network_endpoint_arn.id
+}

--- a/terraform/environments/core-vpc/secrets.tf
+++ b/terraform/environments/core-vpc/secrets.tf
@@ -23,13 +23,13 @@ data "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {
 
 
 # For the Firehose Endpoints - More will be added for the other endpoints
-data "aws_secretsmanager_secret" "preprod_network_secret_arn" {
+data "aws_secretsmanager_secret" "kinesis_preprod_network_secret_arn" {
   provider = aws.modernisation-platform
   name     = "xsiam_preprod_network_secret"
 }
 
-data "aws_secretsmanager_secret_version" "preprod_network_secret_arn_version" {
+data "aws_secretsmanager_secret_version" "kinesis_preprod_network_secret_arn_version" {
   provider = aws.modernisation-platform
-  secret_id = data.aws_secretsmanager_secret.preprod_network_secret_arn.id
+  secret_id = data.aws_secretsmanager_secret.kinesis_preprod_network_secret_arn.id
 }
 

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -85,7 +85,7 @@ locals {
 module "vpc" {
   for_each = local.vpcs[terraform.workspace]
 
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-member-vpc?ref=93ecac996b01626cd262a13f4972b520b33d05ee" # See branch add-aws-firehose
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-member-vpc?ref=87e17c25734a0b5592029cecde2309d318571324" # See branch add-aws-firehose
 
   subnet_sets = { for key, subnet in each.value.cidr.subnet_sets : key => subnet.cidr }
 
@@ -98,13 +98,11 @@ module "vpc" {
 
   # Variables required for Firehose integration
 
-  secret_string = tostring(local.firehose_preprod_network_secret["xsiam_preprod_network_secret"])
+  kinesis_endpoint_secret_string = tostring(local.kinesis_preprod_network_secret_arn_version["xsiam_preprod_network_secret"])
 
-  endpoint_url = local.endpoint_url
+  kinesis_endpoint_url = local.kinesis_endpoint_url # This is a requirement for the resources to build. 
 
-  environment = substr(terraform.workspace, length(local.application_name) + 1, length(terraform.workspace))
-
-  # build_firehose = anytrue([local.is-development, local.is-production]) 
+  # build_firehose = anytrue([local.is-development, local.is-production].
 
   build_firehose = (local.is-development == true && each.key == "hmpps-development")
   

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -102,7 +102,7 @@ module "vpc" {
 
   build_firehose = (local.is-development == true && each.key == "hmpps-development")
   
-  kinesis_endpoint_secret_string = tostring(local.firehose_preprod_network_secretn["xsiam_preprod_network_secret"])
+  kinesis_endpoint_secret_string = tostring(local.firehose_preprod_network_secret["xsiam_preprod_network_secret"])
 
   kinesis_endpoint_url = local.kinesis_endpoint_url # This is a requirement for the resources to build. 
 

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -85,7 +85,7 @@ locals {
 module "vpc" {
   for_each = local.vpcs[terraform.workspace]
 
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-member-vpc?ref=1cdbd1968bba484e86773687f960ae3336495ed4" # See branch add-aws-firehose
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-member-vpc?ref=bf6cda01118296c94a1c8a0c76a7ff21b6556c24" # See branch add-aws-firehose
 
   subnet_sets = { for key, subnet in each.value.cidr.subnet_sets : key => subnet.cidr }
 
@@ -98,16 +98,11 @@ module "vpc" {
 
   # Variables required for Firehose integration
 
-  # build_firehose = anytrue([local.is-development, local.is-production].
-
-  # build_firehose = (local.is-sandbox == true && each.key == "hmpps-development")
+  build_firehose = anytrue([local.is-development, local.is-production]) && length(local.kinesis_endpoint_url) > 0
   
-  build_firehose = local.is-sandbox == true
-
   kinesis_endpoint_secret_string = tostring(local.firehose_preprod_network_secret["xsiam_preprod_network_secret"])
 
   kinesis_endpoint_url = local.kinesis_endpoint_url # This is a requirement for the resources to build. 
-
 
   # Tags
   tags_common = local.tags

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -100,8 +100,10 @@ module "vpc" {
 
   # build_firehose = anytrue([local.is-development, local.is-production].
 
-  build_firehose = (local.is-development == true && each.key == "hmpps-development")
+  # build_firehose = (local.is-sandbox == true && each.key == "hmpps-development")
   
+  build_firehose = local.is-sandbox == true
+
   kinesis_endpoint_secret_string = tostring(local.firehose_preprod_network_secret["xsiam_preprod_network_secret"])
 
   kinesis_endpoint_url = local.kinesis_endpoint_url # This is a requirement for the resources to build. 

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -85,7 +85,7 @@ locals {
 module "vpc" {
   for_each = local.vpcs[terraform.workspace]
 
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-member-vpc?ref=87e17c25734a0b5592029cecde2309d318571324" # See branch add-aws-firehose
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-member-vpc?ref=1cdbd1968bba484e86773687f960ae3336495ed4" # See branch add-aws-firehose
 
   subnet_sets = { for key, subnet in each.value.cidr.subnet_sets : key => subnet.cidr }
 
@@ -98,14 +98,15 @@ module "vpc" {
 
   # Variables required for Firehose integration
 
-  kinesis_endpoint_secret_string = tostring(local.kinesis_preprod_network_secret_arn_version["xsiam_preprod_network_secret"])
-
-  kinesis_endpoint_url = local.kinesis_endpoint_url # This is a requirement for the resources to build. 
-
   # build_firehose = anytrue([local.is-development, local.is-production].
 
   build_firehose = (local.is-development == true && each.key == "hmpps-development")
   
+  kinesis_endpoint_secret_string = tostring(local.kinesis_preprod_network_secret_arn_version["xsiam_preprod_network_secret"])
+
+  kinesis_endpoint_url = local.kinesis_endpoint_url # This is a requirement for the resources to build. 
+
+
   # Tags
   tags_common = local.tags
   tags_prefix = each.key

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -85,7 +85,7 @@ locals {
 module "vpc" {
   for_each = local.vpcs[terraform.workspace]
 
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-member-vpc?ref=e8447fc0906270e0e67bf329e8355cd306ef9fef" #v2.2.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-member-vpc?ref=93ecac996b01626cd262a13f4972b520b33d05ee" # See branch add-aws-firehose
 
   subnet_sets = { for key, subnet in each.value.cidr.subnet_sets : key => subnet.cidr }
 
@@ -96,6 +96,18 @@ module "vpc" {
   # VPC Flow Logs
   vpc_flow_log_iam_role = data.aws_iam_role.vpc-flow-log.arn
 
+  # Variables required for Firehose integration
+
+  secret_string = tostring(local.firehose_preprod_network_secret["xsiam_preprod_network_secret"])
+
+  endpoint_url = local.endpoint_url
+
+  environment = substr(terraform.workspace, length(local.application_name) + 1, length(terraform.workspace))
+
+  # build_firehose = anytrue([local.is-development, local.is-production]) 
+
+  build_firehose = (local.is-development == true && each.key == "hmpps-development")
+  
   # Tags
   tags_common = local.tags
   tags_prefix = each.key

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -102,7 +102,7 @@ module "vpc" {
 
   build_firehose = (local.is-development == true && each.key == "hmpps-development")
   
-  kinesis_endpoint_secret_string = tostring(local.kinesis_preprod_network_secret_arn_version["xsiam_preprod_network_secret"])
+  kinesis_endpoint_secret_string = tostring(local.firehose_preprod_network_secretn["xsiam_preprod_network_secret"])
 
   kinesis_endpoint_url = local.kinesis_endpoint_url # This is a requirement for the resources to build. 
 


### PR DESCRIPTION
## A reference to the issue / Description of it

As per ticket https://github.com/ministryofjustice/modernisation-platform/issues/6163, this covers the initial build of the firehose resources for just one business unit so that we can test the build and confirm with SecOps that the solution is working. It uses a non-production version of the VPC module as a new release for that will not be created until testing is complete.

The firehose resources themselves have been added to the vpc module and are based on a rewrite of this module - https://github.com/ministryofjustice/network-access-control-infrastructure/tree/main/modules/kinesis_firehose_xsiam

The commit of the VPC module that this change uses is - https://github.com/ministryofjustice/modernisation-platform-terraform-member-vpc/tree/93ecac996b01626cd262a13f4972b520b33d05ee

## How does this PR fix the problem?

See ticket link for details.

## How has this been tested?

To date testing has been confirmed to the terraform plan. This will be the first build test.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

To be deployed into core-vpc-development only. The plan does not delete nor force the recreation of any existing resources. E.g.

https://github.com/ministryofjustice/modernisation-platform/actions/runs/8139550048/job/22242989997


## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

This PR is to gather comments on the source.