### PR TITLE
Add fleet manager access in PPUD

### DIFF
--- a/environments/ppud.json
+++ b/environments/ppud.json
@@ -7,6 +7,10 @@
         {
           "github_slug": "modernisation-platform",
           "level": "developer"
+        },
+        {
+          "github_slug": "ppud-replacement-devs",
+          "level": "fleet-manager"
         }
       ],
       "additional_reviewers": ["umeshc-roy", "nbuckingham72"]
@@ -17,6 +21,10 @@
         {
           "github_slug": "ppud-replacement-devs",
           "level": "migration"
+        },
+        {
+          "github_slug": "ppud-replacement-devs",
+          "level": "fleet-manager"
         }
       ],
       "additional_reviewers": ["umeshc-roy", "nbuckingham72"]


### PR DESCRIPTION
## A reference to the issue / Description of it

As requested in the ask channel [here](https://mojdt.slack.com/archives/C01A7QK5VM1/p1710416114736549) I'm adding `fleet-manager` access to development/preproduction environments for members of the `ppud-replacement-devs` GH Team which Andrew Larcombe is in. 

## How does this PR fix the problem?

Updated application.json file to grant access.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [X] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
