### PR TITLE
:wrench: Exclude environment from auto-nuke

### DIFF
--- a/environments/operations-engineering.json
+++ b/environments/operations-engineering.json
@@ -6,7 +6,8 @@
       "access": [
         {
           "github_slug": "operations-engineering",
-          "level": "sandbox"
+          "level": "sandbox",
+          "nuke": "exclude"
         }
       ]
     }


### PR DESCRIPTION
The Operations Engineering team are currently trialling a long running prototype of log streaming. This requires us to keep resources running over long periods (approx. 3 months). After this time, we can enable auto-nuke once more.

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)
