### PR TITLE
Firehose Data Transfers - Adds an additional module call but for the firewall vpc flow logs.

### DIFF
--- a/terraform/environments/core-network-services/firehose.tf
+++ b/terraform/environments/core-network-services/firehose.tf
@@ -4,9 +4,13 @@
 
 locals {
 
-    firewall_logs = toset([module.vpc_inspection["live_data"].fw_cloudwatch_name, module.vpc_inspection["non_live_data"].fw_cloudwatch_name, module.firewall_logging.cloudwatch_log_group_name])
+  firewall_logs = toset([module.vpc_inspection["live_data"].fw_cloudwatch_name, module.vpc_inspection["non_live_data"].fw_cloudwatch_name, module.firewall_logging.cloudwatch_log_group_name])
+
+  firewall_vpc_logs = toset([module.vpc_inspection["live_data"].vpc_cloudwatch_name, module.vpc_inspection["non_live_data"].vpc_cloudwatch_name, aws_cloudwatch_log_group.external_inspection.name])
 
 }
+
+# The initial call is for the creation of firehose stream resources for the firewall inspection logs.
 
 module "external_inspection_firehose" {
   source          = "../../modules/firehose"
@@ -16,4 +20,16 @@ module "external_inspection_firehose" {
   tags            = local.tags
   xsiam_endpoint  = substr(each.value, 3, 3) != "non" ? tostring(local.xsiam["xsiam_prod_firewall_endpoint"]) : tostring(local.xsiam["xsiam_preprod_firewall_endpoint"])
   xsiam_secret    = substr(each.value, 3, 3) != "non" ? tostring(local.xsiam["xsiam_prod_firewall_secret"]) : tostring(local.xsiam["xsiam_preprod_firewall_secret"])
+}
+
+# A 2nd call of the module which will generate the firehose streams for the firewall vpc flow logs.
+
+module "firehose_for_firewall_vpc_flow_logs" {
+  source          = "../../modules/firehose"
+  for_each        = local.firewall_vpc_logs
+  resource_prefix = format("%s-vpc", substr(each.value, 0, 3)) # As above but we add an additional identifier 
+  log_group_name  = each.value
+  tags            = local.tags
+  xsiam_endpoint  = substr(each.value, 0, 3) != "non" ? tostring(local.xsiam["xsiam_prod_network_endpoint"]) : tostring(local.xsiam["xsiam_preprod_network_endpoint"])
+  xsiam_secret    = substr(each.value, 0, 3) != "non" ? tostring(local.xsiam["xsiam_prod_network_secret"]) : tostring(local.xsiam["xsiam_preprod_network_secret"])
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

As per title. This change adds an additional module call to generate firehose data streams for the firewall VPC flow logs.

## How does this PR fix the problem?

This covers one of the requirements to share vpc flow log data with SecOps.

## How has this been tested?

Has been tested via local plan.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
