### PR TITLE
DSOS-2822: add fqdn for ms office http install traffic

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/fqdn_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/fqdn_rules.json
@@ -1,6 +1,7 @@
 {
   "fw_allowed_domains": [
     ".amazontrust.com",
+    ".c2r.ts.cdn.office.net",
     ".docker.com",
     ".docker.io",
     ".download.windowsupdate.com",
@@ -12,6 +13,7 @@
     ".windowsupdate.microsoft.com",
     "microsoft.com",
     "ntservicepack.microsoft.com",
+    "officecdn.microsoft.com",
     "onegetcdn.azureedge.net",
     "saas40.kaseya.net",
     "stats.microsoft.com",


### PR DESCRIPTION
## A reference to the issue / Description of it

Nomis client test servers require MS Office to test an integrated document feature.  MS office won't install on Mod Platform.

## How does this PR fix the problem?

Wireshark reveals that MS office is making some HTTP requests during the install.  Allow these domains through the firewall

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

n/a

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
