### PR TITLE
Fixup Megalinter regex expression

### DIFF
--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -52,7 +52,7 @@ jobs:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
           VALIDATE_ALL_CODEBASE: true
           YAML_PRETTIER_FILTER_REGEX_EXCLUDE: (.github/*)
-          MARKDOWN_MARKDOWNLINT_FILTER_REGEX_EXCLUDE: "(terraform/modules/**/*.md)"
+          MARKDOWN_MARKDOWNLINT_FILTER_REGEX_EXCLUDE: (terraform/modules/.*/.*.md)
           REPORT_OUTPUT_FOLDER: none
 
       - name: Check for changes


### PR DESCRIPTION
update regex expression to exclude `terraform/modules/<dir>/<filename>.md` from markdown linter checker.