### PR TITLE
Feature/2415-monitor-ssm-instances

### DIFF
--- a/.github/workflows/ssm-managed-instances.yml
+++ b/.github/workflows/ssm-managed-instances.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   AWS_REGION: "eu-west-2"
+  ENVIRONMENT_MANAGEMENT: ${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENTS }}
 
 permissions:
   id-token: write # This is required for requesting the JWT

--- a/.github/workflows/ssm-managed-instances.yml
+++ b/.github/workflows/ssm-managed-instances.yml
@@ -1,0 +1,44 @@
+name: "SSM Managed Instances Check"
+
+on:
+  push:
+    branches:
+      - feature/2415-monitor-ssm-instances
+  workflow_dispatch:
+
+env:
+  AWS_REGION: "eu-west-2"
+
+permissions:
+  id-token: write # This is required for requesting the JWT
+  contents: read # This is required for actions/checkout
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+    monitor-ssm-instances:
+        runs-on: ubuntu-latest
+        steps:
+          - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+    
+          - name: Set Account Number
+            run: echo "ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+            
+          - name: Configure AWS Credentials
+            uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
+            with:
+              role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+              role-session-name: githubactionsrolesession
+              aws-region: ${{ env.AWS_REGION }}
+    
+          - name: Run SSM Monitoring Script
+            run: bash ./scripts/monitor-ssm-instances.sh
+
+          - name: Upload ssm-managed-instances.csv file
+            uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+            with:
+              name: ssm-managed-instances.csv
+              path: ./ssm-managed-instances.csv
+              retention-days: 1

