### PR TITLE
📝  Excluded Terraform Docs from Code Formatter

### DIFF
--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -52,7 +52,7 @@ jobs:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
           VALIDATE_ALL_CODEBASE: true
           YAML_PRETTIER_FILTER_REGEX_EXCLUDE: (.github/*)
-          FILTER_REGEX_EXCLUDE: (terraform/modules/**/*.md)
+          MARKDOWN_FILTER_REGEX_EXCLUDE: (terraform/modules/**/*.md)
           REPORT_OUTPUT_FOLDER: none
 
       - name: Check for changes

--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -52,6 +52,7 @@ jobs:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
           VALIDATE_ALL_CODEBASE: true
           YAML_PRETTIER_FILTER_REGEX_EXCLUDE: (.github/*)
+          FILTER_REGEX_EXCLUDE: (terraform/modules/**/*.md)
           REPORT_OUTPUT_FOLDER: none
 
       - name: Check for changes


### PR DESCRIPTION
This PR excludes files matching `'terraform/modules/**/*.md'` from the code-formatter markdown linter as these are covered by the `.github/workflows/documentation.yml` workflow which triggers when a PR is opened. 

These two code formatting are currently conflicting with each...
commit created by code formatter: https://github.com/ministryofjustice/modernisation-platform/pull/6846/commits/f12f04a54cbd6df3f9c3da91e39e58bbf10e11f0
commit created by terraform-docs (undoing the above) https://github.com/ministryofjustice/modernisation-platform/pull/6846/commits/5d03d793658ccf999017ce23b6f28d2dd262bd09