### PR TITLE
DSOS-2720: propose a new instance-access role

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/collaborators.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/collaborators.tf
@@ -119,6 +119,31 @@ data "aws_iam_policy" "migration" {
   name = "migration_policy"
 }
 
+# Collaborator Instance Access role
+module "collaborator_instance_access_role" {
+  # checkov:skip=CKV_TF_1:
+  count   = local.account_data.account-type == "member" ? 1 : 0
+  source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
+  version = "~> 5"
+  trusted_role_arns = [
+    local.modernisation_platform_account.id
+  ]
+
+  create_role       = true
+  role_name         = "instance-access"
+  role_requires_mfa = true
+
+  custom_role_policy_arns = [
+    "arn:aws:iam::aws:policy/ReadOnlyAccess",
+    data.aws_iam_policy.instance-access.arn,
+  ]
+  number_of_custom_role_policy_arns = 2
+}
+
+data "aws_iam_policy" "instance-access" {
+  name = "instance_access_policy"
+}
+
 # Collaborator Database Management role
 module "collaborator_database_mgmt_role" {
   # checkov:skip=CKV_TF_1:

--- a/terraform/environments/bootstrap/single-sign-on/main.tf
+++ b/terraform/environments/bootstrap/single-sign-on/main.tf
@@ -194,6 +194,29 @@ resource "aws_ssoadmin_account_assignment" "administator" {
   target_type = "AWS_ACCOUNT"
 }
 
+resource "aws_ssoadmin_account_assignment" "instance-access" {
+
+  for_each = {
+
+    for sso_assignment in local.sso_data[local.env_name][*] :
+
+    "${sso_assignment.github_slug}-${sso_assignment.level}" => sso_assignment
+
+    if(sso_assignment.level == "instance-access")
+  }
+
+  provider = aws.sso-management
+
+  instance_arn       = local.sso_instance_arn
+  permission_set_arn = data.terraform_remote_state.mp-sso-permissions-sets.outputs.instance_access
+
+  principal_id   = data.aws_identitystore_group.member[each.value.github_slug].group_id
+  principal_type = "GROUP"
+
+  target_id   = local.environment_management.account_ids[terraform.workspace]
+  target_type = "AWS_ACCOUNT"
+}
+
 resource "aws_ssoadmin_account_assignment" "instance-management" {
 
   for_each = {

--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -614,6 +614,7 @@ resource "aws_iam_policy" "instance-access" {
 #   "full"            = s3 put; read-write secret; ec2 ssm full access; ec2 sso local admin
 #tfsec:ignore:aws-iam-no-policy-wildcards
 data "aws_iam_policy_document" "instance-access-document" {
+  #checkov:skip=CKV_AWS_107
   #checkov:skip=CKV_AWS_108
   #checkov:skip=CKV_AWS_109
   #checkov:skip=CKV_AWS_111

--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -607,7 +607,7 @@ resource "aws_iam_policy" "instance-access" {
 }
 
 # cut down version of instance-management policy
-# Use instance-access-role tag on resources to control access:
+# Use instance-access-policy tag on resources to control access:
 #   tag doesn't exist = s3 put; no secret access;  ec2 ssm full access
 #   "none"            = s3 put; no secret access;  no ec2 ssm access
 #   "limited"         = s3 put; read-only  secret; ec2 ssm ssh/port-forwarding only
@@ -645,7 +645,7 @@ data "aws_iam_policy_document" "instance-access-document" {
     resources = ["*"]
     conditions = [{
       test     = "StringEquals"
-      variable = "secretsmanager:ResourceTag/instance-access-role"
+      variable = "secretsmanager:ResourceTag/instance-access-policy"
       values   = ["limited"]
     }]
   }
@@ -659,7 +659,7 @@ data "aws_iam_policy_document" "instance-access-document" {
     resources = ["*"]
     conditions = [{
       test     = "StringEquals"
-      variable = "secretsmanager:ResourceTag/instance-access-role"
+      variable = "secretsmanager:ResourceTag/instance-access-policy"
       values   = ["full"]
     }]
   }

--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -643,11 +643,11 @@ data "aws_iam_policy_document" "instance-access-document" {
       "secretsmanager:GetSecretValue",
     ]
     resources = ["*"]
-    conditions = [{
+    condition {
       test     = "StringEquals"
       variable = "secretsmanager:ResourceTag/instance-access-policy"
       values   = ["limited"]
-    }]
+    }
   }
   statement {
     sid    = "SecretsManagerPut"
@@ -657,11 +657,11 @@ data "aws_iam_policy_document" "instance-access-document" {
       "secretsmanager:PutSecretValue",
     ]
     resources = ["*"]
-    conditions = [{
+    condition {
       test     = "StringEquals"
       variable = "secretsmanager:ResourceTag/instance-access-policy"
       values   = ["full"]
-    }]
+    }
   }
   statement {
     sid    = "SSMStartSessionPortForwarding"
@@ -674,18 +674,16 @@ data "aws_iam_policy_document" "instance-access-document" {
       "arn:aws:ssm:*:*:managed-instance/*",
       "arn:aws:ssm:*:*:document/AWS-StartPortForwardingSession",
     ]
-    conditions = [
-      {
-        test     = "BoolIfExists"
-        variable = "ssm:SessionDocumentAccessCheck"
-        values   = ["true"]
-      },
-      {
-        test     = "StringEqualsIfExists"
-        variable = "ssm:resourceTag/instance-access-policy"
-        values   = ["limited"] # doesn't work as expected with granular tags, e.g. use ssh/portforward
-      },
-    ]
+    condition {
+      test     = "BoolIfExists"
+      variable = "ssm:SessionDocumentAccessCheck"
+      values   = ["true"]
+    }
+    condition {
+      test     = "StringEqualsIfExists"
+      variable = "ssm:resourceTag/instance-access-policy"
+      values   = ["limited"] # doesn't work as expected with granular tags, e.g. use ssh/portforward
+    }
   }
   statement {
     sid    = "SSMStartSessionSSH"
@@ -698,18 +696,16 @@ data "aws_iam_policy_document" "instance-access-document" {
       "arn:aws:ssm:*:*:managed-instance/*",
       "arn:aws:ssm:*:*:document/AWS-StartSSHSession",
     ]
-    conditions = [
-      {
-        test     = "BoolIfExists"
-        variable = "ssm:SessionDocumentAccessCheck"
-        values   = ["true"]
-      },
-      {
-        test     = "StringEqualsIfExists"
-        variable = "ssm:resourceTag/instance-access-policy"
-        values   = ["limited"]
-      },
-    ]
+    condition {
+      test     = "BoolIfExists"
+      variable = "ssm:SessionDocumentAccessCheck"
+      values   = ["true"]
+    }
+    condition {
+      test     = "StringEqualsIfExists"
+      variable = "ssm:resourceTag/instance-access-policy"
+      values   = ["limited"]
+    }
   }
   statement {
     sid    = "SSMStartSession"
@@ -721,13 +717,11 @@ data "aws_iam_policy_document" "instance-access-document" {
       "arn:aws:ec2:*:*:instance/*",
       "arn:aws:ssm:*:*:managed-instance/*",
     ]
-    conditions = [
-      {
-        test     = "StringEqualsIfExists"
-        variable = "ssm:resourceTag/instance-access-policy"
-        values   = ["full"]
-      }
-    ]
+    condition {
+      test     = "StringEqualsIfExists"
+      variable = "ssm:resourceTag/instance-access-policy"
+      values   = ["full"]
+    }
   }
 
   statement {
@@ -741,18 +735,16 @@ data "aws_iam_policy_document" "instance-access-document" {
       "arn:aws:ssm:*:*:managed-instance/*",
       "arn:aws:ssm:*:*:document/AWSSSO-CreateSSOUser"
     ]
-    conditions = [
-      {
-        test     = "BoolIfExists"
-        variable = "ssm:SessionDocumentAccessCheck"
-        values   = ["true"]
-      },
-      {
-        test     = "StringEqualsIfExists"
-        variable = "ssm:resourceTag/instance-access-policy"
-        values   = ["full"]
-      },
-    ]
+    condition {
+      test     = "BoolIfExists"
+      variable = "ssm:SessionDocumentAccessCheck"
+      values   = ["true"]
+    }
+    condition {
+      test     = "StringEqualsIfExists"
+      variable = "ssm:resourceTag/instance-access-policy"
+      values   = ["full"]
+    }
   }
 
 }

--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -598,6 +598,164 @@ data "aws_iam_policy_document" "migration_additional" {
   }
 }
 
+# instance access - member SSO and collaborators
+resource "aws_iam_policy" "instance-access" {
+  provider = aws.workspace
+  name     = "instance_access_policy"
+  path     = "/"
+  policy   = data.aws_iam_policy_document.instance-access-document.json
+}
+
+# cut down version of instance-management policy
+# Use instance-access-role tag on resources to control access:
+#   tag doesn't exist = s3 put; no secret access;  ec2 ssm full access
+#   "none"            = s3 put; no secret access;  no ec2 ssm access
+#   "limited"         = s3 put; read-only  secret; ec2 ssm ssh/port-forwarding only
+#   "full"            = s3 put; read-write secret; ec2 ssm full access; ec2 sso local admin
+#tfsec:ignore:aws-iam-no-policy-wildcards
+data "aws_iam_policy_document" "instance-access-document" {
+  #checkov:skip=CKV_AWS_108
+  #checkov:skip=CKV_AWS_109
+  #checkov:skip=CKV_AWS_111
+  #checkov:skip=CKV_AWS_110
+  #checkov:skip=CKV_AWS_356: Needs to access multiple resources
+  source_policy_documents = [data.aws_iam_policy_document.common_statements.json]
+  statement {
+    sid    = "InstanceAccess"
+    effect = "Allow"
+    actions = [
+      "ec2:GetPasswordData",
+      "kms:Decrypt*",
+      "kms:Encrypt",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:DescribeKey",
+      "rhelkb:GetRhelURL",
+      "s3:PutObject",
+      "ssm-guiconnect:*",
+    ]
+    resources = ["*"]
+  }
+  statement {
+    sid    = "SecretsManagerGet"
+    effect = "Allow"
+    actions = [
+      "secretsmanager:GetSecretValue",
+    ]
+    resources = ["*"]
+    conditions = [{
+      test     = "StringEquals"
+      variable = "secretsmanager:ResourceTag/instance-access-role"
+      values   = ["limited"]
+    }]
+  }
+  statement {
+    sid    = "SecretsManagerPut"
+    effect = "Allow"
+    actions = [
+      "secretsmanager:GetSecretValue",
+      "secretsmanager:PutSecretValue",
+    ]
+    resources = ["*"]
+    conditions = [{
+      test     = "StringEquals"
+      variable = "secretsmanager:ResourceTag/instance-access-role"
+      values   = ["full"]
+    }]
+  }
+  statement {
+    sid    = "SSMStartSessionPortForwarding"
+    effect = "Allow"
+    actions = [
+      "ssm:StartSession"
+    ]
+    resources = [
+      "arn:aws:ec2:*:*:instance/*",
+      "arn:aws:ssm:*:*:managed-instance/*",
+      "arn:aws:ssm:*:*:document/AWS-StartPortForwardingSession",
+    ]
+    conditions = [
+      {
+        test     = "BoolIfExists"
+        variable = "ssm:SessionDocumentAccessCheck"
+        values   = ["true"]
+      },
+      {
+        test     = "StringEqualsIfExists"
+        variable = "ssm:resourceTag/instance-access-policy"
+        values   = ["limited"] # doesn't work as expected with granular tags, e.g. use ssh/portforward
+      },
+    ]
+  }
+  statement {
+    sid    = "SSMStartSessionSSH"
+    effect = "Allow"
+    actions = [
+      "ssm:StartSession"
+    ]
+    resources = [
+      "arn:aws:ec2:*:*:instance/*",
+      "arn:aws:ssm:*:*:managed-instance/*",
+      "arn:aws:ssm:*:*:document/AWS-StartSSHSession",
+    ]
+    conditions = [
+      {
+        test     = "BoolIfExists"
+        variable = "ssm:SessionDocumentAccessCheck"
+        values   = ["true"]
+      },
+      {
+        test     = "StringEqualsIfExists"
+        variable = "ssm:resourceTag/instance-access-policy"
+        values   = ["limited"]
+      },
+    ]
+  }
+  statement {
+    sid    = "SSMStartSession"
+    effect = "Allow"
+    actions = [
+      "ssm:StartSession"
+    ]
+    resources = [
+      "arn:aws:ec2:*:*:instance/*",
+      "arn:aws:ssm:*:*:managed-instance/*",
+    ]
+    conditions = [
+      {
+        test     = "StringEqualsIfExists"
+        variable = "ssm:resourceTag/instance-access-policy"
+        values   = ["full"]
+      }
+    ]
+  }
+
+  statement {
+    sid    = "SSMSendCommand"
+    effect = "Allow"
+    actions = [
+      "ssm:SendCommand",
+    ]
+    resources = [
+      "arn:aws:ec2:*:*:instance/*",
+      "arn:aws:ssm:*:*:managed-instance/*",
+      "arn:aws:ssm:*:*:document/AWSSSO-CreateSSOUser"
+    ]
+    conditions = [
+      {
+        test     = "BoolIfExists"
+        variable = "ssm:SessionDocumentAccessCheck"
+        values   = ["true"]
+      },
+      {
+        test     = "StringEqualsIfExists"
+        variable = "ssm:resourceTag/instance-access-policy"
+        values   = ["full"]
+      },
+    ]
+  }
+
+}
 
 # instance management - member SSO and collaborators
 resource "aws_iam_policy" "instance-management" {

--- a/terraform/single-sign-on/sso-permission-sets.tf
+++ b/terraform/single-sign-on/sso-permission-sets.tf
@@ -264,6 +264,33 @@ resource "aws_ssoadmin_customer_managed_policy_attachment" "modernisation_platfo
   }
 }
 
+# Modernisation Platform instance-access role
+resource "aws_ssoadmin_permission_set" "modernisation_platform_instance_access" {
+  provider         = aws.sso-management
+  name             = "mp-instance-access"
+  description      = "Modernisation Platform: instance-access"
+  instance_arn     = local.sso_admin_instance_arn
+  session_duration = "PT8H"
+  tags             = {}
+}
+
+resource "aws_ssoadmin_managed_policy_attachment" "modernisation_platform_instance_access" {
+  provider           = aws.sso-management
+  instance_arn       = local.sso_admin_instance_arn
+  managed_policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+  permission_set_arn = aws_ssoadmin_permission_set.modernisation_platform_instance_access.arn
+}
+
+resource "aws_ssoadmin_customer_managed_policy_attachment" "modernisation_platform_instance_access" {
+  provider           = aws.sso-management
+  instance_arn       = local.sso_admin_instance_arn
+  permission_set_arn = aws_ssoadmin_permission_set.modernisation_platform_instance_access.arn
+  customer_managed_policy_reference {
+    name = "instance_access_policy"
+    path = "/"
+  }
+}
+
 # Modernisation Platform instance-management role
 resource "aws_ssoadmin_permission_set" "modernisation_platform_instance_management" {
   provider         = aws.sso-management


### PR DESCRIPTION
## A reference to the issue / Description of it

The current instance-management role is quite permissive.  It allows users to see all secrets and to stop/start instances.  Since some secrets may contain system database credentials within DSO accounts, this is too permissive to give to users in production accounts who just want to access instances.

## How does this PR fix the problem?

I propose we create a new instance-access role designed for users who need login access to EC2s.
The proposed role includes conditions based on resource tags to restrict access.

Add an instance-access-policy tag on resources to control access as follows:
tag doesn't exist = s3 put; no secret access;  ec2 ssm full access
"none" = s3 put; no secret access;  no ec2 ssm access
"limited" = s3 put; read-only  secret; ec2 ssm ssh/port-forwarding only
"full"  = s3 put; read-write secret; ec2 ssm full access; ec2 sso local admin

Please feel free to take this away and re-implemented, it is just a proposal but is easier to show as a PR.

Also I just cut and paste from instance-management role but I notice member-bootstrap-plan is failing in sprinkler, not sure if something needs applying there first, or whether PR needs to be split up into 2 stages.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Tested by creating similar role in a member account and checking the policies. Unable to test the SSO login via fleetmanager this way, this will need to be tested after the role is created.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
