### PR TITLE
DSOS-2822: allow outbound CRL http checks

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/fqdn_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/fqdn_rules.json
@@ -2,10 +2,12 @@
   "fw_allowed_domains": [
     ".amazontrust.com",
     ".c2r.ts.cdn.office.net",
+    ".digicert.com",
     ".docker.com",
     ".docker.io",
     ".download.windowsupdate.com",
     ".ghcr.io",
+    ".pki.goog",
     ".servicebus.windows.net",
     ".ubuntu.com",
     ".update.microsoft.com",


### PR DESCRIPTION
## A reference to the issue / Description of it

Unable to sign-in to MS Office to check Nomis functionality

## How does this PR fix the problem?

Currently hanging on CRL checks. Allows the outbound HTTP to relevant URLs.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.


## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
