### PR TITLE
DSOS-2746 | Patch schedules for domain controllers

### DIFF
--- a/terraform/environments/core-shared-services/ad-fixngo.tf
+++ b/terraform/environments/core-shared-services/ad-fixngo.tf
@@ -1039,7 +1039,7 @@ resource "aws_ssm_parameter" "ad_fixngo" {
 
 module "core-shared-service-ad-azure-dc-a" {
   source = "github.com/ministryofjustice/modernisation-platform-terraform-ssm-patching.git?ref=v3.0.0"
-  count  = local.is-production == true ? 1 : 0
+#  count  = local.is-production == true ? 1 : 0
   providers = {
     aws.bucket-replication = aws
   }

--- a/terraform/environments/core-shared-services/ad-fixngo.tf
+++ b/terraform/environments/core-shared-services/ad-fixngo.tf
@@ -22,15 +22,7 @@ locals {
       ad-fixngo-ec2-live    = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC4XM7YBLA/DY3w4oMS4PEYyfYLcK2OuidwRRUKTFyS3lnzoucuPg4fuv3yMbLJxxoUT8QjfHDWUzQRsQorkj6ig8TB68rAz0/BBx3wuA76dNoDXAXSM/sOP1ZA1gXL3BR21hbe8QIvmqP881BLgKvB5WGN7iSPIepNtxea8g6/Eg91ISLnDvVKkqjej+wJbeBKcnGCdv6LJ082HZRMxIBfAuN9snoNyjymXYU/nMeXgwZhfSzLHU9KYOAzuYxOHgVz0k1NOPYCJflSqcYyqNbuvmLmUJVSb3u/8kpOwcTR9UP0awIzuH7PXZf87g1wyfesyAkNPMa4uUoEMIIah2tp+rAp9AUDnzn5MIv84lSkerqp2+0L/dLf+FCjNpIUePpmJiC8JCqD7oemwvrEuPpsvFalmRuRNlg2s+DKg7FVdhUWH7HiIKoiSB7dBtb02AjeY5Hi8c9urFBas4LmtngEbH8mf65VZTA82S2mLjOw8DdGRGPTc/o4MilYqR7cqDcNIw3+eEw1PqYkJUykJP5saKjLZuUxe6U0dog1iY9pimPdRKiYouF95tt43+b7/7zVTajq096r/BY2XkklVmbQ/a1HBO/Q/cfQWxhaaIaQwwnAwGQdMtEZsXaJ0OR650NJYeqtKh9ZKeMF/M+HLddiC7+1ncu78NFLlB98zD8cTw=="
       ad-fixngo-ec2-nonlive = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDZ7Q515wcJIdw68vUuf2v0BFow0GmqFjapC7qJ+x6eiFqfP3Cq7jT/HYS51nzJgiXUUvyXPhQcKJgQ1O0VlTX/AjctUdm9YUbArI+S74BgNFLLbDd9EsMxhm6SKjYqbhrL9S4YxA6C0hgz4+NiEJk8XKEg5laHrOCt7kmtRE8FDvyzTLZLQ7HomHkd43tDLtvTKzKkeV2iOlnYG+l0XAFLC58ufOS3ujtK9jD2vZwyarfLTiyyE/gXTtFpb+ktUnwvJpgNXDdaGHVOOjAdJh7jEmqtl438aXxfDoroX7BQmn+8nrY0lkSY+eUis58exHDqWWtUsSyHqaSUeKvyJvC0dnCUQEVulsCljFVRWeof+xcCpeHGrS4tfDop5Kckoadpwa0LILiun8NeQTLTt8jnPAU3auZZTb4u+vQeWYsE0DSWMsTMEoAh+pKBSfnAFZNYgIIp0jQKJJwL8ndTC/XPm0Wu3eorwFGnMgyNVZbkOA6yjtaknUqNVDb/9MOINZYi12NJSguLJg0tN04F0W4X6nCm2v5I72Uv5BLX/c0YpgKjHMCZdSzjS+EWD2a/WRtSUqSmg/ObHimOinPGhdM3JoIlXXUTXHCLkPADLYJ+b8e2sdEqhHFuGvLgXe302ZYftTqfZANMngkrd9tTM3uIoCxRCibicB/jJJ1u8YBqJQ=="
     }
-    ssm_patching = {
-      ad-fixngo-ssm-patching-nonlive-a = {
-        application-name     = "ad-nonlive-a"
-        approval_days        = "9"
-        patch_schedule       = "cron(0 21 ? * TUE#2 *)" # 2nd Tues @ 9pm
-        patch_tag            = "eu-west-2a"
-        suffix                = "-2a"
-    }
-    }
+
     aws_instances = {
 
       # NOTE: Fixed IPs for IP allow listing and to avoid AD DNS updates
@@ -775,6 +767,16 @@ locals {
       }
     }
 
+    ssm_patching = {
+      ad-fixngo-ssm-patching-nonlive-a = {
+        application-name     = "ad-nonlive-a"
+        approval_days        = "9"
+        patch_schedule       = "cron(0 21 ? * TUE#2 *)" # 2nd Tues @ 9pm
+        patch_tag            = "eu-west-2a"
+        suffix                = "-2a"
+      }
+    }
+
     tags = merge(local.tags, {
       environment-name       = terraform.workspace
       infrastructure-support = "DSO:digital-studio-operations-team@digital.justice.gov.uk"
@@ -1054,7 +1056,7 @@ module "ad_fixngo_ssm_patching" {
     aws.bucket-replication = aws
   }
 
-  account_number       = local.environment_management.account_ids[terraform.workspace]
+  account_number       = local.environment_management.account_ids["core-shared-services-production"]
   application_name     = each.value.application-name
   approval_days        = each.value.approval_days
   patch_schedule       = each.value.patch_schedule
@@ -1065,7 +1067,7 @@ module "ad_fixngo_ssm_patching" {
   tags = merge(
     local.tags,
     {
-      Name = each.key
+      Name = each.value.application-name
     },
   )
 }

--- a/terraform/environments/core-shared-services/ad-fixngo.tf
+++ b/terraform/environments/core-shared-services/ad-fixngo.tf
@@ -92,6 +92,7 @@ locals {
           server-type = "DomainController"
           domain-name = "azure.noms.root"
           description = "domain controller for FixNGo azure.noms.root domain"
+          Patching    = "eu-west-2a"
         }
       }
       ad-azure-dc-b = {

--- a/terraform/environments/core-shared-services/ad-fixngo.tf
+++ b/terraform/environments/core-shared-services/ad-fixngo.tf
@@ -24,6 +24,7 @@ locals {
     }
     ssm_patching = {
       ad-fixngo-ssm-patching-nonlive-a = {
+        application-name     = "ad-nonlive-a"
         approval_days        = "9"
         patch_schedule       = "cron(0 21 ? * TUE#2 *)" # 2nd Tues @ 9pm
         patch_tag            = "eu-west-2a"

--- a/terraform/environments/core-shared-services/ad-fixngo.tf
+++ b/terraform/environments/core-shared-services/ad-fixngo.tf
@@ -1055,7 +1055,7 @@ module "ad_fixngo_ssm_patching" {
   }
 
   account_number       = local.environment_management.account_ids[terraform.workspace]
-  application_name     = each.key
+  application_name     = each.value.application-name
   approval_days        = each.value.approval_days
   patch_schedule       = each.value.patch_schedule
   operating_system     = "WINDOWS"

--- a/terraform/environments/core-shared-services/ad-fixngo.tf
+++ b/terraform/environments/core-shared-services/ad-fixngo.tf
@@ -1046,11 +1046,34 @@ module "core-shared-service-ad-azure-dc-a" {
 
   account_number       = local.environment_management.account_ids[terraform.workspace]
   application_name     = local.application_name
-  approval_days        = "14"
-  patch_schedule       = "cron(0 21 ? * THU#4 *)" # 4th Thurs @ 9pm
+  approval_days        = "9"
+  patch_schedule       = "cron(0 21 ? * TUE#2 *)" # 2nd Tues @ 9pm
+  operating_system     = "WINDOWS"
+  patch_tag            = "eu-west-2a"
+  suffix               = "-2a"
+  patch_classification = ["SecurityUpdates", "CriticalUpdates"]
+  tags = merge(
+    local.tags,
+    {
+      Name = "ssm-patching"
+    },
+  )
+}
+
+module "core-shared-service-ad-azure-dc-b" {
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-ssm-patching.git?ref=v3.0.0"
+  #  count  = local.is-production == true ? 1 : 0
+  providers = {
+    aws.bucket-replication = aws
+  }
+
+  account_number       = local.environment_management.account_ids[terraform.workspace]
+  application_name     = local.application_name
+  approval_days        = "9"
+  patch_schedule       = "cron(0 21 ? * THUR#4 *)" # 4th Thurs @ 9pm
   operating_system     = "WINDOWS"
   patch_tag            = "eu-west-2b"
-  suffix               = "-a"
+  suffix               = "-2b"
   patch_classification = ["SecurityUpdates", "CriticalUpdates"]
   tags = merge(
     local.tags,

--- a/terraform/environments/core-shared-services/ad-fixngo.tf
+++ b/terraform/environments/core-shared-services/ad-fixngo.tf
@@ -769,11 +769,11 @@ locals {
 
     ssm_patching = {
       ad-fixngo-ssm-patching-nonlive-a = {
-        application-name     = "ad-nonlive-a"
-        approval_days        = "9"
-        patch_schedule       = "cron(0 21 ? * TUE#2 *)" # 2nd Tues @ 9pm
-        patch_tag            = "eu-west-2a"
-        suffix                = "-2a"
+        application-name  = "ad-nonlive-a"
+        approval_days     = "9"
+        patch_schedule    = "cron(0 21 ? * TUE#2 *)" # 2nd Tues @ 9pm
+        patch_tag         = "eu-west-2a"
+        suffix             = "-2a"
       }
     }
 

--- a/terraform/environments/core-shared-services/ad-fixngo.tf
+++ b/terraform/environments/core-shared-services/ad-fixngo.tf
@@ -22,7 +22,14 @@ locals {
       ad-fixngo-ec2-live    = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC4XM7YBLA/DY3w4oMS4PEYyfYLcK2OuidwRRUKTFyS3lnzoucuPg4fuv3yMbLJxxoUT8QjfHDWUzQRsQorkj6ig8TB68rAz0/BBx3wuA76dNoDXAXSM/sOP1ZA1gXL3BR21hbe8QIvmqP881BLgKvB5WGN7iSPIepNtxea8g6/Eg91ISLnDvVKkqjej+wJbeBKcnGCdv6LJ082HZRMxIBfAuN9snoNyjymXYU/nMeXgwZhfSzLHU9KYOAzuYxOHgVz0k1NOPYCJflSqcYyqNbuvmLmUJVSb3u/8kpOwcTR9UP0awIzuH7PXZf87g1wyfesyAkNPMa4uUoEMIIah2tp+rAp9AUDnzn5MIv84lSkerqp2+0L/dLf+FCjNpIUePpmJiC8JCqD7oemwvrEuPpsvFalmRuRNlg2s+DKg7FVdhUWH7HiIKoiSB7dBtb02AjeY5Hi8c9urFBas4LmtngEbH8mf65VZTA82S2mLjOw8DdGRGPTc/o4MilYqR7cqDcNIw3+eEw1PqYkJUykJP5saKjLZuUxe6U0dog1iY9pimPdRKiYouF95tt43+b7/7zVTajq096r/BY2XkklVmbQ/a1HBO/Q/cfQWxhaaIaQwwnAwGQdMtEZsXaJ0OR650NJYeqtKh9ZKeMF/M+HLddiC7+1ncu78NFLlB98zD8cTw=="
       ad-fixngo-ec2-nonlive = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDZ7Q515wcJIdw68vUuf2v0BFow0GmqFjapC7qJ+x6eiFqfP3Cq7jT/HYS51nzJgiXUUvyXPhQcKJgQ1O0VlTX/AjctUdm9YUbArI+S74BgNFLLbDd9EsMxhm6SKjYqbhrL9S4YxA6C0hgz4+NiEJk8XKEg5laHrOCt7kmtRE8FDvyzTLZLQ7HomHkd43tDLtvTKzKkeV2iOlnYG+l0XAFLC58ufOS3ujtK9jD2vZwyarfLTiyyE/gXTtFpb+ktUnwvJpgNXDdaGHVOOjAdJh7jEmqtl438aXxfDoroX7BQmn+8nrY0lkSY+eUis58exHDqWWtUsSyHqaSUeKvyJvC0dnCUQEVulsCljFVRWeof+xcCpeHGrS4tfDop5Kckoadpwa0LILiun8NeQTLTt8jnPAU3auZZTb4u+vQeWYsE0DSWMsTMEoAh+pKBSfnAFZNYgIIp0jQKJJwL8ndTC/XPm0Wu3eorwFGnMgyNVZbkOA6yjtaknUqNVDb/9MOINZYi12NJSguLJg0tN04F0W4X6nCm2v5I72Uv5BLX/c0YpgKjHMCZdSzjS+EWD2a/WRtSUqSmg/ObHimOinPGhdM3JoIlXXUTXHCLkPADLYJ+b8e2sdEqhHFuGvLgXe302ZYftTqfZANMngkrd9tTM3uIoCxRCibicB/jJJ1u8YBqJQ=="
     }
-
+    ssm_patching = {
+      ad-fixngo-ssm-patching-nonlive-a = {
+        approval_days        = "9"
+        patch_schedule       = "cron(0 21 ? * TUE#2 *)" # 2nd Tues @ 9pm
+        patch_tag            = "eu-west-2a"
+        suffix                = "-2a"
+    }
+    }
     aws_instances = {
 
       # NOTE: Fixed IPs for IP allow listing and to avoid AD DNS updates
@@ -1037,48 +1044,27 @@ resource "aws_ssm_parameter" "ad_fixngo" {
   })
 }
 
-module "core-shared-service-ad-azure-dc-a" {
+module "ad_fixngo_ssm_patching" {
+  for_each = local.ad_fixngo.ssm_patching
+
   source = "github.com/ministryofjustice/modernisation-platform-terraform-ssm-patching.git?ref=v3.0.0"
-#  count  = local.is-production == true ? 1 : 0
+
   providers = {
     aws.bucket-replication = aws
   }
 
   account_number       = local.environment_management.account_ids[terraform.workspace]
-  application_name     = local.application_name
-  approval_days        = "9"
-  patch_schedule       = "cron(0 21 ? * TUE#2 *)" # 2nd Tues @ 9pm
+  application_name     = each.key
+  approval_days        = each.value.approval_days
+  patch_schedule       = each.value.patch_schedule
   operating_system     = "WINDOWS"
-  patch_tag            = "eu-west-2a"
-  suffix               = "-2a"
-  patch_classification = ["SecurityUpdates", "CriticalUpdates"]
+  patch_tag            = each.value.patch_tag
+  suffix                = each.value.suffix
+  patch_classification  = ["SecurityUpdates", "CriticalUpdates"]
   tags = merge(
     local.tags,
     {
-      Name = "ssm-patching"
-    },
-  )
-}
-
-module "core-shared-service-ad-azure-dc-b" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-ssm-patching.git?ref=v3.0.0"
-  #  count  = local.is-production == true ? 1 : 0
-  providers = {
-    aws.bucket-replication = aws
-  }
-
-  account_number       = local.environment_management.account_ids[terraform.workspace]
-  application_name     = local.application_name
-  approval_days        = "9"
-  patch_schedule       = "cron(0 21 ? * THUR#4 *)" # 4th Thurs @ 9pm
-  operating_system     = "WINDOWS"
-  patch_tag            = "eu-west-2b"
-  suffix               = "-2b"
-  patch_classification = ["SecurityUpdates", "CriticalUpdates"]
-  tags = merge(
-    local.tags,
-    {
-      Name = "ssm-patching"
+      Name = each.key
     },
   )
 }

--- a/terraform/environments/core-shared-services/ad-fixngo.tf
+++ b/terraform/environments/core-shared-services/ad-fixngo.tf
@@ -1036,3 +1036,26 @@ resource "aws_ssm_parameter" "ad_fixngo" {
     Name = each.key
   })
 }
+
+module "core-shared-service-ad-azure-dc-a" {
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-ssm-patching.git?ref=v3.0.0"
+  count  = local.is-production == true ? 1 : 0
+  providers = {
+    aws.bucket-replication = aws
+  }
+
+  account_number       = local.environment_management.account_ids[terraform.workspace]
+  application_name     = local.application_name
+  approval_days        = "14"
+  patch_schedule       = "cron(0 21 ? * THU#4 *)" # 4th Thurs @ 9pm
+  operating_system     = "WINDOWS"
+  patch_tag            = "eu-west-2b"
+  suffix               = "-a"
+  patch_classification = ["SecurityUpdates", "CriticalUpdates"]
+  tags = merge(
+    local.tags,
+    {
+      Name = "ssm-patching"
+    },
+  )
+}


### PR DESCRIPTION
## A reference to the issue / Description of it

PR to set patch maintenance windows on the mod platform DCs
https://dsdmoj.atlassian.net/browse/DSOS-2746

## How does this PR fix the problem?

This PR pulls in the mod platform ssm patching module and is used to patch one AD instance. 
On a successful deployment, I will create another PR to patch the remaining AD instances.

## How has this been tested?

The plan has been inspected via a PR.

`
Plan: 18 to add, 2 to change, 0 to destroy.
`

There seems to be a change to a lambda (`module.instance_scheduler.aws_lambda_function.this`) but I have not done this

## Deployment Plan / Instructions

The deployment will not affect live services but the subsequent patch schedule will automatically patch `ad-azure-dc-a` instance next Tuesday.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)
After a successful deployment, I would like to create a similar PR for the remaining AD instances.