### PR TITLE
Enable Autoscaling for instance management role

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -770,6 +770,9 @@ data "aws_iam_policy_document" "instance-management-document" {
     sid    = "databaseAllow"
     effect = "Allow"
     actions = [
+      "application-autoscaling:ListTagsForResource",
+      "autoscaling:UpdateAutoScalingGroup",
+      "autoscaling:SetDesiredCapacity",
       "aws-marketplace:ViewSubscriptions",
       "ds:*Tags*",
       "ds:*Snapshot*",


### PR DESCRIPTION
## A reference to the issue / Description of it

This PR updates the instance-management role by granting the `autoscaling:UpdateAutoScalingGroup` and `autoscaling:SetDesiredCapacity` permissions.

## How does this PR fix the problem?

Updates instance-management policy

## How has this been tested?

tested this on sprinkler