### PR TITLE
✨ Add version constraint to `random` provider

### DIFF
--- a/terraform/modules/firehose/versions.tf
+++ b/terraform/modules/firehose/versions.tf
@@ -5,5 +5,9 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 5.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.4"
+    }
   }
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

- Terraform Static Analysis check failed [here](https://github.com/ministryofjustice/modernisation-platform/actions/runs/8447886732/job/23138986897)
- The failure was due tflint complaining about a missing version constraint for the `random` provider [here](https://github.com/ministryofjustice/modernisation-platform/actions/runs/8447886732/job/23138986897#step:4:3448)

## How does this PR fix the problem?

- Adds version constraint to the `random` provider. (latest is 3.6, but I've gone for 3.4 since that's what the rest of the codebase uses)

## How has this been tested?

By running `tflint` locally in the `terraform/modules/firehose/` directory before and after the change. I could see the failure disappear ✅ 

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

Interesting how this wasn't caught in the initial [PR](https://github.com/ministryofjustice/modernisation-platform/actions/runs/8447886732/job/23138986897#step:4:3448) 👀 Going to do some more digging around that!
