### PR TITLE
🇫🇷  😢 Unbootstrapping France.

### DIFF
--- a/terraform/environments/bootstrap/secure-baselines/README.md
+++ b/terraform/environments/bootstrap/secure-baselines/README.md
@@ -1,6 +1,6 @@
 # Modernisation Platform: environments bootstrapping
 
-This directory creates and maintains common resources that should be available in every account. It uses `terraform workspace` and replaces the [previous process for bootstrapping accounts](https://github.com/ministryofjustice/modernisation-platform/tree/5a8fd5c6/terraform/environments).
+This directory creates and maintains commmon resources that should be available in every account. It uses `terraform workspace` and replaces the [previous process for bootstrapping accounts](https://github.com/ministryofjustice/modernisation-platform/tree/5a8fd5c6/terraform/environments).
 
 You need to run Terraform commands in this directory using a Ministry of Justice AWS organisational root IAM user that has permissions to `sts:AssumeRole`. It utilises the `OrganizationAccountAccessRole` created by AWS Organizations to assume a role in an account and bootstrap it with the following:
 

--- a/terraform/environments/bootstrap/secure-baselines/README.md
+++ b/terraform/environments/bootstrap/secure-baselines/README.md
@@ -1,6 +1,6 @@
 # Modernisation Platform: environments bootstrapping
 
-This directory creates and maintains commmon resources that should be available in every account. It uses `terraform workspace` and replaces the [previous process for bootstrapping accounts](https://github.com/ministryofjustice/modernisation-platform/tree/5a8fd5c6/terraform/environments).
+This directory creates and maintains common resources that should be available in every account. It uses `terraform workspace` and replaces the [previous process for bootstrapping accounts](https://github.com/ministryofjustice/modernisation-platform/tree/5a8fd5c6/terraform/environments).
 
 You need to run Terraform commands in this directory using a Ministry of Justice AWS organisational root IAM user that has permissions to `sts:AssumeRole`. It utilises the `OrganizationAccountAccessRole` created by AWS Organizations to assume a role in an account and bootstrap it with the following:
 

--- a/terraform/environments/bootstrap/secure-baselines/main.tf
+++ b/terraform/environments/bootstrap/secure-baselines/main.tf
@@ -30,7 +30,7 @@ module "baselines" {
     aws.ap-northeast-1 = aws.workspace-eu-west-2
     aws.ap-northeast-2 = aws.workspace-eu-west-2
     aws.ap-south-1     = aws.workspace-eu-west-2
-    aws.eu-west-3      = aws.workspace-eu-west-2
+    aws.eu-west-3      = aws.workspace-eu-west-3
     aws.ap-southeast-1 = aws.workspace-eu-west-2
     aws.ap-southeast-2 = aws.workspace-eu-west-2
     aws.ca-central-1   = aws.workspace-eu-west-2

--- a/terraform/environments/bootstrap/secure-baselines/providers.tf
+++ b/terraform/environments/bootstrap/secure-baselines/providers.tf
@@ -44,6 +44,17 @@ provider "aws" {
 }
 
 provider "aws" {
+  alias       = "workspace-eu-west-3"
+  region      = "eu-west-3"
+  max_retries = 100
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
+  }
+}
+
+
+provider "aws" {
   alias       = "workspace-us-east-1"
   region      = "us-east-1"
   max_retries = 100


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/data-platform/issues/4222
The code enabling Paris region is breaking secure baseline job for Sprinkler because the account isn't enrolled in eu-west-3 security hub. Once that is fixed, the Paris changes can be reapplied in full.

## How does this PR fix the problem?

The Paris region has been removed from the list of bootstrapped regions but because some of the resources have been created, the provider region change needs to persist as switching it back to the `eu-west-2` region will stop them being found and destroyed. 

Once sprinkler apply ran once, this should be revertable too.

## How has this been tested?

It hasn't been unfortunately.

## Deployment Plan / Instructions

An apply on `sprinkler` should be enough to see if this undid the damage. This PR does not need merging.



## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
