### PR TITLE
Create new 'delete-account' for testing deletion scripts

### DIFF
--- a/environments/delete-account.json
+++ b/environments/delete-account.json
@@ -1,0 +1,31 @@
+{
+  "account-type": "member",
+  "environments": [
+    {
+      "name": "development",
+      "access": [
+        {
+          "github_slug": "modernisation-platform",
+          "level": "developer"
+        }
+      ]
+    },
+    {
+      "name": "test",
+      "access": [
+        {
+          "github_slug": "modernisation-platform",
+          "level": "developer"
+        }
+      ]
+    }
+  ],
+  "tags": {
+    "application": "delete-account",
+    "business-unit": "Platforms",
+    "infrastructure-support": "modernisation-platform@digital.justice.gov.uk",
+    "owner": "Modernisation Platform: modernisation-platform@digital.justice.gov.uk"
+  },
+  "github-oidc-team-repositories": ["ministryofjustice/modernisation-platform"],
+  "go-live-date": ""
+}

--- a/policies/environments/expected.rego
+++ b/policies/environments/expected.rego
@@ -30,6 +30,7 @@ expected :=
     "data-platform",
     "data-platform-apps-and-tools",
     "data-platform-compute",
+    "delete-account",
     "delius-core",
     "delius-iaps",
     "delius-jitbit",


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/6457

## How does this PR fix the problem?

Creating a new account called "delete-account" (unless anyone has another name preference!) 

This will allow us to to an end-to-end test on the account deletion script without disturbing any live member environments.

It has two envs 'development' and 'test' so that we have at least one workspace to delete which we can use to test the logic in our scripts.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [X] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
