### PR TITLE
Adds ec2:DeregisterImage to  modernisation-platform-oidc-cicd role

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -430,6 +430,7 @@ data "aws_iam_policy_document" "policy" {
       "ec2:CreateNetworkInterfacePermission",
       "ec2:AttachNetworkInterface",
       "ec2:DeleteNetworkInterface",
+      "ec2:DeregisterImage",
       "ec2:DescribeSecurityGroups",
       "ec2:DescribeSubnets",
       "ec2:DescribeVpcEndpoints",


### PR DESCRIPTION
## A reference to the issue / Description of it

Adds "ec2:DeregisterImage" to modernisation-platform-oidc-cicd role as requested by Dominic Robinson @20/06/24

## How does this PR fix the problem?

{Please write here}

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
