### PR TITLE
Issue 6614

### DIFF
--- a/terraform/environments/core-logging/sqs.tf
+++ b/terraform/environments/core-logging/sqs.tf
@@ -39,7 +39,7 @@ data "aws_iam_policy_document" "queue_policy_document" {
 
 # S3 bucket event notification for updates to the cloudtrail logging bucket
 resource "aws_s3_bucket_notification" "logging_bucket_notification" {
-  bucket = module.s3-bucket-cloudtrail-logging.bucket.bucket
+  bucket = module.s3-bucket-cloudtrail-logging.bucket.id
   queue {
     queue_arn = aws_sqs_queue.mp_cloudtrail_log_queue.arn
     events    = ["s3:ObjectCreated:*"] # Events to trigger the notification


### PR DESCRIPTION
Though with sprinkler the notification was created with the .bucket property, this is changing it to .id as per the documentation.

## A reference to the issue / Description of it

See above.

## How does this PR fix the problem?

{Please write here}

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
