### PR TITLE
Add runbook for account migration

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -121,6 +121,7 @@ This documentation is for anyone interested in the Modernisation Platform and it
 - [Joining the team](runbooks/joining-the-team.html)
 - [Manage an incident](runbooks/manage-an-incident.html)
 - [Main Platform Runbook](runbooks/runbook.html)
+- [Migrating an existing AWS account into the Modernisation Platform](runbooks/migrating-an-account-into-the-modernisation-platform.html)
 - [Modifying Service Control Policies (SCPs)](runbooks/modifying-scps.html)
 - [Querying CloudTrail logs with Athena](runbooks/using-athena.html)
 - [Querying VPC flow logs](runbooks/querying-vpc-flow-logs.html)

--- a/source/runbooks/migrating-an-account-into-the-modernisation-platform.html.md.erb
+++ b/source/runbooks/migrating-an-account-into-the-modernisation-platform.html.md.erb
@@ -1,0 +1,60 @@
+---
+owner_slack: "#modernisation-platform"
+title: Migrating an existing AWS account into the Modernisation Platform
+last_reviewed_on: 2024-03-11
+review_in: 6 months
+---
+
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-NXTCMQ7ZX6"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-NXTCMQ7ZX6');
+</script>
+
+# <%= current_page.data.title %>
+
+This runbook outlines general steps to take in order to migrate an existing Ministry of Justice Amazon Web Services account into the Modernisation Platform.
+
+## Outline
+
+On occasion, we may be asked to bring an existing AWS account into the Modernisation Platform for ongoing management and application of account baselines.
+
+We can make use of some of our existing processes and our `member-unrestricted` AWS Organizations Unit to import accounts, apply baselines, and provide SSO access.
+
+The following high-level steps need to be undertaken:
+
+* Prepare account
+* Create entries for account in Modernisation Platform repository
+* Import manageable resources
+
+## Preparing an account for import into the Modernisation Platform
+
+You can make use of the [AWS guidance](https://docs.aws.amazon.com/IAM/latest/UserGuide/reset-root-password.html) to log into the account of interest as the root user.
+
+You will want to check that the account being migrated:
+* Conforms to Modernisation Platform naming standards (eg, all lower-case letters, with no spaces as separators).
+* Has been removed from any Terraform statefiles that manage the account.
+* Has been removed from management in code.
+
+## Importing an account into the Modernisation Platform
+
+You will want to create a branch in GitHub in the Modernisation Platform repository with relevant `environments/*.json` values
+* The account-type will be `unrestricted`
+
+You will want to switch your local branch in GitHub to the one with the newly-created/amended `environments/*.json` values in order to import information into Terraform.
+* Ensure you are in the `terraform/environments` directory
+* Import the `module.environments.aws_organizations_account.accounts["$account-name"] $account-id`
+* Import the `module.environments.random_string.email-address["$account-name"] $account-email-address`
+* Merge your new branch into `main`.
+
+It is likely that you will also need to import resources into Terraform state for the [account baselines](https://github.com/ministryofjustice/modernisation-platform-terraform-baselines).
+You will do this through the `terraform/environments/boostrap/member-bootstrap` directory in the relevant workspace(s).
+
+## Examples
+
+* [Removing an account from management in code](https://github.com/ministryofjustice/aws-root-account/pull/885)
+* [Preparing environment files for an imported account](https://github.com/ministryofjustice/modernisation-platform/pull/6620)
+* [Running the Modernisation Platform baselines for an imported account](https://github.com/ministryofjustice/modernisation-platform/actions/runs/8468732300)


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/6416

## How does this PR fix the problem?

Adds a runbook with guideline steps for importing an account.

## How has this been tested?

Based off of notes taken during NOC account import story

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No because it's a runbook

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
