### PR TITLE
Allow elasticache:* permissions in sandbox

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -446,6 +446,7 @@ data "aws_iam_policy_document" "sandbox_additional" {
       "eks:AccessKubernetesApi",
       "eks:Describe*",
       "eks:List*",
+      "elasticache:*"
       "elasticfilesystem:*",
       "elasticloadbalancing:*",
       "events:*",


### PR DESCRIPTION
## A reference to the issue / Description of it

Allow platform users to manage elasticache resources in sandbox environments

## How does this PR fix the problem?

This PR will allow all elasticache IAM actions

## How has this been tested?

n/a

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

no impact expected

## Checklist (check `x` in `[ ]` of list items)

- [ x ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

n/a
