### PR TITLE
Add glue endpoints to vpcs shared with electronic-monitoring-data

### DIFF
--- a/environments-networks/hmpps-development.json
+++ b/environments-networks/hmpps-development.json
@@ -35,6 +35,7 @@
     "additional_endpoints": [
       "com.amazonaws.eu-west-2.email-smtp",
       "com.amazonaws.eu-west-2.execute-api",
+      "com.amazonaws.eu-west-2.glue",
       "com.amazonaws.eu-west-2.kinesis-streams",
       "com.amazonaws.eu-west-2.secretsmanager",
       "com.amazonaws.eu-west-2.transfer.server",

--- a/environments-networks/hmpps-production.json
+++ b/environments-networks/hmpps-production.json
@@ -33,6 +33,7 @@
     "additional_endpoints": [
       "com.amazonaws.eu-west-2.email-smtp",
       "com.amazonaws.eu-west-2.execute-api",
+      "com.amazonaws.eu-west-2.glue",
       "com.amazonaws.eu-west-2.kinesis-streams",
       "com.amazonaws.eu-west-2.secretsmanager",
       "com.amazonaws.eu-west-2.transfer.server"


### PR DESCRIPTION
## A reference to the issue / Description of it

As per [this Slack conversation](https://mojdt.slack.com/archives/C01A7QK5VM1/p1714465418982979)

## How does this PR fix the problem?

Adds AWS Glue VPC endpoints for customer use

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
