### PR TITLE
Add `remove default vpc` job to `new-environment`workflow and corresponding script

### DIFF
--- a/.github/workflows/new-environment.yml
+++ b/.github/workflows/new-environment.yml
@@ -195,6 +195,43 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
         if: ${{ failure() }}
+  remove-default-vpc:
+    runs-on: ubuntu-latest
+    if: github.event.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+    needs: [delegate-access]
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          fetch-depth: 0
+      - name: Set Account Number
+        run: echo "ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+          role-session-name: githubactionsrolesession
+          aws-region: ${{ env.AWS_REGION }}
+      - name: get new account(s)
+        id: new_account
+        run: |
+          files=$(git diff --name-only --diff-filter=AM @^ -- 'environments/*.json' | uniq | sed 's#environments/##' | sed 's/\.json$//' | base64 )
+          echo "files=$files" >> $GITHUB_OUTPUT
+      - name: Remove Default VPC
+        run: |
+          readarray -t accounts <<< "$(echo "${{ steps.new_account.outputs.files }}" | base64 --decode)"
+          if [[ ! -z ${accounts} ]]; then
+          for i in "${accounts[@]}"; do
+          environments=$(jq -r '.environments[].name' "environments/${i}.json")
+          for env in $environments; do
+          key="${i}-${env}"
+          account_number=$(echo "$ENVIRONMENT_MANAGEMENT" | jq -r ".account_ids[\"$key\"]")
+          bash ./scripts/internal/remove-default-vpc/remove_default_vpc_new_account.sh $account_number
+          done
+          done
+          fi
+          else
+          echo "[+] There were no AWS member accounts to process"
+          fi   
   secure-baselines:
     runs-on: ubuntu-latest
     if: github.event.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/new-environment.yml
+++ b/.github/workflows/new-environment.yml
@@ -228,7 +228,6 @@ jobs:
           bash ./scripts/internal/remove-default-vpc/remove_default_vpc_new_account.sh $account_number
           done
           done
-          fi
           else
           echo "[+] There were no AWS member accounts to process"
           fi   

--- a/.github/workflows/new-environment.yml
+++ b/.github/workflows/new-environment.yml
@@ -232,6 +232,15 @@ jobs:
           else
           echo "[+] There were no AWS member accounts to process"
           fi   
+      - name: Slack failure notification
+        uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
+        with:
+          payload: |
+            {"blocks":[{"type": "section","text": {"type": "mrkdwn","text": ":no_entry: Failed GitHub Action:"}},{"type": "section","fields":[{"type": "mrkdwn","text": "*Workflow:*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>"},{"type": "mrkdwn","text": "*Job:*\n${{ github.job }}"},{"type": "mrkdwn","text": "*Repo:*\n${{ github.repository }}"}]}]}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+        if: ${{ failure() }}
   secure-baselines:
     runs-on: ubuntu-latest
     if: github.event.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/remove-default-vpc.yml
+++ b/.github/workflows/remove-default-vpc.yml
@@ -1,6 +1,9 @@
 name: "Remove Default VPC"
 
 on:
+  schedule:
+    # trigger every Monday at 08:30am
+    - cron: "30 8 * * MON"
   workflow_dispatch:
 
 env:

--- a/.github/workflows/remove-default-vpc.yml
+++ b/.github/workflows/remove-default-vpc.yml
@@ -32,5 +32,5 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Remove Default VPC
-        run: bash ./scripts/internal/remove_default_vpc.sh
+        run: bash ./scripts/internal/remove-default-vpc/remove_default_vpc_all_accounts.sh
         

--- a/scripts/internal/remove-default-vpc/remove_default_vpc_all_accounts.sh
+++ b/scripts/internal/remove-default-vpc/remove_default_vpc_all_accounts.sh
@@ -13,7 +13,7 @@ getAssumeRoleCfg() {
 }
 
 for account_id in $(jq -r '.account_ids | to_entries[] | "\(.value)"' <<< $ENVIRONMENT_MANAGEMENT); do
-    echo $account_id
+    echo "account: $account_id"
     getAssumeRoleCfg "$account_id"
     for region in $regions; do
         #Skipping region due to insufficient permissions.

