### PR TITLE
Build additional subnets in correct availability zones

### DIFF
--- a/terraform/environments/core-shared-services/vpc_additional_cidr.tf
+++ b/terraform/environments/core-shared-services/vpc_additional_cidr.tf
@@ -35,9 +35,10 @@ resource "aws_security_group_rule" "live-data-additional-interface_endpoints" {
 }
 
 resource "aws_subnet" "live-data-additional" {
-  for_each   = local.additional_subnet_cidr_map
-  cidr_block = each.value
-  vpc_id     = module.vpc["live_data"].vpc_id
+  for_each          = local.additional_subnet_cidr_map
+  availability_zone = each.key
+  cidr_block        = each.value
+  vpc_id            = module.vpc["live_data"].vpc_id
   tags = merge({
     "Name" = format("live_data-additional-%s", each.key)
     },


### PR DESCRIPTION
Without the enforced `availability_zone` argument we can't be certain where additional subnets will be created.

Because the value we use to populate the `for_each` block looks like this:
```
> local.additional_subnet_cidr_map
{
  "eu-west-2a" = "10.27.136.0/24"
  "eu-west-2b" = "10.27.137.0/24"
  "eu-west-2c" = "10.27.138.0/24"
}
```
We can set `availability_zone = each.key` to consume the AZ name from the map of subnets.