### PR TITLE
Update python runtime to 3.12

### DIFF
--- a/terraform/environments/core-logging/athena.tf
+++ b/terraform/environments/core-logging/athena.tf
@@ -268,7 +268,7 @@ resource "aws_lambda_function" "athena_table_update" {
   role                           = aws_iam_role.athena_lambda.arn
   handler                        = "index.lambda_handler"
   source_code_hash               = data.archive_file.lambda_zip.output_base64sha256
-  runtime                        = "python3.8"
+  runtime                        = "python3.12"
   reserved_concurrent_executions = 1
   kms_key_arn                    = aws_kms_key.athena_logging.arn
   environment {


### PR DESCRIPTION
## A reference to the issue / Description of it

Support for python 3.8 ends in October 2024.  Updating to keep in support.

## How does this PR fix the problem?

Updates to the latest supported version

## How has this been tested?

Tested on the Lambda, changed run time then ran, no issues.

## Deployment Plan / Instructions

No impact

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x All checks have passed
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
