### PR TITLE
Implement Feature to Disable Console Login and Access Keys for `Inactive Collaborator Users`

### DIFF
--- a/.github/workflows/check-inactive-collaborators.yml
+++ b/.github/workflows/check-inactive-collaborators.yml
@@ -6,7 +6,6 @@ on:
 env:
     AWS_REGION: "eu-west-2"
     ENVIRONMENT_MANAGEMENT: ${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENTS }}
-    SCRIPTS_PATH: "./scripts/internal/collaborators-inactivity-notification"
     API_KEY: ${{ secrets.GOV_UK_NOTIFY_API_KEY }}
     TEMPLATE_ID: "44d86b2d-2a73-4179-9b67-7c3fc2b58934"
 
@@ -32,32 +31,12 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Fetch Inactive Collaborators
-        run: bash ${SCRIPTS_PATH}/check_inactive_users.sh
+        run: bash ./scripts/internal/collaborators-inactivity-notification/check_inactive_users.sh
         env:
-          thresold: 120
+          threshold: 120
 
       - name: Disable Console Login
-        run: |
-          # check final_users.list is exist
-          if [ -f final_users.list ]; then
-            while read username; do
-
-              # Disable console access for the user
-              if aws iam get-login-profile --user-name "$username" &> /dev/null; then
-                aws iam delete-login-profile --user-name "$username"
-                echo "Console access for $username has been disabled"
-              fi
-
-              # Get a list of access keys for the user and deactivate them if they are active
-              access_keys=$(aws iam list-access-keys --user-name $username --query "AccessKeyMetadata[].AccessKeyId" --output text 2>/dev/null | xargs -n 1)
-              while read -r key; do
-                aws iam update-access-key --access-key-id $key --status Inactive --user-name $username
-              done <<< "$access_keys"
-            done <<< "$(cat final_users.list)"
-
-          else
-            echo "There are no inactive collaborator users with an inactivity period of 120 days or longer."
-          fi
+        run: bash ./scripts/internal/collaborators-inactivity-notification/disable_user_credentials.sh
 
   notify-inactive-collaborators:
     runs-on: ubuntu-latest
@@ -86,10 +65,10 @@ jobs:
     
       - name: Fetch Inactive Collaborators
         run: |
-          bash ${SCRIPTS_PATH}/check_inactive_users.sh
+          bash ./scripts/internal/collaborators-inactivity-notification/check_inactive_users.sh
           cat final_users.list
         env:
-          thresold: 90
+          threshold: 90
           SKIP_DISABLED_CONSOLE_USERS: true
 
       #- name: Send Notification to Collaborators

--- a/.github/workflows/check-inactive-collaborators.yml
+++ b/.github/workflows/check-inactive-collaborators.yml
@@ -15,8 +15,53 @@ permissions:
     contents: read # This is required for actions/checkout
     issues: write # This is required to create issues
 jobs:
+  disable-login-for-inactive-collaborators:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Set Account Number
+        run: echo "ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+          role-session-name: githubactionsrolesession
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Fetch Inactive Collaborators
+        run: bash ${SCRIPTS_PATH}/check_inactive_users.sh
+        env:
+          thresold: 120
+
+      - name: Disable Console Login
+        run: |
+          # check final_users.list is exist
+          if [ -f final_users.list ]; then
+            while read username; do
+
+              # Disable console access for the user
+              if aws iam get-login-profile --user-name "$username" &> /dev/null; then
+                aws iam delete-login-profile --user-name "$username"
+                echo "Console access for $username has been disabled"
+              fi
+
+              # Get a list of access keys for the user and deactivate them if they are active
+              access_keys=$(aws iam list-access-keys --user-name $username --query "AccessKeyMetadata[].AccessKeyId" --output text 2>/dev/null | xargs -n 1)
+              while read -r key; do
+                aws iam update-access-key --access-key-id $key --status Inactive --user-name $username
+              done <<< "$access_keys"
+            done <<< "$(cat final_users.list)"
+
+          else
+            echo "There are no inactive collaborator users with an inactivity period of 120 days or longer."
+          fi
+
   notify-inactive-collaborators:
     runs-on: ubuntu-latest
