### PR TITLE
DSO: add persmissions for 'resource "aws_oam_sink_policy"' to enable local terraform plan

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -235,6 +235,7 @@ data "aws_iam_policy_document" "developer_additional" {
       "kms:CreateGrant",
       "lambda:InvokeFunction",
       "lambda:UpdateFunctionCode",
+      "oam:ListTagsForResource",
       "rds:AddTagsToResource",
       "rds:CopyDB*",
       "rds:Create*",


### PR DESCRIPTION
## A reference to the issue / Description of it

Running a `terraform plan` locally currently runs into a missing permission for OAM.

## How does this PR fix the problem?

Add the permission to the `modernisation-platform-developer` role.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Added the permission indicated missing by `terraform plan`:

`Error: listing tags for CloudWatch Observability Access Manager Sink (arn:aws:oam:eu-west-2:X:sink/7d4f9ba0-e432-49d1-8f34-1fda2d165bf8): operation error OAM: ListTagsForResource, https response error StatusCode: 403, RequestI
D: 4f6d8ab2-b8dd-4f2f-87dc-2158cc8e05c3, api error AccessDeniedException: User: arn:aws:sts::X:assumed-role/AWSReservedSSO_modernisation-platform-developer_ad9787b9bbb44c29/jnq@digital.justice.gov.uk is not authorized to perform
: oam:ListTagsForResource on resource: arn:aws:oam:eu-west-2:X:sink/7d4f9ba0-e432-49d1-8f34-1fda2d165bf8`

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

n/a

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

n/a