### PR TITLE
Set cica-data-extraction development access to sandbox with rebuild flag

### DIFF
--- a/environments/cica-data-extraction.json
+++ b/environments/cica-data-extraction.json
@@ -6,7 +6,8 @@
       "access": [
         {
           "github_slug": "cica-extract-tool-admins",
-          "level": "developer"
+          "level": "sandbox",
+          "nuke": "rebuild"
         }
       ]
     }


### PR DESCRIPTION
## A reference to the issue / Description of it

Customer wants sandbox access for bedrock investigation

## How does this PR fix the problem?

Sandbox allows clickops for bedrock. Rebuild ensures resources are rebuilt from code following a full account wipe.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Used in other environments (eg. `tipstaff).

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No. Until the nuke job removes everything in the `cica-data-extraction-development` account.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
