### PR TITLE
Fix policy reference for the bedrock provider role

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -492,7 +492,7 @@ module "member-access-eu-central" {
   source                 = "github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access?ref=6819b090bce6d3068d55c7c7b9b3fd18c9dca648" #v3.0.0
   account_id             = local.modernisation_platform_account.id
   additional_trust_roles = [module.github-oidc[0].github_actions_role, one(data.aws_iam_roles.member-sso-admin-access.arns)]
-  policy_arn             = aws_iam_policy.member-access-us-east[0].id
+  policy_arn             = aws_iam_policy.member-access-eu-central[0].id
   role_name              = "MemberInfrastructureBedrockEuCentral"
 }
 


### PR DESCRIPTION
## A reference to the issue / Description of it

Noticed that we had an incorrect policy attachment to the `MemberInfrastructureBedrockEUCentral` role.

## How does this PR fix the problem?

Applies the correct IAM Policy to the `MemberInfrastructureBedrockEUCentral` role

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

It has not.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
