### PR TITLE
Bump baselines module, add dynamic selector for cloudtrail s3 events

### DIFF
--- a/terraform/environments/bootstrap/secure-baselines/locals.tf
+++ b/terraform/environments/bootstrap/secure-baselines/locals.tf
@@ -3,6 +3,7 @@
 data "aws_organizations_organization" "root_account" {}
 
 locals {
+  enable-cloudtrail-events = strcontains(terraform.workspace, "digital-prison-reporting") ? false : true
   enabled_baseline_regions = [
     "eu-central-1", # Europe (Frankfurt)
     "eu-west-1",    # Europe (Ireland)

--- a/terraform/environments/bootstrap/secure-baselines/main.tf
+++ b/terraform/environments/bootstrap/secure-baselines/main.tf
@@ -5,7 +5,7 @@ data "aws_kms_key" "cloudtrail_key" {
 }
 
 module "baselines" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=69afa89a92f1478f42a50ba4423f8d455579b56c" # v6.6.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=385cb6f25209abf444849f4f6ff4d07c0c68d2f8" # v6.6.0
 
   providers = {
     # Default and replication regions
@@ -39,6 +39,9 @@ module "baselines" {
     aws.us-west-1      = aws.workspace-eu-west-2
     aws.us-west-2      = aws.workspace-eu-west-2
   }
+
+  # Selectively enable CloudTrail object-level logging
+  enable_cloudtrail_s3_mgmt_events = local.enable-cloudtrail-events
 
   # Regions to enable IAM Access Analyzer in
   enabled_access_analyzer_regions = local.enabled_baseline_regions


### PR DESCRIPTION
## A reference to the issue / Description of it

https://mojdt.slack.com/archives/C01A7QK5VM1/p1711528538461979

## How does this PR fix the problem?

Bumps the module reference for the baselines module.

Adds a dynamic selector so that if the `terraform.workspace` belongs to `"digital-prison-reporting"`, a `false` value is supplied and S3 management events are not logged.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Ran local terraform plan

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
