### PR TITLE
Initial setup macie instructions

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -130,7 +130,7 @@ This documentation is for anyone interested in the Modernisation Platform and it
 - [Revoke Network Access](runbooks/revoke-network-access.html)
 - [Revoking User Access](runbooks/revoking-user-access.html)
 - [Security Testing and ITHC](user-guide/security-testing-and-ithc.html)
-- [Set up Macie]((runbooks/set-up-macie.html)
+- [Set up Macie](runbooks/set-up-macie.html)
 - [Terraform](runbooks/terraform.html)
 - [Useful scripts](runbooks/useful-scripts.html)
 

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -130,6 +130,7 @@ This documentation is for anyone interested in the Modernisation Platform and it
 - [Revoke Network Access](runbooks/revoke-network-access.html)
 - [Revoking User Access](runbooks/revoking-user-access.html)
 - [Security Testing and ITHC](user-guide/security-testing-and-ithc.html)
+- [Set up Macie]((runbooks/set-up-macie.html)
 - [Terraform](runbooks/terraform.html)
 - [Useful scripts](runbooks/useful-scripts.html)
 

--- a/source/runbooks/set-up-macie.html.md.erb
+++ b/source/runbooks/set-up-macie.html.md.erb
@@ -9,7 +9,7 @@ review_in: 6 months
 
 # Introduction
 
-It is relatively easy to set up Macie for users and it need to be done on an account by account basis. **NOTE** Macie ONLY looks at S3 buckets and checks their access information so it will not look at databases or EC2 settings, for example.
+It is relatively easy to set up Macie for users and it needs to be done on an account by account basis. **NOTE** Macie ONLY looks at S3 buckets and it will not look at databases or EC2 settings, for example.
 
 To do this you should connect to the environment on which you want to create Macie. Note, for accounts with 4 versions (development, test, preproduction, production) you will need to create Macie on each one where you want to use macie. There is an AWS video explaining the set up and use of macie [demo](https://www.youtube.com/watch?v=8piwEQJJXdo).
 
@@ -25,13 +25,13 @@ Below there is an example of how the items were set up in both Example and Cooke
 
 There is one **pre-requisite**, for the code shown here, to allow this to work and run successfully. Make sure that the role for **MemberInfrastructureAccess has ace "macie2:*"** set. If this has not been set up correctly (by the Modernisation Platform Team) the terraform listed below will not work. If this is amended in the future, so that it is enabled globally, this comment will be removed.
 
-Another item is needed before the code below is run. This is the requirements to set up some data. It can be added to "platform_data.tf" or to "data.tf". This shown below in the code (based on example from example and cooker) and is needed to allow the likes of data.aws_s3_bucket.bucket1.id to work. I have shown bucket1 in the code below. 
+Another item is needed before the code below is run. This is the requirements to set up some data. It can be added to "platform_data.tf" or to "data.tf". This shown below in the code (based on example from Cooker) and is needed to allow the likes of "data.aws_s3_bucket.bucket1.id" to work. I have shown bucket1 in the code below. 
 
-Full details of this creation, including information on the likes of job type, are shown in the code (macie.tf) in the modernisation-platform-environments repo for example and cooker. The appropriate environment account reference should be used as shown below. If this data value isn't in place look on the code to see how it's set up. You may have something more appropriate set up. The comments can be removed but are included here to provide explanation. They are not shown in the example and cooker repositories.
+Full details of this creation, including information on the likes of job type, are shown in the code (macie.tf) in the modernisation-platform-environments repo for Example and Cooker. The comments can be removed but are included here to provide explanation. They are not shown in the Example and Cooker repositories.
 
 BOTH the sections shown below are needed
 
-NEEDED IN data.tf (or platform_data.tf). In example and cooker they have been included in data.tf
+NEEDED IN data.tf (or platform_data.tf). In Example and Cooker they have been included in data.tf
 
 ```
 # For macie code
@@ -46,7 +46,6 @@ SEPARATE macie.tf code
 
 ```
 # Create macie account
-# When logging in as administrator this is not needed but may be for our customers - yet to be fully determined.
 # Account name is MacieAccount. Publishes data every hour (choice are FIFTEEN_MINUTES, ONE_HOUR or SIX_HOURS).
 
 resource "aws_macie2_account" "macieaccount" {
@@ -83,21 +82,3 @@ Further information can be found in the links below.
 Set up a [Macie account](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/macie2_account)
 
 Creating a [Macie job](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/macie2_classification_job)
-
-# How to set up Macie jobs
-
-Jobs can be set up on the console quite simply. There is a message about not having an S3 bucket to push the changes to but that can be ignored for the most part. It is suggested that you crete one. To do this you will need to add some code or amend that which is in place. The document [here](https://repost.aws/knowledge-center/macie-s3-kms-permission) explains what is needed. Most importantly ensure that the correct arn is in place on both the S3 and HMS key files as well as following the instructions shown.
-
-Under get started there is an option to create a job. Specify the buckets if only connecting to one account but pick the criteria if more that one account is going to be looked at. Once set work through each of the screens.
-
-If you want something to _run regularly (daily, weekly or monthly)_ pick that option on screen 3, otherwise select a _one-time_ job.
-
-On screen 5 you can select custom data identifiers but these need to be set up first. Picking the option to set these up will open a new screen.
-
-Screen 6 shows allow lists. Again they need to be set up beforehand but can be created through another screen.
-
-The 7th screen makes you enter a job name and, if you want, add tags. The job name **MUST** be entered. You will not be able to move on without setting the job name.
-
-The final screen lists the selected buckets and gives (under the free trial at least) an estimated cost. You can also amend any of the previous settings here.
-
-If you list the jobs you can see if it is running and the results will appear on the Findings screen once it completes. Note, it may take some time to give results. On our example buckets, which are small, it takes over 15 minutes at least initially.

--- a/source/runbooks/set-up-macie.html.md.erb
+++ b/source/runbooks/set-up-macie.html.md.erb
@@ -43,7 +43,7 @@ SEPARATE macie.tf code
 # When logging in as administrator this is not needed but may be for our customers - yet to be fully determined.
 # Account name is MacieAccount. Publishes data every hour (choice are FIFTEEN_MINUTES, ONE_HOUR or SIX_HOURS).
 
-resource "aws_macie2_account" "MacieAccount" {
+resource "aws_macie2_account" "macieaccount" {
   finding_publishing_frequency = "ONE_HOUR"
   status                       = "ENABLED"
 }
@@ -60,7 +60,7 @@ resource "aws_macie2_classification_job" "test" {
   name     = "<an appropriate job name>"
   s3_job_definition {
     bucket_definitions {
-      account_id = ""data.aws_ssm_parameter.modernisation_platform_account_id.value""
+      account_id = "data.aws_ssm_parameter.modernisation_platform_account_id.value"
       buckets    = [
         data.aws_s3_bucket.bucket1.id,
         data.aws_s3_bucket.bucket2.id,
@@ -68,7 +68,7 @@ resource "aws_macie2_classification_job" "test" {
       ]
     }
   }
-  depends_on = [ aws_macie2_account.macieaccess ]
+  depends_on = [ aws_macie2_account.macieaccount ]
 }
 ```
 

--- a/source/runbooks/set-up-macie.html.md.erb
+++ b/source/runbooks/set-up-macie.html.md.erb
@@ -32,7 +32,6 @@ Full details of this creation, including information on the likes of job type, a
 
 ```
 
-SEPARATE macie.tf code
 
 ```
 # Create macie account

--- a/source/runbooks/set-up-macie.html.md.erb
+++ b/source/runbooks/set-up-macie.html.md.erb
@@ -31,7 +31,6 @@ Full details of this creation, including information on the likes of job type, a
 
 
 ```
-   ...
  }
  ```
 

--- a/source/runbooks/set-up-macie.html.md.erb
+++ b/source/runbooks/set-up-macie.html.md.erb
@@ -25,13 +25,13 @@ Below there is an example of how the items were set up in Example following the 
 
 The MemberInfrastructureAccess was amended to include "macie2:*" so no other user access is required. All users can access the Amazon Macie through the system by following the code below.
 
-One item is needed before the code below is run. This is the requirement to set up some access to the S3 buckets you want to check. It can be added to "platform_data.tf" or to "data.tf". This is shown below in the code (based on an example from Example) and is needed to allow the likes of "data.aws_s3_bucket.bucket1.id" to work. I have shown bucket1 in the code below. 
+One item is needed before the code below is run. This is the requirement to set up some access to the S3 buckets you want to check. It can be added to "data.tf". This is shown below in the code (based on an example from Example) and is needed to allow the likes of "data.aws_s3_bucket.bucket1.id" to work. I have shown bucket1 in the code below. 
 
 Full details of this creation, including information on the likes of job type, are shown in the code (macie.tf) in the modernisation-platform-environments repo for Example. The comments can be removed but are included here to provide explanation. They are not shown in the Example repository.
 
 **BOTH** the sections shown below are needed
 
-NEEDED IN data.tf (or platform_data.tf). In Example they have been included in data.tf
+NEEDED IN data.tf. Below we can see the first one in Example.
 
 ```
 # For macie code

--- a/source/runbooks/set-up-macie.html.md.erb
+++ b/source/runbooks/set-up-macie.html.md.erb
@@ -23,7 +23,7 @@ Below there is an example of how the items were set up in both Example and Cooke
 
 ## Example Terraform code
 
-There is one **pre-requisite**, for the code shown here, to allow this to work and run successfully. Make sure that the role for **MemberInfrastructureAccess has ace "macie2:*"** set. If this has not been set up correctly (by the Modernisation Platform Team) the terraform listed below will not work. If this is amended in the future, so that it is enabled globally, this comment will be removed.
+There is one **pre-requisite**, for the code shown here, to allow this to work and run successfully. Make sure that the role for **MemberInfrastructureAccess has "macie2:*" in it**. If this has not been set up correctly (by the Modernisation Platform Team) the terraform listed below will not work. If this is amended in the future, so that it is enabled globally, this comment will be removed.
 
 Another item is needed before the code below is run. This is the requirements to set up some data. It can be added to "platform_data.tf" or to "data.tf". This shown below in the code (based on example from Cooker) and is needed to allow the likes of "data.aws_s3_bucket.bucket1.id" to work. I have shown bucket1 in the code below. 
 

--- a/source/runbooks/set-up-macie.html.md.erb
+++ b/source/runbooks/set-up-macie.html.md.erb
@@ -11,32 +11,33 @@ review_in: 6 months
 
 It is relatively easy to set up Macie for users and it need to be done on an account by account basis. **NOTE** Macie ONLY looks at S3 buckets and checks their access information so it will not look at databases or EC2 settings, for example.
 
-To do this you should connect to the environment on which you want to create Macie. Note, for accounts with 4 versions (development, test, preproduction, production) you will need to create Macie on each one. In theory you can just set it up in each account and allow one (say production) to use every account to access their data. At the time this document was produced this was not tested but can be used according to an AWS video showing a [demo](https://www.youtube.com/watch?v=8piwEQJJXdo).
+To do this you should connect to the environment on which you want to create Macie. Note, for accounts with 4 versions (development, test, preproduction, production) you will need to create Macie on each one where you want to use macie. There is an AWS video explaining the set up and use of macie [demo](https://www.youtube.com/watch?v=8piwEQJJXdo).
 
 AWS also have a brief outline of the purpose of [Macie](https://docs.aws.amazon.com/macie/latest/user/what-is-macie.html) which can be checked to see if this is suitable.
 
-Starting Macie with Terraform is possible and the instructions are shown below. There is a pre-requisite that you need to ensure is completed before this is undertaken. I have also listed the details of setting up jobs. Although they can be set up (another example is shown) it may be beneficial to set these up manually. The example only shows a few of the many items that can be included.
+Starting Macie with Terraform is possible and the instructions are shown below. I have also listed the details of setting up jobs. it may be beneficial to set up jobs manually due to the items that can be included. The example only shows a few of the many items that can be included.
 
 # Terraform code
-
-It is possible to set up Macie using Terraform code. 
-
-To get more detail it is best to do a search for ["aws macie terraform"](https://www.google.com/search?q=aws+macie+terraform&rlz=1C5GCCM_en&oq=&gs_lcrp=EgZjaHJvbWUqCQgAEEUYOxjCAzIJCAAQRRg7GMIDMgkIARBFGDsYwgMyCQgCEEUYOxjCAzIJCAMQRRg7GMIDMgkIBBBFGDsYwgMyCQgFEEUYOxjCAzIJCAYQRRg7GMIDMgkIBxBFGDsYwgPSAQkzMTE4ajBqMTWoAgiwAgE&sourceid=chrome&ie=UTF-8)
-
-Set up a [Macie account](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/macie2_account)
-
-Creating a [Macie job](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/macie2_classification_job)
 
 Below there is an example of how the items were set up in Cooker following the instructions listed here.
 
 ## Example Terraform code
 
-There is one pre-requisite, for the code shown here, to allow this to work and run successfully. Make sure that the role for **MemberInfrastructureAccess has ace macie2:** set. If this has not been set up correctly (by the Modernisation Platform Team) the terraform listed below will not work. If this is amended in the future, so that it is enabled globally, this comment will be removed. 
+There is one **pre-requisite**, for the code shown here, to allow this to work and run successfully. Make sure that the role for **MemberInfrastructureAccess has ace "macie2:*"** set. If this has not been set up correctly (by the Modernisation Platform Team) the terraform listed below will not work. If this is amended in the future, so that it is enabled globally, this comment will be removed.
 
-The full details of the "finding_publishing_frequency" and "job_type" can be seen in the terraform links listed above.
+Another item is needed before the code below is run. This is the requirements to set up some data. It can be added to "platform_data.tf" or to "data.tf". This shown below in the code (based on example from cooker) and is needed to allow the likes of data.aws_s3_bucket.bucket1.id to work. I have shown bucket1 in the code below. 
 
-Full details of this creation, including information on the likes of job type, are shown in the code (macie.tf) in the modernisation-platform-environments repo for cooker. The appropriate environment account reference should be used rather than the "account-code for this environment" shown below.
+Full details of this creation, including information on the likes of job type, are shown in the code (macie.tf) in the modernisation-platform-environments repo for cooker. The appropriate environment account reference should be used rather than the "data.aws_ssm_parameter.modernisation_platform_account_id.value" shown below. If this data value isn't in place look on the code to see how it's set up. You may have something more appropriate set up. The comments can be removed but are included here to provide explanation. They are not shown in the cooker repository.
 
+NEEDED IN data.tf of platform_data.tf
+```
+# For macie code
+data "aws_s3_bucket" "bucket1" {
+   bucket = "config-20220407082146408700000002"
+ }
+ ```
+
+SEPARATE macie.tf code
 ```
 # Create macie account
 # When logging in as administrator this is not needed but may be for our customers - yet to be fully determined.
@@ -59,18 +60,25 @@ resource "aws_macie2_classification_job" "test" {
   name     = "<an appropriate job name>"
   s3_job_definition {
     bucket_definitions {
-      account_id = "<account-code for this environment>"
+      account_id = ""data.aws_ssm_parameter.modernisation_platform_account_id.value""
       buckets    = [
-      "<list of buckets>",
-      "<separated by commas>"
+        data.aws_s3_bucket.bucket1.id,
+        data.aws_s3_bucket.bucket2.id,
+        data.aws_s3_bucket.bucket3.id,
       ]
     }
   }
-  depends_on = [aws_macie2_account.MacieAccount]
+  depends_on = [ aws_macie2_account.macieaccess ]
 }
 ```
 
-# Set up Macie jobs
+Further information can be found in the links below.
+
+Set up a [Macie account](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/macie2_account)
+
+Creating a [Macie job](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/macie2_classification_job)
+
+# How to set up Macie jobs
 
 Jobs can be set up on the console quite simply. There is a message about not having an S3 bucket to push the changes to but that can be ignored for the most part. It is suggested that you crete one. To do this you will need to add some code or amend that which is in place. The document [here](https://repost.aws/knowledge-center/macie-s3-kms-permission) explains what is needed. Most importantly ensure that the correct arn is in place on both the S3 and HMS key files as well as following the instructions shown.
 
@@ -82,7 +90,7 @@ On screen 5 you can select custom data identifiers but these need to be set up f
 
 Screen 6 shows allow lists. Again they need to be set up beforehand but can be created through another screen.
 
-The 7th screen makes you enter a job name and, if you want, add tags. The job name MUST be entered.
+The 7th screen makes you enter a job name and, if you want, add tags. The job name **MUST** be entered. You will not be able to move on without setting the job name.
 
 The final screen lists the selected buckets and gives (under the free trial at least) an estimated cost. You can also amend any of the previous settings here.
 

--- a/source/runbooks/set-up-macie.html.md.erb
+++ b/source/runbooks/set-up-macie.html.md.erb
@@ -15,6 +15,8 @@ To do this you should connect to the environment on which you want to create Mac
 
 AWS also have a brief outline of the purpose of [Macie](https://docs.aws.amazon.com/macie/latest/user/what-is-macie.html) which can be checked to see if this is suitable.
 
+If you want to skip to the terraform code that is lower down the document which can be used as long as the pre-requisite is complete.
+
 # To start Macie
 
 Initially this will show the "how to" on the console. There will be links to the terraform code required at the end. It will need to be set up wth terraform to prevent it being disabled or removed when terraform is run in the future. The code is not show in detail in these instructions.

--- a/source/runbooks/set-up-macie.html.md.erb
+++ b/source/runbooks/set-up-macie.html.md.erb
@@ -28,11 +28,6 @@ The MemberInfrastructureAccess was amended to include "macie2:*" so no other use
 
 Full details of this creation, including information on the likes of job type, are shown in the code (macie.tf) in the modernisation-platform-environments repo for Example. The comments can be removed but are included here to provide explanation. They are not shown in the Example repository.
 
-
-
-```
-
-
 ```
 # Create macie account
 # Account name is MacieAccount. Publishes data every hour (choice are FIFTEEN_MINUTES, ONE_HOUR or SIX_HOURS).

--- a/source/runbooks/set-up-macie.html.md.erb
+++ b/source/runbooks/set-up-macie.html.md.erb
@@ -31,7 +31,6 @@ Full details of this creation, including information on the likes of job type, a
 
 
 ```
-# For macie code
 data "aws_s3_bucket" "bucket1" {
    bucket = "bastion-example-example-development-jxaebg"
    ...

--- a/source/runbooks/set-up-macie.html.md.erb
+++ b/source/runbooks/set-up-macie.html.md.erb
@@ -11,7 +11,7 @@ review_in: 6 months
 
 It is relatively easy to set up Macie for users and it needs to be done on an account by account basis. **NOTE Macie ONLY looks at S3 buckets and it will not look at databases or EC2 settings**, for example.
 
-To do this you should connect to the environment on which you want to create Macie. Note, for accounts with 4 versions (development, test, preproduction, production) you will need to create Macie on each one where you want to use macie. There is an AWS video explaining the set up and use of macie [demo](https://www.youtube.com/watch?v=8piwEQJJXdo) which you can watch.
+There is an AWS video explaining the set up and use of macie [demo](https://www.youtube.com/watch?v=8piwEQJJXdo) which you can watch.
 
 AWS also have a brief outline of the purpose of [Macie](https://docs.aws.amazon.com/macie/latest/user/what-is-macie.html). Check the documentation to to see if it is suitable.
 

--- a/source/runbooks/set-up-macie.html.md.erb
+++ b/source/runbooks/set-up-macie.html.md.erb
@@ -31,7 +31,6 @@ Full details of this creation, including information on the likes of job type, a
 
 
 ```
-   bucket = "bastion-example-example-development-jxaebg"
    ...
    ...
  }

--- a/source/runbooks/set-up-macie.html.md.erb
+++ b/source/runbooks/set-up-macie.html.md.erb
@@ -9,11 +9,11 @@ review_in: 6 months
 
 # Introduction
 
-It is relatively easy to set up Macie for users and it need to be done on an account by account basis. **NOTE** Macie ONLY looks at S3 buckets and checks their access information so it will not look at databases or EC2 settings, for example. 
+It is relatively easy to set up Macie for users and it need to be done on an account by account basis. **NOTE** Macie ONLY looks at S3 buckets and checks their access information so it will not look at databases or EC2 settings, for example.
 
 To do this you should connect to the environment on which you want to create Macie. Note, for accounts with 4 versions (development, test, preproduction, production) you will need to create Macie on each one. In theory you can just set it up in each account and allow one (day production) to use every account to access their data. At the time this document was produced this was not tested but can be used according to an AWS video showing a [demo](https://www.youtube.com/watch?v=8piwEQJJXdo).
 
-AWS also have a brief outline of the purpose of [Macie](https://docs.aws.amazon.com/macie/latest/user/what-is-macie.html) which can be checked to see if this is suitable.  
+AWS also have a brief outline of the purpose of [Macie](https://docs.aws.amazon.com/macie/latest/user/what-is-macie.html) which can be checked to see if this is suitable.
 
 # To start Macie
 
@@ -21,9 +21,9 @@ Initially this will show the "how to" on the console. There will be links to the
 
 Connect to the account you want to use with AdministratorAccess.
 
-Access the Amazon Macie choice and click on "Get started". 
+Access the Amazon Macie choice and click on "Get started".
 
-*Initially it will set up a 30 day trial, which may be useful to look at possible costs of using the service. If you want to disable the trial connect to the settings page and look to the disable option and select the Disable option, type Disable in the box and click Disable. This will stop the Macie access.*
+_Initially it will set up a 30 day trial, which may be useful to look at possible costs of using the service. If you want to disable the trial connect to the settings page and look to the disable option and select the Disable option, type Disable in the box and click Disable. This will stop the Macie access._
 
 Following the Get started choice a window will be available to see what access is needed. I would recommend that the details in here are copied and saved in case you need to give the required access later.
 
@@ -35,9 +35,9 @@ As part of the initial trial there will be an option to see what the costs will 
 
 Jobs can be set up on the console quite simply. There is a message about not having an S3 bucket to push the changes to but that can be ignored for the most part. It is suggested that you crete one. To do this you will need to add some code or amend that which is in place. The document [here](https://repost.aws/knowledge-center/macie-s3-kms-permission) explains what is needed. Most importantly ensure that the correct arn is in place on both the S3 and JMS key files as well as following the instructions shown.
 
-Under get started there is an option to create a job. Specify the buckets if only connecting to one account but pick the criteria if more that one account is going to be looked at. Once set work through each of the screens. 
+Under get started there is an option to create a job. Specify the buckets if only connecting to one account but pick the criteria if more that one account is going to be looked at. Once set work through each of the screens.
 
-If you want something to *run regularly (daily, weekly or monthly)* pick that option on screen 3, otherwise select a *one-time* job.
+If you want something to _run regularly (daily, weekly or monthly)_ pick that option on screen 3, otherwise select a _one-time_ job.
 
 On screen 5 you can select custom data identifiers but these need to be set up first. Picking the option to set these up will open a new screen.
 
@@ -49,7 +49,6 @@ The final screen lists the selected buckets and gives (under the free trial at l
 
 If you list the jobs you can see if it is running and the results will appear on the Findings screen once it completes. Note, it may take some time to give results. On our example buckets, which are small, it takes over 15 minutes at least initially.
 
-
 # Terraform code
 
 Note the items shown here are not actual detailed Terraform code but examples of how to set things up. To get more detail it is best to do a search for ["aws macie terraform"](https://www.google.com/search?q=aws+macie+terraform&rlz=1C5GCCM_en&oq=&gs_lcrp=EgZjaHJvbWUqCQgAEEUYOxjCAzIJCAAQRRg7GMIDMgkIARBFGDsYwgMyCQgCEEUYOxjCAzIJCAMQRRg7GMIDMgkIBBBFGDsYwgMyCQgFEEUYOxjCAzIJCAYQRRg7GMIDMgkIBxBFGDsYwgPSAQkzMTE4ajBqMTWoAgiwAgE&sourceid=chrome&ie=UTF-8)
@@ -58,3 +57,62 @@ Set up a [Macie account](https://registry.terraform.io/providers/hashicorp/aws/l
 
 Creating a [Macie job](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/macie2_classification_job)
 
+Example code is shown below BUT the build of the Macie account fails so there is no guarantee this will work.
+
+```
+# Create macie account
+# When logging in as adminisitrator this is not needed but may be for our customers
+# Account name is MacieAccount. Publishes data every hour (choice are FIFTEEN_MINUTES, ONE_HOUR or SIX_HOURS)
+resource "aws_macie2_account" "MacieAccount" {
+  finding_publishing_frequency = "ONE_HOUR"
+  status                       = "ENABLED"
+}
+
+# Now create a job
+# Job type options are ONE-TIME and SCHEDULED. If scheduled is chosen you need to select a frequency using schedule_frequency of daily_schedule, weekly_schedule or monthly_schedule
+# The buckets should be replaced but a list of buckets to examine. This could be limited to those in the account you are connected to or others to which you have access.
+# Below there is a limited list of those from example shown.
+# There are many other job options available and these should be looked at in terrform [job creation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/macie2_classification_job)
+
+
+resource "aws_macie2_classification_job" "test" {
+  job_type = "ONE_TIME"
+  name     = "JOBNAME"
+  s3_job_definition {
+    bucket_definitions {
+      account_id = "MacieAccount"
+      buckets    = [
+      "bastion-example-example-development-cqx7gf",
+      "config-20220505080423816000000003",
+      "s3-bucket-example20231124172322406400000006"
+      ]
+    }
+  }
+  depends_on = [aws_macie2_account.MacieAccount]
+}
+
+Below is an example of code used in production. Note, unless there is other code to set up the correct access, this will not work.
+Full details of this creation, including information on the likes of job type, are shown in the code (macie.tf) in the environments repo. 
+
+```
+resource "aws_macie2_account" "MacieAccount" {
+  finding_publishing_frequency = "ONE_HOUR"
+  status                       = "ENABLED"
+}
+
+resource "aws_macie2_classification_job" "test" {
+  job_type = "ONE_TIME"
+  name     = "JOBNAME"
+  s3_job_definition {
+    bucket_definitions {
+      account_id = "MacieAccount"
+      buckets    = [
+      "bastion-example-example-development-cqx7gf",
+      "config-20220505080423816000000003",
+      "s3-bucket-example20231124172322406400000006"
+      ]
+    }
+  }
+  depends_on = [aws_macie2_account.MacieAccount]
+}
+```

--- a/source/runbooks/set-up-macie.html.md.erb
+++ b/source/runbooks/set-up-macie.html.md.erb
@@ -31,7 +31,6 @@ Full details of this creation, including information on the likes of job type, a
 
 
 ```
-data "aws_s3_bucket" "bucket1" {
    bucket = "bastion-example-example-development-jxaebg"
    ...
    ...

--- a/source/runbooks/set-up-macie.html.md.erb
+++ b/source/runbooks/set-up-macie.html.md.erb
@@ -9,13 +9,13 @@ review_in: 6 months
 
 # Introduction
 
-It is relatively easy to set up Macie for users and it needs to be done on an account by account basis. **NOTE** Macie ONLY looks at S3 buckets and it will not look at databases or EC2 settings, for example.
+It is relatively easy to set up Macie for users and it needs to be done on an account by account basis. **NOTE Macie ONLY looks at S3 buckets and it will not look at databases or EC2 settings**, for example.
 
-To do this you should connect to the environment on which you want to create Macie. Note, for accounts with 4 versions (development, test, preproduction, production) you will need to create Macie on each one where you want to use macie. There is an AWS video explaining the set up and use of macie [demo](https://www.youtube.com/watch?v=8piwEQJJXdo).
+To do this you should connect to the environment on which you want to create Macie. Note, for accounts with 4 versions (development, test, preproduction, production) you will need to create Macie on each one where you want to use macie. There is an AWS video explaining the set up and use of macie [demo](https://www.youtube.com/watch?v=8piwEQJJXdo) which you can watch.
 
-AWS also have a brief outline of the purpose of [Macie](https://docs.aws.amazon.com/macie/latest/user/what-is-macie.html) which can be checked to see if this is suitable.
+AWS also have a brief outline of the purpose of [Macie](https://docs.aws.amazon.com/macie/latest/user/what-is-macie.html). Check the documentation to to see if it is suitable.
 
-Starting Macie with Terraform is possible and the instructions are shown below. I have also listed the details of setting up jobs. it may be beneficial to set up jobs manually due to the items that can be included. The example only shows a few of the many items that can be included.
+Starting Macie with Terraform is possible and the instructions are shown below. I have also listed the details of setting up jobs. it may be beneficial to set up jobs manually due to the items that can be included. The example only shows a few of the many items that can be included. Details from Terraform are shown below the example code.
 
 # Terraform code
 
@@ -23,13 +23,13 @@ Below there is an example of how the items were set up in both Example and Cooke
 
 ## Example Terraform code
 
-There is one **pre-requisite**, for the code shown here, to allow this to work and run successfully. Make sure that the role for **MemberInfrastructureAccess has "macie2:*" in it**. If this has not been set up correctly (by the Modernisation Platform Team) the terraform listed below will not work. If this is amended in the future, so that it is enabled globally, this comment will be removed.
+The MemberInfrastructureAccess was amended to include "macie2:*" so no other user access is required. All users can access the Amazon Macie through the system by following the code below.
 
-Another item is needed before the code below is run. This is the requirements to set up some data. It can be added to "platform_data.tf" or to "data.tf". This shown below in the code (based on example from Cooker) and is needed to allow the likes of "data.aws_s3_bucket.bucket1.id" to work. I have shown bucket1 in the code below. 
+One item is needed before the code below is run. This is the requirement to set up some access to the S3 buckets you want to check. It can be added to "platform_data.tf" or to "data.tf". This is shown below in the code (based on example from Cooker) and is needed to allow the likes of "data.aws_s3_bucket.bucket1.id" to work. I have shown bucket1 in the code below. 
 
 Full details of this creation, including information on the likes of job type, are shown in the code (macie.tf) in the modernisation-platform-environments repo for Example and Cooker. The comments can be removed but are included here to provide explanation. They are not shown in the Example and Cooker repositories.
 
-BOTH the sections shown below are needed
+**BOTH** the sections shown below are needed
 
 NEEDED IN data.tf (or platform_data.tf). In Example and Cooker they have been included in data.tf
 

--- a/source/runbooks/set-up-macie.html.md.erb
+++ b/source/runbooks/set-up-macie.html.md.erb
@@ -19,25 +19,31 @@ Starting Macie with Terraform is possible and the instructions are shown below. 
 
 # Terraform code
 
-Below there is an example of how the items were set up in Cooker following the instructions listed here.
+Below there is an example of how the items were set up in both Example and Cooker following the instructions listed here.
 
 ## Example Terraform code
 
 There is one **pre-requisite**, for the code shown here, to allow this to work and run successfully. Make sure that the role for **MemberInfrastructureAccess has ace "macie2:*"** set. If this has not been set up correctly (by the Modernisation Platform Team) the terraform listed below will not work. If this is amended in the future, so that it is enabled globally, this comment will be removed.
 
-Another item is needed before the code below is run. This is the requirements to set up some data. It can be added to "platform_data.tf" or to "data.tf". This shown below in the code (based on example from cooker) and is needed to allow the likes of data.aws_s3_bucket.bucket1.id to work. I have shown bucket1 in the code below. 
+Another item is needed before the code below is run. This is the requirements to set up some data. It can be added to "platform_data.tf" or to "data.tf". This shown below in the code (based on example from example and cooker) and is needed to allow the likes of data.aws_s3_bucket.bucket1.id to work. I have shown bucket1 in the code below. 
 
-Full details of this creation, including information on the likes of job type, are shown in the code (macie.tf) in the modernisation-platform-environments repo for cooker. The appropriate environment account reference should be used rather than the "data.aws_ssm_parameter.modernisation_platform_account_id.value" shown below. If this data value isn't in place look on the code to see how it's set up. You may have something more appropriate set up. The comments can be removed but are included here to provide explanation. They are not shown in the cooker repository.
+Full details of this creation, including information on the likes of job type, are shown in the code (macie.tf) in the modernisation-platform-environments repo for example and cooker. The appropriate environment account reference should be used as shown below. If this data value isn't in place look on the code to see how it's set up. You may have something more appropriate set up. The comments can be removed but are included here to provide explanation. They are not shown in the example and cooker repositories.
 
-NEEDED IN data.tf of platform_data.tf
+BOTH the sections shown below are needed
+
+NEEDED IN data.tf (or platform_data.tf). In example and cooker they have been included in data.tf
+
 ```
 # For macie code
 data "aws_s3_bucket" "bucket1" {
    bucket = "config-20220407082146408700000002"
+   ...
+   ...
  }
  ```
 
 SEPARATE macie.tf code
+
 ```
 # Create macie account
 # When logging in as administrator this is not needed but may be for our customers - yet to be fully determined.
@@ -60,7 +66,7 @@ resource "aws_macie2_classification_job" "test" {
   name     = "<an appropriate job name>"
   s3_job_definition {
     bucket_definitions {
-      account_id = "data.aws_ssm_parameter.modernisation_platform_account_id.value"
+      account_id = local.environment_management.account_ids[terraform.workspace]
       buckets    = [
         data.aws_s3_bucket.bucket1.id,
         data.aws_s3_bucket.bucket2.id,

--- a/source/runbooks/set-up-macie.html.md.erb
+++ b/source/runbooks/set-up-macie.html.md.erb
@@ -19,24 +19,24 @@ Starting Macie with Terraform is possible and the instructions are shown below. 
 
 # Terraform code
 
-Below there is an example of how the items were set up in both Example and Cooker following the instructions listed here.
+Below there is an example of how the items were set up in Example following the instructions listed here.
 
 ## Example Terraform code
 
 The MemberInfrastructureAccess was amended to include "macie2:*" so no other user access is required. All users can access the Amazon Macie through the system by following the code below.
 
-One item is needed before the code below is run. This is the requirement to set up some access to the S3 buckets you want to check. It can be added to "platform_data.tf" or to "data.tf". This is shown below in the code (based on example from Cooker) and is needed to allow the likes of "data.aws_s3_bucket.bucket1.id" to work. I have shown bucket1 in the code below. 
+One item is needed before the code below is run. This is the requirement to set up some access to the S3 buckets you want to check. It can be added to "platform_data.tf" or to "data.tf". This is shown below in the code (based on an example from Example) and is needed to allow the likes of "data.aws_s3_bucket.bucket1.id" to work. I have shown bucket1 in the code below. 
 
-Full details of this creation, including information on the likes of job type, are shown in the code (macie.tf) in the modernisation-platform-environments repo for Example and Cooker. The comments can be removed but are included here to provide explanation. They are not shown in the Example and Cooker repositories.
+Full details of this creation, including information on the likes of job type, are shown in the code (macie.tf) in the modernisation-platform-environments repo for Example. The comments can be removed but are included here to provide explanation. They are not shown in the Example repository.
 
 **BOTH** the sections shown below are needed
 
-NEEDED IN data.tf (or platform_data.tf). In Example and Cooker they have been included in data.tf
+NEEDED IN data.tf (or platform_data.tf). In Example they have been included in data.tf
 
 ```
 # For macie code
 data "aws_s3_bucket" "bucket1" {
-   bucket = "config-20220407082146408700000002"
+   bucket = "bastion-example-example-development-jxaebg"
    ...
    ...
  }

--- a/source/runbooks/set-up-macie.html.md.erb
+++ b/source/runbooks/set-up-macie.html.md.erb
@@ -25,7 +25,6 @@ Below there is an example of how the items were set up in Example following the 
 
 The MemberInfrastructureAccess was amended to include "macie2:*" so no other user access is required. All users can access the Amazon Macie through the system by following the code below.
 
-One item is needed before the code below is run. This is the requirement to set up some access to the S3 buckets you want to check. It can be added to "data.tf". This is shown below in the code (based on an example from Example) and is needed to allow the likes of "data.aws_s3_bucket.bucket1.id" to work. I have shown bucket1 in the code below. 
 
 Full details of this creation, including information on the likes of job type, are shown in the code (macie.tf) in the modernisation-platform-environments repo for Example. The comments can be removed but are included here to provide explanation. They are not shown in the Example repository.
 

--- a/source/runbooks/set-up-macie.html.md.erb
+++ b/source/runbooks/set-up-macie.html.md.erb
@@ -28,7 +28,6 @@ The MemberInfrastructureAccess was amended to include "macie2:*" so no other use
 
 Full details of this creation, including information on the likes of job type, are shown in the code (macie.tf) in the modernisation-platform-environments repo for Example. The comments can be removed but are included here to provide explanation. They are not shown in the Example repository.
 
-**BOTH** the sections shown below are needed
 
 NEEDED IN data.tf. Below we can see the first one in Example.
 

--- a/source/runbooks/set-up-macie.html.md.erb
+++ b/source/runbooks/set-up-macie.html.md.erb
@@ -32,7 +32,6 @@ Full details of this creation, including information on the likes of job type, a
 
 ```
    ...
-   ...
  }
  ```
 

--- a/source/runbooks/set-up-macie.html.md.erb
+++ b/source/runbooks/set-up-macie.html.md.erb
@@ -31,7 +31,6 @@ Full details of this creation, including information on the likes of job type, a
 
 
 ```
- ```
 
 SEPARATE macie.tf code
 

--- a/source/runbooks/set-up-macie.html.md.erb
+++ b/source/runbooks/set-up-macie.html.md.erb
@@ -15,7 +15,7 @@ There is an AWS video explaining the set up and use of macie [demo](https://www.
 
 AWS also have a brief outline of the purpose of [Macie](https://docs.aws.amazon.com/macie/latest/user/what-is-macie.html). Check the documentation to to see if it is suitable.
 
-Starting Macie with Terraform is possible and the instructions are shown below. I have also listed the details of setting up jobs. it may be beneficial to set up jobs manually due to the items that can be included. The example only shows a few of the many items that can be included. Details from Terraform are shown below the example code.
+Starting Macie with Terraform is possible and the instructions are shown below. I have also listed the details of setting up jobs. The example only shows a few of the many items that can be included. Details from Terraform are shown below the example code.
 
 # Terraform code
 

--- a/source/runbooks/set-up-macie.html.md.erb
+++ b/source/runbooks/set-up-macie.html.md.erb
@@ -1,0 +1,60 @@
+---
+owner_slack: "#modernisation-platform"
+title: Set Up Macie
+last_reviewed_on: 2024-04-18
+review_in: 6 months
+---
+
+# <%= current_page.data.title %>
+
+# Introduction
+
+It is relatively easy to set up Macie for users and it need to be done on an account by account basis. **NOTE** Macie ONLY looks at S3 buckets and checks their access information so it will not look at databases or EC2 settings, for example. 
+
+To do this you should connect to the environment on which you want to create Macie. Note, for accounts with 4 versions (development, test, preproduction, production) you will need to create Macie on each one. In theory you can just set it up in each account and allow one (day production) to use every account to access their data. At the time this document was produced this was not tested but can be used according to an AWS video showing a [demo](https://www.youtube.com/watch?v=8piwEQJJXdo).
+
+AWS also have a brief outline of the purpose of [Macie](https://docs.aws.amazon.com/macie/latest/user/what-is-macie.html) which can be checked to see if this is suitable.  
+
+# To start Macie
+
+Initially this will show the "how to" on the console. There will be links to the terraform code required at the end. It will need to be set up wth terraform to prevent it being disabled or removed when terraform is run in the future. The code is not show in detail in these instructions.
+
+Connect to the account you want to use with AdministratorAccess.
+
+Access the Amazon Macie choice and click on "Get started". 
+
+*Initially it will set up a 30 day trial, which may be useful to look at possible costs of using the service. If you want to disable the trial connect to the settings page and look to the disable option and select the Disable option, type Disable in the box and click Disable. This will stop the Macie access.*
+
+Following the Get started choice a window will be available to see what access is needed. I would recommend that the details in here are copied and saved in case you need to give the required access later.
+
+At this point you will then be asked if you want to Enable Macie. Click the button if you do.
+
+As part of the initial trial there will be an option to see what the costs will be by looking at the Usage page. If you have large S3 buckets this may appear quite costly.
+
+## Set up jobs
+
+Jobs can be set up on the console quite simply. There is a message about not having an S3 bucket to push the changes to but that can be ignored for the most part. It is suggested that you crete one. To do this you will need to add some code or amend that which is in place. The document [here](https://repost.aws/knowledge-center/macie-s3-kms-permission) explains what is needed. Most importantly ensure that the correct arn is in place on both the S3 and JMS key files as well as following the instructions shown.
+
+Under get started there is an option to create a job. Specify the buckets if only connecting to one account but pick the criteria if more that one account is going to be looked at. Once set work through each of the screens. 
+
+If you want something to *run regularly (daily, weekly or monthly)* pick that option on screen 3, otherwise select a *one-time* job.
+
+On screen 5 you can select custom data identifiers but these need to be set up first. Picking the option to set these up will open a new screen.
+
+Screen 6 shows allow lists. Again they need to be set up beforehand but can be created through another screen.
+
+The 7th screen makes you enter a job name and, if you want, add tags. The job name MUST be entered.
+
+The final screen lists the selected buckets and gives (under the free trial at least) an estimated cost. You can also amend any of the previous settings here.
+
+If you list the jobs you can see if it is running and the results will appear on the Findings screen once it completes. Note, it may take some time to give results. On our example buckets, which are small, it takes over 15 minutes at least initially.
+
+
+# Terraform code
+
+Note the items shown here are not actual detailed Terraform code but examples of how to set things up. To get more detail it is best to do a search for ["aws macie terraform"](https://www.google.com/search?q=aws+macie+terraform&rlz=1C5GCCM_en&oq=&gs_lcrp=EgZjaHJvbWUqCQgAEEUYOxjCAzIJCAAQRRg7GMIDMgkIARBFGDsYwgMyCQgCEEUYOxjCAzIJCAMQRRg7GMIDMgkIBBBFGDsYwgMyCQgFEEUYOxjCAzIJCAYQRRg7GMIDMgkIBxBFGDsYwgPSAQkzMTE4ajBqMTWoAgiwAgE&sourceid=chrome&ie=UTF-8)
+
+Set up a [Macie account](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/macie2_account)
+
+Creating a [Macie job](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/macie2_classification_job)
+

--- a/source/runbooks/set-up-macie.html.md.erb
+++ b/source/runbooks/set-up-macie.html.md.erb
@@ -92,27 +92,36 @@ resource "aws_macie2_classification_job" "test" {
 }
 
 Below is an example of code used in production. Note, unless there is other code to set up the correct access, this will not work.
-Full details of this creation, including information on the likes of job type, are shown in the code (macie.tf) in the environments repo. 
+
+There is one pre-requisites for this to work and run successfully. Make sure that the role for MemberInfrastructureAccess has ace macie2:* set. If this has not been set up correctly (by the Modernisation Platform Team) the terraform listed below will not work. If this is amended in the future, so that it is enabled globally, this comment will be removed. 
+
+Full details of this creation, including information on the likes of job type, are shown in the code (macie.tf) in the environments repo for cooker. The account reference below (236861075084) is the cooker account ID.
 
 ```
-resource "aws_macie2_account" "MacieAccount" {
-  finding_publishing_frequency = "ONE_HOUR"
-  status                       = "ENABLED"
-}
+provider "aws" {
+    alias  = "macie_access" # delegated admin
+    assume_role {
+      role_arn = "arn:aws:iam::236861075084:role/macie_access"
+    }
+  }
+
+resource "aws_macie2_account" "macieaccess" { 
+   finding_publishing_frequency = "ONE_HOUR"
+   status                       = "ENABLED"
+ }
 
 resource "aws_macie2_classification_job" "test" {
   job_type = "ONE_TIME"
   name     = "JOBNAME"
   s3_job_definition {
     bucket_definitions {
-      account_id = "MacieAccount"
+      account_id = "236861075084"
       buckets    = [
-      "bastion-example-example-development-cqx7gf",
-      "config-20220505080423816000000003",
-      "s3-bucket-example20231124172322406400000006"
+      "aws-sam-cli-managed-default-samclisourcebucket-1leowh6voenwy",
+      "config-20220407082146408700000002",
+      "macie-test-results-cooker",
+      "bucket-to-test-macie-for-cooker"
       ]
     }
   }
-  depends_on = [aws_macie2_account.MacieAccount]
-}
 ```

--- a/source/runbooks/set-up-macie.html.md.erb
+++ b/source/runbooks/set-up-macie.html.md.erb
@@ -11,55 +11,23 @@ review_in: 6 months
 
 It is relatively easy to set up Macie for users and it need to be done on an account by account basis. **NOTE** Macie ONLY looks at S3 buckets and checks their access information so it will not look at databases or EC2 settings, for example.
 
-To do this you should connect to the environment on which you want to create Macie. Note, for accounts with 4 versions (development, test, preproduction, production) you will need to create Macie on each one. In theory you can just set it up in each account and allow one (day production) to use every account to access their data. At the time this document was produced this was not tested but can be used according to an AWS video showing a [demo](https://www.youtube.com/watch?v=8piwEQJJXdo).
+To do this you should connect to the environment on which you want to create Macie. Note, for accounts with 4 versions (development, test, preproduction, production) you will need to create Macie on each one. In theory you can just set it up in each account and allow one (say production) to use every account to access their data. At the time this document was produced this was not tested but can be used according to an AWS video showing a [demo](https://www.youtube.com/watch?v=8piwEQJJXdo).
 
 AWS also have a brief outline of the purpose of [Macie](https://docs.aws.amazon.com/macie/latest/user/what-is-macie.html) which can be checked to see if this is suitable.
 
-If you want to skip to the terraform code that is lower down the document which can be used as long as the pre-requisite is complete.
-
-# To start Macie
-
-Initially this will show the "how to" on the console. There will be links to the terraform code required at the end. It will need to be set up wth terraform to prevent it being disabled or removed when terraform is run in the future. The code is not show in detail in these instructions.
-
-Connect to the account you want to use with AdministratorAccess.
-
-Access the Amazon Macie choice and click on "Get started".
-
-_Initially it will set up a 30 day trial, which may be useful to look at possible costs of using the service. If you want to disable the trial connect to the settings page and look to the disable option and select the Disable option, type Disable in the box and click Disable. This will stop the Macie access._
-
-Following the Get started choice a window will be available to see what access is needed. I would recommend that the details in here are copied and saved in case you need to give the required access later.
-
-At this point you will then be asked if you want to Enable Macie. Click the button if you do.
-
-As part of the initial trial there will be an option to see what the costs will be by looking at the Usage page. If you have large S3 buckets this may appear quite costly.
-
-## Set up jobs
-
-Jobs can be set up on the console quite simply. There is a message about not having an S3 bucket to push the changes to but that can be ignored for the most part. It is suggested that you crete one. To do this you will need to add some code or amend that which is in place. The document [here](https://repost.aws/knowledge-center/macie-s3-kms-permission) explains what is needed. Most importantly ensure that the correct arn is in place on both the S3 and JMS key files as well as following the instructions shown.
-
-Under get started there is an option to create a job. Specify the buckets if only connecting to one account but pick the criteria if more that one account is going to be looked at. Once set work through each of the screens.
-
-If you want something to _run regularly (daily, weekly or monthly)_ pick that option on screen 3, otherwise select a _one-time_ job.
-
-On screen 5 you can select custom data identifiers but these need to be set up first. Picking the option to set these up will open a new screen.
-
-Screen 6 shows allow lists. Again they need to be set up beforehand but can be created through another screen.
-
-The 7th screen makes you enter a job name and, if you want, add tags. The job name MUST be entered.
-
-The final screen lists the selected buckets and gives (under the free trial at least) an estimated cost. You can also amend any of the previous settings here.
-
-If you list the jobs you can see if it is running and the results will appear on the Findings screen once it completes. Note, it may take some time to give results. On our example buckets, which are small, it takes over 15 minutes at least initially.
+Starting Macie with Terraform is possible and the instructions are shown below. There is a pre-requisite that you need to ensure is completed before this is undertaken. I have also listed the details of setting up jobs. Although they can be set up (another example is shown) it may be beneficial to set these up manually. The example only shows a few of the many items that can be included.
 
 # Terraform code
 
-Note the items shown above are not actual Terraform code but examples of how to set things up. Below there is an example of how the items were set up in Cooker following the instructions listed here.
+It is possible to set up Macie using Terraform code. 
 
 To get more detail it is best to do a search for ["aws macie terraform"](https://www.google.com/search?q=aws+macie+terraform&rlz=1C5GCCM_en&oq=&gs_lcrp=EgZjaHJvbWUqCQgAEEUYOxjCAzIJCAAQRRg7GMIDMgkIARBFGDsYwgMyCQgCEEUYOxjCAzIJCAMQRRg7GMIDMgkIBBBFGDsYwgMyCQgFEEUYOxjCAzIJCAYQRRg7GMIDMgkIBxBFGDsYwgPSAQkzMTE4ajBqMTWoAgiwAgE&sourceid=chrome&ie=UTF-8)
 
 Set up a [Macie account](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/macie2_account)
 
 Creating a [Macie job](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/macie2_classification_job)
+
+Below there is an example of how the items were set up in Cooker following the instructions listed here.
 
 ## Example Terraform code
 
@@ -101,3 +69,21 @@ resource "aws_macie2_classification_job" "test" {
   depends_on = [aws_macie2_account.MacieAccount]
 }
 ```
+
+# Set up Macie jobs
+
+Jobs can be set up on the console quite simply. There is a message about not having an S3 bucket to push the changes to but that can be ignored for the most part. It is suggested that you crete one. To do this you will need to add some code or amend that which is in place. The document [here](https://repost.aws/knowledge-center/macie-s3-kms-permission) explains what is needed. Most importantly ensure that the correct arn is in place on both the S3 and HMS key files as well as following the instructions shown.
+
+Under get started there is an option to create a job. Specify the buckets if only connecting to one account but pick the criteria if more that one account is going to be looked at. Once set work through each of the screens.
+
+If you want something to _run regularly (daily, weekly or monthly)_ pick that option on screen 3, otherwise select a _one-time_ job.
+
+On screen 5 you can select custom data identifiers but these need to be set up first. Picking the option to set these up will open a new screen.
+
+Screen 6 shows allow lists. Again they need to be set up beforehand but can be created through another screen.
+
+The 7th screen makes you enter a job name and, if you want, add tags. The job name MUST be entered.
+
+The final screen lists the selected buckets and gives (under the free trial at least) an estimated cost. You can also amend any of the previous settings here.
+
+If you list the jobs you can see if it is running and the results will appear on the Findings screen once it completes. Note, it may take some time to give results. On our example buckets, which are small, it takes over 15 minutes at least initially.

--- a/source/runbooks/set-up-macie.html.md.erb
+++ b/source/runbooks/set-up-macie.html.md.erb
@@ -29,7 +29,6 @@ The MemberInfrastructureAccess was amended to include "macie2:*" so no other use
 Full details of this creation, including information on the likes of job type, are shown in the code (macie.tf) in the modernisation-platform-environments repo for Example. The comments can be removed but are included here to provide explanation. They are not shown in the Example repository.
 
 
-NEEDED IN data.tf. Below we can see the first one in Example.
 
 ```
 # For macie code

--- a/source/runbooks/set-up-macie.html.md.erb
+++ b/source/runbooks/set-up-macie.html.md.erb
@@ -51,18 +51,27 @@ If you list the jobs you can see if it is running and the results will appear on
 
 # Terraform code
 
-Note the items shown here are not actual detailed Terraform code but examples of how to set things up. To get more detail it is best to do a search for ["aws macie terraform"](https://www.google.com/search?q=aws+macie+terraform&rlz=1C5GCCM_en&oq=&gs_lcrp=EgZjaHJvbWUqCQgAEEUYOxjCAzIJCAAQRRg7GMIDMgkIARBFGDsYwgMyCQgCEEUYOxjCAzIJCAMQRRg7GMIDMgkIBBBFGDsYwgMyCQgFEEUYOxjCAzIJCAYQRRg7GMIDMgkIBxBFGDsYwgPSAQkzMTE4ajBqMTWoAgiwAgE&sourceid=chrome&ie=UTF-8)
+Note the items shown above are not actual Terraform code but examples of how to set things up. Below there is an example of how the items were set up in Cooker following the instructions listed here.
+
+To get more detail it is best to do a search for ["aws macie terraform"](https://www.google.com/search?q=aws+macie+terraform&rlz=1C5GCCM_en&oq=&gs_lcrp=EgZjaHJvbWUqCQgAEEUYOxjCAzIJCAAQRRg7GMIDMgkIARBFGDsYwgMyCQgCEEUYOxjCAzIJCAMQRRg7GMIDMgkIBBBFGDsYwgMyCQgFEEUYOxjCAzIJCAYQRRg7GMIDMgkIBxBFGDsYwgPSAQkzMTE4ajBqMTWoAgiwAgE&sourceid=chrome&ie=UTF-8)
 
 Set up a [Macie account](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/macie2_account)
 
 Creating a [Macie job](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/macie2_classification_job)
 
-Example code is shown below BUT the build of the Macie account fails so there is no guarantee this will work.
+## Example Terraform code
+
+There is one pre-requisite, for the code shown here, to allow this to work and run successfully. Make sure that the role for **MemberInfrastructureAccess has ace macie2:** set. If this has not been set up correctly (by the Modernisation Platform Team) the terraform listed below will not work. If this is amended in the future, so that it is enabled globally, this comment will be removed. 
+
+The full details of the "finding_publishing_frequency" and "job_type" can be seen in the terraform links listed above.
+
+Full details of this creation, including information on the likes of job type, are shown in the code (macie.tf) in the modernisation-platform-environments repo for cooker. The appropriate environment account reference should be used rather than the "account-code for this environment" shown below.
 
 ```
 # Create macie account
-# When logging in as adminisitrator this is not needed but may be for our customers
-# Account name is MacieAccount. Publishes data every hour (choice are FIFTEEN_MINUTES, ONE_HOUR or SIX_HOURS)
+# When logging in as administrator this is not needed but may be for our customers - yet to be fully determined.
+# Account name is MacieAccount. Publishes data every hour (choice are FIFTEEN_MINUTES, ONE_HOUR or SIX_HOURS).
+
 resource "aws_macie2_account" "MacieAccount" {
   finding_publishing_frequency = "ONE_HOUR"
   status                       = "ENABLED"
@@ -70,58 +79,23 @@ resource "aws_macie2_account" "MacieAccount" {
 
 # Now create a job
 # Job type options are ONE-TIME and SCHEDULED. If scheduled is chosen you need to select a frequency using schedule_frequency of daily_schedule, weekly_schedule or monthly_schedule
-# The buckets should be replaced but a list of buckets to examine. This could be limited to those in the account you are connected to or others to which you have access.
+# The buckets list should be replaced but a list of buckets to examine. This could be limited to those in the account you are connected to or others to which you have access.
 # Below there is a limited list of those from example shown.
 # There are many other job options available and these should be looked at in terrform [job creation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/macie2_classification_job)
 
 
 resource "aws_macie2_classification_job" "test" {
   job_type = "ONE_TIME"
-  name     = "JOBNAME"
+  name     = "<an appropriate job name>"
   s3_job_definition {
     bucket_definitions {
-      account_id = "MacieAccount"
+      account_id = "<account-code for this environment>"
       buckets    = [
-      "bastion-example-example-development-cqx7gf",
-      "config-20220505080423816000000003",
-      "s3-bucket-example20231124172322406400000006"
+      "<list of buckets>",
+      "<separated by commas>"
       ]
     }
   }
   depends_on = [aws_macie2_account.MacieAccount]
 }
-
-Below is an example of code used in production. Note, unless there is other code to set up the correct access, this will not work.
-
-There is one pre-requisites for this to work and run successfully. Make sure that the role for MemberInfrastructureAccess has ace macie2:* set. If this has not been set up correctly (by the Modernisation Platform Team) the terraform listed below will not work. If this is amended in the future, so that it is enabled globally, this comment will be removed. 
-
-Full details of this creation, including information on the likes of job type, are shown in the code (macie.tf) in the environments repo for cooker. The account reference below (236861075084) is the cooker account ID.
-
-```
-provider "aws" {
-    alias  = "macie_access" # delegated admin
-    assume_role {
-      role_arn = "arn:aws:iam::236861075084:role/macie_access"
-    }
-  }
-
-resource "aws_macie2_account" "macieaccess" { 
-   finding_publishing_frequency = "ONE_HOUR"
-   status                       = "ENABLED"
- }
-
-resource "aws_macie2_classification_job" "test" {
-  job_type = "ONE_TIME"
-  name     = "JOBNAME"
-  s3_job_definition {
-    bucket_definitions {
-      account_id = "236861075084"
-      buckets    = [
-      "aws-sam-cli-managed-default-samclisourcebucket-1leowh6voenwy",
-      "config-20220407082146408700000002",
-      "macie-test-results-cooker",
-      "bucket-to-test-macie-for-cooker"
-      ]
-    }
-  }
 ```

--- a/source/runbooks/set-up-macie.html.md.erb
+++ b/source/runbooks/set-up-macie.html.md.erb
@@ -31,7 +31,6 @@ Full details of this creation, including information on the likes of job type, a
 
 
 ```
- }
  ```
 
 SEPARATE macie.tf code


### PR DESCRIPTION
## A reference to the issue / Description of it

New instructions on setting up Macie. Also includes the index to post it to the modernisation-platform instructions.

I have also included some instructions on setting this up using Terraform. This has been tested in Cooker and sets up Macie and includes a sample job. The account should be included in the MemberInfrastructureAccess role so this can be added.

## How does this PR fix the problem?

Information
