### PR TITLE
Issue 6163 - Add Firehose Resources

### DIFF
--- a/terraform/environments/core-vpc/locals.tf
+++ b/terraform/environments/core-vpc/locals.tf
@@ -18,7 +18,7 @@ locals {
   is-development = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-development" 
 
   # Required for determining whether non-prod or prod secrets are referenced for Firehose
-  is-non_production =! local.is-production
+  is-non_production = local.is-production != true
 
   # Determines if Firehose should be built in an environment.
   build_firehose = anytrue ([local.is-development, local.is-production]) ? true : false

--- a/terraform/environments/core-vpc/locals.tf
+++ b/terraform/environments/core-vpc/locals.tf
@@ -14,6 +14,18 @@ locals {
   is-production = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-production"
   is-live_data  = (substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-production") || (substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-preproduction")
 
+  # This applies the same logic as above but to determine whether the environment is the development environment. Required for firehose resources.
+  is-development = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-development" 
+
+  # Determines if Firehose should be built in an environment.
+  build_firehose = anytrue ([local.is-development, local.is-production]) ? true : false
+
+  # Secrets used by Firehose resources which we only require for development & production VPCs.
+  firehose_preprod_network_secret = jsondecode(data.aws_secretsmanager_secret_version.kinesis_preprod_network_secret_arn_version.secret_string)
+  firehose_preprod_network_endpoint = jsondecode(data.aws_secretsmanager_secret_version.kinesis_preprod_network_endpoint_arn_version.secret_string)
+  firehose_prod_network_secret = jsondecode(data.aws_secretsmanager_secret_version.kinesis_prod_network_secret_arn_version.secret_string)
+  firehose_prod_network_endpoint = jsondecode(data.aws_secretsmanager_secret_version.kinesis_prod_network_endpoint_arn_version.secret_string)
+
   tags = {
     business-unit = "Platforms"
     application   = "Modernisation Platform: core-vpc"

--- a/terraform/environments/core-vpc/locals.tf
+++ b/terraform/environments/core-vpc/locals.tf
@@ -17,9 +17,6 @@ locals {
   # This applies the same logic as above but to determine whether the environment is the development environment. Required for firehose resources.
   is-development = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-development" 
 
-  # Required for determining whether non-prod or prod secrets are referenced for Firehose
-  is-non_production = local.is-production != true
-
   # Determines if Firehose should be built in an environment.
   build_firehose = anytrue ([local.is-development, local.is-production]) ? true : false
 

--- a/terraform/environments/core-vpc/locals.tf
+++ b/terraform/environments/core-vpc/locals.tf
@@ -17,6 +17,9 @@ locals {
   # This applies the same logic as above but to determine whether the environment is the development environment. Required for firehose resources.
   is-development = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-development" 
 
+  # Required for determining whether non-prod or prod secrets are referenced for Firehose
+  is-non_production =! local.is-production
+
   # Determines if Firehose should be built in an environment.
   build_firehose = anytrue ([local.is-development, local.is-production]) ? true : false
 

--- a/terraform/environments/core-vpc/secrets.tf
+++ b/terraform/environments/core-vpc/secrets.tf
@@ -20,3 +20,49 @@ data "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {
   provider  = aws.modernisation-platform
   secret_id = data.aws_secretsmanager_secret.pagerduty_integration_keys.id
 }
+
+
+# For the Firehose Endpoint Keys - More will be added for the other endpoints
+data "aws_secretsmanager_secret" "kinesis_preprod_network_secret_arn" {
+  provider = aws.modernisation-platform
+  name     = "xsiam_preprod_network_secret"
+}
+
+data "aws_secretsmanager_secret_version" "kinesis_preprod_network_secret_arn_version" {
+  provider = aws.modernisation-platform
+  secret_id = data.aws_secretsmanager_secret.kinesis_preprod_network_secret_arn.id
+}
+
+# For the Firehose Endpoints URLs
+data "aws_secretsmanager_secret" "kinesis_preprod_network_endpoint_arn" {
+  provider = aws.modernisation-platform
+  name     = "xsiam_preprod_network_endpoint"
+}
+
+data "aws_secretsmanager_secret_version" "kinesis_preprod_network_endpoint_arn_version" {
+  provider = aws.modernisation-platform
+  secret_id = data.aws_secretsmanager_secret.kinesis_preprod_network_endpoint_arn.id
+}
+
+
+# For the Firehose Production Endpoint Keys 
+
+data "aws_secretsmanager_secret" "kinesis_prod_network_secret_arn" {
+  provider = aws.modernisation-platform
+  name     = "xsiam_prod_network_secret"
+}
+
+data "aws_secretsmanager_secret_version" "kinesis_prod_network_secret_arn_version" {
+  provider = aws.modernisation-platform
+  secret_id = data.aws_secretsmanager_secret.kinesis_prod_network_secret_arn.id
+}
+
+data "aws_secretsmanager_secret" "kinesis_prod_network_endpoint_arn" {
+  provider = aws.modernisation-platform
+  name     = "xsiam_prod_network_endpoint"
+}
+
+data "aws_secretsmanager_secret_version" "kinesis_prod_network_endpoint_arn_version" {
+  provider = aws.modernisation-platform
+  secret_id = data.aws_secretsmanager_secret.kinesis_prod_network_endpoint_arn.id
+}

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -100,11 +100,9 @@ module "vpc" {
 
   build_firehose = local.build_firehose
 
-  kinesis_endpoint_secret_string = local.is-non_production ? tostring(local.firehose_preprod_network_secret["xsiam_preprod_network_secret"]) : tostring(local.firehose_prod_network_secret["xsiam_prod_network_secret"]) 
+  kinesis_endpoint_secret_string = local.is-production ? tostring(local.firehose_prod_network_secret["xsiam_prod_network_secret"]) : tostring(local.firehose_preprod_network_secret["xsiam_preprod_network_secret"])
 
-  kinesis_endpoint_url = local.is-non_production ? tostring(local.firehose_preprod_network_endpoint["xsiam_preprod_network_endpoint"]) : tostring(local.firehose_prod_network_endpoint["xsiam_prod_network_endpoint"]) 
-
-
+  kinesis_endpoint_url = local.is-production ? tostring(local.firehose_prod_network_endpoint["xsiam_prod_network_endpoint"]) : tostring(local.firehose_preprod_network_endpoint["xsiam_preprod_network_endpoint"])
 
   # Tags
   tags_common = local.tags

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -85,7 +85,7 @@ locals {
 module "vpc" {
   for_each = local.vpcs[terraform.workspace]
 
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-member-vpc?ref=e8447fc0906270e0e67bf329e8355cd306ef9fef" #v2.2.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-member-vpc?ref=ddcd36b717b937bfa72b6245fd0410861aa40b36" # v2.3.0
 
   subnet_sets = { for key, subnet in each.value.cidr.subnet_sets : key => subnet.cidr }
 
@@ -95,6 +95,16 @@ module "vpc" {
 
   # VPC Flow Logs
   vpc_flow_log_iam_role = data.aws_iam_role.vpc-flow-log.arn
+
+  # Variables required for Firehose integration. We are not building this in all environments hence the "build_firehose" condition below.
+
+  build_firehose = local.build_firehose
+
+  kinesis_endpoint_secret_string = local.is-non_production ? tostring(local.firehose_preprod_network_secret["xsiam_preprod_network_secret"]) : tostring(local.firehose_prod_network_secret["xsiam_prod_network_secret"]) 
+
+  kinesis_endpoint_url = local.is-non_production ? tostring(local.firehose_preprod_network_endpoint["xsiam_preprod_network_endpoint"]) : tostring(local.firehose_prod_network_endpoint["xsiam_prod_network_endpoint"]) 
+
+
 
   # Tags
   tags_common = local.tags


### PR DESCRIPTION
## A reference to the issue / Description of it

As per issue https://github.com/ministryofjustice/modernisation-platform/issues/6163 - this adds data items, locals and variable assignments to support the creation of AWS Firehose resources in the required environments - development & production. These are required for the transfer of vpc flow log data to the MoJ's SecOps team that will be used for protective monitoring purposes.

## How does this PR fix the problem?

The module https://github.com/ministryofjustice/modernisation-platform-terraform-member-vpc has been updated to build these AWS Firehose & associated resources and this change adds the necessary locals, data items and variable assignments to support this for development & production vpcs.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

This build has been tested in core-vpc-sandbox.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

This change covers additions only so there will be no impact on existing services.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
