### PR TITLE
Issue 6614

### DIFF
--- a/terraform/environments/core-logging/s3_logging.tf
+++ b/terraform/environments/core-logging/s3_logging.tf
@@ -286,18 +286,6 @@ data "aws_iam_policy_document" "cloudtrail_bucket_policy" {
       identifiers = [data.aws_caller_identity.current.account_id]
     }
   }
-  statement {
-    sid        = "allowSQSSendMessage"
-    effect     = "Allow"
-    actions    = ["sqs:SendMessage"]
-    resources  = [
-      aws_sqs_queue.mp_cloudtrail_log_queue.arn
-    ]
-    principals {
-      type        = "Service"
-      identifiers = ["sqs.amazonaws.com"]
-    }
-  }
 }
 
 module "cloudtrail-s3-logging-replication-role" {

--- a/terraform/environments/core-logging/sqs.tf
+++ b/terraform/environments/core-logging/sqs.tf
@@ -5,44 +5,44 @@ resource "aws_sqs_queue" "mp_cloudtrail_log_queue" {
   name                              = "mp_cloudtrail_log_queue"
   kms_master_key_id                 = "alias/s3-logging-cloudtrail" # We reuse the S3 bucket key
   kms_data_key_reuse_period_seconds = 300
-  delay_seconds                     = 0       # The default is 0 but can be up to 15 minutes
-  max_message_size                  = 262144  # 256k which is the max size
-  message_retention_seconds         = 345600  # This is 4 days. The max is 14 days
+  delay_seconds                     = 0      # The default is 0 but can be up to 15 minutes
+  max_message_size                  = 262144 # 256k which is the max size
+  message_retention_seconds         = 345600 # This is 4 days. The max is 14 days
   visibility_timeout_seconds        = 30     # This is only useful for queues that have multiple subscribers
 }
 
 # This policy grants queue send message to the s3 logging bucket
 resource "aws_sqs_queue_policy" "queue_policy" {
-    queue_url = aws_sqs_queue.mp_cloudtrail_log_queue.id
-    policy = data.aws_iam_policy_document.queue_policy_document.json
+  queue_url = aws_sqs_queue.mp_cloudtrail_log_queue.id
+  policy    = data.aws_iam_policy_document.queue_policy_document.json
 }
 
 data "aws_iam_policy_document" "queue_policy_document" {
-    statement {
-        sid        = "AllowSendMessage"
-        effect     = "Allow"
-        principals {
-            type        = "Service"
-            identifiers = ["s3.amazonaws.com"]
-        }
-        actions    = ["sqs:SendMessage"]
-        resources  = [
-            aws_sqs_queue.mp_cloudtrail_log_queue.arn
-        ]
-        condition {
-            test     = "ArnEquals"
-            variable = "aws:SourceArn"
-            values   = [module.s3-bucket-cloudtrail-logging.bucket.arn] 
-        }
+  statement {
+    sid    = "AllowSendMessage"
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["s3.amazonaws.com"]
     }
+    actions = ["sqs:SendMessage"]
+    resources = [
+      aws_sqs_queue.mp_cloudtrail_log_queue.arn
+    ]
+    condition {
+      test     = "ArnEquals"
+      variable = "aws:SourceArn"
+      values   = [module.s3-bucket-cloudtrail-logging.bucket.arn]
+    }
+  }
 }
 
 # S3 bucket event notification for updates to the cloudtrail logging bucket
 resource "aws_s3_bucket_notification" "logging_bucket_notification" {
-  bucket = module.s3-bucket-cloudtrail-logging.bucket.bucket  
+  bucket = module.s3-bucket-cloudtrail-logging.bucket.bucket
   queue {
     queue_arn = aws_sqs_queue.mp_cloudtrail_log_queue.arn
-    events    = ["s3:ObjectCreated:*"]  # Events to trigger the notification
+    events    = ["s3:ObjectCreated:*"] # Events to trigger the notification
   }
 }
 
@@ -51,22 +51,22 @@ resource "aws_s3_bucket_notification" "logging_bucket_notification" {
 # Create an IAM policy document to allow access to the SQS Queue
 data "aws_iam_policy_document" "sqs_queue_read_document" {
   statement {
-    sid       = "SQSQueueReceiveMessages"
-    effect    = "Allow"
-    actions   = [
+    sid    = "SQSQueueReceiveMessages"
+    effect = "Allow"
+    actions = [
       "sqs:ReceiveMessage",
       "sqs:DeleteMessage",
       "sqs:GetQueueAttributes",
       "sqs:GetQueueUrl",
       "sqs:ListQueues"
     ]
-    resources = [aws_sqs_queue.mp_cloudtrail_log_queue.arn] 
+    resources = [aws_sqs_queue.mp_cloudtrail_log_queue.arn]
   }
   statement {
     sid       = "SQSReadLoggingS3"
     effect    = "Allow"
     actions   = ["s3:GetObject"]
-    resources = [module.s3-bucket-cloudtrail.bucket.arn, "${module.s3-bucket-cloudtrail.bucket.arn}/*"] 
+    resources = [module.s3-bucket-cloudtrail.bucket.arn, "${module.s3-bucket-cloudtrail.bucket.arn}/*"]
   }
 }
 
@@ -85,6 +85,6 @@ resource "aws_iam_user" "cortex_xsiam_user" {
 
 resource "aws_iam_user_policy_attachment" "sqs_queue_read_policy_attachment" {
   #checkov:skip=CKV_AWS_40: User account only has a single purpose so no role or group is needed
-  user       = "cortex_xsiam_user" 
+  user       = "cortex_xsiam_user"
   policy_arn = aws_iam_policy.sqs_queue_read_policy.arn
 }


### PR DESCRIPTION
This fixes a deployment bug. The additional s3 policy is not required and instead it is replaced by a new SQS queue policy that grants the buckets send message rights. This has been tested in sprinkler.

## A reference to the issue / Description of it

See above.

## How does this PR fix the problem?

Adds the missing queue policy & s3 bucket notification

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

This has been deployed into sprinkler and has been confirmed to work.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
