### PR TITLE
Add checkov skip for false positive on firehose error logging bucket

### DIFF
--- a/terraform/modules/firehose/main.tf
+++ b/terraform/modules/firehose/main.tf
@@ -113,6 +113,7 @@ resource "aws_s3_bucket" "firehose_error_logging_bucket" {
 #tfsec:ignore:aws-ssm-secret-use-customer-key
 #tfsec:ignore:aws-s3-encryption-customer-key
 resource "aws_s3_bucket_server_side_encryption_configuration" "bucket_encryption" {
+  #checkov:skip=CKV2_AWS_67
   bucket = aws_s3_bucket.firehose_error_logging_bucket.id
   rule {
     apply_server_side_encryption_by_default {


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/actions/runs/9013691702/job/24764963203#step:4:2807

Secure Code Analysis run flagged an error to do with CMK rotation, but bucket is not encrypted with CMK

## How does this PR fix the problem?

Adds Checkov skip to resource

## How has this been tested?

Tested with SCA action

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
