### PR TITLE
🔥 Remove `types` from `pull_request`

### DIFF
--- a/.github/workflows/templates/workflow-template.yml
+++ b/.github/workflows/templates/workflow-template.yml
@@ -11,7 +11,6 @@ on:
   pull_request:
     branches:
       - main
-    types: [opened, edited, reopened, synchronize]
     paths:
       - 'terraform/environments/$application_name/**'
       - '.github/workflows/$application_name.yml'


### PR DESCRIPTION
## A reference to the issue / Description of it

is part of https://github.com/ministryofjustice/modernisation-platform/issues/7160

Updates the workflow template to remove `types` from `pull_request`, so that changes to the pull request body don't trigger workflow runs

## How does this PR fix the problem?

See above

## How has this been tested?

Analytical Platform use this in production

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

It shouldn't impact the platform, but will need deploying to MPE

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

Reference Slack thread: https://mojdt.slack.com/archives/C01A7QK5VM1/p1717497987776109
