### PR TITLE
Update `remove-default-vpc` job to retrieve secrets from Secrets Manager

### DIFF
--- a/.github/workflows/new-environment.yml
+++ b/.github/workflows/new-environment.yml
@@ -203,14 +203,17 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0
-      - name: Set Account Number
-        run: echo "ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
         with:
-          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+          role-to-assume: "arn:aws:iam::${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_NUMBER }}:role/github-actions"
           role-session-name: githubactionsrolesession
           aws-region: ${{ env.AWS_REGION }}
+      - name: Retrieve Secrets from AWS Secrets Manager
+        uses: aws-actions/aws-secretsmanager-get-secrets@f91b2a3e784edce744f972af1685eca7e24d2302 #v2.0.2
+        with:
+          secret-ids: |
+            ENVIRONMENT_MANAGEMENT,environment_management
       - name: get new account(s)
         id: new_account
         run: |

--- a/.github/workflows/new-environment.yml
+++ b/.github/workflows/new-environment.yml
@@ -214,6 +214,7 @@ jobs:
         with:
           secret-ids: |
             ENVIRONMENT_MANAGEMENT,environment_management
+            SLACK_WEBHOOK_URL,slack_webhook_url
       - name: get new account(s)
         id: new_account
         run: |
@@ -240,7 +241,7 @@ jobs:
           payload: |
             {"blocks":[{"type": "section","text": {"type": "mrkdwn","text": ":no_entry: Failed GitHub Action:"}},{"type": "section","fields":[{"type": "mrkdwn","text": "*Workflow:*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>"},{"type": "mrkdwn","text": "*Job:*\n${{ github.job }}"},{"type": "mrkdwn","text": "*Repo:*\n${{ github.repository }}"}]}]}
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_URL: ${{ env.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
         if: ${{ failure() }}
   secure-baselines:


### PR DESCRIPTION
## A reference to the issue / Description of it

This PR addresses an issue encountered during the execution of the `Remove Default VPC` job. Previously, the job relied on `GitHub secrets` to access sensitive information, such as the AWS account number. However, this caused a problem as the job was unable to retrieve the new environment number when executed, leading to failure in removing the default VPC in the first run.

To resolve this issue, this PR updates the job to retrieve secrets from AWS Secrets Manager instead of using GitHub secrets. By doing so, the job will be able to fetch the required environment number dynamically during execution, ensuring that it can successfully remove the default VPC.

## How does this PR fix the problem?

This PR fixes the problem by updating the job to retrieve secrets from AWS Secrets Manager, which allows the job to dynamically fetch the necessary environment number during execution. This ensures that the job has access to the correct information needed to remove the default VPC