### PR TITLE
DPR2-713: Add iam:DeletePolicyVersion to circleci

### DIFF
--- a/terraform/environments/digital-prison-reporting/iam.tf
+++ b/terraform/environments/digital-prison-reporting/iam.tf
@@ -167,6 +167,7 @@ data "aws_iam_policy_document" "circleci_iam_policy" {
       "iam:GetPolicy",
       "dms:List*",
       "iam:GetPolicyVersion",
+      "iam:DeletePolicyVersion",
       "dms:DescribeReplicationSubnetGroups",
       "dms:DescribeReplicationInstances",
       "dms:DescribeReplicationTasks",


### PR DESCRIPTION
## A reference to the issue / Description of it

The circle-ci role does not have permissions to perform iam:DeletePolicyVersion and is causing the terraform apply to fail with the error: 
```
│ Error: deleting IAM Policy (arn:aws:iam::771283872747:policy/dpr-reporting-hub-batch-movements-development-policy) version (v1): operation error IAM: DeletePolicyVersion, https response error StatusCode: 403, RequestID: 96eb9db6-fb33-4156-bf27-a21d781b703e, api error AccessDenied: User: arn:aws:sts::771283872747:assumed-role/circleci_iam_role/circleci-oidc-session is not authorized to perform: iam:DeletePolicyVersion on resource: policy arn:aws:iam::771283872747:policy/dpr-reporting-hub-batch-movements-development-policy because no identity-based policy allows the iam:DeletePolicyVersion action
│ 
│   with module.ingestion-jobs["movements"].module.glue_reporting_hub_batch_job.aws_iam_policy.additional-policy[0],
│   on .terraform/modules/ingestion-jobs/terraform/environments/digital-prison-reporting/modules/glue_job/main.tf line 183, in resource "aws_iam_policy" "additional-policy":
│  183: resource "aws_iam_policy" "additional-policy" {
│ 
╵

Exited with code exit status 1
```

## How does this PR fix the problem?

This PR adds the permission iam:DeletePolicyVersion to the circleci role.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

N/A

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

There will be no impact

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

None
