### PR TITLE
Calm down OPA Validation workflow

### DIFF
--- a/.github/workflows/opa-policies.yml
+++ b/.github/workflows/opa-policies.yml
@@ -10,6 +10,9 @@ on:
       - '**.rego'
   merge_group:
     types: [checks_requested]
+    paths:
+      - '**.json'
+      - '**.rego'
 
 permissions:
   contents: read

--- a/.github/workflows/opa-policies.yml
+++ b/.github/workflows/opa-policies.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - '**.json'
+      - '**.rego'
   merge_group:
     types: [checks_requested]
 

--- a/terraform/github/repositories.tf
+++ b/terraform/github/repositories.tf
@@ -10,7 +10,6 @@ module "core" {
     "aws",
     "documentation"
   ]
-  required_checks = ["run-opa-policy-tests"]
   secrets = {
     # Terraform GitHub token for the CI/CD user
     TERRAFORM_GITHUB_TOKEN = data.aws_secretsmanager_secret_version.github_ci_user_token.secret_string


### PR DESCRIPTION
## A reference to the issue / Description of it

`"Open Policy Agent: validate JSON structures"` runs on every PR.

## How does this PR fix the problem?

This PR restricts the use of this action to only trigger when `*.rego` and `*.json` files present in a PR.

## How has this been tested?

It has not been tested.

## Deployment Plan / Instructions

No.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
