### PR TITLE
DSOS-2736: tweak data engineering firewall rules

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
@@ -572,5 +572,12 @@
     "destination_ip": "${dom1-dcs}",
     "destination_port": "49152:65535",
     "protocol": "TCP"
+  },
+  "data_engineering_to_hmpps_preproduction_oracledb": {
+    "action": "PASS",
+    "source_ip": "${data-engineering-stage}",
+    "destination_ip": "${hmpps-preproduction}",
+    "destination_port": "1521",
+    "protocol": "TCP"
   }
 }

--- a/terraform/environments/core-network-services/firewall-rules/production_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/production_rules.json
@@ -638,7 +638,7 @@
   },
   "data_engineering_to_hmpps_production_oracledb": {
     "action": "PASS",
-    "source_ip": "$DATA_ENGINEERING",
+    "source_ip": "${data-engineering-prod}",
     "destination_ip": "${hmpps-production}",
     "destination_port": "1521",
     "protocol": "TCP"


### PR DESCRIPTION
## A reference to the issue / Description of it

Data engineering cannot access preproduction Oasys DB.  Following further conversation with data engineering teams, the production rules are also too permissive.

## How does this PR fix the problem?

Add preproduction firewall rule and restrict the production rule.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
