### PR TITLE
DSOS-2635: add second devtest DC for FixNGo migration

### DIFF
--- a/terraform/environments/core-shared-services/ad-fixngo.tf
+++ b/terraform/environments/core-shared-services/ad-fixngo.tf
@@ -78,21 +78,21 @@ locals {
       #   }
       # }
 
-      # ad-azure-dc-a = {
-      #   ami_name                  = "hmpps_windows_server_2022_release_2024-02-02T00-00-04.569Z"
-      #   availability_zone         = "eu-west-2a"
-      #   iam_instance_profile_role = "ad-fixngo-ec2-nonlive-role"
-      #   instance_type             = "t3.large"
-      #   key_name                  = "ad-fixngo-ec2-nonlive"
-      #   private_ip                = module.ad_fixngo_ip_addresses.mp_ip["ad-azure-dc-a"]
-      #   subnet_id                 = module.vpc["non_live_data"].non_tgw_subnet_ids_map.private[0]
-      #   vpc_security_group_name   = "ad_azure_dc_sg"
-      #   tags = {
-      #     server-type = "DomainController"
-      #     domain-name = "azure.noms.root"
-      #     description = "domain controller for FixNGo azure.noms.root domain"
-      #   }
-      # }
+      ad-azure-dc-a = {
+        ami_name                  = "hmpps_windows_server_2022_release_2024-02-02T00-00-04.569Z"
+        availability_zone         = "eu-west-2a"
+        iam_instance_profile_role = "ad-fixngo-ec2-nonlive-role"
+        instance_type             = "t3.large"
+        key_name                  = "ad-fixngo-ec2-nonlive"
+        private_ip                = module.ad_fixngo_ip_addresses.mp_ip["ad-azure-dc-a"]
+        subnet_id                 = module.vpc["non_live_data"].non_tgw_subnet_ids_map.private[0]
+        vpc_security_group_name   = "ad_azure_dc_sg"
+        tags = {
+          server-type = "DomainController"
+          domain-name = "azure.noms.root"
+          description = "domain controller for FixNGo azure.noms.root domain"
+        }
+      }
       ad-azure-dc-b = {
         ami_name                  = "hmpps_windows_server_2022_release_2024-02-02T00-00-04.569Z"
         availability_zone         = "eu-west-2b"


### PR DESCRIPTION
## A reference to the issue / Description of it

Please see https://github.com/ministryofjustice/modernisation-platform/issues/5970

The first azure.noms.root DC is working properly now, adding a second one for redundancy.

## How does this PR fix the problem?

Provides redundancy for the solution

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

First server is working correctly now

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
