### PR TITLE
Align NACLs used in `vpc-hub` module with `vpc-nacls` approach

### DIFF
--- a/terraform/modules/vpc-hub/locals.tf
+++ b/terraform/modules/vpc-hub/locals.tf
@@ -1,0 +1,205 @@
+locals {
+  # 1000 = intra-vpc traffic
+  # 2000 = inter-vpc traffic (dynamic rules)
+  # 3000 = deny east-west
+  # 4000 = private address ranges
+  # 5000 = internet access
+  # 6000 = public address ranges (dynamic)
+  # 7000 = access from internet
+
+  static_acl_rules = {
+    allow_vpc_cidr_in = {
+      cidr_block  = var.vpc_cidr
+      egress      = false
+      from_port   = null
+      protocol    = "-1"
+      rule_action = "allow"
+      rule_number = 1000
+      to_port     = null
+    },
+    allow_vpc_cidr_out = {
+      cidr_block  = var.vpc_cidr
+      egress      = true
+      from_port   = null
+      protocol    = "-1"
+      rule_action = "allow"
+      rule_number = 1000
+      to_port     = null
+    },
+    allow_10-0-0-0_in = {
+      cidr_block  = "10.0.0.0/8"
+      egress      = false
+      from_port   = null
+      protocol    = "-1"
+      rule_action = "allow"
+      rule_number = 4000
+      to_port     = null
+    },
+    allow_10-0-0-0_out = {
+      cidr_block  = "10.0.0.0/8"
+      egress      = true
+      from_port   = null
+      protocol    = "-1"
+      rule_action = "allow"
+      rule_number = 4000
+      to_port     = null
+    },
+    allow_172-16-0-0_in = {
+      cidr_block  = "172.16.0.0/12"
+      egress      = false
+      from_port   = null
+      protocol    = "-1"
+      rule_action = "allow"
+      rule_number = 4100
+      to_port     = null
+    },
+    allow_172-16-0-0_out = {
+      cidr_block  = "172.16.0.0/12"
+      egress      = true
+      from_port   = null
+      protocol    = "-1"
+      rule_action = "allow"
+      rule_number = 4100
+      to_port     = null
+    },
+    allow_192-168-0-0_in = {
+      cidr_block  = "192.168.0.0/16"
+      egress      = false
+      from_port   = null
+      protocol    = "-1"
+      rule_action = "allow"
+      rule_number = 4200
+      to_port     = null
+    },
+    allow_192-168-0-0_out = {
+      cidr_block  = "192.168.0.0/16"
+      egress      = true
+      from_port   = null
+      protocol    = "-1"
+      rule_action = "allow"
+      rule_number = 4200
+      to_port     = null
+    },
+    allow_0-0-0-0_https_out = {
+      cidr_block  = "0.0.0.0/0"
+      egress      = true
+      from_port   = 443
+      protocol    = "tcp"
+      rule_action = "allow"
+      rule_number = 5000
+      to_port     = 443
+    },
+    allow_0-0-0-0_http_out = {
+      cidr_block  = "0.0.0.0/0"
+      egress      = true
+      from_port   = 80
+      protocol    = "tcp"
+      rule_action = "allow"
+      rule_number = 5100
+      to_port     = 80
+    },
+    allow_0-0-0-0_smtp_465_tcp_out = {
+      cidr_block  = "0.0.0.0/0"
+      egress      = true
+      from_port   = 465
+      protocol    = "tcp"
+      rule_action = "allow"
+      rule_number = 5200
+      to_port     = 465
+    },
+    allow_0-0-0-0_smtp_submission_tcp_out = {
+      cidr_block  = "0.0.0.0/0"
+      egress      = true
+      from_port   = 587
+      protocol    = "tcp"
+      rule_action = "allow"
+      rule_number = 5300
+      to_port     = 587
+    },
+    allow_0-0-0-0_agent_tcp_out = {
+      cidr_block  = "0.0.0.0/0"
+      egress      = true
+      from_port   = 5721
+      protocol    = "tcp"
+      rule_action = "allow"
+      rule_number = 5400
+      to_port     = 5721
+    },
+    allow_0-0-0-0_dynamic_tcp_in = {
+      cidr_block  = "0.0.0.0/0"
+      egress      = false
+      from_port   = 1024
+      protocol    = "tcp"
+      rule_action = "allow"
+      rule_number = 5100
+      to_port     = 65535
+    }
+  }
+
+  public_access_acl_rules = {
+    allow_vpc_cidr_in = {
+      cidr_block  = var.vpc_cidr
+      egress      = false
+      from_port   = null
+      protocol    = "-1"
+      rule_action = "allow"
+      rule_number = 1000
+      to_port     = null
+    },
+    allow_vpc_cidr_out = {
+      cidr_block  = var.vpc_cidr
+      egress      = true
+      from_port   = null
+      protocol    = "-1"
+      rule_action = "allow"
+      rule_number = 1000
+      to_port     = null
+    },
+    allow_https_in = {
+      cidr_block  = "0.0.0.0/0"
+      egress      = false
+      from_port   = 443
+      protocol    = "tcp"
+      rule_action = "allow"
+      rule_number = 7000
+      to_port     = 443
+    },
+    deny_remote-desktop_tcp_in = {
+      cidr_block  = "0.0.0.0/0"
+      egress      = false
+      from_port   = 3389
+      protocol    = "tcp"
+      rule_action = "deny"
+      rule_number = 7100
+      to_port     = 3389
+    },
+    allow_dynamic_tcp_in = {
+      cidr_block  = "0.0.0.0/0"
+      egress      = false
+      from_port   = 1024
+      protocol    = "tcp"
+      rule_action = "allow"
+      rule_number = 7200
+      to_port     = 65535
+    },
+    allow_dynamic_udp_in = {
+      cidr_block  = "0.0.0.0/0"
+      egress      = false
+      from_port   = 1024
+      protocol    = "udp"
+      rule_action = "allow"
+      rule_number = 7300
+      to_port     = 65535
+    },
+    allow_any_out = {
+      cidr_block  = "0.0.0.0/0"
+      egress      = true
+      from_port   = null
+      protocol    = "-1"
+      rule_action = "allow"
+      rule_number = 7000
+      to_port     = null
+    }
+  }
+
+}

