### PR TITLE
Add kms:CreateGrant action to OIDC role

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -464,6 +464,7 @@ data "aws_iam_policy_document" "policy" {
       "kms:DescribeKey",
       "kms:Decrypt",
       "kms:GenerateDataKey",
+      "kms:CreateGrant",
       "logs:CreateLogGroup",
       "logs:DescribeLogGroups",
       "logs:DescribeResourcePolicies",


### PR DESCRIPTION
## A reference to the issue / Description of it

I've hit a permission issue when trying to copy a snapshot encrypted with a shared KMS key in the `core-shared-services` account, using the GitHub OIDC role.
https://github.com/ministryofjustice/hmpps-delius-operational-automation/actions/runs/8754004224/job/24034310053

I think this is due to a missing `kms:CreateGrant` action in the policy.

## How does this PR fix the problem?

Adds required action to GitHub OIDC role.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
