### PR TITLE
New environment for CICA - cica-tariff

### DIFF
--- a/environments/cica-tariff.json
+++ b/environments/cica-tariff.json
@@ -1,0 +1,22 @@
+{
+    "account-type": "member",
+    "environments": [
+      {
+        "name": "development",
+        "access": [
+          {
+            "github_slug": "cica-mp-tariff",
+            "level": "developer"
+          }
+        ]
+      }
+    ],
+    "tags": {
+      "application": "cica-tariff",
+      "business-unit": "CICA",
+      "infrastructure-support": "Infrastructure@cica.gov.uk",
+      "owner": "alan.terry@cica.gov.uk"
+    },
+    "github-oidc-team-repositories": [""]
+  }
+  

--- a/policies/environments/expected.rego
+++ b/policies/environments/expected.rego
@@ -18,6 +18,7 @@ expected :=
     "cdpt-ifs",
     "cica-copilot",
     "cica-data-extraction",
+    "cica-tariff"
     "contract-work-administration",
     "cooker",
     "core-logging",

--- a/policies/environments/expected.rego
+++ b/policies/environments/expected.rego
@@ -18,7 +18,7 @@ expected :=
     "cdpt-ifs",
     "cica-copilot",
     "cica-data-extraction",
-    "cica-tariff"
+    "cica-tariff",
     "contract-work-administration",
     "cooker",
     "core-logging",


### PR DESCRIPTION
## A reference to the issue / Description of it

Create new environment cica-tariff. 
This will replace the current tariff environment. That will be removed under [Remove tariff environment](https://github.com/ministryofjustice/modernisation-platform/issues/7127)