### PR TITLE
Add patch schedules to FixNGo servers

### DIFF
--- a/terraform/environments/core-shared-services/ad-fixngo.tf
+++ b/terraform/environments/core-shared-services/ad-fixngo.tf
@@ -46,6 +46,7 @@ locals {
       #     server-type = "DomainController"
       #     domain-name = "azure.hmpp.root"
       #     description = "domain controller for FixNGo azure.hmpp.root domain"
+      #     Patching    = "ad-live-eu-west-2a"
       #   }
       # }
       # ad-hmpp-dc-b = {
@@ -61,6 +62,7 @@ locals {
       #     server-type = "DomainController"
       #     domain-name = "azure.hmpp.root"
       #     description = "domain controller for FixNGo azure.hmpp.root domain"
+      #     Patching    = "ad-live-eu-west-2b"
       #   }
       # }
       # ad-hmpp-rdlic = {
@@ -76,6 +78,7 @@ locals {
       #     server-type = "RDLicensing"
       #     domain-name = "azure.hmpp.root"
       #     description = "remote desktop licensing server for FixNGo azure.hmpp.root domain"
+      #     Patching    = "rdlic-live-eu-west-2c"
       #   }
       # }
 
@@ -92,7 +95,7 @@ locals {
           server-type = "DomainController"
           domain-name = "azure.noms.root"
           description = "domain controller for FixNGo azure.noms.root domain"
-          Patching    = "eu-west-2a"
+          Patching    = "ad-nonlive-eu-west-2a"
         }
       }
       ad-azure-dc-b = {
@@ -108,6 +111,7 @@ locals {
           server-type = "DomainController"
           domain-name = "azure.noms.root"
           description = "domain controller for FixNGo azure.noms.root domain"
+          Patching    = "ad-nonlive-eu-west-2b"
         }
       }
       # ad-azure-rdlic = {
@@ -123,6 +127,7 @@ locals {
       #     server-type = "RDLicensing"
       #     domain-name = "azure.noms.root"
       #     description = "remote desktop licensing server for FixNGo azure.noms.root domain"
+      #     Patching    = "rdlic-nonlive-eu-west-2c"
       #   }
       # }
     }
@@ -769,12 +774,50 @@ locals {
     }
 
     ssm_patching = {
+      # Non-live Domain Controllers
       ad-fixngo-ssm-patching-nonlive-a = {
         application-name  = "ad-nonlive-a"
         approval_days     = "9"
         patch_schedule    = "cron(0 21 ? * TUE#2 *)" # 2nd Tues @ 9pm
-        patch_tag         = "eu-west-2a"
-        suffix             = "-2a"
+        patch_tag         = "ad-nonlive-eu-west-2a"
+        suffix             = "-ad-nl-2a"
+      }
+      ad-fixngo-ssm-patching-nonlive-b= {
+        application-name  = "ad-nonlive-b"
+        approval_days     = "7"
+        patch_schedule    = "cron(0 21 ? * TUE#3 *)" # 3rd Tues @ 9pm
+        patch_tag         = "ad-nonlive-eu-west-2b"
+        suffix             = "-ad-nl-2b"
+      }
+      # Live Domain Controllers
+      ad-fixngo-ssm-patching-live-a = {
+        application-name  = "ad-live-a"
+        approval_days     = "16"
+        patch_schedule    = "cron(0 21 ? * THU#3 *)" # 3rd Thurs @ 9pm
+        patch_tag         = "ad-live-eu-west-2a"
+        suffix             = "-ad-l-2a"
+      }
+      ad-fixngo-ssm-patching-live-b = {
+        application-name  = "ad-live-b"
+        approval_days     = "14"
+        patch_schedule    = "cron(0 21 ? * THU#4 *)" # 4th Thurs @ 9pm
+        patch_tag         = "ad-live-eu-west-2b"
+        suffix             = "-ad-l-2b"
+      }
+      # RD Licensing
+      rdlic-fixngo-ssm-patching-nonlive = {
+        application-name  = "rdlic-nonlive-c"
+        approval_days     = "7"
+        patch_schedule    = "cron(0 21 ? * WED#2 *)" # 2nd Weds @ 9pm
+        patch_tag         = "rdlic-nonlive-eu-west-2c"
+        suffix             = "-rdlic-nl-2c"
+      }
+      rdlic-fixngo-ssm-patching-live = {
+        application-name  = "rdlic-live-c"
+        approval_days     = "14"
+        patch_schedule    = "cron(0 21 ? * WED#3 *)" # 3rd Weds @ 9pm
+        patch_tag         = "rdlic-live-eu-west-2c"
+        suffix             = "-rdlic-l-2c"
       }
     }
 


### PR DESCRIPTION
## A reference to the issue / Description of it

[PR to create patch schedules for fixngo instances
](https://dsdmoj.atlassian.net/browse/DSOS-2746)

## How does this PR fix the problem?

This PR references the mod platform ssm module to generate patch schedule for all fixngo instances.

## How has this been tested?

An initial test on patching one instance was successfully done on a prior [PR](https://github.com/ministryofjustice/modernisation-platform/pull/7129).

In addition, the plan of this PR has been inspected.

## Deployment Plan / Instructions

The deployment will only deploy schedules so no other service will be affected. When those schedules come around, patching will occur on the instance that is referenced by the maintenance window.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

Some of the schedules are for instances that are temporarily disabled / commented out. Those instances will be re-enabled in the future.