### PR TITLE
Added firebreak section to Ways of Working

### DIFF
--- a/source/team/ways-of-working.html.md.erb
+++ b/source/team/ways-of-working.html.md.erb
@@ -137,3 +137,11 @@ The definition of done should include the following:
  - if it is decided to continue, issues should be created for the work required (linking back to the original spike)
 
 If the decision (to proceed or not) is of architectural significance an [ADR (architectural decision record)](https://github.com/ministryofjustice/modernisation-platform/tree/main/architecture-decision-record) should be created.
+
+## Firebreaks
+
+Firebreaks provide the team with opportunities to explore improvements to the platform outside of our usual process.
+
+Team members are empowered to create issues on our [backlog](https://github.com/ministryofjustice/modernisation-platform/issues) with the `firebreak` label.
+
+Once we accumulate a sufficient quantity of `firebreak` issues, where all participants have an opportunity to pick up something, we then schedule a team `firebreak` sprint.

--- a/source/team/ways-of-working.html.md.erb
+++ b/source/team/ways-of-working.html.md.erb
@@ -145,3 +145,5 @@ Firebreaks provide the team with opportunities to explore improvements to the pl
 Team members are empowered to create issues on our [backlog](https://github.com/ministryofjustice/modernisation-platform/issues) with the `firebreak` label.
 
 Once we accumulate a sufficient quantity of `firebreak` issues, where all participants have an opportunity to pick up something, we then schedule a team `firebreak` sprint.
+
+We can see the current stock of labelled issues [here](https://github.com/orgs/ministryofjustice/projects/17/views/41).


### PR DESCRIPTION
## A reference to the issue / Description of it

Documents our agreed approach towards firebreak sprints, as discussed [here](https://mojdt.slack.com/archives/C013RM6MFFW/p1714385189450159)