### PR TITLE
Updating hmpps-intelligence-management GH slug for the account cleanup

### DIFF
--- a/environments/hmpps-intelligence-management.json
+++ b/environments/hmpps-intelligence-management.json
@@ -5,7 +5,7 @@
       "name": "development",
       "access": [
         {
-          "github_slug": "modernisation-platform",
+          "github_slug": "hmpps-intelligence-management",
           "level": "developer"
         }
       ]
@@ -14,7 +14,7 @@
       "name": "production",
       "access": [
         {
-          "github_slug": "modernisation-platform",
+          "github_slug": "hmpps-intelligence-management",
           "level": "developer"
         }
       ]


### PR DESCRIPTION
The original GH team that was used for the SSO of the `hmpps-intelligence-management` accounts was deleted which meant the loss of access to the accounts for the team that should manage them. These accounts are not used anymore, however they still have application resources in them (e.g. s3 buckets).

Updating GH slug for the ` hmpps-intelligence-management` accounts, so that the application team can do the cleanup of the resources prior to the accounts decommissioning.