### PR TITLE
Fixing VPC Flow Logs Permissions

### DIFF
--- a/terraform/environments/core-logging/iam.tf
+++ b/terraform/environments/core-logging/iam.tf
@@ -17,3 +17,39 @@ data "aws_iam_policy_document" "vpc_flow_log_assume_role_policy" {
     }
   }
 }
+
+# VPC Flow Log: publish to CloudWatch
+resource "aws_iam_policy" "vpc_flow_log_publish_policy" {
+  name   = "AWSVPCFlowLogPublishPolicy"
+  policy = data.aws_iam_policy_document.vpc_flow_log_publish_policy.json
+}
+
+# Extrapolated from:
+# https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs-cwl.html
+# tfsec ignore appropriate as wildcard in line with AWS published guidance
+# tfsec:ignore:aws-iam-no-policy-wildcards
+data "aws_iam_policy_document" "vpc_flow_log_publish_policy" {
+
+  #checkov:skip=CKV_AWS_111: "Ensure IAM policies does not allow write access without constraints - This is limited to the log actions only"
+  #checkov:skip=CKV_AWS_356: "Ensure no IAM policies documents allow "*" as a statement's resource for restrictable actions - This is limited to the log actions only"
+  #checkov:skip=CKV_AWS_111: "Ensure IAM policies does not allow write access without constraints"
+
+  version = "2012-10-17"
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      "logs:DescribeLogGroups",
+      "logs:DescribeLogStreams"
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "vpc_flow_log_publish_policy" {
+  role       = aws_iam_role.vpc_flow_log.id
+  policy_arn = aws_iam_policy.vpc_flow_log_publish_policy.arn
+}

--- a/terraform/environments/core-network-services/iam.tf
+++ b/terraform/environments/core-network-services/iam.tf
@@ -18,6 +18,43 @@ data "aws_iam_policy_document" "vpc_flow_log_assume_role_policy" {
   }
 }
 
+# VPC Flow Log: publish to CloudWatch
+resource "aws_iam_policy" "vpc_flow_log_publish_policy" {
+  name   = "AWSVPCFlowLogPublishPolicy"
+  policy = data.aws_iam_policy_document.vpc_flow_log_publish_policy.json
+}
+
+# Extrapolated from:
+# https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs-cwl.html
+# tfsec ignore appropriate as wildcard in line with AWS published guidance
+# tfsec:ignore:aws-iam-no-policy-wildcards
+data "aws_iam_policy_document" "vpc_flow_log_publish_policy" {
+
+  #checkov:skip=CKV_AWS_111: "Ensure IAM policies does not allow write access without constraints - This is limited to the log actions only"
+  #checkov:skip=CKV_AWS_356: "Ensure no IAM policies documents allow "*" as a statement's resource for restrictable actions - This is limited to the log actions only"
+  #checkov:skip=CKV_AWS_111: "Ensure IAM policies does not allow write access without constraints"
+
+  version = "2012-10-17"
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      "logs:DescribeLogGroups",
+      "logs:DescribeLogStreams"
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "vpc_flow_log_publish_policy" {
+  role       = aws_iam_role.vpc_flow_log.id
+  policy_arn = aws_iam_policy.vpc_flow_log_publish_policy.arn
+}
+
+
 data "aws_route53_zone" "private-zones" {
   for_each     = local.private-application-zones
   name         = each.value

--- a/terraform/environments/core-security/iam.tf
+++ b/terraform/environments/core-security/iam.tf
@@ -17,3 +17,39 @@ data "aws_iam_policy_document" "vpc_flow_log_assume_role_policy" {
     }
   }
 }
