### PR TITLE
amended security_and_analysis{} to account for current use of public …

### DIFF
--- a/terraform/github/modules/repository/main.tf
+++ b/terraform/github/modules/repository/main.tf
@@ -26,17 +26,17 @@ resource "github_repository" "default" {
   topics                 = concat(local.topics, var.topics)
 
   security_and_analysis {
-    dynamic "secret_scanning" {
-      for_each = var.visibility == "public" ? [1] : []
-      content {
-        status = "enabled"
-      }
+    dynamic "advanced_security" {
+      for_each = var.visibility == "public" ? [] : [1]
+        content {
+          status = "disabled"
+        }
+     }
+    secret_scanning {
+      status = var.visibility == "public" ? "enabled" : "disabled"
     }
-    dynamic "secret_scanning_push_protection" {
-      for_each = var.visibility == "public" ? [1] : []
-      content {
-        status = "enabled"
-      }
+    secret_scanning_push_protection {
+      status = var.visibility == "public" ? "enabled" : "disabled"
     }
   }
 


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/6942

## How does this PR fix the problem?

Current use of dynamic blocks leads to changes in plan outputs; the disabled values in `modernisation-platform-security` become `null`.

## How has this been tested?

Tested with local plans

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)


