### PR TITLE
Addressed SCA failure

### DIFF
--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -27,6 +27,9 @@ vulnerabilities:
   - id: CVE-2023-5528
   - id: CVE-2023-37788
   - id: CVE-2023-39325
+  - id: CVE-2024-315
+    expired_at: 2024-10-29
+    statement: "Review in 6 months; this one appeared to be Terratest related"
   - id: CVE-2024-15114
     expired_at: 2024-08-19
     statement: "Review in 6 months"


### PR DESCRIPTION
Added a CVE to trivyignore; this appears to be a downstream dependency that doesn't appear in our local `go.mod`, or in `go mod graph` but I suspect it's [terratest related](https://github.com/ministryofjustice/modernisation-platform/actions/runs/8874592977/job/24362332657#step:4:192):

```
go mod graph | grep github.com/opencontainers
github.com/gruntwork-io/terratest@v0.46.14 github.com/opencontainers/go-digest@v1.0.0
github.com/gruntwork-io/terratest@v0.46.14 github.com/opencontainers/image-spec@v1.0.2
```