### PR TITLE
DPR2-713: Grant glue:GetTrigger to DPR circle-ci role

### DIFF
--- a/terraform/environments/digital-prison-reporting/iam.tf
+++ b/terraform/environments/digital-prison-reporting/iam.tf
@@ -237,6 +237,7 @@ data "aws_iam_policy_document" "circleci_iam_policy" {
       "glue:CreateRegistry",
       "glue:CreateSchema",
       "glue:CreateTable",
+      "glue:GetTrigger",
       "glue:CreateTrigger",
       "glue:DeleteConnection",
       "glue:DeleteJob",


### PR DESCRIPTION
## A reference to the issue / Description of it

The DPR circle-ci role is failing to apply terraform changes in with the error:
```
│ Error: waiting for Glue Trigger (dpr-reporting-hub-archive-prisoner-development-trigger) to be Created: AccessDeniedException: User: arn:aws:sts::771283872747:assumed-role/circleci_iam_role/circleci-oidc-session is not authorized to perform: glue:GetTrigger on resource: arn:aws:glue:eu-west-2:771283872747:trigger/dpr-reporting-hub-archive-prisoner-development-trigger because no identity-based policy allows the glue:GetTrigger action
```

## How does this PR fix the problem?

This PR fixes the issue by granting the glue:GetTrigger permission to the DPR circle-ci role.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

N/A

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No impact to the platform and services on it.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

None
