### PR TITLE
DRAFT - Allow creation of Wafv2 ACL resources through CloudFormation

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -253,12 +253,8 @@ data "aws_iam_policy_document" "member-access" {
   statement {
     effect = "Deny"
     actions = [
-      "cloudformation:ListStacks",
-      "cloudformation:DescribeStacks",
       "cloudformation:CreateStack",
-      "cloudformation:UpdateStack",
-      "cloudformation:DeleteStack",
-      "cloudformation:GetTemplate"
+      "cloudformation:UpdateStack"
     ]
     resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
     condition {

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -302,7 +302,7 @@ resource "aws_iam_policy" "member_access_cloudformation" {
       ],
       "Resource": ["*"],
       "Condition": {
-        "StringEquals": {
+        "ForAllValues:StringEquals": {
           "cloudformation:ResourceTypes": [ "AWS::WAFv2::WebACL" ]
         }
       }

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -239,7 +239,8 @@ data "aws_iam_policy_document" "member-access" {
       "cloudformation:DescribeStacks",
       "cloudformation:CreateStack",
       "cloudformation:UpdateStack",
-      "cloudformation:DeleteStack"
+      "cloudformation:DeleteStack",
+      "cloudformation:GetTemplate"
     ]
     resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
     condition {

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -259,7 +259,7 @@ data "aws_iam_policy_document" "member-access" {
       condition {
         test     = "ForAllValues:StringEquals"
         variable = "cloudformation:ResourceTypes"
-        values   = ["AWS::WAFv2::WebACL"]
+        values   = [ "AWS::WAFv2::RuleGroup", "AWS::WAFv2::WebACL" ]
       }
   }
 

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -259,7 +259,7 @@ data "aws_iam_policy_document" "member-access" {
       resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
       condition {
           test     = "StringNotEquals"
-          variable = "ResourceType"
+          variable = "cloudformation:ResourceTypes"
           values   = ["AWS::WAFv2::WebACL"]
       }
   }

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -259,7 +259,7 @@ data "aws_iam_policy_document" "member-access" {
       condition {
         test     = "ForAllValues:StringEquals"
         variable = "cloudformation:ResourceTypes"
-        values   = [ "AWS::WAFv2::RuleGroup", "AWS::WAFv2::WebACL" ]
+        values   = [ "AWS::WAFv2::WebACL" ]
       }
   }
 

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -233,35 +233,35 @@ data "aws_iam_policy_document" "member-access" {
   }
 
   statement {
-    effect = "Allow"
-    actions = [
-      "cloudformation:ListStacks",
-      "cloudformation:DescribeStacks",
-      "cloudformation:CreateStack",
-      "cloudformation:UpdateStack",
-      "cloudformation:DeleteStack",
-      "cloudformation:GetTemplate"
-    ]
-    resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
-    condition {
-      test     = "ForAllValues:StringEquals"
-      variable = "cloudformation:ResourceTypes"
-      values   = ["AWS::WAFv2::WebACL"]
-    }
+      effect = "Allow"
+      actions = [
+          "cloudformation:ListStacks",
+          "cloudformation:DescribeStacks",
+          "cloudformation:CreateStack",
+          "cloudformation:UpdateStack",
+          "cloudformation:DeleteStack",
+          "cloudformation:GetTemplate"
+      ]
+      resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
+      condition {
+          test     = "ForAnyValue:StringEquals"
+          variable = "cloudformation:ResourceTypes"
+          values   = ["AWS::WAFv2::WebACL"]
+      }
   }
 
   statement {
-    effect = "Deny"
-    actions = [
-      "cloudformation:CreateStack",
-      "cloudformation:UpdateStack"
-    ]
-    resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
-    condition {
-      test     = "ForAllValues:StringNotEquals"
-      variable = "cloudformation:ResourceTypes"
-      values   = ["AWS::WAFv2::WebACL"]
-    }
+      effect = "Deny"
+      actions = [
+          "cloudformation:CreateStack",
+          "cloudformation:UpdateStack"
+      ]
+      resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
+      condition {
+          test     = "ForAllValues:StringNotEquals"
+          variable = "cloudformation:ResourceTypes"
+          values   = ["AWS::WAFv2::WebACL"]
+      }
   }
 
 }

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -251,9 +251,9 @@ data "aws_iam_policy_document" "member-access" {
       ]
       resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
       condition {
-          test     = "StringEquals"
+          test     = "StringLike"
           variable = "cloudformation:ResourceTypes"
-          values   = ["AWS::WAFv2::WebACL"]
+          values   = ["AWS::WAFv2::*"]
       }
   }
 

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -232,37 +232,44 @@ data "aws_iam_policy_document" "member-access" {
     resources = ["arn:aws:iam::*:user/cicd-member-user"]
   }
 
-  statement {
+    statement {
       effect = "Allow"
       actions = [
           "cloudformation:ListStacks",
           "cloudformation:DescribeStacks",
-          "cloudformation:CreateStack",
-          "cloudformation:UpdateStack",
           "cloudformation:DeleteStack",
           "cloudformation:GetTemplate"
       ]
       resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
-      # condition {
-      #     test     = "ForAnyValue:StringEquals"
-      #     variable = "cloudformation:ResourceTypes"
-      #     values   = ["AWS::WAFv2::WebACL"]
-      # }
   }
 
   statement {
-      effect = "Deny"
+      effect = "Allow"
       actions = [
           "cloudformation:CreateStack",
-          "cloudformation:UpdateStack"
+          "cloudformation:UpdateStack",
       ]
       resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
       condition {
-          test     = "StringNotEquals"
+          test     = "StringEquals"
           variable = "cloudformation:ResourceTypes"
           values   = ["AWS::WAFv2::WebACL"]
       }
   }
+
+  # statement {
+  #     effect = "Deny"
+  #     actions = [
+  #         "cloudformation:CreateStack",
+  #         "cloudformation:UpdateStack"
+  #     ]
+  #     resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
+  #     condition {
+  #         test     = "StringNotEquals"
+  #         variable = "cloudformation:ResourceTypes"
+  #         values   = ["AWS::WAFv2::WebACL"]
+  #     }
+  # }
 
 }
 

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -8,7 +8,7 @@ module "member-access" {
   source                 = "github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access?ref=b67419df67f04d3023f410db26432b87186c909a"
   account_id             = local.modernisation_platform_account.id
   additional_trust_roles = [module.github-oidc[0].github_actions_role, one(data.aws_iam_roles.member-sso-admin-access.arns)]
-  policy_arns             = [aws_iam_policy.member-access[0].id, aws_iam_policy.member_access_cloudformation.id ]
+  policy_arns             = [aws_iam_policy.member-access[0].id]
   role_name              = "MemberInfrastructureAccess"
 }
 

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -257,7 +257,7 @@ data "aws_iam_policy_document" "member-access" {
   #         variable = "cloudformation:ResourceTypes"
   #         values   = ["AWS::WAFv2::WebACL"]
   #     }
-  }
+  #}
 
   # statement {
   #     effect = "Deny"

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -238,7 +238,9 @@ data "aws_iam_policy_document" "member-access" {
           "cloudformation:ListStacks",
           "cloudformation:DescribeStacks",
           "cloudformation:DeleteStack",
-          "cloudformation:GetTemplate"
+          "cloudformation:GetTemplate",
+          "cloudformation:GetTemplateSummary",
+          "cloudformation:GetStackPolicy"
       ]
       resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
   }

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -8,7 +8,7 @@ module "member-access" {
   source                 = "github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access?ref=b67419df67f04d3023f410db26432b87186c909a"
   account_id             = local.modernisation_platform_account.id
   additional_trust_roles = [module.github-oidc[0].github_actions_role, one(data.aws_iam_roles.member-sso-admin-access.arns)]
-  policy_arns             = [aws_iam_policy.member-access[0].id]
+  policy_arns             = [aws_iam_policy.member-access[0].id, aws_iam_policy.member_access_cloudformation.id]
   role_name              = "MemberInfrastructureAccess"
 }
 

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -238,26 +238,24 @@ data "aws_iam_policy_document" "member-access" {
           "cloudformation:ListStacks",
           "cloudformation:DescribeStacks",
           "cloudformation:DeleteStack",
-          "cloudformation:GetTemplate",
-          "cloudformation:CreateStack",
-          "cloudformation:UpdateStack"
+          "cloudformation:GetTemplate"
       ]
       resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
   }
 
-  # statement {
-  #     effect = "Allow"
-  #     actions = [
-  #         "cloudformation:CreateStack",
-  #         "cloudformation:UpdateStack",
-  #     ]
-  #     resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
-  #     condition {
-  #         test     = "StringEquals"
-  #         variable = "cloudformation:ResourceTypes"
-  #         values   = ["AWS::WAFv2::WebACL"]
-  #     }
-  #}
+  statement {
+      effect = "Allow"
+      actions = [
+          "cloudformation:CreateStack",
+          "cloudformation:UpdateStack",
+      ]
+      resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
+      condition {
+          test     = "StringEquals"
+          variable = "cloudformation:ResourceTypes"
+          values   = ["AWS::WAFv2::WebACL"]
+      }
+  }
 
   # statement {
   #     effect = "Deny"

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -8,7 +8,7 @@ module "member-access" {
   source                 = "github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access?ref=b67419df67f04d3023f410db26432b87186c909a"
   account_id             = local.modernisation_platform_account.id
   additional_trust_roles = [module.github-oidc[0].github_actions_role, one(data.aws_iam_roles.member-sso-admin-access.arns)]
-  policy_arns             = [aws_iam_policy.member-access[0].id, aws_iam_policy.member_access_cloudformation ]
+  policy_arns             = [aws_iam_policy.member-access[0].id, aws_iam_policy.member_access_cloudformation.id ]
   role_name              = "MemberInfrastructureAccess"
 }
 

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -302,7 +302,7 @@ resource "aws_iam_policy" "member_access_cloudformation" {
       ],
       "Resource": ["*"],
       "Condition": {
-        "StringNotEquals": {
+        "StringEquals": {
           "cloudformation:ResourceTypes": [ "AWS::WAFv2::WebACL" ]
         }
       }

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -312,10 +312,13 @@ resource "aws_iam_policy" "member_access_cloudformation" {
 EOF
 }
 
+data "aws_iam_role" "member_access_role_name" {
+  name       = module.member-access.default.name  
+}
 
 # Attachment to associate the cloudformation policy with the MemberAccess Role
 resource "aws_iam_role_policy_attachment" "memberaccess_role_policy_attachment" {
-  role       = module.member-access.aws_iam_role.default.name  
+  role       = data.aws_iam_role.member_access_role_name
   policy_arn = aws_iam_policy.member_access_cloudformation.arn
 }
 

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -258,8 +258,8 @@ data "aws_iam_policy_document" "member-access" {
       ]
       resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
       condition {
-          test     = "ForAllValues:StringNotEquals"
-          variable = "cloudformation:ResourceTypes"
+          test     = "StringEquals"
+          variable = "ResourceType"
           values   = ["AWS::WAFv2::WebACL"]
       }
   }

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -249,6 +249,24 @@ data "aws_iam_policy_document" "member-access" {
       values   = ["AWS::WAFv2::WebACL"]
     }
   }