+
+# VPC Flow Log: publish to CloudWatch
+resource "aws_iam_policy" "vpc_flow_log_publish_policy" {
+  name   = "AWSVPCFlowLogPublishPolicy"
+  policy = data.aws_iam_policy_document.vpc_flow_log_publish_policy.json
+}
+
+# Extrapolated from:
+# https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs-cwl.html
+# tfsec ignore appropriate as wildcard in line with AWS published guidance
+# tfsec:ignore:aws-iam-no-policy-wildcards
+data "aws_iam_policy_document" "vpc_flow_log_publish_policy" {
+
+  #checkov:skip=CKV_AWS_111: "Ensure IAM policies does not allow write access without constraints - This is limited to the log actions only"
+  #checkov:skip=CKV_AWS_356: "Ensure no IAM policies documents allow "*" as a statement's resource for restrictable actions - This is limited to the log actions only"
+  #checkov:skip=CKV_AWS_111: "Ensure IAM policies does not allow write access without constraints"
+
+  version = "2012-10-17"
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      "logs:DescribeLogGroups",
+      "logs:DescribeLogStreams"
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "vpc_flow_log_publish_policy" {
+  role       = aws_iam_role.vpc_flow_log.id
+  policy_arn = aws_iam_policy.vpc_flow_log_publish_policy.arn
+}

--- a/terraform/environments/core-shared-services/iam.tf
+++ b/terraform/environments/core-shared-services/iam.tf
@@ -18,6 +18,42 @@ data "aws_iam_policy_document" "vpc_flow_log_assume_role_policy" {
   }
 }
 
+# VPC Flow Log: publish to CloudWatch
+resource "aws_iam_policy" "vpc_flow_log_publish_policy" {
+  name   = "AWSVPCFlowLogPublishPolicy"
+  policy = data.aws_iam_policy_document.vpc_flow_log_publish_policy.json
+}
+
+# Extrapolated from:
+# https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs-cwl.html
+# tfsec ignore appropriate as wildcard in line with AWS published guidance
+# tfsec:ignore:aws-iam-no-policy-wildcards
+data "aws_iam_policy_document" "vpc_flow_log_publish_policy" {
+
+  #checkov:skip=CKV_AWS_111: "Ensure IAM policies does not allow write access without constraints - This is limited to the log actions only"
+  #checkov:skip=CKV_AWS_356: "Ensure no IAM policies documents allow "*" as a statement's resource for restrictable actions - This is limited to the log actions only"
+  #checkov:skip=CKV_AWS_111: "Ensure IAM policies does not allow write access without constraints"
+
+  version = "2012-10-17"
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      "logs:DescribeLogGroups",
+      "logs:DescribeLogStreams"
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "vpc_flow_log_publish_policy" {
+  role       = aws_iam_role.vpc_flow_log.id
+  policy_arn = aws_iam_policy.vpc_flow_log_publish_policy.arn
+}
+
 # Create IAM role and instance profile for image builder
 # Instance profile gets associated to the image builder Infrastructure Configuration resource
 data "aws_iam_policy" "image_builder_managed_policies" {

--- a/terraform/environments/core-vpc/iam.tf
+++ b/terraform/environments/core-vpc/iam.tf
@@ -17,3 +17,39 @@ data "aws_iam_policy_document" "vpc_flow_log_assume_role_policy" {
     }
   }
 }
+
+# VPC Flow Log: publish to CloudWatch
+resource "aws_iam_policy" "vpc_flow_log_publish_policy" {
+  name   = "AWSVPCFlowLogPublishPolicy"
+  policy = data.aws_iam_policy_document.vpc_flow_log_publish_policy.json
+}
+
+# Extrapolated from:
+# https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs-cwl.html
+# tfsec ignore appropriate as wildcard in line with AWS published guidance
+# tfsec:ignore:aws-iam-no-policy-wildcards
+data "aws_iam_policy_document" "vpc_flow_log_publish_policy" {
+
+  #checkov:skip=CKV_AWS_111: "Ensure IAM policies does not allow write access without constraints - This is limited to the log actions only"
+  #checkov:skip=CKV_AWS_356: "Ensure no IAM policies documents allow "*" as a statement's resource for restrictable actions - This is limited to the log actions only"
+  #checkov:skip=CKV_AWS_111: "Ensure IAM policies does not allow write access without constraints"
+
+  version = "2012-10-17"
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      "logs:DescribeLogGroups",
+      "logs:DescribeLogStreams"
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "vpc_flow_log_publish_policy" {
+  role       = aws_iam_role.vpc_flow_log.id
+  policy_arn = aws_iam_policy.vpc_flow_log_publish_policy.arn
+}


### PR DESCRIPTION
## A reference to the issue / Description of it

This PR addresses the issue where VPC flow logs were not being sent to the CloudWatch log group due to missing permissions. By adding the necessary permissions to the existing role, this problem is resolved

## How does this PR fix the problem?

This PR fixes the problem by adding the missing permissions required for sending VPC flow logs to the CloudWatch log group.