### PR TITLE
DO NOT MERGE - Testing OPA Status Check Branch Protection

### DIFF
--- a/environments/example.json
+++ b/environments/example.json
@@ -2,7 +2,7 @@
   "account-type": "member",
   "environments": [
     {
-      "name": "development",
+      "name": "dev",
       "access": [
         {
           "github_slug": "modernisation-platform",


### PR DESCRIPTION
Just a test to make sure this PR is not mergeable as the opa policy checks should fail. 

When this has an approving review we want to see that the PR is not mergeable due to failing status checks.
