### PR TITLE
Format-code Fix Varible for terraform flavour 

### DIFF
--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -51,8 +51,8 @@ jobs:
           ENABLE_LINTERS: JSON_PRETTIER,YAML_PRETTIER,TERRAFORM_TERRAFORM_FMT,MARKDOWN_MARKDOWNLINT
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
           VALIDATE_ALL_CODEBASE: true
-          YAML_PRETTIER_FILTER_REGEX_EXCLUDE: '(.github/*)'
-          MFILTER_REGEX_EXCLUDE: '(terraform/modules/**/*.md)'
+          YAML_PRETTIER_FILTER_REGEX_EXCLUDE: (.github/*)
+          MARKDOWN_MARKDOWNLINT_FILTER_REGEX_EXCLUDE: (terraform/modules/**/*.md)
           REPORT_OUTPUT_FOLDER: none
 
       - name: Check for changes

--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -51,8 +51,8 @@ jobs:
           ENABLE_LINTERS: JSON_PRETTIER,YAML_PRETTIER,TERRAFORM_TERRAFORM_FMT,MARKDOWN_MARKDOWNLINT
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
           VALIDATE_ALL_CODEBASE: true
-          YAML_PRETTIER_FILTER_REGEX_EXCLUDE: (.github/*)
-          MARKDOWN_FILTER_REGEX_EXCLUDE: (terraform/modules/**/*.md)
+          YAML_PRETTIER_FILTER_REGEX_EXCLUDE: '(.github/*)'
+          MFILTER_REGEX_EXCLUDE: '(terraform/modules/**/*.md)'
           REPORT_OUTPUT_FOLDER: none
 
       - name: Check for changes


### PR DESCRIPTION
Following this [PR#6856](https://github.com/ministryofjustice/modernisation-platform/pull/6856) yesterday the format-code run failed this morning: https://github.com/ministryofjustice/modernisation-platform/actions/runs/8811176076/job/24193462974 

updating variable for terraform flavour https://megalinter.io/7.11.1/descriptors/markdown_markdownlint/ 