### PR TITLE
Fix a broken link

### DIFF
--- a/source/runbooks/dos-attack.html.md.erb
+++ b/source/runbooks/dos-attack.html.md.erb
@@ -48,4 +48,4 @@ Alternatively the SRT team can assist with creating these rules.
 
 ## Notify users and security
 
-Follow the [general incident guidance](./manage-an-incident.html#5-end-the-incident) to notify users and the security team.
+Follow the [general incident guidance](./manage-an-incident.html#6-end-the-incident) to notify users and the security team.


### PR DESCRIPTION
A recent PR to update our PagerDuty incident documentation adjusted the header numbering in that page; this PR updates a broken reference to the updated incident documentation.