### PR TITLE
Amend NACLs applied to public subnets

### DIFF
--- a/terraform/environments/core-vpc/locals.tf
+++ b/terraform/environments/core-vpc/locals.tf
@@ -9,6 +9,9 @@ locals {
   environment_management     = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
   pagerduty_integration_keys = jsondecode(data.aws_secretsmanager_secret_version.pagerduty_integration_keys.secret_string)
 
+  # This carries out a simple extraction to retrieve the trailing environment name (e.g. development)
+  current_environment = substr(terraform.workspace, length(local.application_name)+1, length(terraform.workspace))
+
   # This takes the name of the Terraform workspace (e.g. core-vpc-production), strips out the application name (e.g. core-vpc), and checks if
   # the string leftover is `-production`, if it isn't (e.g. core-vpc-non-production => -non-production) then it sets the var to false.
   is-production = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-production"
@@ -18,7 +21,6 @@ locals {
   is-development = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-development"
   # Determines if Firehose should be built in an environment.
   build_firehose = anytrue([local.is-development, local.is-production]) ? true : false
-
   # Secrets used by Firehose resources which we only require for development & production VPCs.
   xsiam = jsondecode(data.aws_secretsmanager_secret_version.xsiam_secret_arn_version.secret_string)
 

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -120,6 +120,28 @@ module "vpc_nacls" {
   vpc_name         = each.key
 }
 
+## Insert additional rule to account for Xhibit Portal requirement
+resource "aws_network_acl_rule" "hmcts-public-10" {
+  cidr_block     = "10.193.40.0/24"
+  from_port      = 1514
+  network_acl_id = module.vpc_nacls[format("hmcts-%s", local.current_environment)].general-public.id
+  protocol       = "tcp"
+  rule_action    = "allow"
+  rule_number    = 10
+  to_port        = 1514
+}
+
+## Insert additional rule to account for Xhibit Portal requirement
+resource "aws_network_acl_rule" "hmcts-public-20" {
+  cidr_block     = "10.33.48.0/24"
+  from_port      = 8014
+  network_acl_id = module.vpc_nacls[format("hmcts-%s", local.current_environment)].general-public.id
+  protocol       = "tcp"
+  rule_action    = "allow"
+  rule_number    = 20
+  to_port        = 8014
+}
+
 module "route_53_resolver_logs" {
   source      = "../../modules/r53-resolver-logs"
   for_each    = { for key, value in module.vpc : key => value["vpc_id"] }

--- a/terraform/modules/vpc-nacls/data.tf
+++ b/terraform/modules/vpc-nacls/data.tf
@@ -203,22 +203,13 @@ locals {
       rule_number = 5400
       to_port     = 5721
     },
-    deny_0-0-0-0_remote-desktop_tcp_in = {
-      cidr_block  = "0.0.0.0/0"
-      egress      = false
-      from_port   = 3389
-      protocol    = "tcp"
-      rule_action = "deny"
-      rule_number = 5000
-      to_port     = 3389
-    },
     allow_0-0-0-0_dynamic_tcp_in = {
       cidr_block  = "0.0.0.0/0"
       egress      = false
       from_port   = 1024
       protocol    = "tcp"
       rule_action = "allow"
-      rule_number = 5100
+      rule_number = 5000
       to_port     = 65535
     }
   }
@@ -233,13 +224,22 @@ locals {
       rule_number = 7000
       to_port     = 443
     },
+    deny_remote-desktop_tcp_in = {
+      cidr_block  = "0.0.0.0/0"
+      egress      = false
+      from_port   = 3389
+      protocol    = "tcp"
+      rule_action = "deny"
+      rule_number = 7100
+      to_port     = 3389
+    },
     allow_dynamic_tcp_in = {
       cidr_block  = "0.0.0.0/0"
       egress      = false
       from_port   = 1024
       protocol    = "tcp"
       rule_action = "allow"
-      rule_number = 7100
+      rule_number = 7200
       to_port     = 65535
     },
     allow_dynamic_udp_in = {
@@ -248,7 +248,7 @@ locals {
       from_port   = 1024
       protocol    = "udp"
       rule_action = "allow"
-      rule_number = 7200
+      rule_number = 7300
       to_port     = 65535
     },
     allow_any_out = {

--- a/terraform/modules/vpc-nacls/data.tf
+++ b/terraform/modules/vpc-nacls/data.tf
@@ -215,6 +215,24 @@ locals {
   }
 
   public_access_acl_rules = {
+    allow_vpc_cidr_in = {
+      cidr_block  = data.aws_vpc.current.cidr_block
+      egress      = false
+      from_port   = null
+      protocol    = "-1"
+      rule_action = "allow"
+      rule_number = 1000
+      to_port     = null
+    },
+    allow_vpc_cidr_out = {
+      cidr_block  = data.aws_vpc.current.cidr_block
+      egress      = true
+      from_port   = null
+      protocol    = "-1"
+      rule_action = "allow"
+      rule_number = 1000
+      to_port     = null
+    },
     allow_https_in = {
       cidr_block  = "0.0.0.0/0"
       egress      = false

--- a/terraform/modules/vpc-nacls/main.tf
+++ b/terraform/modules/vpc-nacls/main.tf
@@ -66,21 +66,6 @@ resource "aws_network_acl_rule" "private_subnet_static_rules" {
 }
 
 #tfsec:ignore:aws-vpc-no-excessive-port-access tfsec:ignore:aws-ec2-no-public-ingress-acl
-resource "aws_network_acl_rule" "public_subnet_static_rules" {
-  #checkov:skip=CKV_AWS_352:Verified - these rules are reasonable
-  #checkov:skip=CKV_AWS_231:Allow ingress from 0.0.0.0:0 to port 3389 required
-  for_each       = local.static_acl_rules
-  cidr_block     = each.value.cidr_block
-  egress         = each.value.egress
-  from_port      = each.value.from_port != null ? each.value.from_port : null
-  network_acl_id = aws_network_acl.general-public.id
-  protocol       = each.value.protocol
-  rule_action    = each.value.rule_action
-  rule_number    = each.value.rule_number
-  to_port        = each.value.to_port != null ? each.value.to_port : null
-}
-
-#tfsec:ignore:aws-vpc-no-excessive-port-access tfsec:ignore:aws-ec2-no-public-ingress-acl
 resource "aws_network_acl_rule" "public_subnet_internet_access_rules" {
   #checkov:skip=CKV_AWS_231:Verified - these rules are reasonable
   for_each       = local.public_access_acl_rules

--- a/terraform/modules/vpc-nacls/outputs.tf
+++ b/terraform/modules/vpc-nacls/outputs.tf
@@ -1,0 +1,3 @@
+output "general-public" {
+  value = aws_network_acl.general-public
+}


### PR DESCRIPTION
## A reference to the issue / Description of it

#2403 

## How does this PR fix the problem?

Observed that rules for all private subnets were also being applied to public subnets. Re-sited block for RDP traffic so that it is only applied to public subnets, and removed rules for non-public subnets from public subnets

## How has this been tested?

Checked against production VPC flow logs to ensure no services except HTTPS were listening in the `1-1023` TCP port range.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
