### PR TITLE
Fix SCA Failures

### DIFF
--- a/terraform/templates/modernisation-platform-environments-isolated/vpc.tf
+++ b/terraform/templates/modernisation-platform-environments-isolated/vpc.tf
@@ -18,6 +18,7 @@ module "vpc" {
 }
 
 module "vpc_endpoints" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   source  = "terraform-aws-modules/vpc/aws//modules/vpc-endpoints"
   version = "~> 5.0"
 
@@ -55,6 +56,7 @@ module "vpc_endpoints" {
 }
 
 resource "aws_security_group" "vpc_endpoints" {
+  #checkov:skip=CKV2_AWS_5:skip "Ensure that Security Groups are attached to another resource"
   description = "Security Group for controlling all VPC endpoint traffic"
   name        = format("%s-vpc-endpoint-sg", local.application_name)
   vpc_id      = module.vpc.vpc_id


### PR DESCRIPTION
Our `Secure Code Analysis` is currently failing with two checkov warnings, this PR skips the checks in question. 