### PR TITLE
Add AWSVPCLog role and related resources for VPC logging

### DIFF
--- a/terraform/environments/core-logging/iam.tf
+++ b/terraform/environments/core-logging/iam.tf
@@ -2,7 +2,6 @@
 resource "aws_iam_role" "vpc_flow_log" {
   name               = "AWSVPCFlowLog"
   assume_role_policy = data.aws_iam_policy_document.vpc_flow_log_assume_role_policy.json
-  tags               = var.tags
 }
 
 # VPC Flow Log: assume role policy

--- a/terraform/environments/core-logging/iam.tf
+++ b/terraform/environments/core-logging/iam.tf
@@ -1,3 +1,20 @@
-data "aws_iam_role" "vpc-flow-log" {
-  name = "AWSVPCFlowLog"
+# VPC Flow Log: configure an IAM role
+resource "aws_iam_role" "vpc_flow_log" {
+  name               = "AWSVPCFlowLog"
+  assume_role_policy = data.aws_iam_policy_document.vpc_flow_log_assume_role_policy.json
+  tags               = var.tags
+}
+
+# VPC Flow Log: assume role policy
+data "aws_iam_policy_document" "vpc_flow_log_assume_role_policy" {
+  version = "2012-10-17"
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["vpc-flow-logs.amazonaws.com"]
+    }
+  }
 }

