### PR TITLE
Update Workflow to Retrieve Secrets from AWS Secrets Manager

### DIFF
--- a/.github/actions/decrypt-secrets/action.yml
+++ b/.github/actions/decrypt-secrets/action.yml
@@ -1,0 +1,53 @@
+name: Decrypt Secrets
+
+inputs:
+  environment_management:
+    required: false
+  pagerduty_token:
+    required: false
+  pagerduty_userapi_token:
+    required: false
+  slack_webhook_url:
+    required: false
+  environments:
+    required: false
+  github_ci_user_pat: 
+    required: false
+  passphrase: 
+    required: true
+    
+runs:
+  using: "composite"
+  steps:
+    - name: Decrypt Secrets
+      shell: bash
+      run: |
+        if [ -n "${{ inputs.environment_management }}" ]; then
+        environment_management_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.passphrase }}" --output - <(echo "${{ inputs.environment_management }}" | base64 --decode))
+        echo "::add-mask::$environment_management_decrypt"
+        echo "ENVIRONMENT_MANAGEMENT=$environment_management_decrypt" >> $GITHUB_ENV
+        fi
+        
+        if [ -n "${{ inputs.pagerduty_token }}" ]; then
+        pagerduty_token_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.passphrase }}" --output - <(echo "${{ inputs.pagerduty_token }}" | base64 --decode))
+        echo "::add-mask::$pagerduty_token_decrypt"
+        echo "TF_VAR_pagerduty_token=$pagerduty_token_decrypt" >> $GITHUB_ENV
+        fi
+        
+        if [ -n "${{ inputs.pagerduty_userapi_token }}" ]; then
+        pagerduty_userapi_token_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.passphrase }}" --output - <(echo "${{ inputs.pagerduty_userapi_token }}" | base64 --decode))
+        echo "::add-mask::$pagerduty_userapi_token_decrypt"
+        echo "TF_VAR_pagerduty_user_token=$pagerduty_userapi_token_decrypt" >> $GITHUB_ENV
+        fi
+
+        if [ -n "${{ inputs.slack_webhook_url }}" ]; then
+        slack_webhook_url_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.passphrase }}" --output - <(echo "${{ inputs.slack_webhook_url }}" | base64 --decode))
+        echo "::add-mask::$slack_webhook_url_decrypt"
+        echo "SLACK_WEBHOOK_URL=$slack_webhook_url_decrypt" >> $GITHUB_ENV
+        fi
+
+        if [ -n "${{ inputs.github_ci_user_pat }}" ]; then
+        github_ci_user_pat_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.passphrase }}" --output - <(echo "${{ inputs.github_ci_user_pat }}" | base64 --decode))
+        echo "::add-mask::$github_ci_user_pat_decrypt"
+        echo "TF_VAR_github_token=$github_ci_user_pat_decrypt" >> $GITHUB_ENV
+        fi

--- a/.github/workflows/scheduled-baseline.yml
+++ b/.github/workflows/scheduled-baseline.yml
@@ -16,7 +16,6 @@ on:
 env:
   TF_IN_AUTOMATION: true
   AWS_REGION: "eu-west-2"
-  ENVIRONMENT_MANAGEMENT: ${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENTS }}
 
 permissions:
   id-token: write # This is required for requesting the JWT
@@ -27,12 +26,21 @@ defaults:
     shell: bash
 
 jobs:
+  retrieve-secrets:
+    uses: ./.github/workflows/secrets-retrieval.yml
+    secrets: inherit
   setup-prerequisites:
     runs-on: ubuntu-latest
+    needs: retrieve-secrets
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Decrypt Secrets
+        uses: ./.github/actions/decrypt-secrets
+        with:
+          environment_management: ${{ needs.retrieve-secrets.outputs.environment_management }}
+          passphrase: ${{ secrets.PASSPHRASE }}
       - name: Set Account Number
         run: echo "ACCOUNT_NUMBER=$(jq -r -e '.aws_organizations_root_account_id' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
       - name: Configure AWS Credentials
@@ -56,9 +64,15 @@ jobs:
       matrix:
         workspaces: ${{ fromJSON(needs.setup-prerequisites.outputs.matrix) }}
     runs-on: ubuntu-latest
-    needs: setup-prerequisites
+    needs: [retrieve-secrets,setup-prerequisites]
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Decrypt Secrets
+        uses: ./.github/actions/decrypt-secrets
+        with:
+          environment_management: ${{ needs.retrieve-secrets.outputs.environment_management }}
+          slack_webhook_url: ${{ needs.retrieve-secrets.outputs.slack_webhook_url }}
+          passphrase: ${{ secrets.PASSPHRASE }}
       - name: Set Account Number
         run: echo "ACCOUNT_NUMBER=$(jq -r -e '.aws_organizations_root_account_id' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
       - name: Configure AWS Credentials
