### PR TITLE
Add `environment_management` secret to MP Security Repo

### DIFF
--- a/terraform/environments/secrets.tf
+++ b/terraform/environments/secrets.tf
@@ -130,7 +130,7 @@ locals {
 
 # Store environment management secret in Github secrets
 resource "github_actions_secret" "environment_management" {
-  for_each = toset(["modernisation-platform-environments", "modernisation-platform", "modernisation-platform-ami-builds", "modernisation-platform-configuration-management"])
+  for_each = toset(["modernisation-platform-environments", "modernisation-platform", "modernisation-platform-ami-builds", "modernisation-platform-configuration-management", "modernisation-platform-security"])
   # checkov:skip=CKV_SECRET_6: "secret_name is not a secret"
   secret_name = "MODERNISATION_PLATFORM_ENVIRONMENTS"
   repository  = each.key


### PR DESCRIPTION
## A reference to the issue / Description of it

For https://github.com/ministryofjustice/modernisation-platform/issues/2415

## How does this PR fix the problem?

I'm planning to migrate some code I've created, that monitors all MP ec2 instances to get info back on their status, to the security repo so the results are not displayed in a public repository. I need the secret added to run the workflow in the security repository.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [X] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
