### PR TITLE
Remove forced suffix for ECR REPOs

### DIFF
--- a/terraform/modules/app-ecr-repo/main.tf
+++ b/terraform/modules/app-ecr-repo/main.tf
@@ -1,7 +1,7 @@
 #tfsec:ignore:AWS078 tfsec:ignore:aws-ecr-repository-customer-key
 resource "aws_ecr_repository" "ecr_repo" {
   #checkov:skip=CKV_AWS_51:Skip Tag Mutable requirement we want tags to be overwritten   
-  name                 = "${var.app_name}-ecr-repo"
+  name                 = ${var.app_name}
   image_tag_mutability = "MUTABLE"
 
   encryption_configuration {
@@ -14,12 +14,15 @@ resource "aws_ecr_repository" "ecr_repo" {
 
   lifecycle {
     prevent_destroy = true
+    ignore_changes = [
+      name,
+    ]
   }
 
   tags = merge(
     var.tags_common,
     {
-      Name = "${var.app_name}-ecr-repo"
+      Name = "${var.app_name}"
     }
   )
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

Remove the force suffix `-ecr-repo` from the repo name.

ECR does call it the repo name, but it is technically the image name.

## How does this PR fix the problem?

Removes the forced suffix - adds a ignore on the name so that existing repos are unffected.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
