### PR TITLE
DSOS: grant athena access to instance-access and instance-management roles

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -655,6 +655,8 @@ data "aws_iam_policy_document" "instance-access-document" {
     sid    = "InstanceAccess"
     effect = "Allow"
     actions = [
+      "athena:StartQueryExecution",
+      "athena:StopQueryExecution",
       "ec2:GetPasswordData",
       "kms:Decrypt*",
       "kms:Encrypt",
@@ -801,6 +803,8 @@ data "aws_iam_policy_document" "instance-management-document" {
     effect = "Allow"
     actions = [
       "application-autoscaling:ListTagsForResource",
+      "athena:StartQueryExecution",
+      "athena:StopQueryExecution",
       "autoscaling:StartInstanceRefresh",
       "autoscaling:UpdateAutoScalingGroup",
       "autoscaling:SetDesiredCapacity",


### PR DESCRIPTION
## A reference to the issue / Description of it

Application support teams unable to query nomis load balancer logs

## How does this PR fix the problem?

Grants Athena query access to application support team roles (instance-management and instance-access)

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

N/A - standard policy change

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No since just granting additional permissions

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