--- a/scripts/monitor-ssm-instances.sh
+++ b/scripts/monitor-ssm-instances.sh
@@ -25,7 +25,7 @@ for account_id in $(jq -r '.account_ids | to_entries[] | "\(.value)"' <<< $ENVIR
     for region in $regions; do
         #Set Values
         AWS_REGION=$region
-        account_name=$(jq -r ".account_ids | to_entries[] | select(.value==\"$account_id\").key")
+        account_name=$(jq -r ".account_ids | to_entries[] | select(.value==\"$account_id\").key" <<< $ENVIRONMENT_MANAGEMENT)
         echo "The account name is $account_name"
         # account_id=$(aws sts get-caller-identity --query Account --output text)
 

--- a/scripts/monitor-ssm-instances.sh
+++ b/scripts/monitor-ssm-instances.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+export AWS_PAGER=""
+
+#Create csv file
+echo "Account ID,Account Name, Instance ID,Instance Name,SSM Status" > ssm-managed-instances.csv
+
+#Set Values
+account_name=$(aws iam list-account-aliases --query 'AccountAliases[*]' --output text)
+account_id=$(aws sts get-caller-identity --query Account --output text)
+
+#Check for SSM managed instances
+for instance in $(aws ec2 describe-instances --query 'Reservations[*].Instances[*].[InstanceId]' --output text)
+do
+    instance_name=$(aws ec2 describe-instances --instance-ids $instance --query 'Reservations[*].Instances[*].[Tags[?Key==`Name`].Value]' --output text)
+    managed=$(aws ssm describe-instance-information  --filters "Key=InstanceIds,Values=$instance" --query 'InstanceInformationList[*].[AssociationStatus]' --output text)
+    if [[ "$managed" != "Success" ]]; then 
+        managed="Not Managed";
+    else
+        managed="Managed"
+    fi
+    echo "$account_id,$account_name,$instance,$instance_name,$managed" >> ssm-managed-instances.csv
+done

--- a/scripts/monitor-ssm-instances.sh
+++ b/scripts/monitor-ssm-instances.sh
@@ -26,6 +26,7 @@ for account_id in $(jq -r '.account_ids | to_entries[] | "\(.value)"' <<< $ENVIR
         #Set Values
         AWS_REGION=$region
         account_name=$(jq -r ".account_ids | to_entries[] | select(.value==\"$account_id\").key")
+        echo "The account name is $account_name"
         # account_id=$(aws sts get-caller-identity --query Account --output text)
 
         #Check for SSM managed instances

--- a/scripts/monitor-ssm-instances.sh
+++ b/scripts/monitor-ssm-instances.sh
@@ -1,22 +1,52 @@
 #!/bin/bash
+
+#Set Values
 export AWS_PAGER=""
+regions="eu-central-1 eu-west-1 eu-west-2 eu-west-3 us-east-1"
+ROOT_AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
+ROOT_AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
+ROOT_AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN
 
 #Create csv file
 echo "Account ID,Account Name, Instance ID,Instance Name,SSM Status" > ssm-managed-instances.csv
 
-#Set Values
-account_name=$(aws iam list-account-aliases --query 'AccountAliases[*]' --output text)
-account_id=$(aws sts get-caller-identity --query Account --output text)
+#Assume Role Function
+getAssumeRoleCfg() {
+    account_id=$1
+    aws sts assume-role --role-arn "arn:aws:iam::${account_id}:role/ModernisationPlatformAccess" --role-session-name "test" --output json > credentials.json
+    export AWS_ACCESS_KEY_ID=$(jq -r '.Credentials.AccessKeyId' credentials.json)
+    export AWS_SECRET_ACCESS_KEY=$(jq -r '.Credentials.SecretAccessKey' credentials.json)
+    export AWS_SESSION_TOKEN=$(jq -r '.Credentials.SessionToken' credentials.json)
+}
 
-#Check for SSM managed instances
-for instance in $(aws ec2 describe-instances --query 'Reservations[*].Instances[*].[InstanceId]' --output text)
-do
-    instance_name=$(aws ec2 describe-instances --instance-ids $instance --query 'Reservations[*].Instances[*].[Tags[?Key==`Name`].Value]' --output text)
-    managed=$(aws ssm describe-instance-information  --filters "Key=InstanceIds,Values=$instance" --query 'InstanceInformationList[*].[AssociationStatus]' --output text)
-    if [[ "$managed" != "Success" ]]; then 
-        managed="Not Managed";
-    else
-        managed="Managed"
-    fi
-    echo "$account_id,$account_name,$instance,$instance_name,$managed" >> ssm-managed-instances.csv
+for account_id in $(jq -r '.account_ids | to_entries[] | "\(.value)"' <<< $ENVIRONMENT_MANAGEMENT); do
+    echo "account: $account_id"
+    getAssumeRoleCfg "$account_id"
+    for region in $regions; do
+        #Set Values
+        AWS_REGION=$region
+        account_name=$(aws iam list-account-aliases --query 'AccountAliases[*]' --output text)
+        account_id=$(aws sts get-caller-identity --query Account --output text)
+
+        #Check for SSM managed instances
+        echo "Searching for SSM managed instances in $account_name $region"
+        for instance in $(aws ec2 describe-instances --query 'Reservations[*].Instances[*].[InstanceId]' --output text)
+        do
+            instance_name=$(aws ec2 describe-instances --instance-ids $instance --query 'Reservations[*].Instances[*].[Tags[?Key==`Name`].Value]' --output text)
+            managed=$(aws ssm describe-instance-information  --filters "Key=InstanceIds,Values=$instance" --query 'InstanceInformationList[*].[AssociationStatus]' --output text)
+            if [[ "$managed" != "Success" ]]; then 
+                managed="Not Managed";
+            else
+                managed="Managed"
+            fi
+            echo "$account_id,$account_name,$instance,$instance_name,$managed" >> ssm-managed-instances.csv
+        done
+    done
+    export AWS_ACCESS_KEY_ID=$ROOT_AWS_ACCESS_KEY_ID
+    export AWS_SECRET_ACCESS_KEY=$ROOT_AWS_SECRET_ACCESS_KEY
+    export AWS_SESSION_TOKEN=$ROOT_AWS_SESSION_TOKEN
+    rm credentials.json
 done
+
+# # Print csv file to console
+# cat ssm-managed-instances.csv

--- a/scripts/monitor-ssm-instances.sh
+++ b/scripts/monitor-ssm-instances.sh
@@ -2,7 +2,7 @@
 
 #Set Values
 export AWS_PAGER=""
-regions="eu-central-1 eu-west-1 eu-west-2 eu-west-3 us-east-1"
+regions="eu-west-2"
 ROOT_AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
 ROOT_AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
 ROOT_AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN
@@ -25,8 +25,8 @@ for account_id in $(jq -r '.account_ids | to_entries[] | "\(.value)"' <<< $ENVIR
     for region in $regions; do
         #Set Values
         AWS_REGION=$region
-        account_name=$(aws iam list-account-aliases --query 'AccountAliases[*]' --output text)
-        account_id=$(aws sts get-caller-identity --query Account --output text)
+        account_name=$(jq -r '.account_ids | to_entries[] | select(.value==\"$account_id\").key')
+        # account_id=$(aws sts get-caller-identity --query Account --output text)
 
         #Check for SSM managed instances
         echo "Searching for SSM managed instances in $account_name $region"
@@ -47,6 +47,3 @@ for account_id in $(jq -r '.account_ids | to_entries[] | "\(.value)"' <<< $ENVIR
     export AWS_SESSION_TOKEN=$ROOT_AWS_SESSION_TOKEN
     rm credentials.json
 done
-
-# # Print csv file to console
-# cat ssm-managed-instances.csv

--- a/scripts/monitor-ssm-instances.sh
+++ b/scripts/monitor-ssm-instances.sh
@@ -25,7 +25,7 @@ for account_id in $(jq -r '.account_ids | to_entries[] | "\(.value)"' <<< $ENVIR
     for region in $regions; do
         #Set Values
         AWS_REGION=$region
-        account_name=$(jq -r '.account_ids | to_entries[] | select(.value==\"$account_id\").key')
+        account_name=$(jq -r ".account_ids | to_entries[] | select(.value==\"$account_id\").key")
         # account_id=$(aws sts get-caller-identity --query Account --output text)
 
         #Check for SSM managed instances


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/2415

## How does this PR fix the problem?

I've written a script that runs some cli commands in each account to verify if the SSM agent is installed on any of the the instances that are running.
This gets called by a github workflow script which we could set to run on a schedule or just leave it ad-hoc.
teh results are piped in to a csv file and are uploaded to the job so you can view/filter the results in excel etc.

## How has this been tested?

I tested this workflow on my branch here: https://github.com/ministryofjustice/modernisation-platform/actions/runs/9081286758

The spreadsheet is no longer available but I have uploaded a copy to the issue.

## Deployment Plan / Instructions


## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [X] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

Do we want to keep this in as a workflow that can be run ad-hoc until we have better visibility via the Observability Platform?