### PR TITLE
add vpc endpoints for hmcts preprod and prod

### DIFF
--- a/environments-networks/hmcts-preproduction.json
+++ b/environments-networks/hmcts-preproduction.json
@@ -18,7 +18,12 @@
   "options": {
     "bastion_linux": false,
     "additional_cidrs": [],
-    "additional_endpoints": [],
+    "additional_endpoints": [
+      "com.amazonaws.eu-west-2.ecr.dkr",
+      "com.amazonaws.eu-west-2.ecr.api",
+      "com.amazonaws.eu-west-2.secretsmanager",
+      "com.amazonaws.eu-west-2.elasticloadbalancing"
+    ],
     "additional_private_zones": [],
     "additional_vpcs": [],
     "dns_zone_extend": []

--- a/environments-networks/hmcts-production.json
+++ b/environments-networks/hmcts-production.json
@@ -18,7 +18,12 @@
   "options": {
     "bastion_linux": false,
     "additional_cidrs": [],
-    "additional_endpoints": [],
+    "additional_endpoints": [
+      "com.amazonaws.eu-west-2.ecr.dkr",
+      "com.amazonaws.eu-west-2.ecr.api",
+      "com.amazonaws.eu-west-2.secretsmanager",
+      "com.amazonaws.eu-west-2.elasticloadbalancing"
+    ],
     "additional_private_zones": [],
     "additional_vpcs": [],
     "dns_zone_extend": []


### PR DESCRIPTION
## A reference to the issue / Description of it

Adding vpc endpoints to allow ecs to access ecr. This issue occurred after disabling public ip addresses on the ecs service.

## How does this PR fix the problem?

It allows for internal communication between the services on a vpc.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

The ECS deployments were failing before making this change on the development environment.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