+
+  statement {
+    effect = "Deny"
+    actions = [
+      "cloudformation:ListStacks",
+      "cloudformation:DescribeStacks",
+      "cloudformation:CreateStack",
+      "cloudformation:UpdateStack",
+      "cloudformation:DeleteStack",
+      "cloudformation:GetTemplate"
+    ]
+    resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
+    condition {
+      test     = "StringNotEqualsIfExists"
+      variable = "cloudformation:ResourceTypes"
+      values   = ["AWS::WAFv2::WebACL"]
+    }
+  }
 }
 
 resource "aws_iam_policy" "member-access" {

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -247,13 +247,13 @@ data "aws_iam_policy_document" "member-access" {
       effect = "Allow"
       actions = [
           "cloudformation:CreateStack",
-          "cloudformation:UpdateStack",
+          "cloudformation:UpdateStack"
       ]
       resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
       condition {
-          test     = "StringLike"
-          variable = "cloudformation:ResourceTypes"
-          values   = ["AWS::WAFv2::*"]
+        test     = "StringEquals"
+        variable = "cloudformation:ResourceTypes"
+        values   = ["AWS::WAFv2::WebACL"]
       }
   }
 

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -242,7 +242,8 @@ data "aws_iam_policy_document" "member-access" {
           "cloudformation:GetTemplateSummary",
           "cloudformation:GetStackPolicy",
           "cloudformation:ListChangeSets",
-          "cloudformation:DescribeChangeSet"
+          "cloudformation:DescribeChangeSet",
+          "cloudformation:ListStackResources"
       ]
       resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
   }
