### PR TITLE
Update github slug for cica-data-extraction application

### DIFF
--- a/environments/cica-data-extraction.json
+++ b/environments/cica-data-extraction.json
@@ -5,7 +5,7 @@
       "name": "development",
       "access": [
         {
-          "github_slug": "cica-data-extraction-maintainers",
+          "github_slug": "cica-extract-tool-admins",
           "level": "developer"
         }
       ]


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/6559

## How does this PR fix the problem?

Corrects the `github_slug` of the team after a conversation with @Adenipex 

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

No testing

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)
