### PR TITLE
DPR2-713: Add logs:ListTagsForResource to circleci_iam_policy

### DIFF
--- a/terraform/environments/digital-prison-reporting/iam.tf
+++ b/terraform/environments/digital-prison-reporting/iam.tf
@@ -146,6 +146,7 @@ data "aws_iam_policy_document" "circleci_iam_policy" {
       "logs:CreateLogGroup",
       "logs:CreateLogStream",
       "logs:PutLogEvents",
+      "logs:ListTagsForResource",
       "lambda:*",
       "s3:GetBucketLocation",
       "s3:ListBucket",


### PR DESCRIPTION
## A reference to the issue / Description of it

This fixes the error below observed which prevents deployment of changes.
```
╷
│ Error: listing tags for CloudWatch Logs Log Group (arn:aws:logs:eu-west-2:771283872747:log-group:dms-tasks-dpr-dms-dps-generic-instance-development): operation error CloudWatch Logs: ListTagsForResource, https response error StatusCode: 400, RequestID: b9ac42da-35da-4f2a-bcb7-a634105d2103, api error AccessDeniedException: User: arn:aws:sts::771283872747:assumed-role/circleci_iam_role/circleci-oidc-session is not authorized to perform: logs:ListTagsForResource on resource: arn:aws:logs:eu-west-2:771283872747:log-group:dms-tasks-dpr-dms-dps-generic-instance-development because no identity-based policy allows the logs:ListTagsForResource action
│ 
│   with module.dms-instance["dps"].module.dms_instance.aws_cloudwatch_log_group.dms-instance-log-group[0],
│   on .terraform/modules/dms-instance/terraform/environments/digital-prison-reporting/modules/dms_s3_v2/main.tf line 2, in resource "aws_cloudwatch_log_group" "dms-instance-log-group":
│    2: resource "aws_cloudwatch_log_group" "dms-instance-log-group" {
│ 
╵
╷
│ Error: listing tags for CloudWatch Logs Log Group (arn:aws:logs:eu-west-2:771283872747:log-group:dms-tasks-dpr-dms-nomis-generic-instance-development): operation error CloudWatch Logs: ListTagsForResource, https response error StatusCode: 400, RequestID: 84573f3b-efda-4b0a-9dd4-f20ddb5934fc, api error AccessDeniedException: User: arn:aws:sts::771283872747:assumed-role/circleci_iam_role/circleci-oidc-session is not authorized to perform: logs:ListTagsForResource on resource: arn:aws:logs:eu-west-2:771283872747:log-group:dms-tasks-dpr-dms-nomis-generic-instance-development because no identity-based policy allows the logs:ListTagsForResource action
│ 
│   with module.dms-instance["nomis"].module.dms_instance.aws_cloudwatch_log_group.dms-instance-log-group[0],
│   on .terraform/modules/dms-instance/terraform/environments/digital-prison-reporting/modules/dms_s3_v2/main.tf line 2, in resource "aws_cloudwatch_log_group" "dms-instance-log-group":
│    2: resource "aws_cloudwatch_log_group" "dms-instance-log-group" {
│ 
╵

Exited with code exit status 1
```

## How does this PR fix the problem?

The PR adds the `logs:ListTagsForResource` permission to `circleci_iam_policy`

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

N/A

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No impact

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

N/A