@@ -86,7 +100,7 @@ jobs:
           payload: |
             {"blocks":[{"type": "section","text": {"type": "mrkdwn","text": ":no_entry: Failed GitHub Action:"}},{"type": "section","fields":[{"type": "mrkdwn","text": "*Workflow:*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>"},{"type": "mrkdwn","text": "*Job:*\n${{ github.job }}"},{"type": "mrkdwn","text": "*Repo:*\n${{ github.repository }}"}]}]}
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_URL: ${{ env.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
         if: ${{ failure() }}
     env:
@@ -99,9 +113,15 @@ jobs:
       matrix:
         workspaces: ${{ fromJSON(needs.setup-prerequisites.outputs.matrix) }}
     runs-on: ubuntu-latest
-    needs: [setup-prerequisites, delegate-access]
+    needs: [retrieve-secrets,setup-prerequisites, delegate-access]
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Decrypt Secrets
+        uses: ./.github/actions/decrypt-secrets
+        with:
+          environment_management: ${{ needs.retrieve-secrets.outputs.environment_management }}
+          slack_webhook_url: ${{ needs.retrieve-secrets.outputs.slack_webhook_url }}
+          passphrase: ${{ secrets.PASSPHRASE }}
       - name: Set Account Number
         run: echo "ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
       - name: Configure AWS Credentials
@@ -129,7 +149,7 @@ jobs:
           payload: |
             {"blocks":[{"type": "section","text": {"type": "mrkdwn","text": ":no_entry: Failed GitHub Action:"}},{"type": "section","fields":[{"type": "mrkdwn","text": "*Workflow:*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>"},{"type": "mrkdwn","text": "*Job:*\n${{ github.job }}"},{"type": "mrkdwn","text": "*Repo:*\n${{ github.repository }}"}]}]}
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_URL: ${{ env.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
         if: ${{ failure() }}
     env:
@@ -142,9 +162,15 @@ jobs:
       matrix:
         workspaces: ${{ fromJSON(needs.setup-prerequisites.outputs.matrix) }}
     runs-on: ubuntu-latest
-    needs: [setup-prerequisites, delegate-access]
+    needs: [retrieve-secrets,setup-prerequisites, delegate-access]
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Decrypt Secrets
+        uses: ./.github/actions/decrypt-secrets
+        with:
+          environment_management: ${{ needs.retrieve-secrets.outputs.environment_management }}
+          slack_webhook_url: ${{ needs.retrieve-secrets.outputs.slack_webhook_url }}
+          passphrase: ${{ secrets.PASSPHRASE }}
       - name: Set Account Number
         run: echo "ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
 
@@ -173,7 +199,7 @@ jobs:
           payload: |
             {"blocks":[{"type": "section","text": {"type": "mrkdwn","text": ":no_entry: Failed GitHub Action:"}},{"type": "section","fields":[{"type": "mrkdwn","text": "*Workflow:*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>"},{"type": "mrkdwn","text": "*Job:*\n${{ github.job }}"},{"type": "mrkdwn","text": "*Repo:*\n${{ github.repository }}"}]}]}
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_URL: ${{ env.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
         if: ${{ failure() }}
     env:
@@ -186,9 +212,15 @@ jobs:
       matrix:
         workspaces: ${{ fromJSON(needs.setup-prerequisites.outputs.matrix) }}
     runs-on: ubuntu-latest
-    needs: [setup-prerequisites, single-sign-on]
+    needs: [retrieve-secrets,setup-prerequisites, single-sign-on]
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Decrypt Secrets
+        uses: ./.github/actions/decrypt-secrets
+        with:
+          environment_management: ${{ needs.retrieve-secrets.outputs.environment_management }}
+          slack_webhook_url: ${{ needs.retrieve-secrets.outputs.slack_webhook_url }}
+          passphrase: ${{ secrets.PASSPHRASE }}
       - name: Set Account Number
         run: echo "ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
       - name: Configure AWS Credentials
@@ -216,7 +248,7 @@ jobs:
           payload: |
             {"blocks":[{"type": "section","text": {"type": "mrkdwn","text": ":no_entry: Failed GitHub Action:"}},{"type": "section","fields":[{"type": "mrkdwn","text": "*Workflow:*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>"},{"type": "mrkdwn","text": "*Job:*\n${{ github.job }}"},{"type": "mrkdwn","text": "*Repo:*\n${{ github.repository }}"}]}]}
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_URL: ${{ env.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
         if: ${{ failure() }}
     env:
@@ -225,9 +257,15 @@ jobs:
 
   update-permission-sets:
     runs-on: ubuntu-latest
-    needs: [delegate-access,single-sign-on]
+    needs: [retrieve-secrets,delegate-access,single-sign-on]
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Decrypt Secrets
+        uses: ./.github/actions/decrypt-secrets
+        with:
+          environment_management: ${{ needs.retrieve-secrets.outputs.environment_management }}
+          slack_webhook_url: ${{ needs.retrieve-secrets.outputs.slack_webhook_url }}
+          passphrase: ${{ secrets.PASSPHRASE }}
       - name: Set Account Number
         run: echo "ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
       - name: Set Root Account Number
@@ -252,6 +290,6 @@ jobs:
           payload: |
             {"blocks":[{"type": "section","text": {"type": "mrkdwn","text": ":no_entry: Failed GitHub Action:"}},{"type": "section","fields":[{"type": "mrkdwn","text": "*Workflow:*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>"},{"type": "mrkdwn","text": "*Job:*\n${{ github.job }}"},{"type": "mrkdwn","text": "*Repo:*\n${{ github.repository }}"}]}]}
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_URL: ${{ env.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
         if: ${{ failure() }}

--- a/.github/workflows/secrets-retrieval.yml
+++ b/.github/workflows/secrets-retrieval.yml
@@ -1,0 +1,60 @@
+name: Secrets Retrieval from AWS Secrets Manager
+
+on:
+  workflow_call:
+    outputs:
+      environment_management: 
+        value: ${{ jobs.retrieve-secrets.outputs.environment_management }}
+      pagerduty_token: 
+        value: ${{ jobs.retrieve-secrets.outputs.pagerduty_token }}
+      pagerduty_userapi_token: 
+        value: ${{ jobs.retrieve-secrets.outputs.pagerduty_userapi_token }}
+      slack_webhook_url: 
+        value: ${{ jobs.retrieve-secrets.outputs.slack_webhook_url }}
+      github_ci_user_pat: 
+        value: ${{ jobs.retrieve-secrets.outputs.github_ci_user_pat }}
+
+jobs:
+  retrieve-secrets:
+    runs-on: ubuntu-latest
+    outputs:
+      environment_management: ${{ steps.encrypt-outputs.outputs.environment_management }}
+      pagerduty_token: ${{ steps.encrypt-outputs.outputs.pagerduty_token }}
+      pagerduty_userapi_token: ${{ steps.encrypt-outputs.outputs.pagerduty_userapi_token }}
+      slack_webhook_url: ${{ steps.encrypt-outputs.outputs.slack_webhook_url }}
+      github_ci_user_pat: ${{ steps.encrypt-outputs.outputs.github_ci_user_pat }}
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
+        with:
+          role-to-assume: "arn:aws:iam::${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_NUMBER }}:role/github-actions"
+          role-session-name: githubactionsrolesession
+          aws-region: "eu-west-2"
+          
+      - name: Retrieve Secrets from AWS Secrets Manager
+        uses: aws-actions/aws-secretsmanager-get-secrets@f91b2a3e784edce744f972af1685eca7e24d2302 #v2.0.2
+        with:
+          secret-ids: |
+            MODERNISATION_PLATFORM_ENVIRONMENTS,environment_management
+            PAGERDUTY_TOKEN,pagerduty_token
+            PAGERDUTY_USERAPI_TOKEN,pagerduty_userapi_token
+            SLACK_WEBHOOK_URL,slack_webhook_url
+            TERRAFORM_GITHUB_TOKEN,github_ci_user_pat
+
+      - name: Set outputs
+        id: encrypt-outputs
+        run: |
+          environment_management=$(gpg --symmetric --batch --passphrase "${{ secrets.PASSPHRASE }}" --output - <(echo "$MODERNISATION_PLATFORM_ENVIRONMENTS") | base64 -w0)
+          echo "environment_management=$environment_management" >> $GITHUB_OUTPUT
+
+          pagerduty_token=$(gpg --symmetric --batch --passphrase "${{ secrets.PASSPHRASE }}" --output - <(echo "$PAGERDUTY_TOKEN") | base64 -w0)
+          echo "pagerduty_token=$pagerduty_token" >> $GITHUB_OUTPUT
+
+          pagerduty_userapi_token=$(gpg --symmetric --batch --passphrase "${{ secrets.PASSPHRASE }}" --output - <(echo "$PAGERDUTY_USERAPI_TOKEN") | base64 -w0)
+          echo "pagerduty_userapi_token=$pagerduty_userapi_token" >> $GITHUB_OUTPUT
+
+          slack_webhook_url=$(gpg --symmetric --batch --passphrase "${{ secrets.PASSPHRASE }}" --output - <(echo "$SLACK_WEBHOOK_URL") | base64 -w0)
+          echo "slack_webhook_url=$slack_webhook_url" >> $GITHUB_OUTPUT
+
+          github_ci_user_pat=$(gpg --symmetric --batch --passphrase "${{ secrets.PASSPHRASE }}" --output - <(echo "$TERRAFORM_GITHUB_TOKEN") | base64 -w0)
+          echo "github_ci_user_pat=$github_ci_user_pat" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## A reference to the issue / Description of it

This PR updates the workflow to utilize AWS Secrets Manager for retrieving secrets instead of relying on GitHub secrets. It introduces a new decrypt secrets action within the workflow to handle decryption of the secrets fetched from AWS Secrets Manager. Each job within the workflow has been modified accordingly to incorporate this change. #6627 

## How does this PR fix the problem?

Previously, the workflow relied on GitHub secrets for accessing sensitive information. Now, it will retrieve the secrets from AWS Secrets Manager, enhancing security and providing more robust management of our sensitive data.

## How has this been tested?

I tested this functionality by configuring the updated workflow in my private repository and ensuring that it successfully retrieves secrets from AWS Secrets Manager during workflow execution. I verified that the secrets were decrypted correctly and utilized within the workflow tasks as expected. 

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)