### PR TITLE
Update secrets.tf

### DIFF
--- a/terraform/environments/secrets.tf
+++ b/terraform/environments/secrets.tf
@@ -17,7 +17,8 @@ resource "aws_secretsmanager_secret_version" "environment_management" {
   secret_id = aws_secretsmanager_secret.environment_management.id
   secret_string = jsonencode(merge(
     local.environment_management,
-    { account_ids : module.environments.environment_account_ids }
+    { account_ids : module.environments.environment_account_ids },
+    { account_ids : module.environments.modernisation_platform_member_unrestricted_ou_id }
   ))
   depends_on = [data.aws_secretsmanager_secret_version.environment_management]
 }
@@ -136,7 +137,8 @@ resource "github_actions_secret" "environment_management" {
   repository  = each.key
   plaintext_value = jsonencode(merge(
     local.environment_management,
-    { account_ids : module.environments.environment_account_ids }
+    { account_ids : module.environments.environment_account_ids },
+    { account_ids : module.environments.modernisation_platform_member_unrestricted_ou_id }
   ))
 }
 
@@ -161,13 +163,4 @@ resource "github_actions_secret" "autonuke" {
   # testing-test, cooker-development, and example-development are internal test account which are not sandpits but require nuking.
   plaintext_value = jsonencode(concat(module.environments.environment_nuke_accounts, ["testing-test", "cooker-development", "example-development"]))
 }
-
-resource "github_actions_secret" "member_unrestricted_list" {
-  # checkov:skip=CKV_SECRET_6: "secret_name is not a secret"
-  secret_name     = "MODERNISATION_PLATFORM_MEMBER_UNRESTRICTED_LIST"
-  repository      = "modernisation-platform-environments"
-  plaintext_value = jsonencode(module.environments.modernisation_platform_member_unrestricted_ou_id)
-}
-
-
 


### PR DESCRIPTION
## A reference to the issue / Description of it

Requested here - https://moj.enterprise.slack.com/archives/C01A7QK5VM1/p1718810172489409

## How does this PR fix the problem?

I have created a github secret for Jacob as requested, and was going to follow up with an AWS secret with values for unrestricted accounts. Dave Elliot wanted one secret with different keys in for account numbers, so this does that.

## How has this been tested?

Not tested, this could mess up the value for the environment_management secret so a revert might be necessary quickly


## Deployment Plan / Instructions


```
Terraform will perform the following actions:
  # aws_secretsmanager_secret_version.environment_management must be replaced
-/+ resource "aws_secretsmanager_secret_version" "environment_management" {
      ~ arn            = "arn:aws:secretsmanager:eu-west-2:946070829339:secret:environment_management-BLRCDb" -> (known after apply)
      ~ id             = "arn:aws:secretsmanager:eu-west-2:946070829339:secret:environment_management-BLRCDb|terraform-20240612155624552000000001" -> (known after apply)
      ~ secret_string  = (sensitive value) # forces replacement
      ~ version_id     = "terraform-20240612155624552000000001" -> (known after apply)
      ~ version_stages = [
          - "AWSCURRENT",
        ] -> (known after apply)
        # (2 unchanged attributes hidden)
    }
  # github_actions_secret.environment_management["modernisation-platform"] must be replaced
-/+ resource "github_actions_secret" "environment_management" {
      ~ created_at      = "2024-06-11 15:32:55 +0000 UTC" -> (known after apply)
      ~ id              = "modernisation-platform:MODERNISATION_PLATFORM_ENVIRONMENTS" -> (known after apply)
      ~ plaintext_value = (sensitive value) # forces replacement
      ~ updated_at      = "2024-06-12 15:56:26 +0000 UTC" -> (known after apply)
        # (3 unchanged attributes hidden)
    }
  # github_actions_secret.environment_management["modernisation-platform-ami-builds"] must be replaced
-/+ resource "github_actions_secret" "environment_management" {
      ~ created_at      = "2024-06-12 15:56:30 +0000 UTC" -> (known after apply)
      ~ id              = "modernisation-platform-ami-builds:MODERNISATION_PLATFORM_ENVIRONMENTS" -> (known after apply)
      ~ plaintext_value = (sensitive value) # forces replacement
      ~ updated_at      = "2024-06-12 15:56:30 +0000 UTC" -> (known after apply)
        # (3 unchanged attributes hidden)
    }
  # github_actions_secret.environment_management["modernisation-platform-configuration-management"] must be replaced
-/+ resource "github_actions_secret" "environment_management" {
      ~ created_at      = "2024-06-12 15:56:27 +0000 UTC" -> (known after apply)
      ~ id              = "modernisation-platform-configuration-management:MODERNISATION_PLATFORM_ENVIRONMENTS" -> (known after apply)
      ~ plaintext_value = (sensitive value) # forces replacement
      ~ updated_at      = "2024-06-12 15:56:27 +0000 UTC" -> (known after apply)
        # (3 unchanged attributes hidden)
    }
  # github_actions_secret.environment_management["modernisation-platform-environments"] must be replaced
-/+ resource "github_actions_secret" "environment_management" {
      ~ created_at      = "2024-06-11 15:32:14 +0000 UTC" -> (known after apply)
      ~ id              = "modernisation-platform-environments:MODERNISATION_PLATFORM_ENVIRONMENTS" -> (known after apply)
      ~ plaintext_value = (sensitive value) # forces replacement
      ~ updated_at      = "2024-06-12 15:56:29 +0000 UTC" -> (known after apply)
        # (3 unchanged attributes hidden)
    }
  # github_actions_secret.environment_management["modernisation-platform-security"] must be replaced
-/+ resource "github_actions_secret" "environment_management" {
      ~ created_at      = "2024-06-12 15:56:25 +0000 UTC" -> (known after apply)
      ~ id              = "modernisation-platform-security:MODERNISATION_PLATFORM_ENVIRONMENTS" -> (known after apply)
      ~ plaintext_value = (sensitive value) # forces replacement
      ~ updated_at      = "2024-06-12 15:56:25 +0000 UTC" -> (known after apply)
        # (3 unchanged attributes hidden)
    }
  # github_actions_secret.member_unrestricted_list will be destroyed
  # (because github_actions_secret.member_unrestricted_list is not in configuration)
  - resource "github_actions_secret" "member_unrestricted_list" {
      - created_at      = "2024-06-20 14:33:33 +0000 UTC" -> null
      - id              = "modernisation-platform-environments:MODERNISATION_PLATFORM_MEMBER_UNRESTRICTED_LIST" -> null
      - plaintext_value = (sensitive value) -> null
      - repository      = "modernisation-platform-environments" -> null
      - secret_name     = "MODERNISATION_PLATFORM_MEMBER_UNRESTRICTED_LIST" -> null
      - updated_at      = "2024-06-20 14:33:33 +0000 UTC" -> null
        # (1 unchanged attribute hidden)
    }
Plan: 6 to add, 0 to change, 7 to destroy.
```
