### PR TITLE
Updating GH slug for hmpps-intelligence-management

### DIFF
--- a/environments/hmpps-intelligence-management.json
+++ b/environments/hmpps-intelligence-management.json
@@ -5,7 +5,7 @@
       "name": "development",
       "access": [
         {
-          "github_slug": "dps-ims-tech",
+          "github_slug": "modernisation-platform",
           "level": "developer"
         }
       ]
@@ -14,7 +14,7 @@
       "name": "production",
       "access": [
         {
-          "github_slug": "dps-ims-tech",
+          "github_slug": "modernisation-platform",
           "level": "developer"
         }
       ]


### PR DESCRIPTION
## A reference to the issue / Description of it

[Slack thread](https://mojdt.slack.com/archives/C013RM6MFFW/p1715869004904839) related to the problem.

## How does this PR fix the problem?

Temporarily updating the GH team slug for [hmpps-intelligence-management](https://github.com/ministryofjustice/modernisation-platform/blob/main/environments/hmpps-intelligence-management.json) to unblock the baseline workflow.
