### PR TITLE
nomis: add additional collaborators for T3 environment

### DIFF
--- a/collaborators.json
+++ b/collaborators.json
@@ -343,6 +343,26 @@
           "access": "instance-management"
         }
       ]
+    },
+    {
+      "username": "theo.phillips",
+      "github-username": "theo-phillips",
+      "accounts": [
+        {
+          "account-name": "nomis-test",
+          "access": "instance-management"
+        }
+      ]
+    },
+    {
+      "username": "chris.keep",
+      "github-username": "iamchriskeep",
+      "accounts": [
+        {
+          "account-name": "nomis-test",
+          "access": "instance-management"
+        }
+      ]
     }
   ]
 }

--- a/collaborators.json
+++ b/collaborators.json
@@ -323,6 +323,26 @@
           "access": "instance-management"
         }
       ]
+    },
+    {
+      "username": "joehyland.deeson",
+      "github-username": "joe-hd",
+      "accounts": [
+        {
+          "account-name": "nomis-test",
+          "access": "instance-management"
+        }
+      ]
+    },
+    {
+      "username": "yordi.tak",
+      "github-username": "yorditak",
+      "accounts": [
+        {
+          "account-name": "nomis-test",
+          "access": "instance-management"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

Additional access to T3 jumpserver via FleetManager for MoJ BAs who aren't part of MoJ github org

## How does this PR fix the problem?

Adds them as collaborators

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

n/a - standard process

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
