### PR TITLE
allow oas migration team instance management permissions to oas development

### DIFF
--- a/environments/oas.json
+++ b/environments/oas.json
@@ -7,6 +7,10 @@
         {
           "github_slug": "laa-aws-infrastructure",
           "level": "developer"
+        },
+        {
+          "github_slug": "oas-migration",
+          "level": "instance-management"
         }
       ]
     },


### PR DESCRIPTION
## A reference to the issue / Description of it

https://mojdt.slack.com/archives/C01A7QK5VM1/p1710337677949329

## How does this PR fix the problem?

Adds requested team so that they have SSO access

## How has this been tested?

N/A

## Deployment Plan / Instructions

Deploy through CI / Scheduled Baseline job

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
