### PR TITLE
Firewall rules for laa production

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/production_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/production_rules.json
@@ -642,5 +642,12 @@
     "destination_ip": "${hmpps-production}",
     "destination_port": "1521",
     "protocol": "TCP"
+  },
+  "cp_to_mp_laa_production": {
+    "action": "PASS",
+    "source_ip": "${cloud-platform}",
+    "destination_ip": "${laa-production}",
+    "destination_port": "1521",
+    "protocol": "TCP"
   }
 }


### PR DESCRIPTION
## A reference to the issue / Description of it
as part of a member request from the ask channel
Sahid Khan
:spiral_calendar_pad:  [2 hours ago](https://mojdt.slack.com/archives/C01A7QK5VM1/p1715338638924039)
Hi MP - can i request for a rule to be opened up on the firewall please? We would like connectivity from the Cloud Platform into our Production MP account on port 1521.

## How does this PR fix the problem?

firewall updated

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
