### PR TITLE
Issue 6614

### DIFF
--- a/terraform/environments/core-logging/s3_logging.tf
+++ b/terraform/environments/core-logging/s3_logging.tf
@@ -286,6 +286,20 @@ data "aws_iam_policy_document" "cloudtrail_bucket_policy" {
       identifiers = [data.aws_caller_identity.current.account_id]
     }
   }
+  statement {
+    sid     = "allowSQSSendMessage"
+    effect  = "Allow"
+    actions = ["sqs:SendMessage"]
+    resources = [
+      module.s3-bucket-cloudtrail.bucket.arn,
+      format("%s/*", module.s3-bucket-cloudtrail.bucket.arn)
+    ]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceArn"
+      values   = [aws_sqs_queue.mp_cloudtrail_log_queue.arn] 
+    }
+  }
 }
 
 module "cloudtrail-s3-logging-replication-role" {

--- a/terraform/environments/core-logging/sqs.tf
+++ b/terraform/environments/core-logging/sqs.tf
@@ -1,0 +1,70 @@
+# This covers the SQS and related infrastructure that allows Cortex XSIAM service to access updates to the cloudtrail logging bucket
+
+# SQS Queue to present the logging bucket updates
+resource "aws_sqs_queue" "mp_cloudtrail_log_queue" {
+  name                      = "mp_cloudtrail_log_queue"
+  delay_seconds             = 0       # The default is 0 but can be up to 15 minutes
+  max_message_size          = 262144  # 256k which is the max size
+  message_retention_seconds = 345600  # This is 4 days. The max is 14 days
+  visibility_timeout_seconds = 30     # This is only useful for queues that have multiple subscribers
+}
+
+# Data to grant read access to the s3 bucket
+data "aws_iam_policy_document" "sqs_s3_read_bucket_document" {
+  statement {
+    sid       = "S3BucketGetObject"
+    effect    = "Allow"
+    actions   = ["s3:GetObject"]
+    resources = [module.s3-bucket-cloudtrail.bucket.arn, "${module.s3-bucket-cloudtrail.bucket.arn}/*"] 
+  }
+}
+
+# Grant access for the queue read the S3 logging bucket
+resource "aws_sqs_queue_policy" "sqs_s3_read_bucket_policy" {
+  queue_url = aws_sqs_queue.mp_cloudtrail_log_queue.id
+  policy = data.aws_iam_policy_document.sqs_s3_read_bucket_document.json
+}
+
+# S3 bucket event notification for updates to the cloudtrail logging bucket
+resource "aws_s3_bucket_notification" "logging_bucket_notification" {
+  bucket = module.s3-bucket-cloudtrail-logging.bucket.bucket  
+  queue {
+    queue_arn = aws_sqs_queue.mp_cloudtrail_log_queue.arn
+    events    = ["s3:ObjectCreated:*"]  # Events to trigger the notification
+  }
+}
+
+##### IAM User Account & Resources to access the sqs queue
+
+# Create an IAM policy document to allow access to the SQS Queue
+data "aws_iam_policy_document" "sqs_queue_read_document" {
+  statement {
+    sid       = "SQSQueueReceiveMessages"
+    effect    = "Allow"
+    actions   = [
+      "sqs:ReceiveMessage",
+      "sqs:DeleteMessage",
+      "sqs:GetQueueAttributes",
+      "sqs:GetQueueUrl",
+      "sqs:ListQueues"
+    ]
+    resources = [aws_sqs_queue.mp_cloudtrail_log_queue.arn] 
+  }
+}
+
+# IAM policy to read the SQS queue
+resource "aws_iam_policy" "sqs_queue_read_policy" {
+  name        = "sqs-queue-read-policy"
+  description = "Allows the access to the created SQS queue"
+  policy      = data.aws_iam_policy_document.sqs_queue_read_document.json
+}
+
+# Creates an IAM user that will access the sqs queue
+resource "aws_iam_user" "cortex_xsiam_user" {
+  name = "cortex_xsiam_user"
+}
+
+resource "aws_iam_user_policy_attachment" "sqs_queue_read_policy_attachment" {
+  user       = "cortex_xsiam_user" 
+  policy_arn = aws_iam_policy.sqs_queue_read_policy.arn
+}


### PR DESCRIPTION

## A reference to the issue / Description of it

This is issue 6614 - which creates a number of resources that will allow for updates to the s3 logging bucket in core-logging to be added to an SQS queue. This queue is then consumed by the Cortex Xsiam platform via an IAM account. 

## How does this PR fix the problem?

See above and the issue for details.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Local plan is correct and shows creation of resources.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

Will deploy via GHA.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
