### PR TITLE
Implement error handling for subnet deletion and update cron job schedule

### DIFF
--- a/.github/workflows/collaborator-inactivity-monitoring.yml
+++ b/.github/workflows/collaborator-inactivity-monitoring.yml
@@ -2,7 +2,7 @@ name: Check Inactive Collaborators
 
 on:
   schedule:
-    - cron: "30 9 */100,1-7 * MON" 
+    - cron: '30 9 */100,1-7 * 1'
 
 env:
     AWS_REGION: "eu-west-2"

--- a/.github/workflows/remove-default-vpc.yml
+++ b/.github/workflows/remove-default-vpc.yml
@@ -3,7 +3,7 @@ name: "Remove Default VPC"
 on:
   schedule:
     # trigger every Monday at 08:30am
-    - cron: "30 8 * * MON"
+    - cron: '30 8 * * 1'
   workflow_dispatch:
 
 env:

--- a/scripts/internal/remove-default-vpc/remove_default_vpc_new_account.sh
+++ b/scripts/internal/remove-default-vpc/remove_default_vpc_new_account.sh
@@ -16,6 +16,7 @@ getAssumeRoleCfg() {
 echo "account: $account_id"
 getAssumeRoleCfg "$account_id"
 for region in $regions; do
+    delete_subnet_error=false
     #Skipping region due to insufficient permissions.
     if ! aws ec2 describe-vpcs --region $region &> /dev/null; then
         continue
@@ -37,14 +38,20 @@ for region in $regions; do
 
         # Delete subnets associated with the VPC
         subnets=$(aws ec2 describe-subnets --region $region --filters Name=vpc-id,Values=$vpc_id | jq -r .Subnets[].SubnetId)
-        if [ "$subnets" != "null" ]; then
+        if [ ! -z "$subnets" ]; then
             for subnet_id in $subnets; do
-                aws ec2 delete-subnet --region $region --subnet-id $subnet_id
+                if ! aws ec2 delete-subnet --region $region --subnet-id $subnet_id &> /dev/null; then
+                    echo "Error deleting subnet $subnet_id in region $region. Continuing to next region."
+                    delete_subnet_error=true
+                    break
+                fi
             done
         fi
 
         # Delete the VPC
-        aws ec2 delete-vpc --region $region --vpc-id $vpc_id
+        if [ "$delete_subnet_error" = false ]; then
+            aws ec2 delete-vpc --region $region --vpc-id $vpc_id
+        fi
     fi
 done
 export AWS_ACCESS_KEY_ID=$ROOT_AWS_ACCESS_KEY_ID


### PR DESCRIPTION
## A reference to the issue / Description of it

This PR introduces error handling for subnet deletion in the script. It ensures that if an error occurs during subnet deletion, the script will proceed to the next region without attempting to delete the VPC. Additionally, it updates the cron job schedule to run on Mondays instead of using the day of the week abbreviation.

## How does this PR fix the problem?

This PR addresses the issue by providing error handling for subnet deletion, preventing the script from attempting to delete the VPC if an error occurs during subnet deletion. Furthermore, updating the cron job schedule to specify the day of the week explicitly ensures that the job runs consistently on Mondays, avoiding any ambiguity or potential issues with different system configurations.

## How has this been tested?

tested this on sprinkler

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
