### PR TITLE
Adding scheduler:CreateSchedule permission to the sandbox SSO role

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -466,6 +466,7 @@ data "aws_iam_policy_document" "sandbox_additional" {
       "rds-data:*",
       "route53:*",
       "s3:*",
+      "scheduler:CreateSchedule",
       "secretsmanager:*",
       "ses:*",
       "sns:*",


### PR DESCRIPTION
## A reference to the issue / Description of it

Addressing customer's request from [this thread](https://mojdt.slack.com/archives/C01A7QK5VM1/p1709825598840339).

## How does this PR fix the problem?

It's adding missing permission to the sandbox policy.

## How has this been tested?

This will be deployed to sprinkler first.

## Deployment Plan / Instructions

This will be deployed to all sandbox accounts.

## Checklist (check `x` in `[ ]` of list items)

- [ x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

