### PR TITLE
Default all new instances in MP Accounts to IMDSv2

### DIFF
--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -42,7 +42,6 @@ misconfigurations:
 - id: AVD-AWS-0031
 - id: AVD-AWS-0039
 - id: AVD-AWS-0057
-- id: AVD-AWS-0136
 
 secrets:
 

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,48 +1,49 @@
 vulnerabilities:
-  - id: GHSA-m425-mq94-257g
-  - id: CVE-2017-20146
-  - id: CVE-2019-11253
-  - id: CVE-2020-8558
-  - id: CVE-2020-10675
-  - id: CVE-2020-15114
-    expired_at: 2024-08-20
-    statement: "Review in 6 months"
-  - id: CVE-2020-26160
-  - id: CVE-2020-35381
-  - id: CVE-2021-25741
-  - id: CVE-2021-30465
-  - id: CVE-2021-38561
-  - id: CVE-2021-43565
-  - id: CVE-2021-43816
-  - id: CVE-2022-1996
-  - id: CVE-2022-21698
-  - id: CVE-2022-23648
-  - id: CVE-2022-24778
-  - id: CVE-2022-27191
-  - id: CVE-2022-27664
-  - id: CVE-2022-32149
-  - id: CVE-2022-41723
-  - id: CVE-2023-3676
-  - id: CVE-2023-3955
-  - id: CVE-2023-5528
-  - id: CVE-2023-37788
-  - id: CVE-2023-39325
-  - id: CVE-2024-3154
-    expired_at: 2024-10-29
-    statement: "Review in 6 months; this one appeared to be Terratest related"
-  - id: CVE-2024-15114
-    expired_at: 2024-08-19
-    statement: "Review in 6 months"
-  - id: CVE-2024-21626
-    expired_at: 2024-08-19
-    statement: "Review in 6 months"
+- id: GHSA-m425-mq94-257g
+- id: CVE-2017-20146
+- id: CVE-2019-11253
+- id: CVE-2020-8558
+- id: CVE-2020-10675
+- id: CVE-2020-15114
+  expired_at: 2024-08-20
+  statement: "Review in 6 months"
+- id: CVE-2020-26160
+- id: CVE-2020-35381
+- id: CVE-2021-25741
+- id: CVE-2021-30465
+- id: CVE-2021-38561
+- id: CVE-2021-43565
+- id: CVE-2021-43816
+- id: CVE-2022-1996
+- id: CVE-2022-21698
+- id: CVE-2022-23648
+- id: CVE-2022-24778
+- id: CVE-2022-27191
+- id: CVE-2022-27664
+- id: CVE-2022-32149
+- id: CVE-2022-41723
+- id: CVE-2023-3676
+- id: CVE-2023-3955
+- id: CVE-2023-5528
+- id: CVE-2023-37788
+- id: CVE-2023-39325
+- id: CVE-2024-3154
+  expired_at: 2024-10-29
+  statement: "Review in 6 months; this one appeared to be Terratest related"
+- id: CVE-2024-15114
+  expired_at: 2024-08-19
+  statement: "Review in 6 months"
+- id: CVE-2024-21626
+  expired_at: 2024-08-19
+  statement: "Review in 6 months"
 
 misconfigurations:
-  - id: AVD-GIT-0001
-  - id: AVD-AWS-0031
-  - id: AVD-AWS-0039
-  - id: AVD-AWS-0057
-  
+- id: AVD-GIT-0001
+- id: AVD-AWS-0031
+- id: AVD-AWS-0039
+- id: AVD-AWS-0057
+- id: AVD-AWS-0136
+
 secrets:
 
 licenses:

