### PR TITLE
DSOS-2667: add syscon collaborators to nomis-development

### DIFF
--- a/collaborators.json
+++ b/collaborators.json
@@ -555,6 +555,86 @@
           "access": "developer"
         }
       ]
+    },
+    {
+      "username": "olumide.alabi",
+      "github-username": "olusyscon",
+      "accounts": [
+        {
+          "account-name": "nomis-development",
+          "access": "instance-management"
+        }
+      ]
+    },
+    {
+      "username": "paul.morris",
+      "github-username": "paulmsys",
+      "accounts": [
+        {
+          "account-name": "nomis-development",
+          "access": "instance-management"
+        }
+      ]
+    },
+    {
+      "username": "claus.andresen",
+      "github-username": "clausdk66",
+      "accounts": [
+        {
+          "account-name": "nomis-development",
+          "access": "instance-management"
+        }
+      ]
+    },
+    {
+      "username": "claire.fraser",
+      "github-username": "CFraserSyscon",
+      "accounts": [
+        {
+          "account-name": "nomis-development",
+          "access": "instance-management"
+        }
+      ]
+    },
+    {
+      "username": "adrian.lowe",
+      "github-username": "Alowesyscon",
+      "accounts": [
+        {
+          "account-name": "nomis-development",
+          "access": "instance-management"
+        }
+      ]
+    },
+    {
+      "username": "prashant.thakur",
+      "github-username": "pthakur97",
+      "accounts": [
+        {
+          "account-name": "nomis-development",
+          "access": "instance-management"
+        }
+      ]
+    },
+    {
+      "username": "sunil.ghadigaonkar",
+      "github-username": "sunilsyscon",
+      "accounts": [
+        {
+          "account-name": "nomis-development",
+          "access": "instance-management"
+        }
+      ]
+    },
+    {
+      "username": "richard.stubbs",
+      "github-username": "rs87099",
+      "accounts": [
+        {
+          "account-name": "nomis-development",
+          "access": "instance-management"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

Syscon are responsible for development of nomis and nomis live support. Adding syscon engineers who are not part of the MoJ Org to the collaborators list

## How does this PR fix the problem?

Gives access to nomis-development EC2 instances to syscon

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

N/A

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
