### PR TITLE
Adds firehose stream resources for R53 resolver logs plus other minor changes.

### DIFF
--- a/terraform/environments/core-logging/firehose.tf
+++ b/terraform/environments/core-logging/firehose.tf
@@ -11,9 +11,9 @@ module "firehose_core_logging_vpcs" {
   source          = "../../modules/firehose"
   for_each        = local.vpc_logs
   resource_prefix = format("%s-log", substr(each.value, 0, 3))
-  common_attribute          = "${each.key}-${local.application_name}"
+  common_attribute          = "${local.application_name}-${each.key}"
   log_group_name  = each.value
   tags            = local.tags
-  xsiam_endpoint  = substr(each.value, 0, 3) != "non" ? tostring(local.xsiam["xsiam_prod_network_endpoint"]) : tostring(local.xsiam["xsiam_preprod_network_endpoint"])
-  xsiam_secret    = substr(each.value, 0, 3) != "non" ? tostring(local.xsiam["xsiam_prod_network_secret"]) : tostring(local.xsiam["xsiam_preprod_network_secret"])
+  xsiam_endpoint   = each.value == "live_data" ? local.xsiam["xsiam_prod_network_endpoint"] : local.xsiam["xsiam_preprod_network_endpoint"]
+  xsiam_secret     = each.value == "live_data" ? local.xsiam["xsiam_prod_network_secret"] : local.xsiam["xsiam_preprod_network_secret"]
 }

