### PR TITLE
Add lambda:PutRuntimeManagementConfig permission

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -383,6 +383,7 @@ data "aws_iam_policy_document" "data_engineering_additional" {
       "glue:List*",
       "glue:BatchGetJobs",
       "glue:*Trigger",
+      "lambda:PutRuntimeManagementConfig",
       "states:Describe*",
       "states:List*",
       "states:Stop*",


### PR DESCRIPTION
## A reference to the issue / Description of it

[{Please write here}](https://github.com/ministryofjustice/data-platform-support/issues/572)

The requested permission is needed for operational support and remediation of production problems

## How does this PR fix the problem?

Requested permission is added to the data engineering role

## How has this been tested?

This can only be tested post-apply.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

This change and atomic and shouldn't have impact on the rest of the platform

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
