### PR TITLE
DSOS-2635: enable second prod FixNGo DC

### DIFF
--- a/terraform/environments/core-shared-services/ad-fixngo.tf
+++ b/terraform/environments/core-shared-services/ad-fixngo.tf
@@ -32,36 +32,36 @@ locals {
       # rdlic        = remote desktop licensing server
       # a/b/c suffix = availability zone
 
-      ad-hmpp-dc-a = {
-        ami_name                  = "hmpps_windows_server_2022_release_2024-02-02T00-00-04.569Z"
-        availability_zone         = "eu-west-2a"
-        iam_instance_profile_role = "ad-fixngo-ec2-live-role"
-        instance_type             = "t3.large"
-        key_name                  = "ad-fixngo-ec2-live"
-        private_ip                = module.ad_fixngo_ip_addresses.mp_ip["ad-hmpp-dc-a"]
-        subnet_id                 = module.vpc["live_data"].non_tgw_subnet_ids_map.private[0]
-        vpc_security_group_name   = "ad_hmpp_dc_sg"
-        tags = {
-          server-type = "DomainController"
-          domain-name = "azure.hmpp.root"
-          description = "domain controller for FixNGo azure.hmpp.root domain"
-        }
-      }
-      # ad-hmpp-dc-b = {
+      # ad-hmpp-dc-a = {
       #   ami_name                  = "hmpps_windows_server_2022_release_2024-02-02T00-00-04.569Z"
-      #   availability_zone         = "eu-west-2b"
+      #   availability_zone         = "eu-west-2a"
       #   iam_instance_profile_role = "ad-fixngo-ec2-live-role"
       #   instance_type             = "t3.large"
       #   key_name                  = "ad-fixngo-ec2-live"
-      #   private_ip                = module.ad_fixngo_ip_addresses.mp_ip["ad-hmpp-dc-b"]
-      #   subnet_id                 = module.vpc["live_data"].non_tgw_subnet_ids_map.private[1]
+      #   private_ip                = module.ad_fixngo_ip_addresses.mp_ip["ad-hmpp-dc-a"]
+      #   subnet_id                 = module.vpc["live_data"].non_tgw_subnet_ids_map.private[0]
       #   vpc_security_group_name   = "ad_hmpp_dc_sg"
       #   tags = {
-      #     server-type = "DomainController"
+      #     server-type = "DomainJoin"
       #     domain-name = "azure.hmpp.root"
       #     description = "domain controller for FixNGo azure.hmpp.root domain"
       #   }
       # }
+      ad-hmpp-dc-b = {
+        ami_name                  = "hmpps_windows_server_2022_release_2024-02-02T00-00-04.569Z"
+        availability_zone         = "eu-west-2b"
+        iam_instance_profile_role = "ad-fixngo-ec2-live-role"
+        instance_type             = "t3.large"
+        key_name                  = "ad-fixngo-ec2-live"
+        private_ip                = module.ad_fixngo_ip_addresses.mp_ip["ad-hmpp-dc-b"]
+        subnet_id                 = module.vpc["live_data"].non_tgw_subnet_ids_map.private[1]
+        vpc_security_group_name   = "ad_hmpp_dc_sg"
+        tags = {
+          server-type = "DomainJoin"
+          domain-name = "azure.hmpp.root"
+          description = "domain controller for FixNGo azure.hmpp.root domain"
+        }
+      }
       # ad-hmpp-rdlic = {
       #   ami_name                  = "hmpps_windows_server_2022_release_2024-02-02T00-00-04.569Z"
       #   availability_zone         = "eu-west-2c"
@@ -884,7 +884,7 @@ resource "aws_instance" "ad_fixngo" {
 
   root_block_device {
     encrypted   = true
-    kms_key_id  = module.kms["hmpps"].key_arns["ebs"] # need to specify arn rather than id
+    kms_key_id  = module.kms["hmpps"].key_arns["ebs"] # need to specify arn rather than id
     volume_size = 127
     volume_type = "gp3"
 


### PR DESCRIPTION
## A reference to the issue / Description of it

Please see https://github.com/ministryofjustice/modernisation-platform/issues/5970

First prod DC can't resolve AD Users in infra.int - need to sort this out before promoting to be a DC. 

## How does this PR fix the problem?

Temporarily destroying first DC and enabling the second one.  This will allow me to fix any networking before promoting to DC.  

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

We've done this a few times now.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No impact to prod services

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)


