### PR TITLE
Remove `types` from `pull_request` in workflow template

### DIFF
--- a/.github/workflows/templates/workflow-template.yml
+++ b/.github/workflows/templates/workflow-template.yml
@@ -11,7 +11,6 @@ on:
   pull_request:
     branches:
       - main
-    types: [opened, edited, reopened, synchronize]
     paths:
       - 'terraform/environments/$application_name/**'
       - '.github/workflows/$application_name.yml'


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/7160

This is a ressurection of this [PR](https://github.com/ministryofjustice/modernisation-platform/pull/7159) originally raised by @jacobwoffenden

## How does this PR fix the problem?

Removes `types` from `pull_request` in the workflow template for members so that changes to the PR body does not trigger workflow runs.

https://mojdt.slack.com/archives/C01A7QK5VM1/p1717497987776109 << shows the original convo regarding this

## How has this been tested?

Already tested by Analytical Platform who use this in production

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [X] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