--- a/terraform/environments/bootstrap/secure-baselines/main.tf
+++ b/terraform/environments/bootstrap/secure-baselines/main.tf
@@ -5,7 +5,7 @@ data "aws_kms_key" "cloudtrail_key" {
 }
 
 module "baselines" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=bfe299162486a88e0612dd5c4e295377f3242cee" # v7.1.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=65595d61d9656d6edac5aff6b4c92be1cdfd5fc9" # v7.1.0
 
   providers = {
     # Default and replication regions

--- a/terraform/environments/bootstrap/secure-baselines/main.tf
+++ b/terraform/environments/bootstrap/secure-baselines/main.tf
@@ -5,7 +5,7 @@ data "aws_kms_key" "cloudtrail_key" {
 }
 
 module "baselines" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=035aa0f87675fe6e81db71960f71f2bc748fbab8" # feature/6639-IMDSv2-deafult
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=490318726be164245fedc98fc4c51e6eabe63064" # feature/6639-IMDSv2-deafult
 
   providers = {
     # Default and replication regions

--- a/terraform/environments/bootstrap/secure-baselines/main.tf
+++ b/terraform/environments/bootstrap/secure-baselines/main.tf
@@ -6,7 +6,7 @@ data "aws_kms_key" "cloudtrail_key" {
 
 #trivy:ignore:AVD-AWS-0136
 module "baselines" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=65595d61d9656d6edac5aff6b4c92be1cdfd5fc9" # v7.1.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=2a59110767bd30e949b242818da7dbe72fe9481b" # v7.1.0
 
   providers = {
     # Default and replication regions

--- a/terraform/environments/bootstrap/secure-baselines/main.tf
+++ b/terraform/environments/bootstrap/secure-baselines/main.tf
@@ -5,7 +5,7 @@ data "aws_kms_key" "cloudtrail_key" {
 }
 
 module "baselines" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=c8d971d4caf2aae276e8160ac04095d71d25318d" # feature/6639-IMDSv2-deafult
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=2a59110767bd30e949b242818da7dbe72fe9481b" # v7.1.0
 
   providers = {
     # Default and replication regions

--- a/terraform/environments/bootstrap/secure-baselines/main.tf
+++ b/terraform/environments/bootstrap/secure-baselines/main.tf
@@ -5,7 +5,7 @@ data "aws_kms_key" "cloudtrail_key" {
 }
 
 module "baselines" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=490318726be164245fedc98fc4c51e6eabe63064" # feature/6639-IMDSv2-deafult
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=c8d971d4caf2aae276e8160ac04095d71d25318d" # feature/6639-IMDSv2-deafult
 
   providers = {
     # Default and replication regions

--- a/terraform/environments/bootstrap/secure-baselines/main.tf
+++ b/terraform/environments/bootstrap/secure-baselines/main.tf
@@ -5,7 +5,7 @@ data "aws_kms_key" "cloudtrail_key" {
 }
 
 module "baselines" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=b5ae2be29aaa29d644b6909af51acefdfaa80e14" # v7.0.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=035aa0f87675fe6e81db71960f71f2bc748fbab8" # feature/6639-IMDSv2-deafult
 
   providers = {
     # Default and replication regions

--- a/terraform/environments/bootstrap/secure-baselines/main.tf
+++ b/terraform/environments/bootstrap/secure-baselines/main.tf
@@ -5,7 +5,7 @@ data "aws_kms_key" "cloudtrail_key" {
 }
 
 module "baselines" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=7cd253c991238c86066ef156bd6d758995c1708d" # v7.1.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=bfe299162486a88e0612dd5c4e295377f3242cee" # v7.1.0
 
   providers = {
     # Default and replication regions

--- a/terraform/environments/bootstrap/secure-baselines/main.tf
+++ b/terraform/environments/bootstrap/secure-baselines/main.tf
@@ -64,4 +64,7 @@ module "baselines" {
   cloudtrail_kms_key = data.aws_kms_key.cloudtrail_key.arn
   root_account_id    = local.root_account.master_account_id
   tags               = local.environments
+
+  # Regions to enable IMDSv2 in
+  enabled_imdsv2_regions = local.enabled_baseline_regions
 }

--- a/terraform/environments/bootstrap/secure-baselines/main.tf
+++ b/terraform/environments/bootstrap/secure-baselines/main.tf
@@ -4,6 +4,7 @@ data "aws_kms_key" "cloudtrail_key" {
   key_id   = "alias/s3-logging-cloudtrail"
 }
 
+#trivy:ignore:AVD-AWS-0136
 module "baselines" {
   source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=65595d61d9656d6edac5aff6b4c92be1cdfd5fc9" # v7.1.0
 

--- a/terraform/environments/bootstrap/secure-baselines/main.tf
+++ b/terraform/environments/bootstrap/secure-baselines/main.tf
@@ -5,7 +5,7 @@ data "aws_kms_key" "cloudtrail_key" {
 }
 
 module "baselines" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=2a59110767bd30e949b242818da7dbe72fe9481b" # v7.1.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=7cd253c991238c86066ef156bd6d758995c1708d" # v7.1.0
 
   providers = {
     # Default and replication regions


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/6639

## How does this PR fix the problem?

This PR updates the version of the baselines module to [v7.1.0](https://github.com/ministryofjustice/modernisation-platform-terraform-baselines/releases/tag/v7.1.0) which will set all Modernisation Platform accounts to default to using IMDSv2 for any new instances being created.

## How has this been tested?

Successful plan in sprinkler which will be deployed first before merging the PR. I will test that the settings are enabled appropriately in Sprinkler before merging to main.

```
Terraform will perform the following actions:

  # module.baselines.module.imdsv2-eu-central-1["enabled"].aws_ec2_instance_metadata_defaults.default will be created
  + resource "aws_ec2_instance_metadata_defaults" "default" {
      + http_endpoint               = "no-preference"
      + http_put_response_hop_limit = -1
      + http_tokens                 = "required"
      + id                          = (known after apply)
      + instance_metadata_tags      = "no-preference"
    }

  # module.baselines.module.imdsv2-eu-west-1["enabled"].aws_ec2_instance_metadata_defaults.default will be created
  + resource "aws_ec2_instance_metadata_defaults" "default" {
      + http_endpoint               = "no-preference"
      + http_put_response_hop_limit = -1
      + http_tokens                 = "required"
      + id                          = (known after apply)
      + instance_metadata_tags      = "no-preference"
    }

  # module.baselines.module.imdsv2-eu-west-2["enabled"].aws_ec2_instance_metadata_defaults.default will be created
  + resource "aws_ec2_instance_metadata_defaults" "default" {
      + http_endpoint               = "no-preference"
      + http_put_response_hop_limit = -1
      + http_tokens                 = "required"
      + id                          = (known after apply)
      + instance_metadata_tags      = "no-preference"
    }

  # module.baselines.module.imdsv2-us-east-1["enabled"].aws_ec2_instance_metadata_defaults.default will be created
  + resource "aws_ec2_instance_metadata_defaults" "default" {
      + http_endpoint               = "no-preference"
      + http_put_response_hop_limit = -1
      + http_tokens                 = "required"
      + id                          = (known after apply)
      + instance_metadata_tags      = "no-preference"
    }

Plan: 4 to add, 0 to change, 0 to destroy.
```

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

There will be no impact to existing workloads as the setting only defaults for newly created instances. I will send a message on the updates channel for awareness. 

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [X] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
