### PR TITLE
DPR2-622: Grant glue:StartTrigger and glue:StopTrigger to reporting-operations role

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -950,6 +950,8 @@ data "aws_iam_policy_document" "reporting-operations" {
       "glue:GetJobs",
       "glue:GetJobRun",
       "glue:GetJobRuns",
+      "glue:StartTrigger",
+      "glue:StopTrigger",
       "logs:DescribeLogStreams",
       "logs:GetLogEvents",
       "dynamodb:BatchGet*",


### PR DESCRIPTION
## A reference to the issue / Description of it

This PR grants `glue:StartTrigger` and `glue:StopTrigger` to the reporting-operations role

## How does this PR fix the problem?

This allows the mp-reporting-operations user to deactivate and re-activate glue triggers

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

This is to be tested in development

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

This should not impact the platform and / or services on it

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

N/A
