### PR TITLE
Adding dynamic block for secret scanning

### DIFF
--- a/terraform/github/modules/repository/main.tf
+++ b/terraform/github/modules/repository/main.tf
@@ -26,11 +26,17 @@ resource "github_repository" "default" {
   topics                 = concat(local.topics, var.topics)
 
   security_and_analysis {
-    secret_scanning {
-      status = "enabled"
+    dynamic "secret_scanning" {
+      for_each = var.visibility == "public" ? [1] : []
+      content {
+        status = "enabled"
+      }
     }
-    secret_scanning_push_protection {
-      status = "enabled"
+    dynamic "secret_scanning_push_protection" {
+      for_each = var.visibility == "public" ? [1] : []
+      content {
+        status = "enabled"
+      }
     }
   }
 


### PR DESCRIPTION
## How does this PR fix the problem?

It add a dynamic block for `secret_scanning` and `secret_scanning_push_protection` if the repository is not public and therefore fixes the problem from [this alert](https://mojdt.slack.com/archives/C013RM6MFFW/p1714560729082999).
```
Error: PATCH https://api.github.com/repos/ministryofjustice/modernisation-platform-security: 422 Secret scanning can only be enabled on repos where Advanced Security is enabled. []
```

## How has this been tested?

Terraform plan runs clean.

## Deployment Plan / Instructions

Deployed one merge with main.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)
