### PR TITLE
Switch scheduled baseline to sunday night after weekly nuke run

### DIFF
--- a/.github/workflows/scheduled-baseline.yml
+++ b/.github/workflows/scheduled-baseline.yml
@@ -2,7 +2,7 @@ name: "Terraform: scheduled baseline"
 
 on:
   schedule:
-    - cron: "30 22 * * 6"
+    - cron: "30 22 * * 7"
   push:
     branches:
       - main

--- a/.github/workflows/scheduled-baseline.yml
+++ b/.github/workflows/scheduled-baseline.yml
@@ -2,7 +2,7 @@ name: "Terraform: scheduled baseline"
 
 on:
   schedule:
-    - cron: "30 22 * * 7"
+    - cron: "30 22 * * 0"
   push:
     branches:
       - main


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/6387

## How does this PR fix the problem?

Traced the cause of the bug to the tests relying on something that is destroyed during the weekly nuke and ought to be recreated during the scheduled baseline. This ensures that the resources have been recreated ready for the start of the working week.

## How has this been tested?

It hasn't

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