--- a/terraform/modules/vpc-hub/locals.tf
+++ b/terraform/modules/vpc-hub/locals.tf
@@ -202,4 +202,26 @@ locals {
     }
   }
 
+  # TGW NACL open as per AWS guidance (https://docs.aws.amazon.com/vpc/latest/tgw/tgw-best-design-practices.html)
+  transit_gateway_acl_rules = {
+    allow_any_in = {
+      cidr_block  = "0.0.0.0/0"
+      egress      = false
+      from_port   = null
+      protocol    = "-1"
+      rule_action = "allow"
+      rule_number = 1000
+      to_port     = null
+    },
+    allow_any_out = {
+      cidr_block  = "0.0.0.0/0"
+      egress      = true
+      from_port   = null
+      protocol    = "-1"
+      rule_action = "allow"
+      rule_number = 1000
+      to_port     = null
+    }
+  }
+
 }

--- a/terraform/modules/vpc-hub/main.tf
+++ b/terraform/modules/vpc-hub/main.tf
@@ -126,7 +126,7 @@ resource "aws_default_security_group" "default" {
 #################
 # TF sec exclusions
 # - Ignore warnings regarding log groups not encrypted using customer-managed KMS keys - following cost/benefit discussion and longer term plans for logging solution
-#tfsec:ignore:AWS089
+#trivy:ignore:AVD-AWS-0017
 resource "aws_cloudwatch_log_group" "default" {
   #checkov:skip=CKV_AWS_158:Temporarily skip KMS encryption check while logging solution is being updated
   name              = "${var.tags_prefix}-vpc-flow-logs"
@@ -199,7 +199,8 @@ resource "aws_network_acl" "public" {
 }
 
 # Public NACLs rules
-#tfsec:ignore:aws-vpc-no-public-ingress-acl tfsec:ignore:aws-vpc-no-excessive-port-access
+#trivy:ignore:AVD-AWS-0102
+#trivy:ignore:AVD-AWS-0105
 resource "aws_network_acl_rule" "public" {
   # checkov:skip=CKV_AWS_352:Ports need to be open
   for_each = local.public_access_acl_rules
@@ -297,7 +298,8 @@ resource "aws_network_acl" "private" {
 }
 
 # Private NACLs rules
-#tfsec:ignore:aws-vpc-no-public-ingress-acl
+#trivy:ignore:AVD-AWS-0102
+#trivy:ignore:AVD-AWS-0105
 resource "aws_network_acl_rule" "private" {
   for_each = local.static_acl_rules
 
@@ -368,7 +370,8 @@ resource "aws_network_acl" "data" {
 }
 
 # Data NACLs rules
-#tfsec:ignore:aws-vpc-no-public-ingress-acl
+#trivy:ignore:AVD-AWS-0102
+#trivy:ignore:AVD-AWS-0105
 resource "aws_network_acl_rule" "data" {
   for_each = local.static_acl_rules
 
@@ -439,7 +442,8 @@ resource "aws_network_acl" "transit-gateway" {
 }
 
 # Transit Gateway NACLs rules
-#tfsec:ignore:aws-vpc-no-public-ingress-acl
+#trivy:ignore:AVD-AWS-0102
+#trivy:ignore:AVD-AWS-0105
 resource "aws_network_acl_rule" "transit-gateway" {
   # checkov:skip=CKV_AWS_229:Transit Gateway subnet NACL open by design
   # checkov:skip=CKV_AWS_230:Transit Gateway subnet NACL open by design

--- a/terraform/modules/vpc-hub/main.tf
+++ b/terraform/modules/vpc-hub/main.tf
@@ -249,27 +249,6 @@ resource "aws_network_acl_rule" "public" {
   to_port        = each.value.to_port
 }
 
-#tfsec:ignore:aws-vpc-no-excessive-port-access
-resource "aws_network_acl_rule" "public-local-ingress" {
-  #checkov:skip=CKV_AWS_352: Open as intra vpc traffic
-  network_acl_id = aws_network_acl.public.id
-  rule_number    = 210
-  egress         = false
-  protocol       = "-1"
-  rule_action    = "allow"
-  cidr_block     = var.vpc_cidr
-}
-
-#tfsec:ignore:aws-vpc-no-excessive-port-access
-resource "aws_network_acl_rule" "public-local-egress" {
-  network_acl_id = aws_network_acl.public.id
-  rule_number    = 210
-  egress         = true
-  protocol       = "-1"
-  rule_action    = "allow"
-  cidr_block     = var.vpc_cidr
-}
-
 # Public route table
 resource "aws_route_table" "public" {
   vpc_id = aws_vpc.default.id
@@ -355,37 +334,16 @@ resource "aws_network_acl" "private" {
 # Private NACLs rules
 #tfsec:ignore:aws-vpc-no-public-ingress-acl
 resource "aws_network_acl_rule" "private" {
-  for_each = local.private_nacl_rules_expanded
+  for_each = local.static_acl_rules
 
   network_acl_id = aws_network_acl.private.id
-  rule_number    = each.value.rule_num
+  rule_number    = each.value.rule_number
   egress         = each.value.egress
   protocol       = each.value.protocol
-  rule_action    = each.value.action
-  cidr_block     = each.value.cidr
+  rule_action    = each.value.rule_action
+  cidr_block     = each.value.cidr_block
   from_port      = each.value.from_port
   to_port        = each.value.to_port
-}
-
-#tfsec:ignore:aws-vpc-no-excessive-port-access
-resource "aws_network_acl_rule" "private-local-ingress" {
-  #checkov:skip=CKV_AWS_352: Open as intra vpc traffic
-  network_acl_id = aws_network_acl.private.id
-  rule_number    = 210
-  egress         = false
-  protocol       = "-1"
-  rule_action    = "allow"
-  cidr_block     = var.vpc_cidr
-}
-
-#tfsec:ignore:aws-vpc-no-excessive-port-access
-resource "aws_network_acl_rule" "private-local-egress" {
-  network_acl_id = aws_network_acl.private.id
-  rule_number    = 210
-  egress         = true
-  protocol       = "-1"
-  rule_action    = "allow"
-  cidr_block     = var.vpc_cidr
 }
 
 # Private route table
@@ -447,37 +405,16 @@ resource "aws_network_acl" "data" {
 # Data NACLs rules
 #tfsec:ignore:aws-vpc-no-public-ingress-acl
 resource "aws_network_acl_rule" "data" {
-  for_each = local.private_nacl_rules_expanded
+  for_each = local.static_acl_rules
 
   network_acl_id = aws_network_acl.data.id
-  rule_number    = each.value.rule_num
+  rule_number    = each.value.rule_number
   egress         = each.value.egress
   protocol       = each.value.protocol
-  rule_action    = each.value.action
-  cidr_block     = each.value.cidr
+  rule_action    = each.value.rule_action
+  cidr_block     = each.value.cidr_block
   from_port      = each.value.from_port
   to_port        = each.value.to_port
-}
-
-#tfsec:ignore:aws-vpc-no-excessive-port-access
-resource "aws_network_acl_rule" "data-local-ingress" {
-  #checkov:skip=CKV_AWS_352: Open as intra vpc traffic
-  network_acl_id = aws_network_acl.data.id
-  rule_number    = 210
-  egress         = false
-  protocol       = "-1"
-  rule_action    = "allow"
-  cidr_block     = var.vpc_cidr
-}
-
-#tfsec:ignore:aws-vpc-no-excessive-port-access
-resource "aws_network_acl_rule" "data-local-egress" {
-  network_acl_id = aws_network_acl.data.id
-  rule_number    = 210
-  egress         = true
-  protocol       = "-1"
-  rule_action    = "allow"
-  cidr_block     = var.vpc_cidr
 }
 
 # Data route table

--- a/terraform/modules/vpc-hub/main.tf
+++ b/terraform/modules/vpc-hub/main.tf
@@ -58,41 +58,6 @@ locals {
     }
   }
 
-  # NACLs
-  nacl_rules = [
-    { egress = false, action = "allow", protocol = -1, from_port = 80, to_port = 80, rule_num = 910, cidr = "0.0.0.0/0" },
-    { egress = false, action = "allow", protocol = -1, from_port = 443, to_port = 443, rule_num = 920, cidr = "0.0.0.0/0" },
-    { egress = false, action = "allow", protocol = -1, from_port = 1024, to_port = 65535, rule_num = 930, cidr = "0.0.0.0/0" },
-    { egress = true, action = "allow", protocol = -1, from_port = 80, to_port = 80, rule_num = 910, cidr = "0.0.0.0/0" },
-    { egress = true, action = "allow", protocol = -1, from_port = 443, to_port = 443, rule_num = 920, cidr = "0.0.0.0/0" },
-    { egress = true, action = "allow", protocol = -1, from_port = 1024, to_port = 65535, rule_num = 930, cidr = "0.0.0.0/0" }
-  ]
-
-  # NACL rules with keys
-  nacl_rules_expanded = {
-    for rule in local.nacl_rules : join("-", values(rule)) => rule
-  }
-
-  # Private NACLs. Do not allow communicating with public internet addresses except for outgoing https.
-  private_nacl_rules = [
-    { egress = false, action = "allow", protocol = -1, from_port = 0, to_port = 0, rule_num = 510, cidr = "10.0.0.0/8" },
-    { egress = false, action = "allow", protocol = -1, from_port = 0, to_port = 0, rule_num = 520, cidr = "172.16.0.0/12" },
-    { egress = false, action = "allow", protocol = -1, from_port = 0, to_port = 0, rule_num = 530, cidr = "192.168.0.0/16" },
-    { egress = true, action = "allow", protocol = -1, from_port = 0, to_port = 0, rule_num = 510, cidr = "10.0.0.0/8" },
-    { egress = true, action = "allow", protocol = -1, from_port = 80, to_port = 80, rule_num = 520, cidr = "172.16.0.0/12" },
-    { egress = true, action = "allow", protocol = -1, from_port = 443, to_port = 443, rule_num = 530, cidr = "172.16.0.0/12" },
-    { egress = true, action = "allow", protocol = -1, from_port = 1024, to_port = 65535, rule_num = 540, cidr = "172.16.0.0/12" },
-    { egress = true, action = "allow", protocol = -1, from_port = 80, to_port = 80, rule_num = 550, cidr = "192.168.0.0/16" },
-    { egress = true, action = "allow", protocol = -1, from_port = 443, to_port = 443, rule_num = 560, cidr = "192.168.0.0/16" },
-    { egress = true, action = "allow", protocol = -1, from_port = 1024, to_port = 65535, rule_num = 570, cidr = "192.168.0.0/16" },
-    { egress = false, action = "allow", protocol = 6, from_port = 1024, to_port = 65535, rule_num = 910, cidr = "0.0.0.0/0" },
-    { egress = true, action = "allow", protocol = 6, from_port = 443, to_port = 443, rule_num = 910, cidr = "0.0.0.0/0" }
-  ]
-
-  # Private NACL rules with keys
-  private_nacl_rules_expanded = {
-    for rule in local.private_nacl_rules : join("-", values(rule)) => rule
-  }
 }
 
 #######
@@ -476,37 +441,21 @@ resource "aws_network_acl" "transit-gateway" {
 # Transit Gateway NACLs rules
 #tfsec:ignore:aws-vpc-no-public-ingress-acl
 resource "aws_network_acl_rule" "transit-gateway" {
-  for_each = local.nacl_rules_expanded
+  # checkov:skip=CKV_AWS_229:Transit Gateway subnet NACL open by design
+  # checkov:skip=CKV_AWS_230:Transit Gateway subnet NACL open by design
+  # checkov:skip=CKV_AWS_231:Transit Gateway subnet NACL open by design
+  # checkov:skip=CKV_AWS_232:Transit Gateway subnet NACL open by design
+  # checkov:skip=CKV_AWS_352:Transit Gateway subnet NACL open by design
+  for_each = local.transit_gateway_acl_rules
 
   network_acl_id = aws_network_acl.transit-gateway.id
-  rule_number    = each.value.rule_num
+  rule_number    = each.value.rule_number
   egress         = each.value.egress
   protocol       = each.value.protocol
-  rule_action    = each.value.action
-  cidr_block     = each.value.cidr
+  rule_action    = each.value.rule_action
+  cidr_block     = each.value.cidr_block
   from_port      = each.value.from_port
   to_port        = each.value.to_port
-}
-
-#tfsec:ignore:aws-vpc-no-excessive-port-access
-resource "aws_network_acl_rule" "transit-gateway-local-ingress" {
-  #checkov:skip=CKV_AWS_352: Open as intra vpc traffic
-  network_acl_id = aws_network_acl.transit-gateway.id
-  rule_number    = 210
-  egress         = false
-  protocol       = "-1"
-  rule_action    = "allow"
-  cidr_block     = var.vpc_cidr
-}
-
-#tfsec:ignore:aws-vpc-no-excessive-port-access
-resource "aws_network_acl_rule" "transit-gateway-local-egress" {
-  network_acl_id = aws_network_acl.transit-gateway.id
-  rule_number    = 210
-  egress         = true
-  protocol       = "-1"
-  rule_action    = "allow"
-  cidr_block     = var.vpc_cidr
 }
 
 # Transit Gateway route table

--- a/terraform/modules/vpc-hub/main.tf
+++ b/terraform/modules/vpc-hub/main.tf
@@ -237,14 +237,14 @@ resource "aws_network_acl" "public" {
 #tfsec:ignore:aws-vpc-no-public-ingress-acl tfsec:ignore:aws-vpc-no-excessive-port-access
 resource "aws_network_acl_rule" "public" {
   # checkov:skip=CKV_AWS_352:Ports need to be open
-  for_each = local.nacl_rules_expanded
+  for_each = local.public_access_acl_rules
 
   network_acl_id = aws_network_acl.public.id
-  rule_number    = each.value.rule_num
+  rule_number    = each.value.rule_number
   egress         = each.value.egress
   protocol       = each.value.protocol
-  rule_action    = each.value.action
-  cidr_block     = each.value.cidr
+  rule_action    = each.value.rule_action
+  cidr_block     = each.value.cidr_block
   from_port      = each.value.from_port
   to_port        = each.value.to_port
 }

--- a/terraform/modules/vpc-hub/outputs.tf
+++ b/terraform/modules/vpc-hub/outputs.tf
@@ -13,6 +13,14 @@ output "tgw_subnet_ids" {
   value       = [for subnet in aws_subnet.transit-gateway : subnet.id]
 }
 
+output "network_acls" {
+  value = {
+    "public"  = aws_network_acl.public
+    "private" = aws_network_acl.private
+    "data"    = aws_network_acl.data
+  }
+}
+
 output "non_tgw_subnet_ids" {
   description = "Non-Transit Gateway subnet IDs (public, private, data)"
   value = concat([


### PR DESCRIPTION
## A reference to the issue / Description of it

#2403 

## How does this PR fix the problem?

This PR amends how network ACLs are created in the `vpc-hub` module. When the story was originally written this would have used the same `vpc-nacls` module that is currently used by the `modernisation-platform-terraform-member-vpc` code and applied to `core-vpc-*` environments.

This simplifies how and where NACL rules are defined. The content is now located in `locals.tf` under a series of simple maps - `static_acl_rules`, `public_access_acl_rules`, and `transit_gateway_acl_rules`.

As much as possible this is identical to the content in the `vpc-nacls` module to ensure consistency, although there may be future opportunities to trim these rules if we invest time in inspecting VPC flow logs for potential exceptions.

No changes to the `inspection` VPCs - those in `core-network-services` - are carried out in this PR, although they could also be in scope as part of the story. However, they're a little trickier. 

The inline inspection VPCs used as egress VPCs for traffic from the per-business-unit VPCs in `core-vpc-*` need to be very open because of their purpose; inspecting traffic with AWS Network Firewalls and conducting NAT in AWS NAT Gateways on the way out to the internet.

The `external-inspection` VPC similarly needs to be open because it's an inspection point for traffic moving internally between the MOJ TGW and the MP TGW / MP VPCs. Given the wide range of customers we have, NACLs aren't a better choice for securing flows compared to the AWS Network Firewall that inspects traffic in this position.

In a nutshell, this PR does the following:
* Private subnet and Data subnet NACLs allow unrestricted intra-VPC traffic, and unrestricted private address range traffic.
* Public subnet NACL allows unrestricted intra-VPC traffic, and fairly unrestricted traffic out to the internet.
* Transit Gateway subnet NACL allows unrestricted traffic as per the AWS design guidance

It also removes the old code used to create NACLs.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

- [x] Conducted a local terraform plan
- [x] Checked existing flow logs over a reasonable timeframe to identify if this will break existing functionality.

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
