### PR TITLE
add cicd repos to DSO accounts

### DIFF
--- a/environments/corporate-staff-rostering.json
+++ b/environments/corporate-staff-rostering.json
@@ -61,6 +61,8 @@
     "infrastructure-support": "digital-studio-operations-team@digital.justice.gov.uk",
     "owner": "digital-studio-operations-team@digital.justice.gov.uk"
   },
-  "github-oidc-team-repositories": [""],
+  "github-oidc-team-repositories": [
+    "ministryofjustice/dso-modernisation-platform-automation"
+  ],
   "go-live-date": "2024-03-11"
 }

--- a/environments/hmpps-domain-services.json
+++ b/environments/hmpps-domain-services.json
@@ -61,6 +61,8 @@
     "infrastructure-support": "digital-studio-operations-team@digital.justice.gov.uk",
     "owner": "sean.privett@digital.justice.gov.uk"
   },
-  "github-oidc-team-repositories": [""],
+  "github-oidc-team-repositories": [
+    "ministryofjustice/dso-modernisation-platform-automation"
+  ],
   "go-live-date": "2023-08-22"
 }

--- a/environments/hmpps-oem.json
+++ b/environments/hmpps-oem.json
@@ -77,6 +77,7 @@
     "owner": "digital-studio-operations-team@digital.justice.gov.uk: probation-webops@digital.justice.gov.uk"
   },
   "github-oidc-team-repositories": [
-    "ministryofjustice/hmpps-delius-operational-automation"
+    "ministryofjustice/hmpps-delius-operational-automation",
+    "ministryofjustice/dso-modernisation-platform-automation"
   ]
 }

--- a/environments/nomis-combined-reporting.json
+++ b/environments/nomis-combined-reporting.json
@@ -62,5 +62,7 @@
     "infrastructure-support": "digital-studio-operations-team@digital.justice.gov.uk",
     "owner": "digital-studio-operations-team@digital.justice.gov.uk"
   },
-  "github-oidc-team-repositories": [""]
+  "github-oidc-team-repositories": [
+    "ministryofjustice/dso-modernisation-platform-automation"
+  ]
 }

--- a/environments/nomis-data-hub.json
+++ b/environments/nomis-data-hub.json
@@ -44,5 +44,7 @@
     "infrastructure-support": "digital-studio-operations-team@digital.justice.gov.uk",
     "owner": "digital-studio-operations-team@digital.justice.gov.uk"
   },
-  "github-oidc-team-repositories": [""]
+  "github-oidc-team-repositories": [
+    "ministryofjustice/dso-modernisation-platform-automation"
+  ]
 }

--- a/environments/nomis.json
+++ b/environments/nomis.json
@@ -80,6 +80,8 @@
     "infrastructure-support": "digital-studio-operations-team@digital.justice.gov.uk",
     "owner": "digital-studio-operations-team@digital.justice.gov.uk"
   },
-  "github-oidc-team-repositories": [""],
+  "github-oidc-team-repositories": [
+    "ministryofjustice/dso-modernisation-platform-automation"
+  ],
   "go-live-date": "2022-08-25"
 }

--- a/environments/oasys-national-reporting.json
+++ b/environments/oasys-national-reporting.json
@@ -57,6 +57,8 @@
     "infrastructure-support": "digital-studio-operations-team@digital.justice.gov.uk",
     "owner": "Mark Richardson"
   },
-  "github-oidc-team-repositories": [""],
+  "github-oidc-team-repositories": [
+    "ministryofjustice/dso-modernisation-platform-automation"
+  ],
   "go-live-date": ""
 }

--- a/environments/oasys.json
+++ b/environments/oasys.json
@@ -53,5 +53,7 @@
     "infrastructure-support": "digital-studio-operations-team@digital.justice.gov.uk",
     "owner": "digital-studio-operations-team@digital.justice.gov.uk"
   },
-  "github-oidc-team-repositories": [""]
+  "github-oidc-team-repositories": [
+    "ministryofjustice/dso-modernisation-platform-automation"
+  ]
 }

--- a/environments/planetfm.json
+++ b/environments/planetfm.json
@@ -58,5 +58,7 @@
     "infrastructure-support": "digital-studio-operations-team@digital.justice.gov.uk",
     "owner": "digital-studio-operations-team@digital.justice.gov.uk"
   },
-  "github-oidc-team-repositories": [""]
+  "github-oidc-team-repositories": [
+    "ministryofjustice/dso-modernisation-platform-automation"
+  ]
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

Missing standard mod platform CI/CD role from DSO accounts. Trying to migrate to this rather than having custom CI/CD roles in the account.

## How does this PR fix the problem?

Enables mod platform provided CI/CD role

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

N/A

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
