### PR TITLE
DSOS-2635: re-enable first prod fixngo DC

### DIFF
--- a/terraform/environments/core-shared-services/ad-fixngo.tf
+++ b/terraform/environments/core-shared-services/ad-fixngo.tf
@@ -32,21 +32,21 @@ locals {
       # rdlic        = remote desktop licensing server
       # a/b/c suffix = availability zone
 
-      # ad-hmpp-dc-a = {
-      #   ami_name                  = "hmpps_windows_server_2022_release_2024-02-02T00-00-04.569Z"
-      #   availability_zone         = "eu-west-2a"
-      #   iam_instance_profile_role = "ad-fixngo-ec2-live-role"
-      #   instance_type             = "t3.large"
-      #   key_name                  = "ad-fixngo-ec2-live"
-      #   private_ip                = module.ad_fixngo_ip_addresses.mp_ip["ad-hmpp-dc-a"]
-      #   subnet_id                 = module.vpc["live_data"].non_tgw_subnet_ids_map.private[0]
-      #   vpc_security_group_name   = "ad_hmpp_dc_sg"
-      #   tags = {
-      #     server-type = "DomainJoin"
-      #     domain-name = "azure.hmpp.root"
-      #     description = "domain controller for FixNGo azure.hmpp.root domain"
-      #   }
-      # }
+      ad-hmpp-dc-a = {
+        ami_name                  = "hmpps_windows_server_2022_release_2024-02-02T00-00-04.569Z"
+        availability_zone         = "eu-west-2a"
+        iam_instance_profile_role = "ad-fixngo-ec2-live-role"
+        instance_type             = "t3.large"
+        key_name                  = "ad-fixngo-ec2-live"
+        private_ip                = module.ad_fixngo_ip_addresses.mp_ip["ad-hmpp-dc-a"]
+        subnet_id                 = module.vpc["live_data"].non_tgw_subnet_ids_map.private[0]
+        vpc_security_group_name   = "ad_hmpp_dc_sg"
+        tags = {
+          server-type = "DomainJoin"
+          domain-name = "azure.hmpp.root"
+          description = "domain controller for FixNGo azure.hmpp.root domain"
+        }
+      }
       ad-hmpp-dc-b = {
         ami_name                  = "hmpps_windows_server_2022_release_2024-02-02T00-00-04.569Z"
         availability_zone         = "eu-west-2b"


### PR DESCRIPTION
## A reference to the issue / Description of it

Please see https://github.com/ministryofjustice/modernisation-platform/issues/5970

Prod DC can't resolve AD Users in infra.int - need to sort this out before promoting to be a DC.

## How does this PR fix the problem?

Rebuild of the first prod DC without promoting to a DC this time. We can then sort out any connectivity issues using the fixed IPs of the DCs.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

We've done this a few times now.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