--- a/terraform/environments/core-logging/firehose.tf
+++ b/terraform/environments/core-logging/firehose.tf
@@ -11,6 +11,7 @@ module "firehose_core_logging_vpcs" {
   source          = "../../modules/firehose"
   for_each        = local.vpc_logs
   resource_prefix = format("%s-log", substr(each.value, 0, 3))
+  common_attribute          = "${each.key}-${local.application_name}"
   log_group_name  = each.value
   tags            = local.tags
   xsiam_endpoint  = substr(each.value, 0, 3) != "non" ? tostring(local.xsiam["xsiam_prod_network_endpoint"]) : tostring(local.xsiam["xsiam_preprod_network_endpoint"])

--- a/terraform/environments/core-logging/firehose.tf
+++ b/terraform/environments/core-logging/firehose.tf
@@ -1,6 +1,8 @@
 
 # This generates the firehose stream resources to share VPC flow log data
 
+# For the endpoint & secret values we test using the vpc_logs values rather than the is_production local as both sets of vpcs are in the same account.
+
 locals {
 
   vpc_logs = toset([module.vpc["live_data"].vpc_cloudwatch_name, module.vpc["non_live_data"].vpc_cloudwatch_name])

--- a/terraform/environments/core-network-services/firehose.tf
+++ b/terraform/environments/core-network-services/firehose.tf
@@ -2,6 +2,8 @@
 # The purpose of this module call is to generate firehose & related resources for each cloudwatch log group created for the inline & external inspection firewalls.
 # This uses the cloudwatch log names outputted from the vpc inspection firewall module as well as the log group created for the external inspection firewall
 
+# For the endpoint & secret values we test using the vpc_logs values rather than the is_production local as both sets of vpcs are in the same account.
+
 locals {
 
   firewall_logs = toset([module.vpc_inspection["live_data"].fw_cloudwatch_name, module.vpc_inspection["non_live_data"].fw_cloudwatch_name, module.firewall_logging.cloudwatch_log_group_name])

--- a/terraform/environments/core-network-services/firehose.tf
+++ b/terraform/environments/core-network-services/firehose.tf
@@ -16,6 +16,7 @@ module "firehose_firewalls" {
   source          = "../../modules/firehose"
   for_each        = local.firewall_logs
   resource_prefix = substr(each.value, 3, 3) # We do this because the log name is too long and we want to avoid any invalid characters.
+  common_attribute          = "${each.key}-${local.application_name}"
   log_group_name  = each.value
   tags            = local.tags
   xsiam_endpoint  = substr(each.value, 3, 3) != "non" ? tostring(local.xsiam["xsiam_prod_firewall_endpoint"]) : tostring(local.xsiam["xsiam_preprod_firewall_endpoint"])
@@ -28,6 +29,7 @@ module "firehose_vpcs" {
   source          = "../../modules/firehose"
   for_each        = local.firewall_vpc_logs
   resource_prefix = format("%s-vpc", substr(each.value, 0, 3)) # As above but we add an additional identifier
+  common_attribute          = "${each.key}-${local.application_name}"
   log_group_name  = each.value
   tags            = local.tags
   xsiam_endpoint  = substr(each.value, 0, 3) != "non" ? tostring(local.xsiam["xsiam_prod_network_endpoint"]) : tostring(local.xsiam["xsiam_preprod_network_endpoint"])

--- a/terraform/environments/core-network-services/firehose.tf
+++ b/terraform/environments/core-network-services/firehose.tf
@@ -16,11 +16,11 @@ module "firehose_firewalls" {
   source          = "../../modules/firehose"
   for_each        = local.firewall_logs
   resource_prefix = substr(each.value, 3, 3) # We do this because the log name is too long and we want to avoid any invalid characters.
-  common_attribute          = "${each.key}-${local.application_name}"
+  common_attribute          = "${local.application_name}-${each.key}"
   log_group_name  = each.value
   tags            = local.tags
-  xsiam_endpoint  = substr(each.value, 3, 3) != "non" ? tostring(local.xsiam["xsiam_prod_firewall_endpoint"]) : tostring(local.xsiam["xsiam_preprod_firewall_endpoint"])
-  xsiam_secret    = substr(each.value, 3, 3) != "non" ? tostring(local.xsiam["xsiam_prod_firewall_secret"]) : tostring(local.xsiam["xsiam_preprod_firewall_secret"])
+  xsiam_endpoint  = each.value == "live_data" ? tostring(local.xsiam["xsiam_prod_firewall_endpoint"]) : tostring(local.xsiam["xsiam_preprod_firewall_endpoint"])
+  xsiam_secret    = each.value == "live_data" ? tostring(local.xsiam["xsiam_prod_firewall_secret"]) : tostring(local.xsiam["xsiam_preprod_firewall_secret"])
 }
 
 # A 2nd call of the module which will generate the firehose streams for the firewall vpc flow logs.
@@ -29,9 +29,9 @@ module "firehose_vpcs" {
   source          = "../../modules/firehose"
   for_each        = local.firewall_vpc_logs
   resource_prefix = format("%s-vpc", substr(each.value, 0, 3)) # As above but we add an additional identifier
-  common_attribute          = "${each.key}-${local.application_name}"
+  common_attribute          = "${local.application_name}-${each.key}"
   log_group_name  = each.value
   tags            = local.tags
-  xsiam_endpoint  = substr(each.value, 0, 3) != "non" ? tostring(local.xsiam["xsiam_prod_network_endpoint"]) : tostring(local.xsiam["xsiam_preprod_network_endpoint"])
-  xsiam_secret    = substr(each.value, 0, 3) != "non" ? tostring(local.xsiam["xsiam_prod_network_secret"]) : tostring(local.xsiam["xsiam_preprod_network_secret"])
+  xsiam_endpoint  = each.value == "live_data" ? tostring(local.xsiam["xsiam_prod_network_endpoint"]) : tostring(local.xsiam["xsiam_preprod_network_endpoint"])
+  xsiam_secret    = each.value == "live_data" ? tostring(local.xsiam["xsiam_prod_network_secret"]) : tostring(local.xsiam["xsiam_preprod_network_secret"])
 }

--- a/terraform/environments/core-security/firehose.tf
+++ b/terraform/environments/core-security/firehose.tf
@@ -11,6 +11,7 @@ module "firehose_core_security_vpcs" {
   source          = "../../modules/firehose"
   for_each        = local.vpc_logs
   resource_prefix = format("%s-sec", substr(each.value, 0, 3))
+  common_attribute          = "${each.key}-${local.application_name}"
   log_group_name  = each.value
   tags            = local.tags
   xsiam_endpoint  = substr(each.value, 0, 3) != "non" ? tostring(local.xsiam["xsiam_prod_network_endpoint"]) : tostring(local.xsiam["xsiam_preprod_network_endpoint"])

--- a/terraform/environments/core-security/firehose.tf
+++ b/terraform/environments/core-security/firehose.tf
@@ -8,12 +8,12 @@ locals {
 }
 
 module "firehose_core_security_vpcs" {
-  source          = "../../modules/firehose"
-  for_each        = local.vpc_logs
-  resource_prefix = format("%s-sec", substr(each.value, 0, 3))
-  common_attribute          = "${each.key}-${local.application_name}"
-  log_group_name  = each.value
-  tags            = local.tags
-  xsiam_endpoint  = substr(each.value, 0, 3) != "non" ? tostring(local.xsiam["xsiam_prod_network_endpoint"]) : tostring(local.xsiam["xsiam_preprod_network_endpoint"])
-  xsiam_secret    = substr(each.value, 0, 3) != "non" ? tostring(local.xsiam["xsiam_prod_network_secret"]) : tostring(local.xsiam["xsiam_preprod_network_secret"])
+  source           = "../../modules/firehose"
+  for_each         = local.vpc_logs
+  resource_prefix  = format("%s-sec", substr(each.value, 0, 3))
+  common_attribute = "${local.application_name}-${each.key}"
+  log_group_name   = each.value
+  tags             = local.tags
+  xsiam_endpoint   = each.value == "live_data" ? local.xsiam["xsiam_prod_network_endpoint"] : local.xsiam["xsiam_preprod_network_endpoint"]
+  xsiam_secret     = each.value == "live_data" ? local.xsiam["xsiam_prod_network_secret"] : local.xsiam["xsiam_preprod_network_secret"]
 }

--- a/terraform/environments/core-security/firehose.tf
+++ b/terraform/environments/core-security/firehose.tf
@@ -1,6 +1,9 @@
 
 # This generates the firehose stream resources to share VPC flow log data
 
+# For the endpoint & secret values we test using the vpc_logs values rather than the is_production local as both sets of vpcs are in the same account.
+
+
 locals {
 
   vpc_logs = toset([module.vpc["live_data"].vpc_cloudwatch_name, module.vpc["non_live_data"].vpc_cloudwatch_name])

--- a/terraform/environments/core-shared-services/firehose.tf
+++ b/terraform/environments/core-shared-services/firehose.tf
@@ -8,11 +8,13 @@ locals {
 }
 
 module "firehose_core_logging_vpcs" {
-  source          = "../../modules/firehose"
-  for_each        = local.vpc_logs
-  resource_prefix = format("%s-sha", substr(each.value, 0, 3))
-  log_group_name  = each.value
-  tags            = local.tags
-  xsiam_endpoint  = substr(each.value, 0, 3) != "non" ? tostring(local.xsiam["xsiam_prod_network_endpoint"]) : tostring(local.xsiam["xsiam_preprod_network_endpoint"])
-  xsiam_secret    = substr(each.value, 0, 3) != "non" ? tostring(local.xsiam["xsiam_prod_network_secret"]) : tostring(local.xsiam["xsiam_preprod_network_secret"])
+  source           = "../../modules/firehose"
+  for_each         = local.vpc_logs
+  resource_prefix  = format("%s-sha", substr(each.value, 0, 3))
+  common_attribute = "${each.key}-${local.application_name}"
+
+  log_group_name   = each.value
+  tags             = local.tags
+  xsiam_endpoint   = substr(each.value, 0, 3) != "non" ? tostring(local.xsiam["xsiam_prod_network_endpoint"]) : tostring(local.xsiam["xsiam_preprod_network_endpoint"])
+  xsiam_secret     = substr(each.value, 0, 3) != "non" ? tostring(local.xsiam["xsiam_prod_network_secret"]) : tostring(local.xsiam["xsiam_preprod_network_secret"])
 }

--- a/terraform/environments/core-shared-services/firehose.tf
+++ b/terraform/environments/core-shared-services/firehose.tf
@@ -1,6 +1,9 @@
 
 # This generates the firehose stream resources to share VPC flow log data
 
+# For the endpoint & secret values we test using the vpc_logs values rather than the is_production local as both sets of vpcs are in the same account.
+
+
 locals {
 
   vpc_logs = toset([module.vpc["live_data"].vpc_cloudwatch_name, module.vpc["non_live_data"].vpc_cloudwatch_name])

--- a/terraform/environments/core-shared-services/firehose.tf
+++ b/terraform/environments/core-shared-services/firehose.tf
@@ -11,10 +11,9 @@ module "firehose_core_logging_vpcs" {
   source           = "../../modules/firehose"
   for_each         = local.vpc_logs
   resource_prefix  = format("%s-sha", substr(each.value, 0, 3))
-  common_attribute = "${each.key}-${local.application_name}"
-
+  common_attribute          = "${local.application_name}-${each.key}"
   log_group_name   = each.value
   tags             = local.tags
-  xsiam_endpoint   = substr(each.value, 0, 3) != "non" ? tostring(local.xsiam["xsiam_prod_network_endpoint"]) : tostring(local.xsiam["xsiam_preprod_network_endpoint"])
-  xsiam_secret     = substr(each.value, 0, 3) != "non" ? tostring(local.xsiam["xsiam_prod_network_secret"]) : tostring(local.xsiam["xsiam_preprod_network_secret"])
+  xsiam_endpoint   = each.value == "live_data" ? local.xsiam["xsiam_prod_network_endpoint"] : local.xsiam["xsiam_preprod_network_endpoint"]
+  xsiam_secret     = each.value == "live_data" ? local.xsiam["xsiam_prod_network_secret"] : local.xsiam["xsiam_preprod_network_secret"]
 }

--- a/terraform/environments/core-vpc/firehose.tf
+++ b/terraform/environments/core-vpc/firehose.tf
@@ -1,13 +1,10 @@
 
 # The purpose of this module call is to generate firehose & related resources for each R53 resolver log in core-vpc
 
-
-# The initial call is for the creation of firehose stream resources for the firewall inspection logs.
-
 # We are only building for production & development.
 
 
-module "firehose_firewalls" {
+module "firehose_r53_resolver_logs" {
   source          = "../../modules/firehose"  
   for_each = { for key, value in module.vpc : 
             key => value["vpc_id"] 

--- a/terraform/environments/core-vpc/firehose.tf
+++ b/terraform/environments/core-vpc/firehose.tf
@@ -9,8 +9,9 @@
 
 module "firehose_firewalls" {
   source          = "../../modules/firehose"  
-  for_each                    = { for key, value in module.vpc : key => value["vpc_id"] }
-    count                     = anytrue(local.is-production, local.is-development, local.is-sandbox) ? 1 : 0
+  for_each = { for key, value in module.vpc : 
+            key => value["vpc_id"] 
+            if anytrue(local.local.is-development, local.local.is-production) }
     common_attribute          = "${each.key}-${local.application_name}"
     resource_prefix           = format("R53-%s",each.key) # We do this to ensure the resource names are unique
     log_group_name            = module.route_53_resolver_logs[each.key].r53_resolver_log_name

--- a/terraform/environments/core-vpc/firehose.tf
+++ b/terraform/environments/core-vpc/firehose.tf
@@ -14,3 +14,7 @@ module "firehose_r53_resolver_logs" {
   xsiam_endpoint   = each.value == "live_data" ? local.xsiam["xsiam_prod_network_endpoint"] : local.xsiam["xsiam_preprod_network_endpoint"]
   xsiam_secret     = each.value == "live_data" ? local.xsiam["xsiam_prod_r53_secret"] : local.xsiam["xsiam_preprod_r53_secret"]
 }
+
+output "vpc-module" {
+  value = module.vpc
+}

--- a/terraform/environments/core-vpc/firehose.tf
+++ b/terraform/environments/core-vpc/firehose.tf
@@ -4,13 +4,3 @@
 # We are only building for production & development.
 
 
-module "firehose_r53_resolver_logs" {
-  source           = "../../modules/firehose"
-  for_each         = { for key, value in module.vpc : key => value["vpc_id"] } # if anytrue([local.is-development, local.is-production]) }
-  common_attribute = "${local.application_name}-${each.key}"
-  resource_prefix  = format("R53-%s", each.key) # We do this to ensure the resource names are unique
-  log_group_name   = module.route_53_resolver_logs[each.key].r53_resolver_log_name
-  tags             = local.tags
-  xsiam_endpoint   = each.value == "live_data" ? local.xsiam["xsiam_prod_network_endpoint"] : local.xsiam["xsiam_preprod_network_endpoint"]
-  xsiam_secret     = each.value == "live_data" ? local.xsiam["xsiam_prod_r53_secret"] : local.xsiam["xsiam_preprod_r53_secret"]
-}

--- a/terraform/environments/core-vpc/firehose.tf
+++ b/terraform/environments/core-vpc/firehose.tf
@@ -6,7 +6,7 @@
 
 module "firehose_r53_resolver_logs" {
   source           = "../../modules/firehose"
-  for_each         = { for key, value in module.vpc : key => value["vpc_id"] } # if anytrue([local.is-development, local.is-production]) }
+  for_each         = { for key, value in module.vpc : key => value["vpc_id"] if anytrue([local.is-development, local.is-production])} 
   common_attribute = "${local.application_name}-${each.key}"
   resource_prefix  = format("%s-R53", each.key) # We do this to ensure the resource names are unique
   log_group_name   = module.route_53_resolver_logs[each.key].r53_resolver_log_name

--- a/terraform/environments/core-vpc/firehose.tf
+++ b/terraform/environments/core-vpc/firehose.tf
@@ -6,13 +6,11 @@
 
 module "firehose_r53_resolver_logs" {
   source = "../../modules/firehose"
-  for_each = { for key, value in module.vpc :
-    key => value["vpc_id"]
-  if anytrue([local.is-development, local.is-production]) }
-  common_attribute = "${local.application_name}-${each.key}"
-  resource_prefix  = format("R53-%s", each.key) # We do this to ensure the resource names are unique
-  log_group_name   = module.route_53_resolver_logs[each.key].r53_resolver_log_name
-  tags             = local.tags
-  xsiam_endpoint   = each.value == "live_data" ? local.xsiam["xsiam_prod_network_endpoint"] : local.xsiam["xsiam_preprod_network_endpoint"]
-  xsiam_secret     = each.value == "live_data" ? local.xsiam["xsiam_prod_r53_secret"] : local.xsiam["xsiam_preprod_r53_secret"]
+  for_each = { for key, value in module.vpc : key => value["vpc_id"] if anytrue([local.is-development, local.is-production]) }
+    common_attribute = "${local.application_name}-${each.key}"
+    resource_prefix  = format("R53-%s", each.key) # We do this to ensure the resource names are unique
+    log_group_name   = module.route_53_resolver_logs[each.key].r53_resolver_log_name
+    tags             = local.tags
+    xsiam_endpoint   = each.value == "live_data" ? local.xsiam["xsiam_prod_network_endpoint"] : local.xsiam["xsiam_preprod_network_endpoint"]
+    xsiam_secret     = each.value == "live_data" ? local.xsiam["xsiam_prod_r53_secret"] : local.xsiam["xsiam_preprod_r53_secret"]
 }

--- a/terraform/environments/core-vpc/firehose.tf
+++ b/terraform/environments/core-vpc/firehose.tf
@@ -11,7 +11,7 @@ module "firehose_firewalls" {
   source          = "../../modules/firehose"  
   for_each = { for key, value in module.vpc : 
             key => value["vpc_id"] 
-            if anytrue(local.local.is-development, local.local.is-production) }
+            if anytrue(local.is-development, local.is-production) }
     common_attribute          = "${each.key}-${local.application_name}"
     resource_prefix           = format("R53-%s",each.key) # We do this to ensure the resource names are unique
     log_group_name            = module.route_53_resolver_logs[each.key].r53_resolver_log_name

--- a/terraform/environments/core-vpc/firehose.tf
+++ b/terraform/environments/core-vpc/firehose.tf
@@ -4,3 +4,13 @@
 # We are only building for production & development.
 
 
+module "firehose_r53_resolver_logs" {
+  source           = "../../modules/firehose"
+  for_each         = { for key, value in module.vpc : key => value["vpc_id"] } # if anytrue([local.is-development, local.is-production]) }
+  common_attribute = "${local.application_name}-${each.key}"
+  resource_prefix  = format("%s-R53", each.key) # We do this to ensure the resource names are unique
+  log_group_name   = module.route_53_resolver_logs[each.key].r53_resolver_log_name
+  tags             = local.tags
+  xsiam_endpoint   = each.value == "live_data" ? local.xsiam["xsiam_prod_network_endpoint"] : local.xsiam["xsiam_preprod_network_endpoint"]
+  xsiam_secret     = each.value == "live_data" ? local.xsiam["xsiam_prod_r53_secret"] : local.xsiam["xsiam_preprod_r53_secret"]
+}

--- a/terraform/environments/core-vpc/firehose.tf
+++ b/terraform/environments/core-vpc/firehose.tf
@@ -5,14 +5,14 @@
 
 
 module "firehose_r53_resolver_logs" {
-  source          = "../../modules/firehose"  
-  for_each = { for key, value in module.vpc : 
-            key => value["vpc_id"] 
-            if anytrue(local.is-development, local.is-production) }
-    common_attribute          = "${each.key}-${local.application_name}"
-    resource_prefix           = format("R53-%s",each.key) # We do this to ensure the resource names are unique
-    log_group_name            = module.route_53_resolver_logs[each.key].r53_resolver_log_name
-    tags                      = local.tags
-    xsiam_endpoint            = local.is-production ? tostring(local.xsiam["xsiam_prod_network_endpoint"]): tostring(local.xsiam["xsiam_preprod_network_endpoint"])
-    xsiam_secret              = local.is-production ? tostring(local.xsiam["xsiam_prod_network_secret"]) : tostring(local.xsiam["xsiam_preprod_network_secret"])
+  source = "../../modules/firehose"
+  for_each = { for key, value in module.vpc :
+    key => value["vpc_id"]
+  if anytrue([local.is-development, local.is-production]) }
+  common_attribute = "${local.application_name}-${each.key}"
+  resource_prefix  = format("R53-%s", each.key) # We do this to ensure the resource names are unique
+  log_group_name   = module.route_53_resolver_logs[each.key].r53_resolver_log_name
+  tags             = local.tags
+  xsiam_endpoint   = each.value == "live_data" ? local.xsiam["xsiam_prod_network_endpoint"] : local.xsiam["xsiam_preprod_network_endpoint"]
+  xsiam_secret     = each.value == "live_data" ? local.xsiam["xsiam_prod_r53_secret"] : local.xsiam["xsiam_preprod_r53_secret"]
 }

--- a/terraform/environments/core-vpc/firehose.tf
+++ b/terraform/environments/core-vpc/firehose.tf
@@ -6,15 +6,11 @@
 
 module "firehose_r53_resolver_logs" {
   source           = "../../modules/firehose"
-  for_each         = { for key, value in module.vpc : key => value["vpc_id"] if anytrue([local.is-development, local.is-production]) }
+  for_each         = { for key, value in module.vpc : key => value["vpc_id"] } # if anytrue([local.is-development, local.is-production]) }
   common_attribute = "${local.application_name}-${each.key}"
   resource_prefix  = format("R53-%s", each.key) # We do this to ensure the resource names are unique
   log_group_name   = module.route_53_resolver_logs[each.key].r53_resolver_log_name
   tags             = local.tags
   xsiam_endpoint   = each.value == "live_data" ? local.xsiam["xsiam_prod_network_endpoint"] : local.xsiam["xsiam_preprod_network_endpoint"]
   xsiam_secret     = each.value == "live_data" ? local.xsiam["xsiam_prod_r53_secret"] : local.xsiam["xsiam_preprod_r53_secret"]
-}
-
-output "vpc-module" {
-  value = module.vpc
 }

--- a/terraform/environments/core-vpc/firehose.tf
+++ b/terraform/environments/core-vpc/firehose.tf
@@ -1,0 +1,20 @@
+
+# The purpose of this module call is to generate firehose & related resources for each R53 resolver log in core-vpc
+
+
+# The initial call is for the creation of firehose stream resources for the firewall inspection logs.
+
+# We are only building for production & development.
+
+
+module "firehose_firewalls" {
+  source          = "../../modules/firehose"  
+  for_each                    = { for key, value in module.vpc : key => value["vpc_id"] }
+    count                     = anytrue(local.is-production, local.is-development, local.is-sandbox) ? 1 : 0
+    common_attribute          = "${each.key}-${local.application_name}"
+    resource_prefix           = format("R53-%s",each.key) # We do this to ensure the resource names are unique
+    log_group_name            = module.route_53_resolver_logs[each.key].r53_resolver_log_name
+    tags                      = local.tags
+    xsiam_endpoint            = local.is-production ? tostring(local.xsiam["xsiam_prod_network_endpoint"]): tostring(local.xsiam["xsiam_preprod_network_endpoint"])
+    xsiam_secret              = local.is-production ? tostring(local.xsiam["xsiam_prod_network_secret"]) : tostring(local.xsiam["xsiam_preprod_network_secret"])
+}

--- a/terraform/environments/core-vpc/firehose.tf
+++ b/terraform/environments/core-vpc/firehose.tf
@@ -5,12 +5,12 @@
 
 
 module "firehose_r53_resolver_logs" {
-  source = "../../modules/firehose"
-  for_each = { for key, value in module.vpc : key => value["vpc_id"] if anytrue([local.is-development, local.is-production]) }
-    common_attribute = "${local.application_name}-${each.key}"
-    resource_prefix  = format("R53-%s", each.key) # We do this to ensure the resource names are unique
-    log_group_name   = module.route_53_resolver_logs[each.key].r53_resolver_log_name
-    tags             = local.tags
-    xsiam_endpoint   = each.value == "live_data" ? local.xsiam["xsiam_prod_network_endpoint"] : local.xsiam["xsiam_preprod_network_endpoint"]
-    xsiam_secret     = each.value == "live_data" ? local.xsiam["xsiam_prod_r53_secret"] : local.xsiam["xsiam_preprod_r53_secret"]
+  source           = "../../modules/firehose"
+  for_each         = { for key, value in module.vpc : key => value["vpc_id"] if anytrue([local.is-development, local.is-production]) }
+  common_attribute = "${local.application_name}-${each.key}"
+  resource_prefix  = format("R53-%s", each.key) # We do this to ensure the resource names are unique
+  log_group_name   = module.route_53_resolver_logs[each.key].r53_resolver_log_name
+  tags             = local.tags
+  xsiam_endpoint   = each.value == "live_data" ? local.xsiam["xsiam_prod_network_endpoint"] : local.xsiam["xsiam_preprod_network_endpoint"]
+  xsiam_secret     = each.value == "live_data" ? local.xsiam["xsiam_prod_r53_secret"] : local.xsiam["xsiam_preprod_r53_secret"]
 }

--- a/terraform/environments/core-vpc/locals.tf
+++ b/terraform/environments/core-vpc/locals.tf
@@ -16,6 +16,7 @@ locals {
 
   # This applies the same logic as above but to determine whether the environment is the development environment. Required for firehose resources.
   is-development = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-development"
+  is-sandbox = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-sandbox"
 
   # Determines if Firehose should be built in an environment.
   build_firehose = anytrue([local.is-development, local.is-production]) ? true : false

--- a/terraform/environments/core-vpc/locals.tf
+++ b/terraform/environments/core-vpc/locals.tf
@@ -16,7 +16,7 @@ locals {
 
   # This applies the same logic as above but to determine whether the environment is the development environment. Required for firehose resources.
   is-development = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-development"
-  is-sandbox = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-sandbox"
+  is-sandbox     = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-sandbox"
 
   # Determines if Firehose should be built in an environment.
   build_firehose = anytrue([local.is-development, local.is-production]) ? true : false

--- a/terraform/environments/core-vpc/locals.tf
+++ b/terraform/environments/core-vpc/locals.tf
@@ -16,8 +16,6 @@ locals {
 
   # This applies the same logic as above but to determine whether the environment is the development environment. Required for firehose resources.
   is-development = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-development"
-  is-sandbox     = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-sandbox"
-
   # Determines if Firehose should be built in an environment.
   build_firehose = anytrue([local.is-development, local.is-production]) ? true : false
 

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -110,17 +110,6 @@ module "vpc" {
   tags_prefix = each.key
 }
 
-module "firehose_r53_resolver_logs" {
-  source           = "../../modules/firehose"
-  for_each         = { for key, value in module.vpc : key => value["vpc_id"] } # if anytrue([local.is-development, local.is-production]) }
-  common_attribute = "${local.application_name}-${each.key}"
-  resource_prefix  = format("%s-R53", each.key) # We do this to ensure the resource names are unique
-  log_group_name   = module.route_53_resolver_logs[each.key].r53_resolver_log_name
-  tags             = local.tags
-  xsiam_endpoint   = each.value == "live_data" ? local.xsiam["xsiam_prod_network_endpoint"] : local.xsiam["xsiam_preprod_network_endpoint"]
-  xsiam_secret     = each.value == "live_data" ? local.xsiam["xsiam_prod_r53_secret"] : local.xsiam["xsiam_preprod_r53_secret"]
-}
-
 module "vpc_nacls" {
   source           = "../../modules/vpc-nacls"
   for_each         = local.vpcs[terraform.workspace]

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -110,6 +110,17 @@ module "vpc" {
   tags_prefix = each.key
 }
 
+module "firehose_r53_resolver_logs" {
+  source           = "../../modules/firehose"
+  for_each         = { for key, value in module.vpc : key => value["vpc_id"] } # if anytrue([local.is-development, local.is-production]) }
+  common_attribute = "${local.application_name}-${each.key}"
+  resource_prefix  = format("%s-R53", each.key) # We do this to ensure the resource names are unique
+  log_group_name   = module.route_53_resolver_logs[each.key].r53_resolver_log_name
+  tags             = local.tags
+  xsiam_endpoint   = each.value == "live_data" ? local.xsiam["xsiam_prod_network_endpoint"] : local.xsiam["xsiam_preprod_network_endpoint"]
+  xsiam_secret     = each.value == "live_data" ? local.xsiam["xsiam_prod_r53_secret"] : local.xsiam["xsiam_preprod_r53_secret"]
+}
+
 module "vpc_nacls" {
   source           = "../../modules/vpc-nacls"
   for_each         = local.vpcs[terraform.workspace]

--- a/terraform/modules/firehose/main.tf
+++ b/terraform/modules/firehose/main.tf
@@ -53,7 +53,7 @@ resource "aws_kinesis_firehose_delivery_stream" "delivery_stream" {
 
       common_attributes {
         name  = "Firewall Name & Log Type"
-        value = var.resource_prefix
+        value = var.common_attribute
       }
     }
 

--- a/terraform/modules/firehose/variables.tf
+++ b/terraform/modules/firehose/variables.tf
@@ -4,6 +4,11 @@ variable "tags" {
   type        = map(any)
 }
 
+variable "common_attribute" {
+  description = "The value of the common_attributes property which should be the name of the aws account or the account name & live / non-live"
+  type        = string
+}
+
 variable "resource_prefix" {
   description = "The prefix to be used for the resource names - used for easy identification"
   type        = string

--- a/terraform/modules/r53-resolver-logs/main.tf
+++ b/terraform/modules/r53-resolver-logs/main.tf
@@ -15,3 +15,7 @@ resource "aws_cloudwatch_log_group" "main" {
   name              = format("%s-r53-resolver-logs", var.vpc_name)
   retention_in_days = 365
 }
+
+output "r53_resolver_log_name" {
+  value = aws_cloudwatch_log_group.main.name
+}


### PR DESCRIPTION
## A reference to the issue / Description of it

This covers the last set of firehose stream transfers to SecOps - namely the resolver logs for the member account shared VPCs that is managed in core-vpc. It also covers a number of other changes including the use of a more descriptive common_attribute value plus other simplifications.

## How does this PR fix the problem?

See above.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Local plan with the core-vpc workspaces

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No resources are being deleted - mainly additions and some changes for the new common_attribute var.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
