### PR TITLE
DSOS-2720: revised DSO account access

### DIFF
--- a/environments/hmpps-oem.json
+++ b/environments/hmpps-oem.json
@@ -16,6 +16,10 @@
         {
           "github_slug": "hmpps-dba",
           "level": "developer"
+        },
+        {
+          "github_slug": "csr-application-support",
+          "level": "instance-management"
         }
       ]
     },
@@ -33,6 +37,10 @@
         {
           "github_slug": "hmpps-dba",
           "level": "developer"
+        },
+        {
+          "github_slug": "csr-application-support",
+          "level": "instance-management"
         }
       ]
     },
@@ -50,6 +58,10 @@
         {
           "github_slug": "hmpps-dba",
           "level": "developer"
+        },
+        {
+          "github_slug": "csr-application-support",
+          "level": "instance-access"
         }
       ]
     },
@@ -67,6 +79,10 @@
         {
           "github_slug": "hmpps-dba",
           "level": "developer"
+        },
+        {
+          "github_slug": "csr-application-support",
+          "level": "instance-access"
         }
       ]
     }

--- a/environments/nomis-combined-reporting.json
+++ b/environments/nomis-combined-reporting.json
@@ -6,13 +6,16 @@
       "access": [
         {
           "github_slug": "national-applications-reporting-team",
-          "level": "sandbox",
-          "nuke": "exclude"
+          "level": "instance-management"
         },
         {
           "github_slug": "studio-webops",
           "level": "sandbox",
           "nuke": "exclude"
+        },
+        {
+          "github_slug": "csr-application-support",
+          "level": "instance-management"
         }
       ]
     },
@@ -21,11 +24,15 @@
       "access": [
         {
           "github_slug": "national-applications-reporting-team",
-          "level": "developer"
+          "level": "instance-management"
         },
         {
           "github_slug": "studio-webops",
           "level": "developer"
+        },
+        {
+          "github_slug": "csr-application-support",
+          "level": "instance-management"
         }
       ]
     },
@@ -34,11 +41,15 @@
       "access": [
         {
           "github_slug": "national-applications-reporting-team",
-          "level": "developer"
+          "level": "instance-access"
         },
         {
           "github_slug": "studio-webops",
           "level": "developer"
+        },
+        {
+          "github_slug": "csr-application-support",
+          "level": "instance-access"
         }
       ]
     },
@@ -47,11 +58,15 @@
       "access": [
         {
           "github_slug": "national-applications-reporting-team",
-          "level": "developer"
+          "level": "instance-access"
         },
         {
           "github_slug": "studio-webops",
           "level": "developer"
+        },
+        {
+          "github_slug": "csr-application-support",
+          "level": "instance-access"
         }
       ]
     }

--- a/environments/nomis-data-hub.json
+++ b/environments/nomis-data-hub.json
@@ -7,6 +7,10 @@
         {
           "github_slug": "studio-webops",
           "level": "sandbox"
+        },
+        {
+          "github_slug": "csr-application-support",
+          "level": "instance-management"
         }
       ]
     },
@@ -16,6 +20,10 @@
         {
           "github_slug": "studio-webops",
           "level": "developer"
+        },
+        {
+          "github_slug": "csr-application-support",
+          "level": "instance-management"
         }
       ]
     },
@@ -25,6 +33,10 @@
         {
           "github_slug": "studio-webops",
           "level": "developer"
+        },
+        {
+          "github_slug": "csr-application-support",
+          "level": "instance-access"
         }
       ]
     },
@@ -34,6 +46,10 @@
         {
           "github_slug": "studio-webops",
           "level": "developer"
+        },
+        {
+          "github_slug": "csr-application-support",
+          "level": "instance-access"
         }
       ]
     }

--- a/environments/nomis.json
+++ b/environments/nomis.json
@@ -23,6 +23,10 @@
         {
           "github_slug": "syscon-nomis",
           "level": "instance-management"
+        },
+        {
+          "github_slug": "csr-application-support",
+          "level": "instance-management"
         }
       ]
     },
@@ -40,6 +44,10 @@
         {
           "github_slug": "syscon-nomis",
           "level": "instance-management"
+        },
+        {
+          "github_slug": "csr-application-support",
+          "level": "instance-management"
         }
       ]
     },
@@ -52,11 +60,15 @@
         },
         {
           "github_slug": "syscon-devs",
-          "level": "instance-management"
+          "level": "instance-access"
         },
         {
           "github_slug": "syscon-nomis",
-          "level": "instance-management"
+          "level": "instance-access"
+        },
+        {
+          "github_slug": "csr-application-support",
+          "level": "instance-access"
         }
       ]
     },
@@ -69,11 +81,15 @@
         },
         {
           "github_slug": "syscon-devs",
-          "level": "instance-management"
+          "level": "instance-access"
         },
         {
           "github_slug": "syscon-nomis",
-          "level": "instance-management"
+          "level": "instance-access"
+        },
+        {
+          "github_slug": "csr-application-support",
+          "level": "instance-access"
         }
       ]
     }


### PR DESCRIPTION
## A reference to the issue / Description of it

Current SSO access is too permissive, e.g. root access and secret access to all accounts for application support teams

## How does this PR fix the problem?

Modified existing access for application support teams
- instance-management for dev and test (so servers can be restarted etc, and full secret access)
- instance-access for preprod and prod (no root access or secret access unless tags allow)

Add csr-application-support to nomis accounts for visibility and hmpps-oem which is centralised monitoring. On Glenn Barber's request.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Instance-access role tested in nomis-development by DSO.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
