### PR TITLE
Test to check for appended environment name in `environments-networks/*.json` files

### DIFF
--- a/policies/networking/core-vpc.rego
+++ b/policies/networking/core-vpc.rego
@@ -1,5 +1,7 @@
 package main
 
+import future.keywords.in
+
 nice_name := replace(replace(input.filename, ".json", ""), "environments-networks/", "")
 
 deny[msg] {
@@ -60,4 +62,11 @@ deny[msg] {
 deny[msg] {
   not is_array(input.nacl)
   msg := sprintf("`%v` invalid nacl type - must be an array", [input.filename])
+}
+
+# Check that application name is appended with environment name
+deny[msg] {
+  some account in input.cidr.subnet_sets.general.accounts
+  not regex.match(`\S+(-development|-test|-preproduction|-production)`, account)
+  msg := sprintf("%v does not end include the environment name e.g. *-development|*-test|*-preproduction|*-production", [account])
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

https://mojdt.slack.com/archives/C013RM6MFFW/p1714474635487709
We had an issue where we missed adding the environment name to the end of the application in the environments-networks/*.json files when adding a new account.

## How does this PR fix the problem?

I've added a test that will just check to see that all the account names end in either 
`*-development|*-test|*-preproduction|*-production`

## How has this been tested?

Locally by amending some of the names to make it fail... e.g.

```
./scripts/tests/validate/run-opa-tests.sh
PASS - Environment files check
PASS - Environment network files check

8 tests, 8 passed, 0 warnings, 0 failures, 0 exceptions
FAIL - - main - pra-register- does not end include the environment name e.g. *-development|*-test|*-preproduction|*-production
FAIL - - main - wardship- does not end include the environment name e.g. *-development|*-test|*-preproduction|*-production
FAIL - - main - xhibit-portal does not end include the environment name e.g. *-development|*-test|*-preproduction|*-production
FAIL - - main - corporate-staff-rostering- does not end include the environment name e.g. *-development|*-test|*-preproduction|*-production
FAIL - - main - nomis-combined-reporting does not end include the environment name e.g. *-development|*-test|*-preproduction|*-production
FAIL - - main - data-and-insights-wepi- does not end include the environment name e.g. *-development|*-test|*-preproduction|*-production

408 tests, 402 passed, 0 warnings, 6 failures, 0 exceptions

120 tests, 120 passed, 0 warnings, 0 failures, 0 exceptions

1125 tests, 1125 passed, 0 warnings, 0 failures, 0 exceptions
```

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [X] All checks have passed


