### PR TITLE
Add acm:DeleteCertificate permission to developer role

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -166,8 +166,9 @@ data "aws_iam_policy_document" "developer_additional" {
     sid    = "developerAllow"
     effect = "Allow"
     actions = [
-      "acm:ImportCertificate",
       "acm:AddTagsToCertificate",
+      "acm:DeleteCertificate",
+      "acm:ImportCertificate",
       "acm:RemoveTagsFromCertificate",
       "application-autoscaling:ListTagsForResource",
       "autoscaling:UpdateAutoScalingGroup",


### PR DESCRIPTION
as per Slack request https://mojdt.slack.com/archives/C01A7QK5VM1/p1710772027207819 user would like temp permissions to delete certificates.

(also sorted the acm permissions alphabetically)