### PR TITLE
Fix Static Code Failures for MP Baseline module call

### DIFF
--- a/terraform/modernisation-platform-account/baselines.tf
+++ b/terraform/modernisation-platform-account/baselines.tf
@@ -16,6 +16,7 @@ locals {
 }
 
 # Secure baselines (GuardDuty, Config, SecurityHub, etc)
+#trivy:ignore:AVD-AWS-0136
 module "baselines-modernisation-platform" {
   source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=2a59110767bd30e949b242818da7dbe72fe9481b" # v7.1.0
   providers = {

--- a/terraform/modernisation-platform-account/baselines.tf
+++ b/terraform/modernisation-platform-account/baselines.tf
@@ -16,7 +16,7 @@ locals {
 }
 
 # Secure baselines (GuardDuty, Config, SecurityHub, etc)
-#trivy:ignore:AVD-AWS-0136
+#trivy:ignore:AVD-AWS-0136 trivy:ignore:AVD-AWS-0132
 module "baselines-modernisation-platform" {
   source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=2a59110767bd30e949b242818da7dbe72fe9481b" # v7.1.0
   providers = {

--- a/terraform/modernisation-platform-account/baselines.tf
+++ b/terraform/modernisation-platform-account/baselines.tf
@@ -65,5 +65,8 @@ module "baselines-modernisation-platform" {
 
   root_account_id = local.root_account.master_account_id
   tags            = local.tags
+
+  # Regions to enable IMDSv2 in
+  enabled_imdsv2_regions = local.enabled_baseline_regions
 }
 

--- a/terraform/modernisation-platform-account/baselines.tf
+++ b/terraform/modernisation-platform-account/baselines.tf
@@ -17,7 +17,7 @@ locals {
 
 # Secure baselines (GuardDuty, Config, SecurityHub, etc)
 module "baselines-modernisation-platform" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=b5ae2be29aaa29d644b6909af51acefdfaa80e14" # v7.0.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=2a59110767bd30e949b242818da7dbe72fe9481b" # v7.1.0
   providers = {
     # Default and replication regions
     aws                    = aws.modernisation-platform-eu-west-2


### PR DESCRIPTION
## A reference to the issue / Description of it

Scheduled SCA job is failing with errors: https://github.com/ministryofjustice/modernisation-platform/actions/runs/9058641080/job/24884654889

## How does this PR fix the problem?

Pointed MP account baseline to v7.1.0 (I forgot to do this when updating the baseline call for members last week!) which will enable IMDSv2 as default for MP account.

Also ignoring Trivy warnings AVD-AWS-0136 & AVD-AWS-0132 at the module call.

## How has this been tested?

Status check below.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [X] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
