### PR TITLE
Update additional address range for core-shared-services VPC to production range

### DIFF
--- a/terraform/environments/core-shared-services/vpc_additional_cidr.tf
+++ b/terraform/environments/core-shared-services/vpc_additional_cidr.tf
@@ -15,7 +15,7 @@ locals {
 }
 
 resource "aws_vpc_ipv4_cidr_block_association" "live-data-additional" {
-  cidr_block = "10.26.144.0/21"
+  cidr_block = "10.27.136.0/21"
   vpc_id     = module.vpc["live_data"].vpc_id
 }
 


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/6633

## How does this PR fix the problem?

Aligns additional VPC cidr block with allocated range

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Tested with non-prod range successfully

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
