### PR TITLE
Removed pinned provider version & increased max_retries for Secure Baselines

### DIFF
--- a/terraform/environments/bootstrap/secure-baselines/providers.tf
+++ b/terraform/environments/bootstrap/secure-baselines/providers.tf
@@ -14,8 +14,9 @@ provider "aws" {
 
 # Region specific providers for the workspace. Required for bootstrapping resources in enabled regions.
 provider "aws" {
-  alias  = "workspace-eu-central-1"
-  region = "eu-central-1"
+  alias       = "workspace-eu-central-1"
+  region      = "eu-central-1"
+  max_retries = 100
 
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
@@ -23,8 +24,9 @@ provider "aws" {
 }
 
 provider "aws" {
-  alias  = "workspace-eu-west-1"
-  region = "eu-west-1"
+  alias       = "workspace-eu-west-1"
+  region      = "eu-west-1"
+  max_retries = 100
 
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
@@ -32,8 +34,9 @@ provider "aws" {
 }
 
 provider "aws" {
-  alias  = "workspace-eu-west-2"
-  region = "eu-west-2"
+  alias       = "workspace-eu-west-2"
+  region      = "eu-west-2"
+  max_retries = 100
 
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
@@ -41,8 +44,9 @@ provider "aws" {
 }
 
 provider "aws" {
-  alias  = "workspace-us-east-1"
-  region = "us-east-1"
+  alias       = "workspace-us-east-1"
+  region      = "us-east-1"
+  max_retries = 100
 
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"

--- a/terraform/environments/bootstrap/secure-baselines/versions.tf
+++ b/terraform/environments/bootstrap/secure-baselines/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "5.38.0" #pinned temporarily due to rate limiting bug #6486
+      version = "~> 5.0"
       source  = "hashicorp/aws"
     }
   }

--- a/terraform/environments/bootstrap/secure-baselines/versions.tf
+++ b/terraform/environments/bootstrap/secure-baselines/versions.tf
@@ -1,8 +1,9 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
-      source  = "hashicorp/aws"
+      version     = "~> 5.0"
+      source      = "hashicorp/aws"
+      max_retries = 100
     }
   }
   required_version = "~> 1.0"

--- a/terraform/environments/bootstrap/secure-baselines/versions.tf
+++ b/terraform/environments/bootstrap/secure-baselines/versions.tf
@@ -1,9 +1,8 @@
 terraform {
   required_providers {
     aws = {
-      version     = "~> 5.0"
-      source      = "hashicorp/aws"
-      max_retries = 100
+      version = "~> 5.0"
+      source  = "hashicorp/aws"
     }
   }
   required_version = "~> 1.0"


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/6486

## How does this PR fix the problem?

I've reverted the code that was pinning the version of the AWS TF provider back to `v5.38.0`

The jobs are now picking up the latest version `v5.42.0` which has had an update that stops client side rate limiting which stops you getting the original error we encountered e.g. 
`failed to get rate limit token, retry quota exceeded, 3 available, 5 requested`

But we were still encountering this error e.g. 
`ListTagsForResource, exceeded maximum number of attempts, 25, https response error StatusCode: 400, RequestID: c17f1153-756e-4968-bd57-e38a51792366, api error ThrottlingException: Rate exceeded`

There is an optional [max_retries](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#max_retries) setting that can be applied to the provider so you can raise it from the default of `25`.
In this PR I have set it to `100` which has been tested successfully on two subsequent runs of the scheduled baseline job.

## How has this been tested?

It worked ... https://github.com/ministryofjustice/modernisation-platform/actions/runs/8422101284

twice... https://github.com/ministryofjustice/modernisation-platform/actions/runs/8422873826

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [X] All checks have passed


## Additional comments (if any)

This might just be a setting we keep our eye on over time as with all the scheduled baseline code which is growing as the platform grows.