### PR TITLE
🛂 Add `GetBucketOwnershipControls` to Data Engineering policy

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -410,6 +410,7 @@ data "aws_iam_policy_document" "data_engineering_additional" {
       "states:Start*",
       "states:RedriveExecution",
       "s3:PutBucketNotificationConfiguration",
+      "s3:GetBucketOwnershipControls"
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
## A reference to the issue / Description of it

This pull request _hopefully_ resolves https://github.com/ministryofjustice/data-platform-support/issues/707

## How does this PR fix the problem?

Adds missing S3 permission highlighted in CloudTrail event `c2b862e5-7854-45b7-88be-a7a9b4a129be`

## How has this been tested?

It hasn't been tested

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No, it is an additional IAM action

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
