### PR TITLE
Fix step output expansion

### DIFF
--- a/.github/workflows/new-environment.yml
+++ b/.github/workflows/new-environment.yml
@@ -173,7 +173,7 @@ jobs:
           echo "files=$files" >> $GITHUB_OUTPUT
       - name: Run delegate access
         run: |
-          accounts=(${{ steps.new_account.outputs.files }} | base64 --decode)
+          accounts=($(echo "${{ steps.new_account.outputs.files }}" | base64 --decode))
           if [ ! -z ${accounts} ]
           then
           for i in "${accounts[@]}"
@@ -223,7 +223,7 @@ jobs:
           echo "files=$files" >> $GITHUB_OUTPUT
       - name: Run secure baselines
         run: |
-          accounts=(${{ steps.new_account.outputs.files }} | base64 --decode)
+          accounts=($(echo "${{ steps.new_account.outputs.files }}" | base64 --decode))
           if [ ! -z ${accounts} ]
           then
           for i in "${accounts[@]}"
@@ -273,7 +273,7 @@ jobs:
           echo "files=$files" >> $GITHUB_OUTPUT
       - name: Run single sign on
         run: |
-          accounts=(${{ steps.new_account.outputs.files }} | base64 --decode)
+          accounts=($(echo "${{ steps.new_account.outputs.files }}" | base64 --decode))
           if [ ! -z ${accounts} ]
           then
           for i in "${accounts[@]}"
@@ -323,7 +323,7 @@ jobs:
           echo "files=$files" >> $GITHUB_OUTPUT
       - name: Run secure baselines
         run: |
-          accounts=(${{ steps.new_account.outputs.files }} | base64 --decode)
+          accounts=($(echo "${{ steps.new_account.outputs.files }}" | base64 --decode))
           if [ ! -z ${accounts} ]
           then
           for i in "${accounts[@]}"

--- a/.github/workflows/new-environment.yml
+++ b/.github/workflows/new-environment.yml
@@ -173,7 +173,7 @@ jobs:
           echo "files=$files" >> $GITHUB_OUTPUT
       - name: Run delegate access
         run: |
-          accounts=($(echo "${{ steps.new_account.outputs.files }}" | base64 --decode))
+          accounts=$(echo "${{ steps.new_account.outputs.files }}" | base64 --decode)
           if [ ! -z ${accounts} ]
           then
           for i in "${accounts[@]}"
@@ -223,7 +223,7 @@ jobs:
           echo "files=$files" >> $GITHUB_OUTPUT
       - name: Run secure baselines
         run: |
-          accounts=($(echo "${{ steps.new_account.outputs.files }}" | base64 --decode))
+          accounts=$(echo "${{ steps.new_account.outputs.files }}" | base64 --decode)
           if [ ! -z ${accounts} ]
           then
           for i in "${accounts[@]}"
@@ -273,7 +273,7 @@ jobs:
           echo "files=$files" >> $GITHUB_OUTPUT
       - name: Run single sign on
         run: |
-          accounts=($(echo "${{ steps.new_account.outputs.files }}" | base64 --decode))
+          accounts=$(echo "${{ steps.new_account.outputs.files }}" | base64 --decode)
           if [ ! -z ${accounts} ]
           then
           for i in "${accounts[@]}"
@@ -323,7 +323,7 @@ jobs:
           echo "files=$files" >> $GITHUB_OUTPUT
       - name: Run secure baselines
         run: |
-          accounts=($(echo "${{ steps.new_account.outputs.files }}" | base64 --decode))
+          accounts=$(echo "${{ steps.new_account.outputs.files }}" | base64 --decode)
           if [ ! -z ${accounts} ]
           then
           for i in "${accounts[@]}"


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/actions/runs/8604863743/job/23580726692

## How does this PR fix the problem?

This should resolve the incorrect output expansion introduced in https://github.com/ministryofjustice/modernisation-platform/pull/6720

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Ran expansion in local bash (substituting expansion of step output for existing variable)

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
