### PR TITLE
Add entry to prevent RDP traffic in to public subnet hosts

### DIFF
--- a/terraform/modules/vpc-nacls/data.tf
+++ b/terraform/modules/vpc-nacls/data.tf
@@ -208,7 +208,7 @@ locals {
       egress      = false
       from_port   = 3389
       protocol    = "tcp"
-      rule_action = "allow"
+      rule_action = "deny"
       rule_number = 5000
       to_port     = 3389
     },

--- a/terraform/modules/vpc-nacls/data.tf
+++ b/terraform/modules/vpc-nacls/data.tf
@@ -203,13 +203,22 @@ locals {
       rule_number = 5400
       to_port     = 5721
     },
+    deny_0-0-0-0_remote-desktop_tcp_in = {
+      cidr_block  = "0.0.0.0/0"
+      egress      = false
+      from_port   = 3389
+      protocol    = "tcp"
+      rule_action = "allow"
+      rule_number = 5000
+      to_port     = 3389
+    },
     allow_0-0-0-0_dynamic_tcp_in = {
       cidr_block  = "0.0.0.0/0"
       egress      = false
       from_port   = 1024
       protocol    = "tcp"
       rule_action = "allow"
-      rule_number = 5300
+      rule_number = 5100
       to_port     = 65535
     }
   }


### PR DESCRIPTION
## A reference to the issue / Description of it

While some legacy services may require the use of a wide range of ports for return traffic, RDP traffic in from internet hosts is not desirable.

## How does this PR fix the problem?

Ensures that traffic to the registered port for Remote Desktop Protocol (`tcp/3389`) is dropped by VPC NACLs applied to public subnets.

## How has this been tested?

Ran local `terraform plan`

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
