### PR TITLE
Issue 6615.

### DIFF
--- a/.github/workflows/core-vpc-preproduction-deployment.yml
+++ b/.github/workflows/core-vpc-preproduction-deployment.yml
@@ -93,7 +93,7 @@ jobs:
           terraform -chdir="terraform/environments/core-vpc" workspace select "core-vpc-${TF_ENV}"
 
           #RUN TERRAFORM PLAN
-          PLAN=`bash scripts/terraform-plan.sh terraform/environments/core-vpc "-target=module.vpc -target=module.vpc_tgw_routing -target=module.core-vpc-tgw-routes -target=module.dns-zone -target=module.dns_zone_extend -target=module.pagerduty_core_alerts" | tee /dev/stderr | grep '^Plan: \|^No changes.'`
+          PLAN=`bash scripts/terraform-plan.sh terraform/environments/core-vpc | tee /dev/stderr | grep '^Plan: \|^No changes.'`
           PLAN="> TERRAFORM PLAN RESULT - core-vpc - ${TF_ENV}
           ${PLAN}"
           bash scripts/update-pr-comments.sh "${PLAN}"

--- a/.github/workflows/core-vpc-production-deployment.yml
+++ b/.github/workflows/core-vpc-production-deployment.yml
@@ -93,7 +93,7 @@ jobs:
           terraform -chdir="terraform/environments/core-vpc" workspace select "core-vpc-${TF_ENV}"
 
           #RUN TERRAFORM PLAN
-          PLAN=`bash scripts/terraform-plan.sh terraform/environments/core-vpc "-target=module.vpc -target=module.vpc_tgw_routing -target=module.core-vpc-tgw-routes -target=module.dns-zone -target=module.dns_zone_extend -target=module.pagerduty_core_alerts" | tee /dev/stderr | grep '^Plan: \|^No changes.'`
+          PLAN=`bash scripts/terraform-plan.sh terraform/environments/core-vpc | tee /dev/stderr | grep '^Plan: \|^No changes.'`
           PLAN="> TERRAFORM PLAN RESULT - core-vpc - ${TF_ENV}
           ${PLAN}"
           bash scripts/update-pr-comments.sh "${PLAN}"

--- a/.github/workflows/core-vpc-test-deployment.yml
+++ b/.github/workflows/core-vpc-test-deployment.yml
@@ -93,7 +93,7 @@ jobs:
           terraform -chdir="terraform/environments/core-vpc" workspace select "core-vpc-${TF_ENV}"
 
           #RUN TERRAFORM PLAN
-          PLAN=`bash scripts/terraform-plan.sh terraform/environments/core-vpc "-target=module.vpc -target=module.vpc_tgw_routing -target=module.core-vpc-tgw-routes -target=module.dns-zone -target=module.dns_zone_extend -target=module.pagerduty_core_alerts" | tee /dev/stderr | grep '^Plan: \|^No changes.'`
+          PLAN=`bash scripts/terraform-plan.sh terraform/environments/core-vpc | tee /dev/stderr | grep '^Plan: \|^No changes.'`
           PLAN="> TERRAFORM PLAN RESULT - core-vpc - ${TF_ENV}
           ${PLAN}"
           bash scripts/update-pr-comments.sh "${PLAN}"


### PR DESCRIPTION
Removes the -target flags from the plan workflows for core-vpc test, preprod and prod.

## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/6615

## How does this PR fix the problem?

Following on from the change to the development workflow for core-vpc, this applies the change change but to test, preprod & prod workflows.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Tested in development.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
