### PR TITLE
DSOS: give nomis-access github team instance-access level

### DIFF
--- a/environments/nomis.json
+++ b/environments/nomis.json
@@ -10,10 +10,6 @@
         },
         {
           "github_slug": "studio-webops",
-          "level": "instance-access"
-        },
-        {
-          "github_slug": "studio-webops",
           "level": "instance-management"
         },
         {
@@ -27,6 +23,10 @@
         {
           "github_slug": "csr-application-support",
           "level": "instance-management"
+        },
+        {
+          "github_slug": "nomis-access",
+          "level": "instance-access"
         }
       ]
     },
@@ -48,6 +48,10 @@
         {
           "github_slug": "csr-application-support",
           "level": "instance-management"
+        },
+        {
+          "github_slug": "nomis-access",
+          "level": "instance-access"
         }
       ]
     },
@@ -69,6 +73,10 @@
         {
           "github_slug": "csr-application-support",
           "level": "instance-access"
+        },
+        {
+          "github_slug": "nomis-access",
+          "level": "instance-access"
         }
       ]
     },
@@ -89,6 +97,10 @@
         },
         {
           "github_slug": "csr-application-support",
+          "level": "instance-access"
+        },
+        {
+          "github_slug": "nomis-access",
           "level": "instance-access"
         }
       ]


### PR DESCRIPTION
## A reference to the issue / Description of it

Additional access to nomis jump servers for `nomis-access` github team.

## How does this PR fix the problem?

Allows members of this team access to Nomis jump servers.
Removes studio-webops instance-access access so we can test it works via this team.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

n/a

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
