### PR TITLE
Updated role with CloudWatch cross account permissions

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -328,6 +328,15 @@ data "aws_iam_policy_document" "developer_additional" {
   }
 
   statement {
+      sid = "cloudWatchCrossAccountAllow"
+      effect = "Allow"
+      action = [
+        "iam:CreateServiceLinkedRole"
+      ]
+      resources = ["arn:aws:iam::*:role/aws-service-role/cloudwatch-crossaccount.amazonaws.com/AWSServiceRoleForCloudWatchCrossAccount"]
+    }
+
+  statement {
     sid    = "coreSharedServicesCreateGrantAllow"
     effect = "Allow"
     actions = [

--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -330,7 +330,7 @@ data "aws_iam_policy_document" "developer_additional" {
   statement {
       sid = "cloudWatchCrossAccountAllow"
       effect = "Allow"
-      action = [
+      actions = [
         "iam:CreateServiceLinkedRole"
       ]
       resources = ["arn:aws:iam::*:role/aws-service-role/cloudwatch-crossaccount.amazonaws.com/AWSServiceRoleForCloudWatchCrossAccount"]


### PR DESCRIPTION
## A reference to the issue / Description of it

https://dsdmoj.atlassian.net/browse/DSOS-2832

There are cross account dashboards in cloudwatch that display errors when trying to display data. I believe we need to enable the  **View cross-account cross-region** feature in cloudwatch however attempting to do this triggers the below error.

```
User: arn:aws:sts::123456789:assumed-role/AWSReservedSSO_modernisation-platform-developer_ad9787b9bbb44c29/xxxxj@xxxx.justice.gov.uk is not authorized to perform: iam:CreateServiceLinkedRole on resource: arn:aws:iam::123456789:role/aws-service-role/cloudwatch-crossaccount.amazonaws.com/AWSServiceRoleForCloudWatchCrossAccount because no identity-based policy allows the iam:CreateServiceLinkedRole action 
```

## How does this PR fix the problem?

Added `iam:CreateServiceLinkedRole` permission to developer_policy for `modernisation-platform-developer` role

## How has this been tested?

[Plan has been inspected, only one change expected
](https://github.com/ministryofjustice/modernisation-platform/actions/runs/9503150338/job/26192922749#step:7:121)
`Plan: 0 to add, 1 to change, 0 to destroy.
`
## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

no - permissions are additive 

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)