### PR TITLE
DSO: add cloudwatch:PutMetricData to cicd role

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -381,6 +381,7 @@ data "aws_iam_policy_document" "policy" {
       "autoscaling:PutScheduledUpdateGroupAction",
       "autoscaling:SetDesiredCapacity",
       "backup:Start*",
+      "cloudwatch:PutMetricData",
       "codebuild:Start*",
       "codebuild:StartBuild",
       "codebuild:BatchGetBuilds",


### PR DESCRIPTION
## A reference to the issue / Description of it

Enabling the OIDC CI/CD role to write clouwatch metric data

## How does this PR fix the problem?

Adds the  relevant permission to the policy for the above mentioned user

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

n/a

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No impact expected.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

n/a
