### PR TITLE
:wrench: Enable Retrieval for Lambdas - AP Ingestion

### DIFF
--- a/terraform/environments/core-shared-services/ecr_repos.tf
+++ b/terraform/environments/core-shared-services/ecr_repos.tf
@@ -1077,6 +1077,13 @@ module "analytical_platform_ingestion_scan_ecr_repo" {
     local.environment_management.account_ids["analytical-platform-ingestion-production"]
   ]
 
+  enable_retrieval_policy_for_lambdas = [
+    "arn:aws:lambda:eu-west-2:${local.environment_management.account_ids["analytical-platform-ingestion-development"]}:function:scan*",
+    "arn:aws:lambda:eu-west-2:${local.environment_management.account_ids["analytical-platform-ingestion-production"]}:function:scan*",
+    "arn:aws:lambda:eu-west-2:${local.environment_management.account_ids["analytical-platform-ingestion-development"]}:function:definition-upload*",
+    "arn:aws:lambda:eu-west-2:${local.environment_management.account_ids["analytical-platform-ingestion-production"]}:function:definition-upload*"
+  ]
+
   # Tags
   tags_common = local.tags
 }
@@ -1092,6 +1099,11 @@ module "analytical_platform_ingestion_transfer_ecr_repo" {
     "arn:aws:iam::${local.environment_management.account_ids["analytical-platform-ingestion-development"]}:role/modernisation-platform-oidc-cicd",
     local.environment_management.account_ids["analytical-platform-ingestion-development"],
     local.environment_management.account_ids["analytical-platform-ingestion-production"]
+  ]
+
+  enable_retrieval_policy_for_lambdas = [
+    "arn:aws:lambda:eu-west-2:${local.environment_management.account_ids["analytical-platform-ingestion-development"]}:function:transfer*",
+    "arn:aws:lambda:eu-west-2:${local.environment_management.account_ids["analytical-platform-ingestion-production"]}:function:transfer*"
   ]
 
   # Tags


### PR DESCRIPTION
## A reference to the issue / Description of it

This is required to allow our Lambda functions which are being created in `analytical-platform-ingestion` to pull their images.

## How does this PR fix the problem?

Enables the above. 

## How has this been tested?

Mirrors the same approach in other ECR repositories in the same file. 

## Deployment Plan / Instructions

No

## Checklist

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation - Not needed
- [ ] Plan and discussed how it should be deployed to PROD (If needed) - Not needed imo

## Additional comments (if any)
NA
