### PR TITLE
DSOS: temporarily decom HMPP DCs

### DIFF
--- a/terraform/environments/core-shared-services/ad-fixngo.tf
+++ b/terraform/environments/core-shared-services/ad-fixngo.tf
@@ -33,36 +33,36 @@ locals {
       # rdlic        = remote desktop licensing server
       # a/b/c suffix = availability zone
 
-      ad-hmpp-dc-a = {
-        ami_name                  = "hmpps_windows_server_2022_release_2024-02-02T00-00-04.569Z"
-        availability_zone         = "eu-west-2a"
-        iam_instance_profile_role = "ad-fixngo-ec2-live-role"
-        instance_type             = "t3.large"
-        key_name                  = "ad-fixngo-ec2-live"
-        private_ip                = module.ad_fixngo_ip_addresses.mp_ip["ad-hmpp-dc-a"]
-        subnet_id                 = aws_subnet.live-data-additional["eu-west-2a"].id
-        vpc_security_group_name   = "ad_hmpp_dc_sg"
-        tags = {
-          server-type = "DomainController"
-          domain-name = "azure.hmpp.root"
-          description = "domain controller for FixNGo azure.hmpp.root domain"
-        }
-      }
-      ad-hmpp-dc-b = {
-        ami_name                  = "hmpps_windows_server_2022_release_2024-02-02T00-00-04.569Z"
-        availability_zone         = "eu-west-2b"
-        iam_instance_profile_role = "ad-fixngo-ec2-live-role"
-        instance_type             = "t3.large"
-        key_name                  = "ad-fixngo-ec2-live"
-        private_ip                = module.ad_fixngo_ip_addresses.mp_ip["ad-hmpp-dc-b"]
-        subnet_id                 = aws_subnet.live-data-additional["eu-west-2b"].id
-        vpc_security_group_name   = "ad_hmpp_dc_sg"
-        tags = {
-          server-type = "DomainController"
-          domain-name = "azure.hmpp.root"
-          description = "domain controller for FixNGo azure.hmpp.root domain"
-        }
-      }
+      # ad-hmpp-dc-a = {
+      #   ami_name                  = "hmpps_windows_server_2022_release_2024-02-02T00-00-04.569Z"
+      #   availability_zone         = "eu-west-2a"
+      #   iam_instance_profile_role = "ad-fixngo-ec2-live-role"
+      #   instance_type             = "t3.large"
+      #   key_name                  = "ad-fixngo-ec2-live"
+      #   private_ip                = module.ad_fixngo_ip_addresses.mp_ip["ad-hmpp-dc-a"]
+      #   subnet_id                 = aws_subnet.live-data-additional["eu-west-2a"].id
+      #   vpc_security_group_name   = "ad_hmpp_dc_sg"
+      #   tags = {
+      #     server-type = "DomainController"
+      #     domain-name = "azure.hmpp.root"
+      #     description = "domain controller for FixNGo azure.hmpp.root domain"
+      #   }
+      # }
+      # ad-hmpp-dc-b = {
+      #   ami_name                  = "hmpps_windows_server_2022_release_2024-02-02T00-00-04.569Z"
+      #   availability_zone         = "eu-west-2b"
+      #   iam_instance_profile_role = "ad-fixngo-ec2-live-role"
+      #   instance_type             = "t3.large"
+      #   key_name                  = "ad-fixngo-ec2-live"
+      #   private_ip                = module.ad_fixngo_ip_addresses.mp_ip["ad-hmpp-dc-b"]
+      #   subnet_id                 = aws_subnet.live-data-additional["eu-west-2b"].id
+      #   vpc_security_group_name   = "ad_hmpp_dc_sg"
+      #   tags = {
+      #     server-type = "DomainController"
+      #     domain-name = "azure.hmpp.root"
+      #     description = "domain controller for FixNGo azure.hmpp.root domain"
+      #   }
+      # }
       # ad-hmpp-rdlic = {
       #   ami_name                  = "hmpps_windows_server_2022_release_2024-02-02T00-00-04.569Z"
       #   availability_zone         = "eu-west-2c"


### PR DESCRIPTION
## A reference to the issue / Description of it

PlanetFM has had a couple of incidents with failed DOM1 auth.

## How does this PR fix the problem?

Removes the Mod Platform HMPP DCs to be on the safe side as issues correspond to periods of these DCs being in use. 

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No - safe to run, DC software already stopped.

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
