### PR TITLE
Adds appstream permissions to sandbox_additional policy.

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -418,6 +418,7 @@ data "aws_iam_policy_document" "sandbox_additional" {
       "airflow:*",
       "apigateway:*",
       "application-autoscaling:*",
+      "appstream:*",
       "athena:*",
       "autoscaling:*",
       "cloudformation:*",


### PR DESCRIPTION
## A reference to the issue / Description of it

This adds appstream permissions to the sandbox_additional policy.

## How does this PR fix the problem?

Member account user using oasys-development (which is a sandbox account) has experienced issues when attempting to create resources of that type.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
