### PR TITLE
giving csr app support team to developer role access

### DIFF
--- a/environments/planetfm.json
+++ b/environments/planetfm.json
@@ -20,7 +20,7 @@
         },
         {
           "github_slug": "csr-application-support",
-          "level": "instance-management"
+          "level": "developer"
         }
       ]
     },
@@ -33,7 +33,7 @@
         },
         {
           "github_slug": "csr-application-support",
-          "level": "instance-management"
+          "level": "developer"
         }
       ]
     },
@@ -46,7 +46,7 @@
         },
         {
           "github_slug": "csr-application-support",
-          "level": "instance-management"
+          "level": "developer"
         }
       ]
     }


### PR DESCRIPTION
## A reference to the issue / Description of it

App support team wants ability to create dashboards in cloudwatch for Planet FM 

## How does this PR fix the problem?

Gives app support team developer level access to Planet FM

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Same changes applied in CSR, app team confirmed they are able to make dashboards

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
