### PR TITLE
feature/6753 - networking for ccms-ebs-upgrade-test

### DIFF
--- a/environments-networks/laa-test.json
+++ b/environments-networks/laa-test.json
@@ -6,6 +6,7 @@
         "accounts": [
           "apex-test",
           "ccms-ebs-test",
+          "ccms-ebs-upgrade-test",
           "edw-test",
           "eric-test",
           "laa-oem-test",

--- a/policies/networking/expected.rego
+++ b/policies/networking/expected.rego
@@ -274,6 +274,7 @@ expected :=
           "eric-test",
           "mlra-test",
           "ccms-ebs-test",
+          "ccms-ebs-upgrade-test",
           "laa-oem-test",
           "maat-test",
           "oas-test",


### PR DESCRIPTION
## A reference to the issue / Description of it

Creating the networking for ccms-ebs-upgrade-test as per the guideline below, by adding the application to the subnet sets in [environments-networks](https://github.com/ministryofjustice/modernisation-platform/tree/main/environments-networks) and updatinf the OPA policies  in expected.rego

https://user-guide.modernisation-platform.service.justice.gov.uk/runbooks/creating-accounts-for-end-users.html#information-required

## How does this PR fix the problem?

This PR follows step 1 and 2 of the networking stage


## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [X] All checks have passed
