### PR TITLE
Add Conditional Logic for Notification Script and Error Handling for Access Keys

### DIFF
--- a/.github/workflows/check-inactive-collaborators.yml
+++ b/.github/workflows/check-inactive-collaborators.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Send Notification to Collaborators
         run: |
           if [ -f final_users.list ]; then
-            python ${SCRIPTS_PATH}/notification.py collaborators.json final_users.list
+            python ./scripts/internal/collaborators-inactivity-notification/notification.py collaborators.json final_users.list
           else
             echo "There are no inactive collaborator users with an inactivity period of 90 days or longer"
           fi

--- a/.github/workflows/check-inactive-collaborators.yml
+++ b/.github/workflows/check-inactive-collaborators.yml
@@ -64,12 +64,15 @@ jobs:
         run: pip install notifications-python-client
     
       - name: Fetch Inactive Collaborators
-        run: |
-          bash ./scripts/internal/collaborators-inactivity-notification/check_inactive_users.sh
-          cat final_users.list
+        run: bash ./scripts/internal/collaborators-inactivity-notification/check_inactive_users.sh
         env:
           threshold: 90
           SKIP_DISABLED_CONSOLE_USERS: true
 
-      #- name: Send Notification to Collaborators
-      #  run: python ${SCRIPTS_PATH}/notification.py collaborators.json final_users.list
+      - name: Send Notification to Collaborators
+        run: |
+          if [ -f final_users.list ]; then
+            python ${SCRIPTS_PATH}/notification.py collaborators.json final_users.list
+          else
+            echo "There are no inactive collaborator users with an inactivity period of 90 days or longer"
+          fi

--- a/scripts/internal/collaborators-inactivity-notification/disable_user_credentials.sh
+++ b/scripts/internal/collaborators-inactivity-notification/disable_user_credentials.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # check final_users.list is exist
 if [ -f final_users.list ]; then
   while read username; do

--- a/scripts/internal/collaborators-inactivity-notification/disable_user_credentials.sh
+++ b/scripts/internal/collaborators-inactivity-notification/disable_user_credentials.sh
@@ -8,9 +8,11 @@ if [ -f final_users.list ]; then
     fi
     # Get a list of access keys for the user and deactivate them if they are active
     access_keys=$(aws iam list-access-keys --user-name $username --query "AccessKeyMetadata[].AccessKeyId" --output text 2>/dev/null | xargs -n 1)
-    while read -r key; do
-      aws iam update-access-key --access-key-id $key --status Inactive --user-name $username
-    done <<< "$access_keys"
+    if [ ! -z $access_keys ]; then
+      while read -r key; do
+        aws iam update-access-key --access-key-id $key --status Inactive --user-name $username
+      done <<< "$access_keys"
+    fi
   done <<< "$(cat final_users.list)"
 else
   echo "There are no inactive collaborator users with an inactivity period of 120 days or longer."


### PR DESCRIPTION
## A reference to the issue / Description of it

This PR addresses two issues:

1. It adds conditional logic to the notify-inactive-collaborators job to run the notification script only if the final_users.list file exists. This prevents unnecessary execution of the script when the file is absent.

2. It includes an if block in the disable_user_credentials.sh script to check if access keys are not empty before executing commands related to making access keys inactive. This prevents errors that occur when attempting to execute commands on empty access key lists.

## How does this PR fix the problem?

This PR fixes the issues by adding conditional logic to ensure the notification script is only executed when the final_users.list file exists, preventing unnecessary execution and potential errors. It also adds an if block to the disable_user_credentials.sh script to check for empty access key lists before executing commands, preventing errors in such cases.

## How has this been tested?

locally tested by executing the affected scripts in various scenarios

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
