### PR TITLE
Removed references to the S3 replication role

### DIFF
--- a/terraform/environments/core-logging/s3_logging.tf
+++ b/terraform/environments/core-logging/s3_logging.tf
@@ -168,16 +168,9 @@ data "aws_iam_policy_document" "kms_logging_cloudtrail_replication" {
   }
 }
 
-module "cloudtrail-s3-replication-role" {
-  source             = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket-replication-role?ref=3b8a2945c1d266cc0ec2b21edb7f186b6574bda7" # v4.0.0
-  buckets            = [module.s3-bucket-cloudtrail.bucket.arn]
-  replication_bucket = "modernisation-platform-logs-cloudtrail-replication"
-  suffix_name        = "-cloudtrail"
-  tags               = local.tags
-}
 
 module "s3-bucket-cloudtrail" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=8688bc15a08fbf5a4f4eef9b7433c5a417df8df1" # v7.0.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=f109c88e2cacf1437cce197cf6643109fd96a8d5" # v7.2.0
   providers = {
     aws.bucket-replication = aws.modernisation-platform-eu-west-1
   }
@@ -222,7 +215,6 @@ module "s3-bucket-cloudtrail" {
     }
   ]
   log_bucket           = module.s3-bucket-cloudtrail-logging.bucket.id
-  replication_role_arn = module.cloudtrail-s3-replication-role.role.arn
   tags                 = local.tags
 }
 # Allow access to the bucket from the MoJ root account
@@ -301,13 +293,13 @@ data "aws_iam_policy_document" "cloudtrail_bucket_policy" {
   }
 }
 
-module "cloudtrail-s3-logging-replication-role" {
-  source             = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket-replication-role?ref=3b8a2945c1d266cc0ec2b21edb7f186b6574bda7" # v4.0.0
-  buckets            = [module.s3-bucket-cloudtrail-logging.bucket.arn]
-  replication_bucket = "modernisation-platform-logs-cloudtrail-logging-replication"
-  suffix_name        = "-cloudtrail-logging"
-  tags               = local.tags
-}
+# module "cloudtrail-s3-logging-replication-role" {
+#   source             = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket-replication-role?ref=3b8a2945c1d266cc0ec2b21edb7f186b6574bda7" # v4.0.0
+#   buckets            = [module.s3-bucket-cloudtrail-logging.bucket.arn]
+#   replication_bucket = "modernisation-platform-logs-cloudtrail-logging-replication"
+#   suffix_name        = "-cloudtrail-logging"
+#   tags               = local.tags
+# }
 
 module "s3-bucket-cloudtrail-logging" {
   source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=8688bc15a08fbf5a4f4eef9b7433c5a417df8df1" # v7.0.0
@@ -356,6 +348,6 @@ module "s3-bucket-cloudtrail-logging" {
     }
   ]
 
-  replication_role_arn = module.cloudtrail-s3-logging-replication-role.role.arn
+  replication_role_arn = module.s3-bucket-cloudtrail-logging.role.arn
   tags                 = local.tags
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

#6492 

## How does this PR fix the problem?

The replication role module has been integrated into the main s3 bucket module so I removed the references to it and updated the source with the new release for the S3 bucket module.

