### PR TITLE
Created bucket for AWS input

### DIFF
--- a/terraform/environments/cooker/s3.tf
+++ b/terraform/environments/cooker/s3.tf
@@ -1,4 +1,5 @@
 module "s3-bucket" {
+    # checkov:skip=CKV_TF_1:
     source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=v7.0.0"
 
   bucket_prefix                            = "s3-security-testing-bucket"

--- a/terraform/environments/cooker/s3.tf
+++ b/terraform/environments/cooker/s3.tf
@@ -1,0 +1,65 @@
+module "s3-bucket" {
+    source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=v7.0.0"
+
+  bucket_prefix                            = "s3-security-testing-bucket"
+  versioning_enabled                       = true
+
+  # to disable ACLs in preference of BucketOwnership controls as per https://aws.amazon.com/blogs/aws/heads-up-amazon-s3-security-changes-are-coming-in-april-of-2023/ set:
+  ownership_controls = "BucketOwnerEnforced"
+
+  # Refer to the below section "Replication" before enabling replication
+  replication_enabled                      = false
+  # Below two variables and providers configuration are only relevant if 'replication_enabled' is set to true
+  # replication_region                       = "eu-west-2"
+  # replication_role_arn                     = module.s3-bucket.role.arn
+  providers = {
+    # Here we use the default provider Region for replication. Destination buckets can be within the same Region as the
+    # source bucket. On the other hand, if you need to enable cross-region replication, please contact the Modernisation
+    # Platform team to add a new provider for the additional Region.
+    # Leave this provider block in even if you are not using replication
+    aws.bucket-replication = aws
+  }
+
+  lifecycle_rule = [
+    {
+      id      = "main"
+      enabled = "Enabled"
+      prefix  = ""
+
+      tags = {
+        rule      = "log"
+        autoclean = "true"
+      }
+
+      transition = [
+        {
+          days          = 90
+          storage_class = "STANDARD_IA"
+          }, {
+          days          = 365
+          storage_class = "GLACIER"
+        }
+      ]
+
+      expiration = {
+        days = 730
+      }
+
+      noncurrent_version_transition = [
+        {
+          days          = 90
+          storage_class = "STANDARD_IA"
+          }, {
+          days          = 365
+          storage_class = "GLACIER"
+        }
+      ]
+
+      noncurrent_version_expiration = {
+        days = 730
+      }
+    }
+  ]
+
+  tags                 = local.tags
+}


### PR DESCRIPTION
## A reference to the issue / Description of it

Part of this ticket https://github.com/ministryofjustice/modernisation-platform/issues/5346

It mentions " with the assistance of AWS support"

I want to merge this into main, have a bucket made from our module, and get AWS input on the security surrounding it and the policies. 


## How has this been tested?

Already deployed.