+    needs: disable-login-for-inactive-collaborators
     steps:
       - name: Checkout Repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -39,9 +84,13 @@ jobs:
       - name: Install the client
         run: pip install notifications-python-client
     
-      - name: Get Inactive Collaborator Users
+      - name: Fetch Inactive Collaborators
         run: |
           bash ${SCRIPTS_PATH}/check_inactive_users.sh
+          cat final_users.list
+        env:
+          thresold: 90
+          SKIP_DISABLED_CONSOLE_USERS: true
 
-      - name: Send Notification to Collaborators
-        run: python ${SCRIPTS_PATH}/notification.py collaborators.json final_users.list
+      #- name: Send Notification to Collaborators
+      #  run: python ${SCRIPTS_PATH}/notification.py collaborators.json final_users.list

--- a/scripts/internal/collaborators-inactivity-notification/check_inactive_users.sh
+++ b/scripts/internal/collaborators-inactivity-notification/check_inactive_users.sh
@@ -24,8 +24,8 @@ while read -r username lastactivity; do
     fi
   fi
 
-  # Check if last console login activity is more than or equal to thresold days or is "None"
-  if [ "$lastactivity" == "None" ] || [ "$(date -d "$lastactivity" +%s)" -le "$(date -d "now - $thresold days" +%s)" ]; then
+  # Check if last console login activity is more than or equal to threshold days or is "None"
+  if [ "$lastactivity" == "None" ] || [ "$(date -d "$lastactivity" +%s)" -le "$(date -d "now - $threshold days" +%s)" ]; then
     # Get information about the access keys for the current user
     access_keys=$(aws iam list-access-keys --user-name "$username" --query 'AccessKeyMetadata[].AccessKeyId' --output text)
     
@@ -36,8 +36,8 @@ while read -r username lastactivity; do
     for access_key_id in $access_keys; do
       # Get the last used information for the access key
       last_used=$(aws iam get-access-key-last-used --access-key-id "$access_key_id" --query 'AccessKeyLastUsed.LastUsedDate' --output text)
-      if [ "$last_used" != "None" ] && [ "$(date -d "$last_used" +%s)" -ge "$(date -d "now - $thresold days" +%s)" ]; then
-        # If any access key was used within the last thresold days, user does not meet the criteria
+      if [ "$last_used" != "None" ] && [ "$(date -d "$last_used" +%s)" -ge "$(date -d "now - $threshold days" +%s)" ]; then
+        # If any access key was used within the last threshold days, user does not meet the criteria
         meets_criteria=0
         break
       fi

--- a/scripts/internal/collaborators-inactivity-notification/disable_user_credentials.sh
+++ b/scripts/internal/collaborators-inactivity-notification/disable_user_credentials.sh
@@ -1,0 +1,17 @@
+# check final_users.list is exist
+if [ -f final_users.list ]; then
+  while read username; do
+    # Disable console access for the user
+    if aws iam get-login-profile --user-name "$username" &> /dev/null; then
+      aws iam delete-login-profile --user-name "$username"
+      echo "Console access for $username has been disabled"
+    fi
+    # Get a list of access keys for the user and deactivate them if they are active
+    access_keys=$(aws iam list-access-keys --user-name $username --query "AccessKeyMetadata[].AccessKeyId" --output text 2>/dev/null | xargs -n 1)
+    while read -r key; do
+      aws iam update-access-key --access-key-id $key --status Inactive --user-name $username
+    done <<< "$access_keys"
+  done <<< "$(cat final_users.list)"
+else
+  echo "There are no inactive collaborator users with an inactivity period of 120 days or longer."
+fi


### PR DESCRIPTION
## A reference to the issue / Description of it

This PR addresses the implementation of a feature to disable console logins and access keys for `inactive collaborator users` after 120 days of inactivity. #6390 
 
## How does this PR fix the problem?

This PR introduces a new job that identifies collaborator users with inactivity of 120 days or more and disables their console login and access keys. 

## How has this been tested?

Tested this new functionality in the sprinkler environment to validate its effectiveness and reliability under various scenarios.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
