### PR TITLE
🛂 Add IGW and NAT GW permissions to `MemberInfrastructureAccess`

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -111,6 +111,7 @@ data "aws_iam_policy_document" "member-access" {
       "ec2:*PlacementGroup*",
       "ec2:*IdFormat*",
       "ec2:*Spot*",
+      "ec2:*InternetGateway*",
       "ecr-public:*",
       "ecr:*",
       "ecs:*",

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -112,6 +112,8 @@ data "aws_iam_policy_document" "member-access" {
       "ec2:*IdFormat*",
       "ec2:*Spot*",
       "ec2:*InternetGateway*",
+      "ec2:*NatGateway*",
+      
       "ecr-public:*",
       "ecr:*",
       "ecs:*",


### PR DESCRIPTION
## A reference to the issue / Description of it

This pull request adds permissions for interacting with Internet and NAT Gateways

## How does this PR fix the problem?

When trying to create a new VPC in Analytical Platform Ingestion, this error is returned

```bash
Error: creating EC2 Internet Gateway: UnauthorizedOperation: You are not authorized to perform this operation. User: arn:aws:sts::730335344807:assumed-role/MemberInfrastructureAccess/aws-go-sdk-1710763531327859576 is not authorized to perform: ec2:CreateInternetGateway on resource: arn:aws:ec2:eu-west-2:730335344807:internet-gateway/* because no identity-based policy allows the ec2:CreateInternetGateway action.
```

https://github.com/ministryofjustice/modernisation-platform-environments/pull/5400

## How has this been tested?

It hasn't

## Deployment Plan / Instructions

A quick search for `CreateInternetGateway` in GitHub doesn't show an `Deny` policies

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
