### PR TITLE
Create `operations-engineering` account

### DIFF
--- a/environments/operations-engineering.json
+++ b/environments/operations-engineering.json
@@ -1,0 +1,23 @@
+{
+    "account-type": "member",
+    "environments": [
+      {
+        "name": "development",
+        "access": [
+          {
+            "github_slug": "operations-engineering",
+            "level": "sandbox"
+          }
+        ]
+      }
+    ],
+    "tags": {
+      "application": "operations-engineering",
+      "business-unit": "operations-engineering",
+      "infrastructure-support": "operations-engineering@digital.justice.gov.uk",
+      "owner": "operations-engineering@digital.justice.gov.uk"
+    },
+    "github-oidc-team-repositories": [""],
+    "go-live-date": ""
+  }
+  

--- a/environments/operations-engineering.json
+++ b/environments/operations-engineering.json
@@ -13,7 +13,7 @@
     ],
     "tags": {
       "application": "operations-engineering",
-      "business-unit": "operations-engineering",
+      "business-unit": "Platforms",
       "infrastructure-support": "operations-engineering@digital.justice.gov.uk",
       "owner": "operations-engineering@digital.justice.gov.uk"
     },

--- a/policies/environments/expected.rego
+++ b/policies/environments/expected.rego
@@ -60,6 +60,7 @@ expected :=
     "oasys",
     "oasys-national-reporting",
     "observability-platform",
+    "operations-engineering",
     "opg-lpa-data-store",
     "performance-hub",
     "planetfm",


### PR DESCRIPTION
## A reference to the issue / Description of it

#6361 

## How does this PR fix the problem?

Adds content required to create new `operations-engineering` account

## How has this been tested?

Followed steps in [team runbook](https://user-guide.modernisation-platform.service.justice.gov.uk/runbooks/creating-accounts-for-end-users.html#new-environment-files).

## Deployment Plan / Instructions

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
