### PR TITLE
🐛  Add dynamodb permissions to 'oidc_assume_role_member'

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -113,7 +113,6 @@ data "aws_iam_policy_document" "member-access" {
       "ec2:*Spot*",
       "ec2:*InternetGateway*",
       "ec2:*NatGateway*",
-
       "ecr-public:*",
       "ecr:*",
       "ecs:*",
@@ -646,6 +645,14 @@ data "aws_iam_policy_document" "oidc_assume_role_member" {
     resources = ["arn:aws:s3:::modernisation-platform-terraform-state/environments/members/*"]
     actions = ["s3:PutObject",
     "s3:PutObjectAcl"]
+  }
+  statement {
+    effect = "Allow"
+    actions = [
+      "dynamodb:GetItem",
+      "dynamodb:PutItem"
+    ]
+    resources = ["arn:aws:dynamodb:eu-west-2:${data.aws_caller_identity.modernisation_platform.account_id}:table/modernisation-platform-terraform-state-lock"]
   }
 }
 


### PR DESCRIPTION
investigation into BUG https://github.com/ministryofjustice/modernisation-platform/issues/6702 This PR adds the `dynamodb:GetItem` and `dynamodb:PutItem` permissions

Error message (account numbers removed) 
```
Error message: 2 errors occurred:
	* operation error DynamoDB: PutItem, https response error StatusCode: 400,
RequestID: api error
AccessDeniedException: User:
arn:aws:sts:::assumed-role/github-actions/githubactionsrolesession
is not authorized to perform: dynamodb:PutItem on resource:
arn:aws:dynamodb:eu-west-2::table/modernisation-platform-terraform-state-lock
because no identity-based policy allows the dynamodb:PutItem action
	* Unable to retrieve item from DynamoDB table
"modernisation-platform-terraform-state-lock": operation error DynamoDB
```