### PR TITLE
Decommissioning the incident response

### DIFF
--- a/terraform/github/README.md
+++ b/terraform/github/README.md
@@ -48,3 +48,14 @@ Since the new repository you're creating is for a terraform module, please also 
 2. GitHub job for documentation, refer for example to [documentation.yml](https://github.com/ministryofjustice/modernisation-platform-terraform-ecs/blob/main/.github/workflows/documentation.yml)
 
 Note the [template-repository](https://github.com/ministryofjustice/template-repository) holds all the files that will be added to every new repository.
+
+## How to archive a repository
+In a browser, navigate to the target GitHub repository's settings and manually archive it.
+
+Once manually archived, delete its references in code:
+1. Remove the repository module reference in [modernisation-platform/terraform/github/repositories.tf](https://github.com/ministryofjustice/modernisation-platform/blob/main/terraform/github/repositories.tf)
+2. Remove the repository reference from the core team's repository list in [modernisation-platform/terraform/github/teams.tf](https://github.com/ministryofjustice/modernisation-platform/blob/be29e5e601e39749c8d3acc784e8dbdea2d2db1c/terraform/github/teams.tf#L2)
+
+You can run a local plan in `modernisation-platform/terraform/github/` to verify the correctness of changes. You will need to pass your GH token when prompted.
+
+Once happy with the changes, create a PR, get a review and merge your code.  Because `archive_on_destroy` is set to `true` in the [`github_repository`](https://github.com/ministryofjustice/modernisation-platform/blob/be29e5e601e39749c8d3acc784e8dbdea2d2db1c/terraform/github/modules/repository/main.tf#L24) resource it will [archive](https://github.com/integrations/terraform-provider-github/blob/2881a2a4c19475ca8a9f0b4ea6570dda4fd12b71/github/resource_github_repository.go#L857) the repository, rather than delete it, even though it will be deleted from the terraform code.

--- a/terraform/github/README.md
+++ b/terraform/github/README.md
@@ -50,7 +50,7 @@ Since the new repository you're creating is for a terraform module, please also 
 Note the [template-repository](https://github.com/ministryofjustice/template-repository) holds all the files that will be added to every new repository.
 
 ## How to archive a repository
-In a browser, navigate to the target GitHub repository's settings and manually archive it.
+In a browser, navigate to the target GitHub repository's settings and manually archive it (this is needed due to pipeline permissions limitations).
 
 Once manually archived, delete its references in code:
 1. Remove the repository module reference in [modernisation-platform/terraform/github/repositories.tf](https://github.com/ministryofjustice/modernisation-platform/blob/main/terraform/github/repositories.tf)
@@ -58,4 +58,4 @@ Once manually archived, delete its references in code:
 
 You can run a local plan in `modernisation-platform/terraform/github/` to verify the correctness of changes. You will need to pass your GH token when prompted.
 
-Once happy with the changes, create a PR, get a review and merge your code.  Because `archive_on_destroy` is set to `true` in the [`github_repository`](https://github.com/ministryofjustice/modernisation-platform/blob/be29e5e601e39749c8d3acc784e8dbdea2d2db1c/terraform/github/modules/repository/main.tf#L24) resource it will [archive](https://github.com/integrations/terraform-provider-github/blob/2881a2a4c19475ca8a9f0b4ea6570dda4fd12b71/github/resource_github_repository.go#L857) the repository, rather than delete it, even though it will be deleted from the terraform code.
+Once happy with the changes, create a PR, get a review and merge your code.  Because `archive_on_destroy` is set to `true` in the [`github_repository`](https://github.com/ministryofjustice/modernisation-platform/blob/be29e5e601e39749c8d3acc784e8dbdea2d2db1c/terraform/github/modules/repository/main.tf#L24) resource it will reamin [archived](https://github.com/integrations/terraform-provider-github/blob/2881a2a4c19475ca8a9f0b4ea6570dda4fd12b71/github/resource_github_repository.go#L857) the repository, rather than delete it, even though it will be deleted from the terraform code.

--- a/terraform/github/repositories.tf
+++ b/terraform/github/repositories.tf
@@ -348,21 +348,6 @@ module "modernisation-platform-configuration-management" {
   ]
 }
 
-module "modernisation-platform-incident-response" {
-  source      = "./modules/repository"
-  name        = "modernisation-platform-incident-response"
-  type        = "core"
-  description = "Repository for incident management code used to manage and document Modernisation Platform incidents. Originally forked from https://github.com/ministryofjustice/opg-incident-response"
-  topics = [
-    "incident-management",
-    "javascript",
-    "python",
-    "django",
-    "docker",
-    "kubernetes",
-    "helm"
-  ]
-}
 module "modernisation-platform-terraform-dns-certificates" {
   source      = "./modules/repository"
   name        = "modernisation-platform-terraform-dns-certificates"

--- a/terraform/github/teams.tf
+++ b/terraform/github/teams.tf
@@ -26,7 +26,6 @@ module "core-team" {
     module.modernisation-platform-configuration-management.repository.name,
     module.terraform-module-lambda-function.repository.name,
     module.terraform-module-ssm-patching.repository.name,
-    module.modernisation-platform-incident-response.repository.name,
     module.terraform-module-ec2-instance.repository.name,
     module.terraform-module-ec2-autoscaling-group.repository.name,
     module.terraform-module-ecs-cluster.repository.name,


### PR DESCRIPTION
## A reference to the issue / Description of it

Removing the [modernisation-platform-incident-response](https://github.com/ministryofjustice/modernisation-platform-incident-response) from our repositories, as the infrastructure that this code relates to has been decommissioned a while ago. This repository has been archived in the past, but then kept in code which resulted in it being unarchived.

This repository has been archived again and now it needs deleting in code.

## How does this PR fix the problem?

It will make sure that [modernisation-platform-incident-response](https://github.com/ministryofjustice/modernisation-platform-incident-response)

## How has this been tested?

Terraform plan run clean locally.

## Deployment Plan / Instructions

No impact, the repo is already archived, this is just a code cleanup.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [x] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments
Updated README to include instructions on how to archive a repository.