### PR TITLE
Modify jq query to check for `github_action_reviewer` flag

### DIFF
--- a/environments/delius-core.json
+++ b/environments/delius-core.json
@@ -9,7 +9,8 @@
         {
           "github_slug": "hmpps-migration",
           "level": "sandbox",
-          "nuke": "exclude"
+          "nuke": "exclude",
+          "github_action_reviewer" : "true"
         },
         {
           "github_slug": "hmpps-dba",
@@ -19,7 +20,8 @@
         {
           "github_slug": "unilink",
           "level": "developer",
-          "nuke": "exclude"
+          "nuke": "exclude",
+          "github_action_reviewer" : "true"
         }
       ]
     },

--- a/environments/delius-core.json
+++ b/environments/delius-core.json
@@ -1,7 +1,6 @@
 {
   "account-type": "member",
   "codeowners": ["hmpps-migration"],
-  "github_action_reviewers": ["hmpps-migration"],
   "environments": [
     {
       "name": "development",
@@ -30,7 +29,8 @@
       "access": [
         {
           "github_slug": "hmpps-migration",
-          "level": "developer"
+          "level": "developer",
+          "github_action_reviewer": "true"
         },
         {
           "github_slug": "hmpps-dba",
@@ -47,7 +47,8 @@
       "access": [
         {
           "github_slug": "hmpps-migration",
-          "level": "developer"
+          "level": "developer",
+          "github_action_reviewer": "true"
         },
         {
           "github_slug": "hmpps-dba",
@@ -64,7 +65,8 @@
       "access": [
         {
           "github_slug": "hmpps-migration",
-          "level": "developer"
+          "level": "developer",
+          "github_action_reviewer": "true"
         },
         {
           "github_slug": "hmpps-dba",

--- a/environments/delius-nextcloud.json
+++ b/environments/delius-nextcloud.json
@@ -1,7 +1,6 @@
 {
   "account-type": "member",
   "codeowners": ["hmpps-migration"],
-  "github_action_reviewers": ["hmpps-migration"],
   "environments": [
     {
       "name": "development",
@@ -9,7 +8,8 @@
         {
           "github_slug": "hmpps-migration",
           "level": "sandbox",
-          "nuke": "exclude"
+          "nuke": "exclude",
+          "github_action_reviewer": "true"
         }
       ]
     },
@@ -18,7 +18,8 @@
       "access": [
         {
           "github_slug": "hmpps-migration",
-          "level": "developer"
+          "level": "developer",
+          "github_action_reviewer": "true"
         }
       ]
     },
@@ -27,7 +28,8 @@
       "access": [
         {
           "github_slug": "hmpps-migration",
-          "level": "developer"
+          "level": "developer",
+          "github_action_reviewer": "true"
         }
       ]
     },
@@ -36,7 +38,8 @@
       "access": [
         {
           "github_slug": "hmpps-migration",
-          "level": "developer"
+          "level": "developer",
+          "github_action_reviewer": "true"
         }
       ]
     }

--- a/scripts/git-create-environments.sh
+++ b/scripts/git-create-environments.sh
@@ -169,7 +169,7 @@ main() {
           teams=$github_action_reviewers
         else
           # If github_action_reviewers wasn't provided, get environment GitHub team slugs from member access array instead
-          teams=$(jq -r --arg e "${env}" '.environments[] | select( .name == $e ) | .access[].github_slug' $json_file)
+          teams=$(jq -r --arg e "${env}" '.environments[] | select( .name == $e ) | .access[] | select(.github_action_reviewer=="true") | .github_slug' $json_file)
         fi
 
         echo "Teams for $environment: $teams"

--- a/scripts/git-create-environments.sh
+++ b/scripts/git-create-environments.sh
@@ -161,20 +161,11 @@ main() {
       account_type=$(jq -r '."account-type"' ${json_file})
       if [ "${account_type}" = "member" ]
       then
-        
-        # Get environment GitHub team slugs from github_action_reviewers array
-        github_action_reviewers=$(jq -r 'try (.github_action_reviewers[])' $json_file)
-        # If github_action_reviewers is not empty, use it as the teams
-         if ([ ${#github_action_reviewers[@]} -gt 0 ] && [ -n "$github_action_reviewers" ]); then
-          teams=$github_action_reviewers
-        else
-          # If github_action_reviewers wasn't provided, get environment GitHub team slugs from member access array instead
-          # Check for teams that have the github_action_reviewer flag set to true
-          teams=$(jq -r --arg e "${env}" '.environments[] | select( .name == $e ) | .access[] | select(.github_action_reviewer=="true") | .github_slug' $json_file)
-          # if teams is empty (none of the teams have the github_action_reviewer flag), get all teams
-          if [ -z "$teams" ]; then
-            teams=$(jq -r --arg e "${env}" '.environments[] | select( .name == $e ) | .access[].github_slug' $json_file)
-          fi
+        # Check for teams that have the github_action_reviewer flag set to true
+        teams=$(jq -r --arg e "${env}" '.environments[] | select( .name == $e ) | .access[] | select(.github_action_reviewer=="true") | .github_slug' $json_file)
+        # if teams is empty (none of the teams have the github_action_reviewer flag), get all teams
+        if [ -z "$teams" ]; then
+          teams=$(jq -r --arg e "${env}" '.environments[] | select( .name == $e ) | .access[].github_slug' $json_file)
         fi
 
         echo "Teams for $environment: $teams"

--- a/scripts/git-create-environments.sh
+++ b/scripts/git-create-environments.sh
@@ -169,7 +169,12 @@ main() {
           teams=$github_action_reviewers
         else
           # If github_action_reviewers wasn't provided, get environment GitHub team slugs from member access array instead
+          # Check for teams that have the github_action_reviewer flag set to true
           teams=$(jq -r --arg e "${env}" '.environments[] | select( .name == $e ) | .access[] | select(.github_action_reviewer=="true") | .github_slug' $json_file)
+          # if teams is empty (none of the teams have the github_action_reviewer flag), get all teams
+          if [ -z "$teams" ]; then
+            teams=$(jq -r --arg e "${env}" '.environments[] | select( .name == $e ) | .access[].github_slug' $json_file)
+          fi
         fi
 
         echo "Teams for $environment: $teams"

--- a/source/runbooks/creating-accounts-for-end-users.html.md.erb
+++ b/source/runbooks/creating-accounts-for-end-users.html.md.erb
@@ -56,10 +56,6 @@ See [#5957](https://github.com/ministryofjustice/modernisation-platform/pull/595
 
 By default all teams listed in the access blocks for an environment can approve the corresponding Github action runs.
 
-You can override this by defining `github_action_reviewers` as an attribute for the application.
-
-`"github_action_reviewers" : ["<owner-name>"],` Replace \<owner-name\> with a GitHub team such as `modernisation-platform`. This will set the GitHub team slugs that can approve the Github action runs for every environment and will override the default behaviour.
-
 Alternatively, if you wish to specify the GitHub team slugs that can approve the Github action runs for a specific environment, you can define `github_action_reviewer` as an attribute for that environment by setting `"github_action_reviewer" : "true"` in the access block for that environment/team.
 
 ```json

--- a/source/runbooks/creating-accounts-for-end-users.html.md.erb
+++ b/source/runbooks/creating-accounts-for-end-users.html.md.erb
@@ -76,8 +76,6 @@ Alternatively, if you wish to specify the GitHub team slugs that can approve the
 
 In this example, only the `modernisation-platform` team can approve the Github action runs for the development environment.
 
-This will restrict Github action approval to only the GitHub team slugs listed in the 'github_action_reviewers' attribute.
-
 See [#6338](https://github.com/ministryofjustice/modernisation-platform/pull/6338) for an example of the change required.
 
 #### 2. Update the `expected.rego`

--- a/source/runbooks/creating-accounts-for-end-users.html.md.erb
+++ b/source/runbooks/creating-accounts-for-end-users.html.md.erb
@@ -58,7 +58,27 @@ By default all teams listed in the access blocks for an environment can approve 
 
 You can override this by defining `github_action_reviewers` as an attribute for the application.
 
-`"github_action_reviewers" : ["<owner-name>"],` Replace \<owner-name\> with a GitHub team such as `modernisation-platform`.
+`"github_action_reviewers" : ["<owner-name>"],` Replace \<owner-name\> with a GitHub team such as `modernisation-platform`. This will set the GitHub team slugs that can approve the Github action runs for every environment and will override the default behaviour.
+
+Alternatively, if you wish to specify the GitHub team slugs that can approve the Github action runs for a specific environment, you can define `github_action_reviewer` as an attribute for that environment by setting `"github_action_reviewer" : "true"` in the access block for that environment/team.
+
+```json
+    "name": "development",
+      "access": [
+        {
+          "github_slug": "modernisation-platform",
+          "level": "developer",
+          "github_action_reviewer" : "true"
+        },
+        {
+          "github_slug": "some-other-team",
+          "level": "developer"
+        }
+      ]
+    },
+```
+
+In this example, only the `modernisation-platform` team can approve the Github action runs for the development environment.
 
 This will restrict Github action approval to only the GitHub team slugs listed in the 'github_action_reviewers' attribute.
 

--- a/source/user-guide/creating-environments.html.md.erb
+++ b/source/user-guide/creating-environments.html.md.erb
@@ -191,9 +191,9 @@ Here are some examples of the environments JSON file that the Modernisation Plat
 - `account-type` determines if this is a core modernisation platform account or a user member account.
 - `isolated-network` is an optional field which can be set to 'true' if you require an isolated environment with no internet or shared network connectivity.
 - `codeowners` is an optional list of GitHub slugs if you want specific teams to review code changes before they are released into environments.
-- `github_action_reviewers` is an optional list of GitHub slugs if you want specific teams to approve GitHub action runs.
 - `environments` should be an array of objects for environments required. If the environment is `production`, retention periods, backup frequency, and similar will be different compared to non-production environments.
 - the `name` key and `access` object are required, see: [Another example](#another-example)
+- `github_action_reviewer` is an optional true/false for each team listed and determines if the team should be the approver for GitHub action runs.
 - the `nuke` key is optional and is only read if the `access.level` is `sandbox`.
 - `tags` should be an object of the mandatory tags defined in the MoJ [Tagging Guidance](https://ministryofjustice.github.io/technical-guidance/documentation/standards/documenting-infrastructure-owners.html#tagging-your-infrastructure). You can omit `is-production` as we infer this from the environment name.
 
@@ -206,7 +206,6 @@ Here are some examples of the environments JSON file that the Modernisation Plat
   "account-type": "",
   "isolated-network": "",
   "codeowners": [""],
-  "github_action_reviewers": [""],
   "environments": [
     {
       "name": ""
@@ -214,7 +213,8 @@ Here are some examples of the environments JSON file that the Modernisation Plat
         {
           "github_slug": "",
           "level": "",
-          "nuke": ""
+          "nuke": "",
+          "github_action_reviewer": "true"
         }
       ]
     }


### PR DESCRIPTION
## A reference to the issue / Description of it

Following on from #6338, this allows specifying the owners at the access array level.

In #6338, github actions reviewers can be specified to override the default behavior (of selecting all teams), but this applies to all environments.

## How does this PR fix the problem?

Adding support for the `github_action_reviewer` flag to each team allows picking a choosing which teams are added to the github environments required reviewers.

It is backwards compatible as if no `github_action_reviewer` flags are detected in the environment, it falls back to allowing all listed github slugs access.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

I have tested the change to the environments file + the jq query locally - all other logic should still apply.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
