### PR TITLE
Adding merge group for merge queue

### DIFF
--- a/.github/workflows/opa-policies.yml
+++ b/.github/workflows/opa-policies.yml
@@ -5,6 +5,8 @@ on:
   pull_request:
     branches:
       - main
+  merge_group:
+    types: [checks_requested]
 
 permissions:
   contents: read


### PR DESCRIPTION
This PR adds merge_group to the OPA workflow check required for merge queue.

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#merge_group