### PR TITLE
Allow Terraform to make Shield changes

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -147,6 +147,7 @@ data "aws_iam_policy_document" "member-access" {
       "s3:*",
       "secretsmanager:*",
       "ses:*",
+      "shield:*",
       "sns:*",
       "sqs:*",
       "ssm:*",


### PR DESCRIPTION
## A reference to the issue / Description of it

#7032 

## How does this PR fix the problem?

Allows role assumed through GitHub Actions to make changes to AWS Shield, such as SRT role association.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Added permission as previous ones are added.

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