@@ -256,7 +257,7 @@ data "aws_iam_policy_document" "member-access" {
       ]
       resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
       condition {
-        test     = "StringEquals"
+        test     = "ForAllValues:StringEquals"
         variable = "cloudformation:ResourceTypes"
         values   = ["AWS::WAFv2::WebACL"]
       }

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -8,7 +8,7 @@ module "member-access" {
   source                 = "github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access?ref=b67419df67f04d3023f410db26432b87186c909a"
   account_id             = local.modernisation_platform_account.id
   additional_trust_roles = [module.github-oidc[0].github_actions_role, one(data.aws_iam_roles.member-sso-admin-access.arns)]
-  policy_arn             = [aws_iam_policy.member-access[0].id, aws_iam_policy.member_access_cloudformation ]
+  policy_arns             = [aws_iam_policy.member-access[0].id, aws_iam_policy.member_access_cloudformation ]
   role_name              = "MemberInfrastructureAccess"
 }
 

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -238,23 +238,25 @@ data "aws_iam_policy_document" "member-access" {
           "cloudformation:ListStacks",
           "cloudformation:DescribeStacks",
           "cloudformation:DeleteStack",
-          "cloudformation:GetTemplate"
+          "cloudformation:GetTemplate",
+          "cloudformation:CreateStack",
+          "cloudformation:UpdateStack"
       ]
       resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
   }
 
