### PR TITLE
DSOS-2711: add second azure.hmpp.root domain controller

### DIFF
--- a/terraform/environments/core-shared-services/ad-fixngo.tf
+++ b/terraform/environments/core-shared-services/ad-fixngo.tf
@@ -43,26 +43,26 @@ locals {
         subnet_id                 = aws_subnet.live-data-additional["eu-west-2a"].id
         vpc_security_group_name   = "ad_hmpp_dc_sg"
         tags = {
-          server-type = "DomainJoin"
+          server-type = "DomainController"
           domain-name = "azure.hmpp.root"
           description = "domain controller for FixNGo azure.hmpp.root domain"
         }
       }
-      # ad-hmpp-dc-b = {
-      #   ami_name                  = "hmpps_windows_server_2022_release_2024-02-02T00-00-04.569Z"
-      #   availability_zone         = "eu-west-2b"
-      #   iam_instance_profile_role = "ad-fixngo-ec2-live-role"
-      #   instance_type             = "t3.large"
-      #   key_name                  = "ad-fixngo-ec2-live"
-      #   private_ip                = module.ad_fixngo_ip_addresses.mp_ip["ad-hmpp-dc-b"]
-      #   subnet_id                 = aws_subnet.live-data-additional["eu-west-2b"].id
-      #   vpc_security_group_name   = "ad_hmpp_dc_sg"
-      #   tags = {
-      #     server-type = "DomainJoin"
-      #     domain-name = "azure.hmpp.root"
-      #     description = "domain controller for FixNGo azure.hmpp.root domain"
-      #   }
-      # }
+      ad-hmpp-dc-b = {
+        ami_name                  = "hmpps_windows_server_2022_release_2024-02-02T00-00-04.569Z"
+        availability_zone         = "eu-west-2b"
+        iam_instance_profile_role = "ad-fixngo-ec2-live-role"
+        instance_type             = "t3.large"
+        key_name                  = "ad-fixngo-ec2-live"
+        private_ip                = module.ad_fixngo_ip_addresses.mp_ip["ad-hmpp-dc-b"]
+        subnet_id                 = aws_subnet.live-data-additional["eu-west-2b"].id
+        vpc_security_group_name   = "ad_hmpp_dc_sg"
+        tags = {
+          server-type = "DomainController"
+          domain-name = "azure.hmpp.root"
+          description = "domain controller for FixNGo azure.hmpp.root domain"
+        }
+      }
       # ad-hmpp-rdlic = {
       #   ami_name                  = "hmpps_windows_server_2022_release_2024-02-02T00-00-04.569Z"
       #   availability_zone         = "eu-west-2c"

--- a/terraform/environments/core-shared-services/files/ad-fixngo-ec2-user-data.yaml
+++ b/terraform/environments/core-shared-services/files/ad-fixngo-ec2-user-data.yaml
@@ -10,14 +10,62 @@ tasks:
         type: powershell
         runAs: admin
         content: |-
+          # Install / upgrade chocolatey since the version installed can be very old
+          $ErrorActionPreference = "Stop"
+          if (Get-Command choco.exe -ErrorAction SilentlyContinue) {
+            $version=choco --version
+            if ($version -lt "2.2.2") {
+              Write-Output "Upgrading old version of chocolatey $version to 2.2.2"
+              choco upgrade chocolatey --version 2.2.2 -y
+            } else {
+              Write-Output "Chocolatey already installed version $version"
+            }
+          } else {
+            Write-Output "Installing Chocolatey"
+            Set-ExecutionPolicy Bypass -Scope Process -Force
+            [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
+            Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
+          }
+          Start-Sleep -Seconds 1 # helps debugging as logs have different timestamps
+      - frequency: once
+        type: powershell
+        runAs: admin
+        content: |-
           # Install git - it should be in AMI but install if missing
           $ErrorActionPreference = "Stop"
           if (Get-Command "git" -ErrorAction SilentlyContinue) {
-            Write-Output "git already installed"
+            Write-Output "git already installed, skipping choco install"
           } else {
+            Write-Output "choco upgrade chocolatey-compatibility.extension -y"
+            choco upgrade chocolatey-compatibility.extension -y
+            Write-Output "choco upgrade chocolatey-core.extension -y"
+            choco upgrade chocolatey-core.extension -y
             Write-Output "choco install git.install -y"
             choco install git.install -y
           }
+          Start-Sleep -Seconds 1 # helps debugging as logs have different timestamps
+      - frequency: once
+        type: powershell
+        runAs: admin
+        content: |-
+          # Fallback installation for git
+          $ErrorActionPreference = "Stop"
+          if (Get-Command "git" -ErrorAction SilentlyContinue) {
+            Write-Output "git already installed, skipping fallback install"
+          } else {
+            Set-Location -Path ([System.IO.Path]::GetTempPath())
+            Url="https://github.com/git-for-windows/git/releases/download/v2.44.0.windows.1/Git-2.44.0-64-bit.exe"
+            Write-Output "Fallback installation for git - downloading from $Url"
+            Invoke-WebRequest $Url -OutFile ".\Git.exe"
+            .\Git.exe /VERYSILENT /NORESTART
+          }
+          Start-Sleep -Seconds 1 # helps debugging as logs have different timestamps
+      - frequency: once
+        type: powershell
+        runAs: admin
+        content: |-
+          Write-Output "choco upgrade all -y"
+          choco upgrade all -y
           Start-Sleep -Seconds 1 # helps debugging as logs have different timestamps
       - frequency: once
         type: powershell


### PR DESCRIPTION
## A reference to the issue / Description of it

Please see https://github.com/ministryofjustice/modernisation-platform/issues/5970 and https://github.com/ministryofjustice/modernisation-platform/issues/6633

The first azure.hmpp.root DC is built and can connect to some of the dom1.infra.int DCs. 
Building the second one.  Also fixes issue with the automatic provisioning due to old version of chocolatey on the windows AMI.

## How does this PR fix the problem?

Installs second domain controller for redundancy

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

First DC is working and no issues reported.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
