### PR TITLE
DSOS-2668: new-environment pipeline fix

### DIFF
--- a/.github/workflows/new-environment.yml
+++ b/.github/workflows/new-environment.yml
@@ -169,10 +169,8 @@ jobs:
       - name: get new account(s)
         id: new_account
         run: |
-          echo "files=$(cat <<EOF
-          $(git diff --no-commit-id --name-only --diff-filter=AM -r @^ | awk '{print $1}' | grep ".json" | grep -a "environments//*"  | uniq | cut -f2-4 -d"/" | sed 's/.\{5\}$//')
-          EOF
-          )" >> $GITHUB_OUTPUT
+          files=$(git diff --no-commit-id --name-only --diff-filter=AM -r @^ | awk '{print $1}' | grep ".json" | grep -a "environments//*"  | uniq | cut -f2-4 -d"/" | sed 's/.\{5\}$//' | tr [[:space:]] ' ')
+          echo "files=$files" >> $GITHUB_OUTPUT
       - name: Run delegate access
         run: |
           accounts=(${{ steps.new_account.outputs.files }})
@@ -221,10 +219,8 @@ jobs:
       - name: get new account(s)
         id: new_account
         run: |
-          echo "files=$(cat <<EOF
-          $(git diff --no-commit-id --name-only --diff-filter=AM -r @^ | awk '{print $1}' | grep ".json" | grep -a "environments//*"  | uniq | cut -f2-4 -d"/" | sed 's/.\{5\}$//')
-          EOF
-          )" >> $GITHUB_OUTPUT
+          files=$(git diff --no-commit-id --name-only --diff-filter=AM -r @^ | awk '{print $1}' | grep ".json" | grep -a "environments//*"  | uniq | cut -f2-4 -d"/" | sed 's/.\{5\}$//' | tr [[:space:]] ' ')
+          echo "files=$files" >> $GITHUB_OUTPUT
       - name: Run secure baselines
         run: |
           accounts=(${{ steps.new_account.outputs.files }})
@@ -273,10 +269,8 @@ jobs:
       - name: get new account(s)
         id: new_account
         run: |
-          echo "files=$(cat <<EOF
-          $(git diff --no-commit-id --name-only --diff-filter=AM -r @^ | awk '{print $1}' | grep ".json" | grep -a "environments//*"  | uniq | cut -f2-4 -d"/" | sed 's/.\{5\}$//')
-          EOF
-          )" >> $GITHUB_OUTPUT
+          files=$(git diff --no-commit-id --name-only --diff-filter=AM -r @^ | awk '{print $1}' | grep ".json" | grep -a "environments//*"  | uniq | cut -f2-4 -d"/" | sed 's/.\{5\}$//' | tr [[:space:]] ' ')
+          echo "files=$files" >> $GITHUB_OUTPUT
       - name: Run single sign on
         run: |
           accounts=(${{ steps.new_account.outputs.files }})
@@ -325,10 +319,8 @@ jobs:
       - name: get new account(s)
         id: new_account
         run: |
-          echo "files=$(cat <<EOF
-          $(git diff --no-commit-id --name-only --diff-filter=AM -r @^ | awk '{print $1}' | grep ".json" | grep -a "environments//*"  | uniq | cut -f2-4 -d"/" | sed 's/.\{5\}$//')
-          EOF
-          )" >> $GITHUB_OUTPUT
+          files=$(git diff --no-commit-id --name-only --diff-filter=AM -r @^ | awk '{print $1}' | grep ".json" | grep -a "environments//*"  | uniq | cut -f2-4 -d"/" | sed 's/.\{5\}$//' | tr [[:space:]] ' ')
+          echo "files=$files" >> $GITHUB_OUTPUT
       - name: Run secure baselines
         run: |
           accounts=(${{ steps.new_account.outputs.files }})

--- a/environments/corporate-staff-rostering.json
+++ b/environments/corporate-staff-rostering.json
@@ -55,6 +55,7 @@
       ]
     }
   ],
+
   "tags": {
     "application": "corporate-staff-rostering",
     "business-unit": "HMPPS",

--- a/environments/hmpps-domain-services.json
+++ b/environments/hmpps-domain-services.json
@@ -55,6 +55,7 @@
       ]
     }
   ],
+
   "tags": {
     "application": "hmpps-domain-services",
     "business-unit": "HMPPS",

--- a/environments/hmpps-oem.json
+++ b/environments/hmpps-oem.json
@@ -70,6 +70,7 @@
       ]
     }
   ],
+
   "tags": {
     "application": "hmpps-oem",
     "business-unit": "HMPPS",

--- a/environments/nomis-combined-reporting.json
+++ b/environments/nomis-combined-reporting.json
@@ -56,6 +56,7 @@
       ]
     }
   ],
+
   "tags": {
     "application": "nomis-combined-reporting",
     "business-unit": "HMPPS",

--- a/environments/nomis-data-hub.json
+++ b/environments/nomis-data-hub.json
@@ -38,6 +38,7 @@
       ]
     }
   ],
+
   "tags": {
     "application": "nomis-data-hub",
     "business-unit": "HMPPS",

--- a/environments/nomis.json
+++ b/environments/nomis.json
@@ -74,6 +74,7 @@
       ]
     }
   ],
+
   "tags": {
     "application": "nomis",
     "business-unit": "HMPPS",

--- a/environments/oasys-national-reporting.json
+++ b/environments/oasys-national-reporting.json
@@ -51,6 +51,7 @@
       ]
     }
   ],
+
   "tags": {
     "application": "Oasys National Reporting/ONR",
     "business-unit": "HMPPS",

--- a/environments/oasys.json
+++ b/environments/oasys.json
@@ -47,6 +47,7 @@
       ]
     }
   ],
+
   "tags": {
     "application": "oasys",
     "business-unit": "HMPPS",

--- a/environments/planetfm.json
+++ b/environments/planetfm.json
@@ -51,7 +51,6 @@
       ]
     }
   ],
-
   "tags": {
     "application": "planetfm",
     "business-unit": "HMPPS",


### PR DESCRIPTION
## A reference to the issue / Description of it

New environment pipeline is failing when multiple environment json files are changed.
See https://github.com/ministryofjustice/modernisation-platform/actions/runs/8525989352

## How does this PR fix the problem?

I think it is because the syntax for adding a multiline variable to GITHUB_OUTPUT is not quite right.
This PR just uses single line instead, which seems to be what the $accounts variable a bit further down is expecting anyway.
Note the whitespace changes are just to trigger applies in the environments that were changed in previous PR

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Not easy to test as this section of pipeline only runs on main.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No - worst case the variable is not set properly so the subsequent pipeline steps will fail

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

Just a suggested fix...