-  statement {
-      effect = "Allow"
-      actions = [
-          "cloudformation:CreateStack",
-          "cloudformation:UpdateStack",
-      ]
-      resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
-      condition {
-          test     = "StringEquals"
-          variable = "cloudformation:ResourceTypes"
-          values   = ["AWS::WAFv2::WebACL"]
-      }
+  # statement {
+  #     effect = "Allow"
+  #     actions = [
+  #         "cloudformation:CreateStack",
+  #         "cloudformation:UpdateStack",
+  #     ]
+  #     resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
+  #     condition {
+  #         test     = "StringEquals"
+  #         variable = "cloudformation:ResourceTypes"
+  #         values   = ["AWS::WAFv2::WebACL"]
+  #     }
   }
 
   # statement {

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -231,6 +231,23 @@ data "aws_iam_policy_document" "member-access" {
     ]
     resources = ["arn:aws:iam::*:user/cicd-member-user"]
   }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "cloudformation:ListStacks",
+      "cloudformation:DescribeStacks",
+      "cloudformation:CreateStack",
+      "cloudformation:UpdateStack",
+      "cloudformation:DeleteStack"
+    ]
+    resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
+    condition {
+      test     = "StringEquals"
+      variable = "cloudformation:ResourceTypes"
+      values   = ["AWS::WAFv2::WebACL"]
+    }
+  }
 }
 
 resource "aws_iam_policy" "member-access" {

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -258,7 +258,7 @@ data "aws_iam_policy_document" "member-access" {
       ]
       resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
       condition {
-          test     = "StringEquals"
+          test     = "StringNotEquals"
           variable = "ResourceType"
           values   = ["AWS::WAFv2::WebACL"]
       }

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -243,7 +243,7 @@ data "aws_iam_policy_document" "member-access" {
     ]
     resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
     condition {
-      test     = "StringEquals"
+      test     = "StringEqualsIfExists"
       variable = "cloudformation:ResourceTypes"
       values   = ["AWS::WAFv2::WebACL"]
     }

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -286,7 +286,7 @@ resource "aws_iam_policy" "member-access" {
   policy      = data.aws_iam_policy_document.member-access.json
 }
 
-resource "aws_iam_policy" "member-access-cloudformation" {
+resource "aws_iam_policy" "member_access_cloudformation" {
   name        = "member-access-cloudformation"
   description = "This policy grants create and update permissions for cloudformation stack resources based on the resource types being created."
   policy      = <<EOF
@@ -300,17 +300,18 @@ resource "aws_iam_policy" "member-access-cloudformation" {
         "cloudformation:UpdateStack",
         "cloudformation:CreateChangeSet"
       ],
-      "Resource": ["*"]
-    },
-    "Condition": {
-      "StringNotEquals": {
-        "cloudformation:ResourceTypes": [ "AWS::WAFv2::WebAC" ]
+      "Resource": ["*"],
+      "Condition": {
+        "StringNotEquals": {
+          "cloudformation:ResourceTypes": [ "AWS::WAFv2::WebACL" ]
+        }
       }
     }
   ]
 }
 EOF
 }
