### PR TITLE
allow nart team access to test, preproduction and production onr envs

### DIFF
--- a/environments/oasys-national-reporting.json
+++ b/environments/oasys-national-reporting.json
@@ -17,6 +17,10 @@
         {
           "github_slug": "studio-webops",
           "level": "developer"
+        },
+        {
+          "github_slug": "national-applications-reporting-team",
+          "level": "instance-management"
         }
       ]
     },
@@ -26,6 +30,10 @@
         {
           "github_slug": "studio-webops",
           "level": "developer"
+        },
+        {
+          "github_slug": "national-applications-reporting-team",
+          "level": "instance-management"
         }
       ]
     },
@@ -35,6 +43,10 @@
         {
           "github_slug": "studio-webops",
           "level": "developer"
+        },
+        {
+          "github_slug": "national-applications-reporting-team",
+          "level": "instance-management"
         }
       ]
     }


### PR DESCRIPTION
## A reference to the issue / Description of it

Nart team need access to oasys-national-reporting environment, mainly to familiarise themselves as it's moved

## How does this PR fix the problem?

Gives them access

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Adding github stub, should just work

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No 

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
