### PR TITLE
Allow new `core-shared-services` CIDR range to communicate with VPC endpoints

### DIFF
--- a/terraform/environments/core-shared-services/vpc_additional_cidr.tf
+++ b/terraform/environments/core-shared-services/vpc_additional_cidr.tf
@@ -19,7 +19,7 @@ resource "aws_vpc_ipv4_cidr_block_association" "live-data-additional" {
   vpc_id     = module.vpc["live_data"].vpc_id
 }
 
-resource "aws_vpc_endpoint_route_table_association" "example" {
+resource "aws_vpc_endpoint_route_table_association" "live-data-additional" {
   route_table_id  = aws_route_table.live-data-additional.id
   vpc_endpoint_id = aws_vpc_endpoint.vpc_gateway_endpoints["live_data-com.amazonaws.eu-west-2.s3"].id
 }

--- a/terraform/environments/core-shared-services/vpc_additional_cidr.tf
+++ b/terraform/environments/core-shared-services/vpc_additional_cidr.tf
@@ -19,13 +19,23 @@ resource "aws_vpc_ipv4_cidr_block_association" "live-data-additional" {
   vpc_id     = module.vpc["live_data"].vpc_id
 }
 
+resource "aws_security_group_rule" "live-data-additional-interface_endpoints" {
+  description       = "Permit secure traffic to this endpoint within the VPC"
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = [aws_vpc_ipv4_cidr_block_association.live-data-additional.cidr_block]
+  security_group_id = aws_security_group.interface_endpoint_security_group["live_data"].id
+}
+
 resource "aws_subnet" "live-data-additional" {
   for_each   = local.additional_subnet_cidr_map
   cidr_block = each.value
   vpc_id     = module.vpc["live_data"].vpc_id
   tags = merge({
     "Name" = format("live_data-additional-%s", each.key)
-  },
+    },
   local.tags)
 }
 
@@ -33,7 +43,7 @@ resource "aws_route_table" "live-data-additional" {
   vpc_id = module.vpc["live_data"].vpc_id
   tags = merge({
     "Name" = "live_data-additional"
-  },
+    },
   local.tags)
 }
 
@@ -54,7 +64,7 @@ resource "aws_network_acl" "live-data-additional" {
   subnet_ids = values(aws_subnet.live-data-additional)[*].id
   tags = merge({
     "Name" = "live_data-additional"
-  },
+    },
   local.tags)
 }
 

--- a/terraform/environments/core-shared-services/vpc_additional_cidr.tf
+++ b/terraform/environments/core-shared-services/vpc_additional_cidr.tf
@@ -19,6 +19,11 @@ resource "aws_vpc_ipv4_cidr_block_association" "live-data-additional" {
   vpc_id     = module.vpc["live_data"].vpc_id
 }
 
+resource "aws_vpc_endpoint_route_table_association" "example" {
+  route_table_id  = aws_route_table.live-data-additional.id
+  vpc_endpoint_id = aws_vpc_endpoint.vpc_gateway_endpoints["live_data-com.amazonaws.eu-west-2.s3"].id
+}
+
 resource "aws_security_group_rule" "live-data-additional-interface_endpoints" {
   description       = "Permit secure traffic to this endpoint within the VPC"
   type              = "ingress"


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/6633

## How does this PR fix the problem?

* Adds a security group entry allowing traffic to reach VPC endpoints.
* Adds a route table association resource to ensure the additional subnets are correctly routed to the S3 endpoint

## How has this been tested?

Tested locally & through manual change

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
