### PR TITLE
Remove modernisation-platform-infrastructure-test

### DIFF
--- a/terraform/github/repositories.tf
+++ b/terraform/github/repositories.tf
@@ -270,19 +270,6 @@ module "modernisation-platform-environments" {
   }
 }
 
-module "modernisation-platform-infrastructure-test" {
-  source      = "./modules/repository"
-  name        = "modernisation-platform-infrastructure-test"
-  type        = "core"
-  description = "Infrastructure test tool based on Cucumber.js"
-  topics = [
-    "aws",
-    "networking",
-    "test",
-    "moj-security"
-  ]
-}
-
 module "terraform-module-aws-loadbalancer" {
   source      = "./modules/repository"
   name        = "modernisation-platform-terraform-loadbalancer"

--- a/terraform/github/teams.tf
+++ b/terraform/github/teams.tf
@@ -17,7 +17,6 @@ module "core-team" {
     module.terraform-module-aws-loadbalancer.repository.name,
     module.modernisation-platform-ami-builds.repository.name,
     module.modernisation-platform-environments.repository.name,
-    module.modernisation-platform-infrastructure-test.repository.name,
     module.modernisation-platform-terraform-member-vpc.repository.name,
     module.modernisation-platform-cp-network-test.repository.name,
     module.modernisation-platform-terraform-module-template.repository.name,


### PR DESCRIPTION
## A reference to the issue / Description of it

After some discussion [here](https://github.com/ministryofjustice/modernisation-platform/issues/6334) this PR removes the module from code.

## How does this PR fix the problem?

The behaviour of the terraform resource will archive this repository on deletion, and remove it from state so that it is no longer managed

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

https://mojdt.slack.com/archives/C013RM6MFFW/p1708431624229989

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
