### PR TITLE
:fr: Enabling Paris II: Rebaselining

### DIFF
--- a/terraform/environments/bootstrap/secure-baselines/locals.tf
+++ b/terraform/environments/bootstrap/secure-baselines/locals.tf
@@ -8,6 +8,7 @@ locals {
     "eu-central-1", # Europe (Frankfurt)
     "eu-west-1",    # Europe (Ireland)
     "eu-west-2",    # Europe (London)
+    "eu-west-3",    # Europe (Paris)
     "us-east-1",    # US East (N. Virginia) (for global services)
   ]
   environments = {

--- a/terraform/environments/bootstrap/secure-baselines/main.tf
+++ b/terraform/environments/bootstrap/secure-baselines/main.tf
@@ -17,6 +17,7 @@ module "baselines" {
     aws.eu-central-1 = aws.workspace-eu-central-1
     aws.eu-west-1    = aws.workspace-eu-west-1
     aws.eu-west-2    = aws.workspace-eu-west-2
+    aws.eu-west-3    = aws.workspace-eu-west-3
     aws.us-east-1    = aws.workspace-us-east-1
 
     # We're part of a Organization SCP that restricts regional usage, so we can't assume roles in non-restricted regions.
@@ -31,7 +32,6 @@ module "baselines" {
     aws.ap-northeast-1 = aws.workspace-eu-west-2
     aws.ap-northeast-2 = aws.workspace-eu-west-2
     aws.ap-south-1     = aws.workspace-eu-west-2
-    aws.eu-west-3      = aws.workspace-eu-west-2
     aws.ap-southeast-1 = aws.workspace-eu-west-2
     aws.ap-southeast-2 = aws.workspace-eu-west-2
     aws.ca-central-1   = aws.workspace-eu-west-2

--- a/terraform/environments/bootstrap/secure-baselines/providers.tf
+++ b/terraform/environments/bootstrap/secure-baselines/providers.tf
@@ -44,6 +44,16 @@ provider "aws" {
 }
 
 provider "aws" {
+  alias       = "workspace-eu-west-3"
+  region      = "eu-west-3"
+  max_retries = 100
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
+  }
+}
+
+provider "aws" {
   alias       = "workspace-us-east-1"
   region      = "us-east-1"
   max_retries = 100

--- a/terraform/modernisation-platform-account/README.md
+++ b/terraform/modernisation-platform-account/README.md
@@ -1,3 +1,4 @@
 # Modernisation Platform - Modernisation Platform account
 
-These are resources that are implemented within the Modernisation Platform account. For example, this includes an [backend definition](main.tf) that can be used for other Modernisation Platform-managed implementations.
+These are resources that are implemented within the Modernisation Platform account.
+For example, this includes an [backend definition](main.tf) that can be used for other Modernisation Platform-managed implementations.

--- a/terraform/modernisation-platform-account/baselines.tf
+++ b/terraform/modernisation-platform-account/baselines.tf
@@ -10,6 +10,7 @@ locals {
     "eu-central-1", # Europe (Frankfurt)
     "eu-west-1",    # Europe (Ireland)
     "eu-west-2",    # Europe (London)
+    "eu-west-3",    # Europe (Paris)
     "us-east-1",    # US East (N. Virginia) (for global services)
   ]
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/6917
https://github.com/ministryofjustice/data-platform/issues/4222

Analytical Platform had a customer request to make Bedrock available in Paris due to model selection being better than Frankfurt. The region is not currently used and therefore bootstrapped on MP.

## How does this PR fix the problem?

This updates provider definitions and adds `eu-west-3` to enabled regions. The last attempt had failed due to `sprinkler` not having been enrolled in SecurityHub at the org level. `sprinkler` and other accounts [have now been enrolled](https://github.com/ministryofjustice/aws-root-account/pull/904) and future accounts will be enrolled automatically.

## How has this been tested?

[Last attempt](https://github.com/ministryofjustice/modernisation-platform/pull/6952) failed on apply to sprinkler step during the initial PR checks. The main test is running the secure-baselines component on sprinkler again.


## Deployment Plan / Instructions

This shouldn't impact live services. However, it will break further secure-baselines run if the apply on sprinkler fails. The backout steps are [here](https://github.com/ministryofjustice/modernisation-platform/pull/6959)


{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [X] All checks have passed
- [X] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
