### PR TITLE
NIT-1148 slack and pagerduty integration for delius core nonprod env

### DIFF
--- a/terraform/pagerduty/aws.tf
+++ b/terraform/pagerduty/aws.tf
@@ -63,6 +63,7 @@ resource "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {
     laa_maat_api_prod_alarms             = pagerduty_service_integration.laa_maat_api_prod_cloudwatch.integration_key,
     hmpps_domain_services_prod_alarms    = pagerduty_service_integration.hmpps_domain_services_prod_cloudwatch.integration_key,
     hmpps_domain_services_nonprod_alarms = pagerduty_service_integration.hmpps_domain_services_nonprod_cloudwatch.integration_key
+    delius_core_nonprod_alarms           = pagerduty_service_integration.delius_core_nonprod_cloudwatch.integration_key
   })
 }
 

--- a/terraform/pagerduty/member-services-integrations.tf
+++ b/terraform/pagerduty/member-services-integrations.tf
@@ -1843,3 +1843,56 @@ resource "pagerduty_slack_connection" "hmpps_domain_services_nonprod_connection"
   }
 }
 # Slack channel: #dso_alerts_devtest_modernisation_platform
+
+
+# Slack channel: #delius_core_nonprod_alerts_modernisation_platform
+
+# Delius Core Non Prod
+resource "pagerduty_service" "delius_core_nonprod" {
+  name                    = "Delius Core Non Prod"
+  description             = "Delius Core Non Prod Alarms"
+  auto_resolve_timeout    = 345600
+  acknowledgement_timeout = "null"
+  escalation_policy       = pagerduty_escalation_policy.member_policy.id
+  alert_creation          = "create_alerts_and_incidents"
+}
+
+resource "pagerduty_service_integration" "delius_core_nonprod_cloudwatch" {
+  name    = data.pagerduty_vendor.cloudwatch.name
+  service = pagerduty_service.delius_core_nonprod.id
+  vendor  = data.pagerduty_vendor.cloudwatch.id
+}
+
+resource "pagerduty_slack_connection" "delius_core_nonprod_connection" {
+  source_id         = pagerduty_service.delius_core_nonprod.id
+  source_type       = "service_reference"
+  workspace_id      = local.slack_workspace_id
+  channel_id        = "CRMJZ0PGB"
+  notification_type = "responder"
+  lifecycle {
+    ignore_changes = [
+      config,
+    ]
+  }
+  config {
+    events = [
+      "incident.triggered",
+      "incident.acknowledged",
+      "incident.escalated",
+      "incident.resolved",
+      "incident.reassigned",
+      "incident.annotated",
+      "incident.unacknowledged",
+      "incident.delegated",
+      "incident.action_invocation.created",
+      "incident.action_invocation.terminated",
+      "incident.action_invocation.updated",
+      "incident.priority_updated",
+      "incident.responder.added",
+      "incident.responder.replied",
+      "incident.status_update_published",
+      "incident.reopened"
+    ]
+    priorities = ["*"]
+  }
+}


### PR DESCRIPTION
## A reference to the issue / Description of it

Integrating alarms with PagerDuty and slack for Delius Core Application

## How does this PR fix the problem?

creates new PD service and slack integration for delius core 

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

using the same template/blueprint to create the PD service and integrate with slack to send notifications to

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
