### PR TITLE
Terraform code amended to correct CKV_TF_2 error.

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/collaborators.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/collaborators.tf
@@ -1,12 +1,11 @@
 # read only role for collaborators
 module "collaborator_readonly_role" {
   # checkov:skip=CKV_TF_1:
-  # checkov:skip=CKV_TF_2:
-  count                = local.account_data.account-type == "member" || local.account_data.account-type == "core" ? 1 : 0
-  source               = "terraform-aws-modules/iam/aws//modules/iam-assumable-roles"
-  version              = "~> 5"
-  max_session_duration = 43200
 
+  count                = local.account_data.account-type == "member" || local.account_data.account-type == "core" ? 1 : 0
+  source                = "github.com/terraform-aws-modules/terraform-aws-iam//modules/iam-assumable-roles?ref=de95e21a3bc51cd3a44b3b95a4c2f61000649ebb"
+
+  max_session_duration = 43200
   # Read-only role
   create_readonly_role       = true
   readonly_role_name         = "read-only"
@@ -25,10 +24,10 @@ data "aws_iam_policy" "common_policy" {
 # security audit role for collaborators
 module "collaborator_security_audit_role" {
   # checkov:skip=CKV_TF_1:
-  # checkov:skip=CKV_TF_2:
+
   count                = local.account_data.account-type == "member" || local.account_data.account-type == "core" ? 1 : 0
-  source               = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
-  version              = "~> 5"
+  source               = "github.com/terraform-aws-modules/terraform-aws-iam//modules/iam-assumable-role?ref=de95e21a3bc51cd3a44b3b95a4c2f61000649ebb"
+
   max_session_duration = 43200
 
   create_role       = true
@@ -48,10 +47,10 @@ module "collaborator_security_audit_role" {
 # developer role for collaborators
 module "collaborator_developer_role" {
   # checkov:skip=CKV_TF_1:
-  # checkov:skip=CKV_TF_2:
+
   count   = local.account_data.account-type == "member" ? 1 : 0
-  source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
-  version = "~> 5"
+  source  = "github.com/terraform-aws-modules/terraform-aws-iam//modules/iam-assumable-role?ref=de95e21a3bc51cd3a44b3b95a4c2f61000649ebb"
+
   trusted_role_arns = [
     local.modernisation_platform_account.id
   ]
@@ -75,10 +74,10 @@ data "aws_iam_policy" "developer" {
 # Collaborator Sandbox role
 module "collaborator_sandbox_role" {
   # checkov:skip=CKV_TF_1:
-  # checkov:skip=CKV_TF_2:
+
   count   = local.account_data.account-type == "member" && local.application_environment == "development" ? 1 : 0
-  source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
-  version = "~> 5"
+  source  = "github.com/terraform-aws-modules/terraform-aws-iam//modules/iam-assumable-role?ref=de95e21a3bc51cd3a44b3b95a4c2f61000649ebb"
+
   trusted_role_arns = [
     local.modernisation_platform_account.id
   ]
@@ -106,10 +105,10 @@ data "aws_iam_policy" "bedrock" {
 # Collaborator Migration role
 module "collaborator_migration_role" {
   # checkov:skip=CKV_TF_1:
-  # checkov:skip=CKV_TF_2:
+
   count   = local.account_data.account-type == "member" ? 1 : 0
-  source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
-  version = "~> 5"
+  source  = "github.com/terraform-aws-modules/terraform-aws-iam//modules/iam-assumable-role?ref=de95e21a3bc51cd3a44b3b95a4c2f61000649ebb"
+
   trusted_role_arns = [
     local.modernisation_platform_account.id
   ]
@@ -139,10 +138,10 @@ data "aws_iam_policy" "migration" {
 # Collaborator Instance Access role
 module "collaborator_instance_access_role" {
   # checkov:skip=CKV_TF_1:
-  # checkov:skip=CKV_TF_2:
+
   count   = local.account_data.account-type == "member" ? 1 : 0
-  source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
-  version = "~> 5"
+  source  = "github.com/terraform-aws-modules/terraform-aws-iam//modules/iam-assumable-role?ref=de95e21a3bc51cd3a44b3b95a4c2f61000649ebb"
+
   trusted_role_arns = [
     local.modernisation_platform_account.id
   ]
@@ -166,10 +165,10 @@ data "aws_iam_policy" "instance-access" {
 # Collaborator Database Management role
 module "collaborator_database_mgmt_role" {
   # checkov:skip=CKV_TF_1:
-  # checkov:skip=CKV_TF_2:
+
   count   = local.account_data.account-type == "member" ? 1 : 0
-  source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
-  version = "~> 5"
+  source  = "github.com/terraform-aws-modules/terraform-aws-iam//modules/iam-assumable-role?ref=de95e21a3bc51cd3a44b3b95a4c2f61000649ebb"
+
   trusted_role_arns = [
     local.modernisation_platform_account.id
   ]
@@ -193,10 +192,10 @@ data "aws_iam_policy" "instance-management" {
 # fleet-manager role for collaborators
 module "collaborator_fleet_manager_role" {
   # checkov:skip=CKV_TF_1:
-  # checkov:skip=CKV_TF_2:
+
   count   = local.account_data.account-type == "member" ? 1 : 0
-  source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
-  version = "~> 5"
+  source  = "github.com/terraform-aws-modules/terraform-aws-iam//modules/iam-assumable-role?ref=de95e21a3bc51cd3a44b3b95a4c2f61000649ebb"
+
   trusted_role_arns = [
     local.modernisation_platform_account.id
   ]

--- a/terraform/environments/bootstrap/member-bootstrap/collaborators.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/collaborators.tf
@@ -3,7 +3,7 @@ module "collaborator_readonly_role" {
   # checkov:skip=CKV_TF_1:
 
   count                = local.account_data.account-type == "member" || local.account_data.account-type == "core" ? 1 : 0
-  source                = "github.com/terraform-aws-modules/terraform-aws-iam//modules/iam-assumable-roles?ref=de95e21a3bc51cd3a44b3b95a4c2f61000649ebb" v5.39.1
+  source                = "github.com/terraform-aws-modules/terraform-aws-iam//modules/iam-assumable-roles?ref=de95e21a3bc51cd3a44b3b95a4c2f61000649ebb" # v5.39.1
 
   max_session_duration = 43200
   # Read-only role
@@ -26,7 +26,7 @@ module "collaborator_security_audit_role" {
   # checkov:skip=CKV_TF_1:
 
   count                = local.account_data.account-type == "member" || local.account_data.account-type == "core" ? 1 : 0
-  source               = "github.com/terraform-aws-modules/terraform-aws-iam//modules/iam-assumable-role?ref=de95e21a3bc51cd3a44b3b95a4c2f61000649ebb" v5.39.1
+  source               = "github.com/terraform-aws-modules/terraform-aws-iam//modules/iam-assumable-role?ref=de95e21a3bc51cd3a44b3b95a4c2f61000649ebb" # v5.39.1
 
   max_session_duration = 43200
 
@@ -49,7 +49,7 @@ module "collaborator_developer_role" {
   # checkov:skip=CKV_TF_1:
 
   count   = local.account_data.account-type == "member" ? 1 : 0
-  source  = "github.com/terraform-aws-modules/terraform-aws-iam//modules/iam-assumable-role?ref=de95e21a3bc51cd3a44b3b95a4c2f61000649ebb" v5.39.1
+  source  = "github.com/terraform-aws-modules/terraform-aws-iam//modules/iam-assumable-role?ref=de95e21a3bc51cd3a44b3b95a4c2f61000649ebb" # v5.39.1
 
   trusted_role_arns = [
     local.modernisation_platform_account.id
@@ -76,7 +76,7 @@ module "collaborator_sandbox_role" {
   # checkov:skip=CKV_TF_1:
 
   count   = local.account_data.account-type == "member" && local.application_environment == "development" ? 1 : 0
-  source  = "github.com/terraform-aws-modules/terraform-aws-iam//modules/iam-assumable-role?ref=de95e21a3bc51cd3a44b3b95a4c2f61000649ebb" v5.39.1
+  source  = "github.com/terraform-aws-modules/terraform-aws-iam//modules/iam-assumable-role?ref=de95e21a3bc51cd3a44b3b95a4c2f61000649ebb" # v5.39.1
 
   trusted_role_arns = [
     local.modernisation_platform_account.id
@@ -107,7 +107,7 @@ module "collaborator_migration_role" {
   # checkov:skip=CKV_TF_1:
 
   count   = local.account_data.account-type == "member" ? 1 : 0
-  source  = "github.com/terraform-aws-modules/terraform-aws-iam//modules/iam-assumable-role?ref=de95e21a3bc51cd3a44b3b95a4c2f61000649ebb" v5.39.1
+  source  = "github.com/terraform-aws-modules/terraform-aws-iam//modules/iam-assumable-role?ref=de95e21a3bc51cd3a44b3b95a4c2f61000649ebb" # v5.39.1
 
   trusted_role_arns = [
     local.modernisation_platform_account.id
@@ -140,7 +140,7 @@ module "collaborator_instance_access_role" {
   # checkov:skip=CKV_TF_1:
 
   count   = local.account_data.account-type == "member" ? 1 : 0
-  source  = "github.com/terraform-aws-modules/terraform-aws-iam//modules/iam-assumable-role?ref=de95e21a3bc51cd3a44b3b95a4c2f61000649ebb" v5.39.1
+  source  = "github.com/terraform-aws-modules/terraform-aws-iam//modules/iam-assumable-role?ref=de95e21a3bc51cd3a44b3b95a4c2f61000649ebb" # v5.39.1
 
   trusted_role_arns = [
     local.modernisation_platform_account.id
@@ -167,7 +167,7 @@ module "collaborator_database_mgmt_role" {
   # checkov:skip=CKV_TF_1:
 
   count   = local.account_data.account-type == "member" ? 1 : 0
-  source  = "github.com/terraform-aws-modules/terraform-aws-iam//modules/iam-assumable-role?ref=de95e21a3bc51cd3a44b3b95a4c2f61000649ebb" v5.39.1
+  source  = "github.com/terraform-aws-modules/terraform-aws-iam//modules/iam-assumable-role?ref=de95e21a3bc51cd3a44b3b95a4c2f61000649ebb" # v5.39.1
 
   trusted_role_arns = [
     local.modernisation_platform_account.id
@@ -194,7 +194,7 @@ module "collaborator_fleet_manager_role" {
   # checkov:skip=CKV_TF_1:
 
   count   = local.account_data.account-type == "member" ? 1 : 0
-  source  = "github.com/terraform-aws-modules/terraform-aws-iam//modules/iam-assumable-role?ref=de95e21a3bc51cd3a44b3b95a4c2f61000649ebb" v5.39.1
+  source  = "github.com/terraform-aws-modules/terraform-aws-iam//modules/iam-assumable-role?ref=de95e21a3bc51cd3a44b3b95a4c2f61000649ebb" # v5.39.1
 
   trusted_role_arns = [
     local.modernisation_platform_account.id

--- a/terraform/environments/bootstrap/member-bootstrap/collaborators.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/collaborators.tf
@@ -1,6 +1,7 @@
 # read only role for collaborators
 module "collaborator_readonly_role" {
   # checkov:skip=CKV_TF_1:
+  # checkov:skip=CKV_TF_2:
   count                = local.account_data.account-type == "member" || local.account_data.account-type == "core" ? 1 : 0
   source               = "terraform-aws-modules/iam/aws//modules/iam-assumable-roles"
   version              = "~> 5"
@@ -24,6 +25,7 @@ data "aws_iam_policy" "common_policy" {
 # security audit role for collaborators
 module "collaborator_security_audit_role" {
   # checkov:skip=CKV_TF_1:
+  # checkov:skip=CKV_TF_2:
   count                = local.account_data.account-type == "member" || local.account_data.account-type == "core" ? 1 : 0
   source               = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
   version              = "~> 5"
@@ -46,6 +48,7 @@ module "collaborator_security_audit_role" {
 # developer role for collaborators
 module "collaborator_developer_role" {
   # checkov:skip=CKV_TF_1:
+  # checkov:skip=CKV_TF_2:
   count   = local.account_data.account-type == "member" ? 1 : 0
   source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
   version = "~> 5"
@@ -72,6 +75,7 @@ data "aws_iam_policy" "developer" {
 # Collaborator Sandbox role
 module "collaborator_sandbox_role" {
   # checkov:skip=CKV_TF_1:
+  # checkov:skip=CKV_TF_2:
   count   = local.account_data.account-type == "member" && local.application_environment == "development" ? 1 : 0
   source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
   version = "~> 5"
@@ -102,6 +106,7 @@ data "aws_iam_policy" "bedrock" {
 # Collaborator Migration role
 module "collaborator_migration_role" {
   # checkov:skip=CKV_TF_1:
+  # checkov:skip=CKV_TF_2:
   count   = local.account_data.account-type == "member" ? 1 : 0
   source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
   version = "~> 5"
@@ -134,6 +139,7 @@ data "aws_iam_policy" "migration" {
 # Collaborator Instance Access role
 module "collaborator_instance_access_role" {
   # checkov:skip=CKV_TF_1:
+  # checkov:skip=CKV_TF_2:
   count   = local.account_data.account-type == "member" ? 1 : 0
   source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
   version = "~> 5"
@@ -160,6 +166,7 @@ data "aws_iam_policy" "instance-access" {
 # Collaborator Database Management role
 module "collaborator_database_mgmt_role" {
   # checkov:skip=CKV_TF_1:
+  # checkov:skip=CKV_TF_2:
   count   = local.account_data.account-type == "member" ? 1 : 0
   source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
   version = "~> 5"
@@ -186,6 +193,7 @@ data "aws_iam_policy" "instance-management" {
 # fleet-manager role for collaborators
 module "collaborator_fleet_manager_role" {
   # checkov:skip=CKV_TF_1:
+  # checkov:skip=CKV_TF_2:
   count   = local.account_data.account-type == "member" ? 1 : 0
   source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
   version = "~> 5"

--- a/terraform/environments/bootstrap/member-bootstrap/collaborators.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/collaborators.tf
@@ -3,7 +3,7 @@ module "collaborator_readonly_role" {
   # checkov:skip=CKV_TF_1:
 
   count                = local.account_data.account-type == "member" || local.account_data.account-type == "core" ? 1 : 0
-  source                = "github.com/terraform-aws-modules/terraform-aws-iam//modules/iam-assumable-roles?ref=de95e21a3bc51cd3a44b3b95a4c2f61000649ebb"
+  source                = "github.com/terraform-aws-modules/terraform-aws-iam//modules/iam-assumable-roles?ref=de95e21a3bc51cd3a44b3b95a4c2f61000649ebb" v5.39.1
 
   max_session_duration = 43200
   # Read-only role
@@ -26,7 +26,7 @@ module "collaborator_security_audit_role" {
   # checkov:skip=CKV_TF_1:
 
   count                = local.account_data.account-type == "member" || local.account_data.account-type == "core" ? 1 : 0
-  source               = "github.com/terraform-aws-modules/terraform-aws-iam//modules/iam-assumable-role?ref=de95e21a3bc51cd3a44b3b95a4c2f61000649ebb"
+  source               = "github.com/terraform-aws-modules/terraform-aws-iam//modules/iam-assumable-role?ref=de95e21a3bc51cd3a44b3b95a4c2f61000649ebb" v5.39.1
 
   max_session_duration = 43200
 
@@ -49,7 +49,7 @@ module "collaborator_developer_role" {
   # checkov:skip=CKV_TF_1:
 
   count   = local.account_data.account-type == "member" ? 1 : 0
-  source  = "github.com/terraform-aws-modules/terraform-aws-iam//modules/iam-assumable-role?ref=de95e21a3bc51cd3a44b3b95a4c2f61000649ebb"
+  source  = "github.com/terraform-aws-modules/terraform-aws-iam//modules/iam-assumable-role?ref=de95e21a3bc51cd3a44b3b95a4c2f61000649ebb" v5.39.1
 
   trusted_role_arns = [
     local.modernisation_platform_account.id
@@ -76,7 +76,7 @@ module "collaborator_sandbox_role" {
   # checkov:skip=CKV_TF_1:
 
   count   = local.account_data.account-type == "member" && local.application_environment == "development" ? 1 : 0
-  source  = "github.com/terraform-aws-modules/terraform-aws-iam//modules/iam-assumable-role?ref=de95e21a3bc51cd3a44b3b95a4c2f61000649ebb"
+  source  = "github.com/terraform-aws-modules/terraform-aws-iam//modules/iam-assumable-role?ref=de95e21a3bc51cd3a44b3b95a4c2f61000649ebb" v5.39.1
 
   trusted_role_arns = [
     local.modernisation_platform_account.id
@@ -107,7 +107,7 @@ module "collaborator_migration_role" {
   # checkov:skip=CKV_TF_1:
 
   count   = local.account_data.account-type == "member" ? 1 : 0
-  source  = "github.com/terraform-aws-modules/terraform-aws-iam//modules/iam-assumable-role?ref=de95e21a3bc51cd3a44b3b95a4c2f61000649ebb"
+  source  = "github.com/terraform-aws-modules/terraform-aws-iam//modules/iam-assumable-role?ref=de95e21a3bc51cd3a44b3b95a4c2f61000649ebb" v5.39.1
 
   trusted_role_arns = [
     local.modernisation_platform_account.id
@@ -140,7 +140,7 @@ module "collaborator_instance_access_role" {
   # checkov:skip=CKV_TF_1:
 
   count   = local.account_data.account-type == "member" ? 1 : 0
-  source  = "github.com/terraform-aws-modules/terraform-aws-iam//modules/iam-assumable-role?ref=de95e21a3bc51cd3a44b3b95a4c2f61000649ebb"
+  source  = "github.com/terraform-aws-modules/terraform-aws-iam//modules/iam-assumable-role?ref=de95e21a3bc51cd3a44b3b95a4c2f61000649ebb" v5.39.1
 
   trusted_role_arns = [
     local.modernisation_platform_account.id
@@ -167,7 +167,7 @@ module "collaborator_database_mgmt_role" {
   # checkov:skip=CKV_TF_1:
 
   count   = local.account_data.account-type == "member" ? 1 : 0
-  source  = "github.com/terraform-aws-modules/terraform-aws-iam//modules/iam-assumable-role?ref=de95e21a3bc51cd3a44b3b95a4c2f61000649ebb"
+  source  = "github.com/terraform-aws-modules/terraform-aws-iam//modules/iam-assumable-role?ref=de95e21a3bc51cd3a44b3b95a4c2f61000649ebb" v5.39.1
 
   trusted_role_arns = [
     local.modernisation_platform_account.id
@@ -194,7 +194,7 @@ module "collaborator_fleet_manager_role" {
   # checkov:skip=CKV_TF_1:
 
   count   = local.account_data.account-type == "member" ? 1 : 0
-  source  = "github.com/terraform-aws-modules/terraform-aws-iam//modules/iam-assumable-role?ref=de95e21a3bc51cd3a44b3b95a4c2f61000649ebb"
+  source  = "github.com/terraform-aws-modules/terraform-aws-iam//modules/iam-assumable-role?ref=de95e21a3bc51cd3a44b3b95a4c2f61000649ebb" v5.39.1
 
   trusted_role_arns = [
     local.modernisation_platform_account.id

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -652,9 +652,9 @@ data "aws_iam_policy_document" "oidc_assume_role_member" {
 # AWS Shield Advanced SRT (Shield Response Team) support role
 module "shield_response_team_role" {
   # checkov:skip=CKV_TF_1:
-  # checkov:skip=CKV_TF_2:
-  source                = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
-  version               = "~> 5"
+
+  source                = "github.com/terraform-aws-modules/terraform-aws-iam//modules/iam-assumable-role?ref=de95e21a3bc51cd3a44b3b95a4c2f61000649ebb"
+
   trusted_role_services = ["drt.shield.amazonaws.com"]
 
   create_role       = true

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -653,7 +653,7 @@ data "aws_iam_policy_document" "oidc_assume_role_member" {
 module "shield_response_team_role" {
   # checkov:skip=CKV_TF_1:
 
-  source                = "github.com/terraform-aws-modules/terraform-aws-iam//modules/iam-assumable-role?ref=de95e21a3bc51cd3a44b3b95a4c2f61000649ebb"
+  source                = "github.com/terraform-aws-modules/terraform-aws-iam//modules/iam-assumable-role?ref=de95e21a3bc51cd3a44b3b95a4c2f61000649ebb" # v5.39.1
 
   trusted_role_services = ["drt.shield.amazonaws.com"]
 

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -652,6 +652,7 @@ data "aws_iam_policy_document" "oidc_assume_role_member" {
 # AWS Shield Advanced SRT (Shield Response Team) support role
 module "shield_response_team_role" {
   # checkov:skip=CKV_TF_1:
+  # checkov:skip=CKV_TF_2:
   source                = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
   version               = "~> 5"
   trusted_role_services = ["drt.shield.amazonaws.com"]

--- a/terraform/templates/modernisation-platform-environments-isolated/vpc.tf
+++ b/terraform/templates/modernisation-platform-environments-isolated/vpc.tf
@@ -20,7 +20,7 @@ module "vpc" {
 module "vpc_endpoints" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
-  source  = "terraform-aws-modules/vpc/aws/modules/vpc-endpoints?ref=9163310db647ed98094319980bd8eef72bee492b"
+  source  = "github.com/terraform-aws-modules/vpc/aws//modules/vpc-endpoints?ref=25322b6b6be69db6cca7f167d7b0e5327156a595" # v5.8.1
 
   security_group_ids = [aws_security_group.vpc_endpoints.id]
   subnet_ids         = module.vpc.private_subnets

--- a/terraform/templates/modernisation-platform-environments-isolated/vpc.tf
+++ b/terraform/templates/modernisation-platform-environments-isolated/vpc.tf
@@ -1,7 +1,7 @@
 module "vpc" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
-  source  = "github.com/terraform-aws-modules/vpc/aws?ref=25322b6b6be69db6cca7f167d7b0e5327156a595" # v5.8.1
+  source  = "github.com/terraform-aws-modules/terraform-aws-vpc//modules/vpc-endpoints?ref=25322b6b6be69db6cca7f167d7b0e5327156a595" # v5.8.1
 
   name            = "${local.application_name}-${local.environment}"
   azs             = local.availability_zones
@@ -20,7 +20,7 @@ module "vpc" {
 module "vpc_endpoints" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
-  source  = "github.com/terraform-aws-modules/vpc/aws//modules/vpc-endpoints?ref=25322b6b6be69db6cca7f167d7b0e5327156a595" # v5.8.1
+  source  = "github.com/terraform-aws-modules/terraform-aws-vpc//modules/vpc-endpoints?ref=25322b6b6be69db6cca7f167d7b0e5327156a595" # v5.8.1
 
   security_group_ids = [aws_security_group.vpc_endpoints.id]
   subnet_ids         = module.vpc.private_subnets

--- a/terraform/templates/modernisation-platform-environments-isolated/vpc.tf
+++ b/terraform/templates/modernisation-platform-environments-isolated/vpc.tf
@@ -1,7 +1,7 @@
 module "vpc" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
-  source  = "github.com/terraform-aws-modules/vpc/aws?ref=25322b6b6be69db6cca7f167d7b0e5327156a595"
+  source  = "github.com/terraform-aws-modules/vpc/aws?ref=25322b6b6be69db6cca7f167d7b0e5327156a595" # v5.8.1
 
   name            = "${local.application_name}-${local.environment}"
   azs             = local.availability_zones

--- a/terraform/templates/modernisation-platform-environments-isolated/vpc.tf
+++ b/terraform/templates/modernisation-platform-environments-isolated/vpc.tf
@@ -1,8 +1,8 @@
 module "vpc" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
-  source  = "github.com/terraform-aws-modules/terraform-aws-vpc//modules/vpc-endpoints?ref=25322b6b6be69db6cca7f167d7b0e5327156a595" # v5.8.1
-
+  source = "github.com/terraform-aws-modules/terraform-aws-vpc?ref=25322b6b6be69db6cca7f167d7b0e5327156a595" # v5.8.1
+  
   name            = "${local.application_name}-${local.environment}"
   azs             = local.availability_zones
   cidr            = local.application_data.accounts[local.environment].vpc_cidr
@@ -20,7 +20,7 @@ module "vpc" {
 module "vpc_endpoints" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
-  source  = "github.com/terraform-aws-modules/terraform-aws-vpc//modules/vpc-endpoints?ref=25322b6b6be69db6cca7f167d7b0e5327156a595" # v5.8.1
+  source = "github.com/terraform-aws-modules/terraform-aws-vpc?ref=25322b6b6be69db6cca7f167d7b0e5327156a595" # v5.8.1
 
   security_group_ids = [aws_security_group.vpc_endpoints.id]
   subnet_ids         = module.vpc.private_subnets

--- a/terraform/templates/modernisation-platform-environments-isolated/vpc.tf
+++ b/terraform/templates/modernisation-platform-environments-isolated/vpc.tf
@@ -1,5 +1,6 @@
 module "vpc" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  # checkov:skip=CKV_TF_2:
   source  = "terraform-aws-modules/vpc/aws"
   version = "~> 5.0"
 
@@ -19,6 +20,7 @@ module "vpc" {
 
 module "vpc_endpoints" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  # checkov:skip=CKV_TF_2:
   source  = "terraform-aws-modules/vpc/aws//modules/vpc-endpoints"
   version = "~> 5.0"
 

--- a/terraform/templates/modernisation-platform-environments-isolated/vpc.tf
+++ b/terraform/templates/modernisation-platform-environments-isolated/vpc.tf
@@ -1,8 +1,7 @@
 module "vpc" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
-  # checkov:skip=CKV_TF_2:
-  source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 5.0"
+
+  source  = "github.com/terraform-aws-modules/vpc/aws?ref=25322b6b6be69db6cca7f167d7b0e5327156a595"
 
   name            = "${local.application_name}-${local.environment}"
   azs             = local.availability_zones
@@ -20,9 +19,8 @@ module "vpc" {
 
 module "vpc_endpoints" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
-  # checkov:skip=CKV_TF_2:
-  source  = "terraform-aws-modules/vpc/aws//modules/vpc-endpoints"
-  version = "~> 5.0"
+
+  source  = "terraform-aws-modules/vpc/aws/modules/vpc-endpoints?ref=9163310db647ed98094319980bd8eef72bee492b"
 
   security_group_ids = [aws_security_group.vpc_endpoints.id]
   subnet_ids         = module.vpc.private_subnets

--- a/terraform/templates/modernisation-platform-environments-isolated/vpc.tf
+++ b/terraform/templates/modernisation-platform-environments-isolated/vpc.tf
@@ -20,7 +20,7 @@ module "vpc" {
 module "vpc_endpoints" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
-  source = "github.com/terraform-aws-modules/terraform-aws-vpc?ref=25322b6b6be69db6cca7f167d7b0e5327156a595" # v5.8.1
+  source = "github.com/terraform-aws-modules/terraform-aws-vpc//modules/vpc-endpoints?ref=25322b6b6be69db6cca7f167d7b0e5327156a595" # v5.8.1
 
   security_group_ids = [aws_security_group.vpc_endpoints.id]
   subnet_ids         = module.vpc.private_subnets


### PR DESCRIPTION
## A reference to the issue / Description of it

As part of the check #6989 some errors are listed on checkov - CKV_TF_2 based on [ckv_ft_2 errors](https://github.com/ministryofjustice/modernisation-platform/actions/runs/9121756649) from the list of actions in [workflow action status]( https://user-guide.modernisation-platform.service.justice.gov.uk/user-guide/workflow-status.html#modernisation-platform-tools-amp-checks). The error relates to the code having no tag with a version number.

The code has been amended to put so that connects to the correct version of the called code and has removed the version number which is no longer needed.

Note, if terraform change the code, in the future, this will require updates to be made to the code.
