### PR TITLE
feat: Add Delius MIS production and non-production alarms to PagerDuty

### DIFF
--- a/terraform/pagerduty/aws.tf
+++ b/terraform/pagerduty/aws.tf
@@ -72,6 +72,8 @@ resource "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {
     nomis_data_hub_prod_alarms           = pagerduty_service_integration.ndh_prod.integration_key
     laa_apex_nonprod_alarms              = pagerduty_service_integration.apex_non_prod.integration_key
     laa_apex_prod_alarms                 = pagerduty_service_integration.apex_prod.integration_key
+    delius_mis_nonprod_alarms            = pagerduty_service_integration.delius_mis_non_prod.integration_key
+    delius__mis_prod_alarms              = pagerduty_service_integration.delius_mis_prod.integration_key
   })
 }
 

--- a/terraform/pagerduty/member-services-integrations.tf
+++ b/terraform/pagerduty/member-services-integrations.tf
@@ -606,6 +606,98 @@ resource "pagerduty_slack_connection" "iaps_prod_connection" {
 
 # Slack channel: #hmpps-iaps-alerts-prod
 
+# Delius MIS Prod
+# hmpps-mis-alerts-prod
+resource "pagerduty_service" "delius_mis_prod" {
+  name                    = "Delius MIS Production"
+  description             = "Delius MIS Production Alarms"
+  auto_resolve_timeout    = 345600
+  acknowledgement_timeout = "null"
+  escalation_policy       = pagerduty_escalation_policy.member_policy.id
+  alert_creation          = "create_alerts_and_incidents"
+}
+
+resource "pagerduty_service_integration" "delius_mis_prod" {
+  name    = data.pagerduty_vendor.cloudwatch.name
+  service = pagerduty_service.my_application.id
+  vendor  = data.pagerduty_vendor.cloudwatch.id
+}
+
+resource "pagerduty_slack_connection" "delius_mis_prod" {
+  source_id = pagerduty_service.my_application.id
+  source_type = "service_reference"
+  workspace_id = local.slack_workspace_id
+  channel_id = "C07868KH4AK"
+  notification_type = "responder"
+  config {
+    events = [
+      "incident.triggered",
+      "incident.acknowledged",
+      "incident.escalated",
+      "incident.resolved",
+      "incident.reassigned",
+      "incident.annotated",
+      "incident.unacknowledged",
+      "incident.delegated",
+      "incident.priority_updated",
+      "incident.responder.added",
+      "incident.responder.replied",
+      "incident.action_invocation.created",
+      "incident.action_invocation.terminated",
+      "incident.action_invocation.updated",
+      "incident.status_update_published",
+      "incident.reopened"
+    ]
+    priorities = ["*"]
+  }
+}
+
+# Delius MIS Non-prod
+# hmpps-mis-alerts-non-prod
+resource "pagerduty_service" "delius_mis_non_prod" {
+  name                    = "Delius MIS Non-production"
+  description             = "Delius MIS Non-production Alarms"
+  auto_resolve_timeout    = 345600
+  acknowledgement_timeout = "null"
+  escalation_policy       = pagerduty_escalation_policy.member_policy.id
+  alert_creation          = "create_alerts_and_incidents"
+}
+
+resource "pagerduty_service_integration" "delius_mis_non_prod" {
+  name    = data.pagerduty_vendor.cloudwatch.name
+  service = pagerduty_service.my_application.id
+  vendor  = data.pagerduty_vendor.cloudwatch.id
+}
+
+resource "pagerduty_slack_connection" "delius_mis_non_prod" {
+  source_id = pagerduty_service.my_application.id
+  source_type = "service_reference"
+  workspace_id = local.slack_workspace_id
+  channel_id = "C07868JGQVD"
+  notification_type = "responder"
+  config {
+    events = [
+      "incident.triggered",
+      "incident.acknowledged",
+      "incident.escalated",
+      "incident.resolved",
+      "incident.reassigned",
+      "incident.annotated",
+      "incident.unacknowledged",
+      "incident.delegated",
+      "incident.priority_updated",
+      "incident.responder.added",
+      "incident.responder.replied",
+      "incident.action_invocation.created",
+      "incident.action_invocation.terminated",
+      "incident.action_invocation.updated",
+      "incident.status_update_published",
+      "incident.reopened"
+    ]
+    priorities = ["*"]
+  }
+}
+
 # LAA MojFin - Prod
 resource "pagerduty_service" "laa_mojfin_prod" {
   name                    = "Legal Aid Agency MojFin Application Production"

--- a/terraform/pagerduty/member-services-integrations.tf
+++ b/terraform/pagerduty/member-services-integrations.tf
@@ -619,12 +619,12 @@ resource "pagerduty_service" "delius_mis_prod" {
 
 resource "pagerduty_service_integration" "delius_mis_prod" {
   name    = data.pagerduty_vendor.cloudwatch.name
-  service = pagerduty_service.my_application.id
+  service = pagerduty_service.delius_mis_prod.id
   vendor  = data.pagerduty_vendor.cloudwatch.id
 }
 
 resource "pagerduty_slack_connection" "delius_mis_prod" {
-  source_id = pagerduty_service.my_application.id
+  source_id = pagerduty_service.delius_mis_prod.id
   source_type = "service_reference"
   workspace_id = local.slack_workspace_id
   channel_id = "C07868KH4AK"
@@ -665,12 +665,12 @@ resource "pagerduty_service" "delius_mis_non_prod" {
 
 resource "pagerduty_service_integration" "delius_mis_non_prod" {
   name    = data.pagerduty_vendor.cloudwatch.name
-  service = pagerduty_service.my_application.id
+  service = pagerduty_service.delius_mis_non_prod.id
   vendor  = data.pagerduty_vendor.cloudwatch.id
 }
 
 resource "pagerduty_slack_connection" "delius_mis_non_prod" {
-  source_id = pagerduty_service.my_application.id
+  source_id = pagerduty_service.delius_mis_non_prod.id
   source_type = "service_reference"
   workspace_id = local.slack_workspace_id
   channel_id = "C07868JGQVD"


### PR DESCRIPTION
This commit adds the necessary resources and configurations to integrate Delius MIS production and non-production alarms with PagerDuty. It includes the creation of PagerDuty services, service integrations, and Slack connections for both environments.

## A reference to the issue / Description of it

{Please write here}

## How does this PR fix the problem?

{Please write here}

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