--- a/terraform/environments/core-logging/vpc.tf
+++ b/terraform/environments/core-logging/vpc.tf
@@ -20,7 +20,7 @@ module "vpc" {
   gateway = "transit"
 
   # VPC Flow Logs
-  vpc_flow_log_iam_role = data.aws_iam_role.vpc-flow-log.arn
+  vpc_flow_log_iam_role = aws_iam_role.vpc_flow_log.arn
 
   # Transit Gateway ID
   transit_gateway_id = data.aws_ec2_transit_gateway.transit-gateway.id

--- a/terraform/environments/core-network-services/firewall.tf
+++ b/terraform/environments/core-network-services/firewall.tf
@@ -57,7 +57,7 @@ resource "aws_cloudwatch_log_group" "external_inspection" {
 }
 
 resource "aws_flow_log" "external_inspection" {
-  iam_role_arn             = data.aws_iam_role.vpc-flow-log.arn
+  iam_role_arn             = aws_iam_role.vpc_flow_log.arn
   log_destination          = aws_cloudwatch_log_group.external_inspection.arn
   traffic_type             = "ALL"
   log_destination_type     = "cloud-watch-logs"

--- a/terraform/environments/core-network-services/iam.tf
+++ b/terraform/environments/core-network-services/iam.tf
@@ -2,7 +2,6 @@
 resource "aws_iam_role" "vpc_flow_log" {
   name               = "AWSVPCFlowLog"
   assume_role_policy = data.aws_iam_policy_document.vpc_flow_log_assume_role_policy.json
-  tags               = var.tags
 }
 
 # VPC Flow Log: assume role policy

--- a/terraform/environments/core-network-services/iam.tf
+++ b/terraform/environments/core-network-services/iam.tf
@@ -1,5 +1,22 @@
-data "aws_iam_role" "vpc-flow-log" {
-  name = "AWSVPCFlowLog"
+# VPC Flow Log: configure an IAM role
+resource "aws_iam_role" "vpc_flow_log" {
+  name               = "AWSVPCFlowLog"
+  assume_role_policy = data.aws_iam_policy_document.vpc_flow_log_assume_role_policy.json
+  tags               = var.tags
+}
+
+# VPC Flow Log: assume role policy
+data "aws_iam_policy_document" "vpc_flow_log_assume_role_policy" {
+  version = "2012-10-17"
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["vpc-flow-logs.amazonaws.com"]
+    }
+  }
 }
 
 data "aws_route53_zone" "private-zones" {

--- a/terraform/environments/core-network-services/monitoring.tf
+++ b/terraform/environments/core-network-services/monitoring.tf
@@ -142,7 +142,7 @@ resource "aws_cloudwatch_log_group" "tgw_flowlog_group" {
 resource "aws_flow_log" "tgw_flowlog" {
   depends_on                    = [aws_cloudwatch_log_group.tgw_flowlog_group]
   for_each                      = merge(data.aws_ec2_transit_gateway_vpc_attachment.transit_gateway_all, data.aws_ec2_transit_gateway_peering_attachment.transit_gateway_production)
-  iam_role_arn                  = data.aws_iam_role.vpc-flow-log.arn
+  iam_role_arn                  = aws_iam_role.vpc_flow_log.arn
   log_destination               = aws_cloudwatch_log_group.tgw_flowlog_group.arn
   log_destination_type          = "cloud-watch-logs"
   traffic_type                  = "ALL"

--- a/terraform/environments/core-network-services/vpc.tf
+++ b/terraform/environments/core-network-services/vpc.tf
@@ -16,7 +16,7 @@ module "vpc_inspection" {
   fw_kms_arn            = data.aws_kms_key.general_shared.arn
   fw_rules              = local.inline_firewall_rules
   vpc_cidr              = each.value
-  vpc_flow_log_iam_role = data.aws_iam_role.vpc-flow-log.arn
+  vpc_flow_log_iam_role = aws_iam_role.vpc_flow_log.arn
   transit_gateway_id    = aws_ec2_transit_gateway.transit-gateway.id
 
   # Tags

--- a/terraform/environments/core-security/iam.tf
+++ b/terraform/environments/core-security/iam.tf
@@ -2,7 +2,6 @@
 resource "aws_iam_role" "vpc_flow_log" {
   name               = "AWSVPCFlowLog"
   assume_role_policy = data.aws_iam_policy_document.vpc_flow_log_assume_role_policy.json
-  tags               = var.tags
 }
 
 # VPC Flow Log: assume role policy

--- a/terraform/environments/core-security/iam.tf
+++ b/terraform/environments/core-security/iam.tf
@@ -1,3 +1,20 @@
-data "aws_iam_role" "vpc-flow-log" {
-  name = "AWSVPCFlowLog"
+# VPC Flow Log: configure an IAM role
+resource "aws_iam_role" "vpc_flow_log" {
+  name               = "AWSVPCFlowLog"
+  assume_role_policy = data.aws_iam_policy_document.vpc_flow_log_assume_role_policy.json
+  tags               = var.tags
+}
+
+# VPC Flow Log: assume role policy
+data "aws_iam_policy_document" "vpc_flow_log_assume_role_policy" {
+  version = "2012-10-17"
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["vpc-flow-logs.amazonaws.com"]
+    }
+  }
 }

--- a/terraform/environments/core-security/vpc.tf
+++ b/terraform/environments/core-security/vpc.tf
@@ -20,7 +20,7 @@ module "vpc" {
   gateway = "transit"
 
   # VPC Flow Logs
-  vpc_flow_log_iam_role = data.aws_iam_role.vpc-flow-log.arn
+  vpc_flow_log_iam_role = aws_iam_role.vpc_flow_log.arn
 
   # Transit Gateway ID
   transit_gateway_id = data.aws_ec2_transit_gateway.transit-gateway.id

--- a/terraform/environments/core-shared-services/iam.tf
+++ b/terraform/environments/core-shared-services/iam.tf
@@ -2,7 +2,6 @@
 resource "aws_iam_role" "vpc_flow_log" {
   name               = "AWSVPCFlowLog"
   assume_role_policy = data.aws_iam_policy_document.vpc_flow_log_assume_role_policy.json
-  tags               = var.tags
 }
 
 # VPC Flow Log: assume role policy

--- a/terraform/environments/core-shared-services/iam.tf
+++ b/terraform/environments/core-shared-services/iam.tf
@@ -1,5 +1,22 @@
-data "aws_iam_role" "vpc-flow-log" {
-  name = "AWSVPCFlowLog"
+# VPC Flow Log: configure an IAM role
+resource "aws_iam_role" "vpc_flow_log" {
+  name               = "AWSVPCFlowLog"
+  assume_role_policy = data.aws_iam_policy_document.vpc_flow_log_assume_role_policy.json
+  tags               = var.tags
+}
+
+# VPC Flow Log: assume role policy
+data "aws_iam_policy_document" "vpc_flow_log_assume_role_policy" {
+  version = "2012-10-17"
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["vpc-flow-logs.amazonaws.com"]
+    }
+  }
 }
 
 # Create IAM role and instance profile for image builder

--- a/terraform/environments/core-shared-services/vpc.tf
+++ b/terraform/environments/core-shared-services/vpc.tf
@@ -32,7 +32,7 @@ module "vpc" {
   gateway = "transit"
 
   # VPC Flow Logs
-  vpc_flow_log_iam_role = data.aws_iam_role.vpc-flow-log.arn
+  vpc_flow_log_iam_role = aws_iam_role.vpc_flow_log.arn
 
   # Transit Gateway ID
   transit_gateway_id = data.aws_ec2_transit_gateway.transit-gateway.id

--- a/terraform/environments/core-vpc/iam.tf
+++ b/terraform/environments/core-vpc/iam.tf
@@ -2,7 +2,6 @@
 resource "aws_iam_role" "vpc_flow_log" {
   name               = "AWSVPCFlowLog"
   assume_role_policy = data.aws_iam_policy_document.vpc_flow_log_assume_role_policy.json
-  tags               = var.tags
 }
 
 # VPC Flow Log: assume role policy

--- a/terraform/environments/core-vpc/iam.tf
+++ b/terraform/environments/core-vpc/iam.tf
@@ -1,3 +1,20 @@
-data "aws_iam_role" "vpc-flow-log" {
-  name = "AWSVPCFlowLog"
+# VPC Flow Log: configure an IAM role
+resource "aws_iam_role" "vpc_flow_log" {
+  name               = "AWSVPCFlowLog"
+  assume_role_policy = data.aws_iam_policy_document.vpc_flow_log_assume_role_policy.json
+  tags               = var.tags
+}
+
+# VPC Flow Log: assume role policy
+data "aws_iam_policy_document" "vpc_flow_log_assume_role_policy" {
+  version = "2012-10-17"
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["vpc-flow-logs.amazonaws.com"]
+    }
+  }
 }

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -94,7 +94,7 @@ module "vpc" {
   transit_gateway_id = data.aws_ec2_transit_gateway.transit-gateway.id
 
   # VPC Flow Logs
-  vpc_flow_log_iam_role = data.aws_iam_role.vpc-flow-log.arn
+  vpc_flow_log_iam_role = aws_iam_role.vpc_flow_log.arn
 
   # Variables required for Firehose integration. We are not building this in all environments hence the "build_firehose" condition below.
 


### PR DESCRIPTION
This PR addresses the issue caused by the removal of the baseline module, which contained the AWSVPCLog role. To resolve this, I've added the AWSVPCLog role and related resources directly to the core accounts. 