+
 
 # Attachment to associate the cloudformation policy with the MemberAccess Role
 resource "aws_iam_role_policy_attachment" "memberaccess_role_policy_attachment" {

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -316,7 +316,7 @@ EOF
 # Attachment to associate the cloudformation policy with the MemberAccess Role
 resource "aws_iam_role_policy_attachment" "memberaccess_role_policy_attachment" {
   role       = module.member-access.aws_iam_role.default.name  
-  policy_arn = aws_iam_policy.member-access-cloudformation.arn
+  policy_arn = aws_iam_policy.member_access_cloudformation.arn
 }
 
 # Testing-test member access - separate as need the testing user created in the testing account to be able to access as well

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -5,10 +5,10 @@ locals {
 
 module "member-access" {
   count                  = local.account_data.account-type == "member" && terraform.workspace != "testing-test" ? 1 : 0
-  source                 = "github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access?ref=6819b090bce6d3068d55c7c7b9b3fd18c9dca648" #v3.0.0
+  source                 = "github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access?ref=b67419df67f04d3023f410db26432b87186c909a"
   account_id             = local.modernisation_platform_account.id
   additional_trust_roles = [module.github-oidc[0].github_actions_role, one(data.aws_iam_roles.member-sso-admin-access.arns)]
-  policy_arn             = aws_iam_policy.member-access[0].id
+  policy_arn             = [aws_iam_policy.member-access[0].id, aws_iam_policy.member_access_cloudformation ]
   role_name              = "MemberInfrastructureAccess"
 }
 
@@ -312,15 +312,6 @@ resource "aws_iam_policy" "member_access_cloudformation" {
 EOF
 }
 
-data "aws_iam_role" "member_access_role_name" {
-  name       = module.member-access.default.name  
-}
-
-# Attachment to associate the cloudformation policy with the MemberAccess Role
-resource "aws_iam_role_policy_attachment" "memberaccess_role_policy_attachment" {
-  role       = data.aws_iam_role.member_access_role_name
-  policy_arn = aws_iam_policy.member_access_cloudformation.arn
-}
 
 # Testing-test member access - separate as need the testing user created in the testing account to be able to access as well
 data "aws_iam_policy_document" "assume_role_policy" {

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -240,7 +240,9 @@ data "aws_iam_policy_document" "member-access" {
           "cloudformation:DeleteStack",
           "cloudformation:GetTemplate",
           "cloudformation:GetTemplateSummary",
-          "cloudformation:GetStackPolicy"
+          "cloudformation:GetStackPolicy",
+          "cloudformation:ListChangeSets",
+          "cloudformation:DescribeChangeSet"
       ]
       resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
   }
@@ -248,6 +250,7 @@ data "aws_iam_policy_document" "member-access" {
   statement {
       effect = "Allow"
       actions = [
+          "cloudformation:CreateChangeSet",
           "cloudformation:CreateStack",
           "cloudformation:UpdateStack"
       ]

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -244,25 +244,12 @@ data "aws_iam_policy_document" "member-access" {
     ]
     resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
     condition {
-      test     = "StringEqualsIfExists"
-      variable = "cloudformation:ResourceTypes"
+      test     = "ForAllValues:StringEquals"
+      variable = "cloudformation:TemplateResourceTypes"
       values   = ["AWS::WAFv2::WebACL"]
     }
   }
 
-  statement {
-    effect = "Deny"
-    actions = [
-      "cloudformation:CreateStack",
-      "cloudformation:UpdateStack"
-    ]
-    resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
-    condition {
-      test     = "StringNotEqualsIfExists"
-      variable = "cloudformation:ResourceTypes"
-      values   = ["AWS::WAFv2::WebACL"]
-    }
-  }
 }
 
 resource "aws_iam_policy" "member-access" {

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -250,6 +250,20 @@ data "aws_iam_policy_document" "member-access" {
     }
   }
 
+  statement {
+    effect = "Deny"
+    actions = [
+      "cloudformation:CreateStack",
+      "cloudformation:UpdateStack"
+    ]
+    resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
+    condition {
+      test     = "ForAllValues:StringNotEquals"
+      variable = "cloudformation:TemplateResourceTypes"
+      values   = ["AWS::WAFv2::WebACL"]
+    }
+  }
+
 }
 
 resource "aws_iam_policy" "member-access" {

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -243,11 +243,11 @@ data "aws_iam_policy_document" "member-access" {
           "cloudformation:GetTemplate"
       ]
       resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
-      condition {
-          test     = "ForAnyValue:StringEquals"
-          variable = "cloudformation:ResourceTypes"
-          values   = ["AWS::WAFv2::WebACL"]
-      }
+      # condition {
+      #     test     = "ForAnyValue:StringEquals"
+      #     variable = "cloudformation:ResourceTypes"
+      #     values   = ["AWS::WAFv2::WebACL"]
+      # }
   }
 
   statement {

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -245,7 +245,7 @@ data "aws_iam_policy_document" "member-access" {
     resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
     condition {
       test     = "ForAllValues:StringEquals"
-      variable = "cloudformation:TemplateResourceTypes"
+      variable = "cloudformation:ResourceTypes"
       values   = ["AWS::WAFv2::WebACL"]
     }
   }
@@ -259,7 +259,7 @@ data "aws_iam_policy_document" "member-access" {
     resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
     condition {
       test     = "ForAllValues:StringNotEquals"
-      variable = "cloudformation:TemplateResourceTypes"
+      variable = "cloudformation:ResourceTypes"
       values   = ["AWS::WAFv2::WebACL"]
     }
   }

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -8,7 +8,7 @@ module "member-access" {
   source                 = "github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access?ref=6819b090bce6d3068d55c7c7b9b3fd18c9dca648" #v3.0.0"
   account_id             = local.modernisation_platform_account.id
   additional_trust_roles = [module.github-oidc[0].github_actions_role, one(data.aws_iam_roles.member-sso-admin-access.arns)]
-  policy_arns             = aws_iam_policy.member-access[0].id
+  policy_arn             = aws_iam_policy.member-access[0].id
   role_name              = "MemberInfrastructureAccess"
 }
 

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -258,7 +258,7 @@ data "aws_iam_policy_document" "member-access" {
       ]
       resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
       condition {
-        test     = "StringEquals"
+        test     = "ForAllValues:StringEquals"
         variable = "cloudformation:ResourceTypes"
         values   = [ "AWS::WAFv2::WebACL", "AWS::S3::Bucket" ]
       }

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -243,7 +243,8 @@ data "aws_iam_policy_document" "member-access" {
           "cloudformation:GetStackPolicy",
           "cloudformation:ListChangeSets",
           "cloudformation:DescribeChangeSet",
-          "cloudformation:ListStackResources"
+          "cloudformation:ListStackResources",
+          "cloudformation:CreateUploadBucket"
       ]
       resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
   }

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -257,7 +257,7 @@ data "aws_iam_policy_document" "member-access" {
       ]
       resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
       condition {
-        test     = "StringEquals"
+        test     = "ForAllValues:StringEquals"
         variable = "cloudformation:ResourceTypes"
         values   = [ "AWS::WAFv2::WebACL", "AWS::S3::Bucket" ]
       }

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -258,9 +258,9 @@ data "aws_iam_policy_document" "member-access" {
       ]
       resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
       condition {
-        test     = "ForAllValues:StringEquals"
+        test     = "StringEquals"
         variable = "cloudformation:ResourceTypes"
-        values   = [ "AWS::WAFv2::WebACL", "AWS::S3::Bucket" ]
+        values   = [ "AWS::WAFv2::WebACL" ]
       }
   }
 

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -259,7 +259,7 @@ data "aws_iam_policy_document" "member-access" {
       condition {
         test     = "StringEquals"
         variable = "cloudformation:ResourceTypes"
-        values   = [ "aws::wafv2::webacl", "aws::s3::bucket" ]
+        values   = [ "AWS::WAFv2::WebACL", "AWS::S3::Bucket" ]
       }
   }
 

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -257,7 +257,7 @@ data "aws_iam_policy_document" "member-access" {
       ]
       resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
       condition {
-        test     = "ForAllValues:StringEquals"
+        test     = "StringEquals"
         variable = "cloudformation:ResourceTypes"
         values   = [ "AWS::WAFv2::WebACL", "AWS::S3::Bucket" ]
       }


### PR DESCRIPTION
**_Note - this is pending advice from AWS on issues arising from this proposed change._**

Amends aws_iam_policy_document "member-access" and adds permissions that allow only the creation of wafv2:acl resources via an aws_cloudformation_stack. Note that the permissions are limited only to stack-level operations and does not include those actions for stacksets or the creation/exec of changesets.

## A reference to the issue / Description of it

See issue 6991 - https://github.com/ministryofjustice/modernisation-platform/issues/6991

## How does this PR fix the problem?

This change has been requested by the LAA Ops team due to limitations with terraform implementing wafv2:acl rules nested beyond 3 levels. The identified solution is to create the acl via an aws_cloudformation_stack resources. The added statement has been written to only allow the creation of resources of type AWS:WAFv2:ACL via cloudformation so as to avoid the potential for this approach to be used more generally.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

This change will be tested in sprinkler first where I will attempt to create both a wafv2:acl and other types of resource. If the tests are successful, the acl will be created via a cloudformation stack but not others.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

As this is a supplemental change it should not adversely impact existing resources.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
