### PR TITLE
Adding data-engineer role to DPR dev/test/prod accounts

### DIFF
--- a/environments/digital-prison-reporting.json
+++ b/environments/digital-prison-reporting.json
@@ -20,6 +20,10 @@
         {
           "github_slug": "hmpps-digital-prison-reporting-non-cleared-team",
           "level": "reporting-operations"
+        },
+        {
+          "github_slug": "digital-prisons-reporting-development-data-engineer",
+          "level": "data-engineer"
         }
       ]
     },
@@ -41,6 +45,10 @@
         {
           "github_slug": "hmpps-digital-prison-reporting-non-cleared-team",
           "level": "reporting-operations"
+        },
+        {
+          "github_slug": "digital-prisons-reporting-test-data-engineer",
+          "level": "data-engineer"
         }
       ]
     },
@@ -54,6 +62,10 @@
         {
           "github_slug": "hmpps-digital-prison-reporting",
           "level": "reporting-operations"
+        },
+        {
+          "github_slug": "digital-prisons-reporting-preproduction-data-engineer",
+          "level": "data-engineer"
         }
       ]
     },


### PR DESCRIPTION
## A reference to the issue / Description of it

Resolves https://github.com/ministryofjustice/analytical-platform/issues/4551

In order to facilitate testing of integration between Analytical Platform and DPR, `data-engineer` access will be added to the dev, test and preprod DPR environments. 

## How does this PR fix the problem?

It adds the roles to the json files.

## How has this been tested?

This is difficult to test outside of applying.


## Deployment Plan / Instructions

This should not produce destructive changes

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

Prior to MP, this PR will be reviewed by the DPR developers.
