### PR TITLE
oasys: DSOS-2736: allow data engineering ip ranges to hmpps production

### DIFF
--- a/terraform/environments/core-network-services/cidr-ranges.tf
+++ b/terraform/environments/core-network-services/cidr-ranges.tf
@@ -18,6 +18,9 @@ locals {
   other_cidr_ranges = {
     analytical-platform-airflow-dev  = "10.200.0.0/16"
     analytical-platform-airflow-prod = "10.201.0.0/16"
+    data-engineering-dev             = "172.24.0.0/16"
+    data-engineering-prod            = "172.25.0.0/16"
+    data-engineering-stage           = "172.26.0.0/16"
     atos_arkc_ras                    = "10.175.0.0/16" # for DOM1 devices connected to Cisco RAS VPN
     atos_arkf_ras                    = "10.176.0.0/16" # for DOM1 devices connected to Cisco RAS VPN
     cloud-platform                   = "172.20.0.0/16"

--- a/terraform/environments/core-network-services/firewall-rules/production_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/production_rules.json
@@ -635,5 +635,12 @@
     "destination_ip": "${dom1-dcs}",
     "destination_port": "49152:65535",
     "protocol": "TCP"
+  },
+  "data_engineering_to_hmpps_production_oracledb": {
+    "action": "PASS",
+    "source_ip": "$DATA_ENGINEERING",
+    "destination_ip": "${hmpps-production}",
+    "destination_port": "1521",
+    "protocol": "TCP"
   }
 }

--- a/terraform/environments/core-network-services/firewall-rules/sets.json
+++ b/terraform/environments/core-network-services/firewall-rules/sets.json
@@ -1,7 +1,8 @@
 {
   "IP_SETS": {
     "IP_SET_EXAMPLE": ["1.1.1.1/32", "1.0.0.1/32"],
-    "AD_HMPP_DCS": ["${ad-hmpp-dc-a}", "${ad-hmpp-dc-b}"]
+    "AD_HMPP_DCS": ["${ad-hmpp-dc-a}", "${ad-hmpp-dc-b}"],
+    "DATA_ENGINEERING": ["${data-engineering-dev}", "${data-engineering-prod}", "${data-engineering-stage}"]
   },
   "PORT_SETS": {
     "PORT_SET_EXAMPLE": ["80, 443"],


### PR DESCRIPTION
## A reference to the issue / Description of it

Data Engineering are unable to access Oasys DB in Mod Platform

## How does this PR fix the problem?

Adds required firewall rules

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

n/a

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
