### PR TITLE
Add test to check for missing github-oidc-team-repositories field

### DIFF
--- a/policies/environments/environment-definitions.rego
+++ b/policies/environments/environment-definitions.rego
@@ -114,3 +114,8 @@ deny[msg] {
   not startswith(input.filename, "environments/sprinkler") # to allow testing
   msg := sprintf("`%v` uses `powerbi-user` access level but is not an analytical platform or sprinkler account", [input.filename])
 }
+
+deny[msg] {
+  not has_field(input, "github-oidc-team-repositories")
+  msg := sprintf("`%v` is missing the `github-oidc-team-repositories` key", [input.filename])
+}


### PR DESCRIPTION
## A reference to the issue / Description of it
In this Slack thread https://mojdt.slack.com/archives/C013RM6MFFW/p1710935860985819 - we created a new account but missed out a mandatory field `github-oidc-team-repositories`

## How does this PR fix the problem?

Test added which will check for inclusion of this field in application.json file. If this fails PRs wont be able to be merged.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Locally I tested this by removing the field in example.json...

```
❯ ./scripts/tests/validate/run-opa-tests.sh
PASS - Environment files check
PASS - Environment network files check

8 tests, 8 passed, 0 warnings, 0 failures, 0 exceptions

374 tests, 374 passed, 0 warnings, 0 failures, 0 exceptions

110 tests, 110 passed, 0 warnings, 0 failures, 0 exceptions
FAIL - - main - `environments/example.json` is missing the `github-oidc-team-repositories` key

1050 tests, 1049 passed, 0 warnings, 1 failure, 0 exceptions
```

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [X] All checks have passed

## Additional comments (if any)

