### PR TITLE
New Secret for XSIAM Endpoints & Keys

### DIFF
--- a/terraform/modernisation-platform-account/secrets.tf
+++ b/terraform/modernisation-platform-account/secrets.tf
@@ -173,3 +173,18 @@ data "aws_secretsmanager_secret_version" "circleci" {
   secret_id = aws_secretsmanager_secret.circleci.id
 }
 
+# Secrets for the XIAM data transfers. Note that the secrets contained in here are provided by Technology Services and so cannot be rotated unless initiated by them.
+# Secrets should be manually set in the console.
+
+resource "aws_secretsmanager_secret" "xsiam_secrets" {
+  # checkov:skip=CKV2_AWS_57:Auto rotation not possible
+    name        = "xsiam_secrets"
+    description = "Secret that holds the preprod & prod XSIAM endpoint values & keys for the firewall inspection & vpc flow log transfers"
+    kms_key_id  = aws_kms_key.secrets_key.id
+    tags        = local.tags
+    replica {
+      region = local.replica_region
+    }  
+}
+
+


### PR DESCRIPTION
This adds a new secrets that hold Xsiam endpoint values for sharing data for the vpc flow log data and firewall inspection logs.

## A reference to the issue / Description of it

Ref issue 6163 (https://github.com/ministryofjustice/modernisation-platform/issues/6163)

## How does this PR fix the problem?

See title

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
