### PR TITLE
Allow traffic to temporary `core-shared-services` range

### DIFF
--- a/terraform/modules/vpc-nacls/data.tf
+++ b/terraform/modules/vpc-nacls/data.tf
@@ -77,6 +77,24 @@ locals {
       rule_number = 3000
       to_port     = null
     },
+    allow_10-27-136-0_in = {
+      cidr_block  = "10.27.136.0/21"
+      egress      = false
+      from_port   = null
+      protocol    = "-1"
+      rule_action = "allow"
+      rule_number = 2010
+      to_port     = null
+    },
+    allow_10-27-136-0_out = {
+      cidr_block  = "10.27.136.0/21"
+      egress      = true
+      from_port   = null
+      protocol    = "-1"
+      rule_action = "allow"
+      rule_number = 2010
+      to_port     = null
+    },
     deny_mp_cidr_out = {
       cidr_block  = "10.26.0.0/15"
       egress      = true


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/6633

## How does this PR fix the problem?

Because our `vpc-nacls` module was never written with the expectation that we would allow east/west traffic between accounts, and because the use of a routable range in `core-shared-services` is a temporary addition until we can have the `core` address ranges routable, I've allowed this traffic in a static rule that will appear before a NACL rule that denies east/west traffic.

It's possible that we could re-write the module to allow lookups in different accounts, but I think this would mean more engineering time than we expected and I don't think it's behaviour that we'd like to encourage vs more cloud-centric approaches like PrivateLink.

## How has this been tested?

Tested behaviour with a local plan against `core-vpc-development`

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