--- a/scripts/internal/remove-default-vpc/remove_default_vpc_all_accounts.sh
+++ b/scripts/internal/remove-default-vpc/remove_default_vpc_all_accounts.sh
@@ -51,4 +51,3 @@ for account_id in $(jq -r '.account_ids | to_entries[] | "\(.value)"' <<< $ENVIR
     export AWS_SESSION_TOKEN=$ROOT_AWS_SESSION_TOKEN
     rm credentials.json
 done
-unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN

--- a/scripts/internal/remove-default-vpc/remove_default_vpc_all_accounts.sh
+++ b/scripts/internal/remove-default-vpc/remove_default_vpc_all_accounts.sh
@@ -38,9 +38,11 @@ for account_id in $(jq -r '.account_ids | to_entries[] | "\(.value)"' <<< $ENVIR
 
             # Delete subnets associated with the VPC
             subnets=$(aws ec2 describe-subnets --region $region --filters Name=vpc-id,Values=$vpc_id | jq -r .Subnets[].SubnetId)
-            for subnet_id in $subnets; do
-              aws ec2 delete-subnet --region $region --subnet-id $subnet_id
-            done
+            if [ "$subnets" != "null" ]; then
+                for subnet_id in $subnets; do
+                    aws ec2 delete-subnet --region $region --subnet-id $subnet_id
+                done
+            fi
 
             # Delete the VPC
             aws ec2 delete-vpc --region $region --vpc-id $vpc_id

--- a/scripts/internal/remove-default-vpc/remove_default_vpc_new_account.sh
+++ b/scripts/internal/remove-default-vpc/remove_default_vpc_new_account.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+regions="eu-central-1 eu-west-1 eu-west-2 us-east-1"
+account_id="$1"
+ROOT_AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
+ROOT_AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
+ROOT_AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN
+
+getAssumeRoleCfg() {
+    account_id=$1
+    aws sts assume-role --role-arn "arn:aws:iam::${account_id}:role/ModernisationPlatformAccess" --role-session-name "test" --output json > credentials.json
+    export AWS_ACCESS_KEY_ID=$(jq -r '.Credentials.AccessKeyId' credentials.json)
+    export AWS_SECRET_ACCESS_KEY=$(jq -r '.Credentials.SecretAccessKey' credentials.json)
+    export AWS_SESSION_TOKEN=$(jq -r '.Credentials.SessionToken' credentials.json)
+}
+
+echo "account: $account_id"
+getAssumeRoleCfg "$account_id"
+for region in $regions; do
+    #Skipping region due to insufficient permissions.
+    if ! aws ec2 describe-vpcs --region $region &> /dev/null; then
+        continue
+    fi
+    # Get default VPC ID
+    vpc_id=$(aws ec2 describe-vpcs --region $region --filters Name=isDefault,Values=true | jq -r .Vpcs[0].VpcId)
+    echo "region: $region vpc: $vpc_id"
+    if [ "$vpc_id" != "null" ]; then
+        echo "Deleting default VPC ($vpc_id) in region $region..."
+        # Detach and delete any internet gateway associated with the VPC
+        internet_gateway_id=$(aws ec2 describe-internet-gateways --region $region --filters Name=attachment.vpc-id,Values=$vpc_id | jq -r .InternetGateways[0].InternetGatewayId)
+        if [ "$internet_gateway_id" != "null" ]; then
+            if ! aws ec2 detach-internet-gateway --region $region --internet-gateway-id $internet_gateway_id --vpc-id $vpc_id &> /dev/null; then
+                echo "Error: Failed to detach internet gateway for account $account_id. Continuing with the next account..."
+                continue  # Skip to the next iteration of the loop for the next account
+            fi
+            aws ec2 delete-internet-gateway --region $region --internet-gateway-id $internet_gateway_id
+        fi
+
+        # Delete subnets associated with the VPC
+        subnets=$(aws ec2 describe-subnets --region $region --filters Name=vpc-id,Values=$vpc_id | jq -r .Subnets[].SubnetId)
+        if [ "$subnets" != "null" ]; then
+            for subnet_id in $subnets; do
+                aws ec2 delete-subnet --region $region --subnet-id $subnet_id
+            done
+        fi
+
+        # Delete the VPC
+        aws ec2 delete-vpc --region $region --vpc-id $vpc_id
+    fi
+done
+export AWS_ACCESS_KEY_ID=$ROOT_AWS_ACCESS_KEY_ID
+export AWS_SECRET_ACCESS_KEY=$ROOT_AWS_SECRET_ACCESS_KEY
+export AWS_SESSION_TOKEN=$ROOT_AWS_SESSION_TOKEN
+rm credentials.json


### PR DESCRIPTION
## A reference to the issue / Description of it

This PR adds a new job, "remove default vpc," to the existing workflow. Additionally, it includes the corresponding script to handle the removal of default VPCs. This job is triggered when a new file is added or modified in the environments folder. It ensures that any default VPCs associated with the affected accounts are removed, addressing potential issues related to default VPC configurations. #6488 

## How does this PR fix the problem?

This PR addresses the problem by introducing a systematic approach to handle default VPC removal when new files are added or modified in the environments folder. By adding the `remove default vpc` job to the `new-environment` workflow and providing the necessary script, it ensures that default VPCs are removed for the affected accounts

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
