### PR TITLE
feature/6753 - firewall rule to allow traffic between laa LZ account and new test account

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/test_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/test_rules.json
@@ -41,6 +41,13 @@
     "destination_port": "5432",
     "protocol": "TCP"
   },
+  "laa_test_to_mp_laa_test": {
+    "action": "PASS",
+    "source_ip": "${laa-lz-test}",
+    "destination_ip": "${laa-test}",
+    "destination_port": "ANY",
+    "protocol": "IP"
+  },
   "laa_test_to_mp_laa_test_http": {
     "action": "PASS",
     "source_ip": "${laa-lz-test}",


### PR DESCRIPTION
## A reference to the issue / Description of it

Customer needs traffic to flow between the ccms-ebs-upgrade test account and their LZ test account. In order to do this, i have followed the process below,

https://user-guide.modernisation-platform.service.justice.gov.uk/concepts/networking/network-firewall.html#amending-rules

## How does this PR fix the problem?

The PR amends the rule that allows connectivity between the 2 accounts


## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [X] All checks have passed

## Additional comments (if any)

{Please write here}
