### PR TITLE
Adds firehose resources for vpc flow logs in core-shared-services and core-logging.

### DIFF
--- a/terraform/environments/core-logging/firehose.tf
+++ b/terraform/environments/core-logging/firehose.tf
@@ -1,0 +1,18 @@
+
+# This generates the firehose stream resources to share VPC flow log data
+
+locals {
+
+  vpc_logs = toset([module.vpc["live_data"].vpc_cloudwatch_name, module.vpc["non_live_data"].vpc_cloudwatch_name])
+
+}
+
+module "firehose_core_logging_vpcs" {
+  source          = "../../modules/firehose"
+  for_each        = local.vpc_logs
+  resource_prefix = format("%s-log", substr(each.value, 0, 3)) 
+  log_group_name  = each.value
+  tags            = local.tags
+  xsiam_endpoint  = substr(each.value, 0, 3) != "non" ? tostring(local.xsiam["xsiam_prod_network_endpoint"]) : tostring(local.xsiam["xsiam_preprod_network_endpoint"])
+  xsiam_secret    = substr(each.value, 0, 3) != "non" ? tostring(local.xsiam["xsiam_prod_network_secret"]) : tostring(local.xsiam["xsiam_preprod_network_secret"])
+}

--- a/terraform/environments/core-logging/locals.tf
+++ b/terraform/environments/core-logging/locals.tf
@@ -11,6 +11,9 @@ locals {
   # the string leftover is `-production`, if it isn't (e.g. core-vpc-non-production => -non-production) then it sets the var to false.
   is-production = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-production"
 
+ # This local allows us to references the key / value pairs held in xsiam_secrets.
+  xsiam = jsondecode(data.aws_secretsmanager_secret_version.xsiam_secret_arn_version.secret_string)
+
   tags = {
     business-unit = "Platforms"
     application   = "Modernisation Platform: ${terraform.workspace}"

--- a/terraform/environments/core-logging/secrets.tf
+++ b/terraform/environments/core-logging/secrets.tf
@@ -20,3 +20,15 @@ data "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {
   provider  = aws.modernisation-platform
   secret_id = data.aws_secretsmanager_secret.pagerduty_integration_keys.id
 }
+
+# Data for Firehose Endpoint URL & Key that are held in secrets manager.
+
+data "aws_secretsmanager_secret" "xsiam_secret_arn" {
+  provider = aws.modernisation-platform
+  name     = "xsiam_secrets"
+}
+
+data "aws_secretsmanager_secret_version" "xsiam_secret_arn_version" {
+  provider  = aws.modernisation-platform
+  secret_id = data.aws_secretsmanager_secret.xsiam_secret_arn.id
+}

--- a/terraform/environments/core-shared-services/firehose.tf
+++ b/terraform/environments/core-shared-services/firehose.tf
@@ -1,0 +1,18 @@
+
+# This generates the firehose stream resources to share VPC flow log data
+
+locals {
+
+  vpc_logs = toset([module.vpc["live_data"].vpc_cloudwatch_name, module.vpc["non_live_data"].vpc_cloudwatch_name])
+
+}
+
+module "firehose_core_logging_vpcs" {
+  source          = "../../modules/firehose"
+  for_each        = local.vpc_logs
+  resource_prefix = format("%s-sha", substr(each.value, 0, 3)) 
+  log_group_name  = each.value
+  tags            = local.tags
+  xsiam_endpoint  = substr(each.value, 0, 3) != "non" ? tostring(local.xsiam["xsiam_prod_network_endpoint"]) : tostring(local.xsiam["xsiam_preprod_network_endpoint"])
+  xsiam_secret    = substr(each.value, 0, 3) != "non" ? tostring(local.xsiam["xsiam_prod_network_secret"]) : tostring(local.xsiam["xsiam_preprod_network_secret"])
+}

--- a/terraform/environments/core-shared-services/locals.tf
+++ b/terraform/environments/core-shared-services/locals.tf
@@ -45,6 +45,9 @@ locals {
     ]
   }
 
+   # This local allows us to references the key / value pairs held in xsiam_secrets.
+  xsiam = jsondecode(data.aws_secretsmanager_secret_version.xsiam_secret_arn_version.secret_string)
+
   tags = {
     business-unit = "Platforms"
     application   = "Modernisation Platform: ${terraform.workspace}"

--- a/terraform/environments/core-shared-services/secrets.tf
+++ b/terraform/environments/core-shared-services/secrets.tf
@@ -20,3 +20,15 @@ data "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {
   provider  = aws.modernisation-platform
   secret_id = data.aws_secretsmanager_secret.pagerduty_integration_keys.id
 }
+
+# Data for Firehose Endpoint URL & Key that are held in secrets manager.
+
+data "aws_secretsmanager_secret" "xsiam_secret_arn" {
+  provider = aws.modernisation-platform
+  name     = "xsiam_secrets"
+}
+
+data "aws_secretsmanager_secret_version" "xsiam_secret_arn_version" {
+  provider  = aws.modernisation-platform
+  secret_id = data.aws_secretsmanager_secret.xsiam_secret_arn.id
+}


### PR DESCRIPTION
## A reference to the issue / Description of it

As per title, this adds firehose resources into the two above core accounts in order to share vpc flow log data with SecOps.

## How does this PR fix the problem?

{Please write here}

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
