### PR TITLE
Issue with values assigned to resource_prefix being too long.

### DIFF
--- a/terraform/environments/core-network-services/firehose.tf
+++ b/terraform/environments/core-network-services/firehose.tf
@@ -11,7 +11,7 @@ locals {
 module "external_inspection_firehose" {
   source          = "../../modules/firehose"
   for_each        = local.firewall_logs
-  resource_prefix = each.value
+  resource_prefix = substr(each.value, 3, 3) # We do this because the log name is too long and we want to avoid any invalid characters.
   log_group_name  = each.value
   tags            = local.tags
   xsiam_endpoint  = each.value != "fw-non-live*" ? tostring(local.xsiam["xsiam_prod_firewall_endpoint"]) : tostring(local.xsiam["xsiam_nonprod_firewall_endpoint"])


### PR DESCRIPTION
## A reference to the issue / Description of it

Fixes bug whereby the unique prefix assigned to the firehose resource names was too long. This reduces it to three and allows for it to be identifiable.

## How does this PR fix the problem?

See above

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
