### PR TITLE
Test to confirm the core-vpc-development-deployment plan runs correctly without the -target flags.

### DIFF
--- a/.github/workflows/core-vpc-development-deployment.yml
+++ b/.github/workflows/core-vpc-development-deployment.yml
@@ -93,7 +93,7 @@ jobs:
           terraform -chdir="terraform/environments/core-vpc" workspace select "core-vpc-${TF_ENV}"
 
           #RUN TERRAFORM PLAN
-          PLAN=`bash scripts/terraform-plan.sh terraform/environments/core-vpc "-target=module.vpc -target=module.vpc_tgw_routing -target=module.core-vpc-tgw-routes -target=module.dns-zone -target=module.dns_zone_extend -target=module.pagerduty_core_alerts" | tee /dev/stderr | grep '^Plan: \|^No changes.'`
+          PLAN=`bash scripts/terraform-plan.sh terraform/environments/core-vpc | tee /dev/stderr | grep '^Plan: \|^No changes.'`
           PLAN="> TERRAFORM PLAN RESULT - core-vpc - ${TF_ENV}
           ${PLAN}"
           bash scripts/update-pr-comments.sh "${PLAN}"


### PR DESCRIPTION
Removes the -target flags from the core-vpc-development-deployment job in order to confirm its correct working. If the plan runs correctly then other -target flags will be removed from the plan for the other accounts. If it fails the change will be reverted. 

## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/6615

## How does this PR fix the problem?

As -targets limits the scope of the plan, any new resources created via a module call will be excluded from the plan. This is to confirm whether removing the targets doesn't result in plan errors.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
