### PR TITLE
Issue/6614

### DIFF
--- a/terraform/environments/core-logging/s3_logging.tf
+++ b/terraform/environments/core-logging/s3_logging.tf
@@ -287,16 +287,17 @@ data "aws_iam_policy_document" "cloudtrail_bucket_policy" {
     }
   }
   statement {
-    sid     = "allowSQSSendMessage"
-    effect  = "Allow"
-    actions = ["sqs:SendMessage"]
-    resources = [
+    sid        = "allowSQSSendMessage"
+    effect     = "Allow"
+    actions    = ["sqs:SendMessage"]
+    resources  = [
       module.s3-bucket-cloudtrail.bucket.arn,
-      format("%s/*", module.s3-bucket-cloudtrail.bucket.arn)
+      format("%s/*", module.s3-bucket-cloudtrail.bucket.arn),
+      aws_sqs_queue.mp_cloudtrail_log_queue.arn
     ]
     principals {
-    type        = "Service"
-    identifiers = ["sqs.amazonaws.com"]
+      type        = "Service"
+      identifiers = ["sqs.amazonaws.com"]
     }
     condition {
       test     = "StringEquals"

--- a/terraform/environments/core-logging/s3_logging.tf
+++ b/terraform/environments/core-logging/s3_logging.tf
@@ -294,6 +294,10 @@ data "aws_iam_policy_document" "cloudtrail_bucket_policy" {
       module.s3-bucket-cloudtrail.bucket.arn,
       format("%s/*", module.s3-bucket-cloudtrail.bucket.arn)
     ]
+    principals {
+    type        = "Service"
+    identifiers = ["sqs.amazonaws.com"]
+    }
     condition {
       test     = "StringEquals"
       variable = "aws:SourceArn"


### PR DESCRIPTION
## A reference to the issue / Description of it

This is issue 6614 - which creates a number of resources that will allow for updates to the s3 logging bucket in core-logging to be added to an SQS queue. This queue is then consumed by the Cortex Xsiam platform via an IAM account. Note that the SQS queue reuses the S3 logging bucket KMS key on the basis that it is covering the same data.

## How does this PR fix the problem?

This PR fixes the missing principle as well as adds the queue arn.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

This follows an earlier failed deployment.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
