### PR TITLE
Add Missing SSM Permissions to Migration Role

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -565,8 +565,10 @@ data "aws_iam_policy_document" "migration_additional" {
       "drs:*",
       "mgh:*",
       "mgn:*",
-      "sts:DecodeAuthorizationMessage",
-      "migrationhub-strategy:*"
+      "migrationhub-strategy:*",
+      "ssm:*",
+      "ssm-guiconnect:*",
+      "sts:DecodeAuthorizationMessage"
     ]
     resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
   }


### PR DESCRIPTION
## A reference to the issue / Description of it

This PR addresses an issue where users were unable to connect to EC2 instances due to missing permissions. The problem stemmed from insufficient permissions related to SSM. To resolve this issue, this PR adds the necessary permissions to the migration role.

## How does this PR fix the problem?

This fix ensures that users can now successfully connect to EC2 instances using the SSM
.
## How has this been tested?

tested this one on sprinkler