### PR TITLE
DST-17030 - Grant UMT repo permission to push images

### DIFF
--- a/environments/delius-core.json
+++ b/environments/delius-core.json
@@ -89,6 +89,7 @@
     "ministryofjustice/hmpps-delius-operational-automation",
     "ministryofjustice/hmpps-openldap-container",
     "ministryofjustice/hmpps-delius-docker-images",
-    "ministryofjustice/hmpps-pwm"
+    "ministryofjustice/hmpps-pwm",
+    "ministryofjustice/ndelius-um"
   ]
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

[DST-17030](https://jira.engineering-dev.probation.hmpps.dsd.io/browse/DST-17030) - Initial work to migrate User Management Tool to Modernisation Platform.

## How does this PR fix the problem?

Grants UMT repo permission to push docker images to ECR.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

N/A

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

N/A

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)
