### PR TITLE
DSOS-2748: give DSO team instance-management and access roles for nomis combined reporting

### DIFF
--- a/environments/nomis-combined-reporting.json
+++ b/environments/nomis-combined-reporting.json
@@ -14,6 +14,10 @@
           "nuke": "exclude"
         },
         {
+          "github_slug": "studio-webops",
+          "level": "instance-management"
+        },
+        {
           "github_slug": "csr-application-support",
           "level": "instance-management"
         }
@@ -29,6 +33,10 @@
         {
           "github_slug": "studio-webops",
           "level": "developer"
+        },
+        {
+          "github_slug": "studio-webops",
+          "level": "instance-management"
         },
         {
           "github_slug": "csr-application-support",
@@ -48,6 +56,10 @@
           "level": "developer"
         },
         {
+          "github_slug": "studio-webops",
+          "level": "instance-access"
+        },
+        {
           "github_slug": "csr-application-support",
           "level": "instance-access"
         }
@@ -63,6 +75,10 @@
         {
           "github_slug": "studio-webops",
           "level": "developer"
+        },
+        {
+          "github_slug": "studio-webops",
+          "level": "instance-access"
         },
         {
           "github_slug": "csr-application-support",


### PR DESCRIPTION
## A reference to the issue / Description of it

Unable to test access for application support teams within the nomis-combined-reporting application

## How does this PR fix the problem?

Grants DSO team the same permissions as application support teams.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

n/a

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
