### PR TITLE
Remove duplicate targeted terraform apply in core-vpc workflows

### DIFF
--- a/.github/workflows/core-vpc-development-deployment.yml
+++ b/.github/workflows/core-vpc-development-deployment.yml
@@ -132,8 +132,6 @@ jobs:
           terraform --version
           bash scripts/terraform-init.sh terraform/environments/core-vpc
           terraform -chdir="terraform/environments/core-vpc" workspace select "core-vpc-${TF_ENV}"
-          bash scripts/terraform-apply.sh terraform/environments/core-vpc -target=module.vpc
-          echo "Target apply finished"
           bash scripts/terraform-apply.sh terraform/environments/core-vpc
           echo "Terraform apply finished"
 

--- a/.github/workflows/core-vpc-preproduction-deployment.yml
+++ b/.github/workflows/core-vpc-preproduction-deployment.yml
@@ -132,8 +132,6 @@ jobs:
           terraform --version
           bash scripts/terraform-init.sh terraform/environments/core-vpc
           terraform -chdir="terraform/environments/core-vpc" workspace select "core-vpc-${TF_ENV}"
-          bash scripts/terraform-apply.sh terraform/environments/core-vpc -target=module.vpc
-          echo "Target apply finished"
           bash scripts/terraform-apply.sh terraform/environments/core-vpc
           echo "Terraform apply finished"
 

--- a/.github/workflows/core-vpc-production-deployment.yml
+++ b/.github/workflows/core-vpc-production-deployment.yml
@@ -132,8 +132,6 @@ jobs:
           terraform --version
           bash scripts/terraform-init.sh terraform/environments/core-vpc
           terraform -chdir="terraform/environments/core-vpc" workspace select "core-vpc-${TF_ENV}"
-          bash scripts/terraform-apply.sh terraform/environments/core-vpc -target=module.vpc
-          echo "Target apply finished"
           bash scripts/terraform-apply.sh terraform/environments/core-vpc
           echo "Terraform apply finished"
 

--- a/.github/workflows/core-vpc-test-deployment.yml
+++ b/.github/workflows/core-vpc-test-deployment.yml
@@ -132,8 +132,6 @@ jobs:
           terraform --version
           bash scripts/terraform-init.sh terraform/environments/core-vpc
           terraform -chdir="terraform/environments/core-vpc" workspace select "core-vpc-${TF_ENV}"
-          bash scripts/terraform-apply.sh terraform/environments/core-vpc -target=module.vpc
-          echo "Target apply finished"
           bash scripts/terraform-apply.sh terraform/environments/core-vpc
           echo "Terraform apply finished"
 


### PR DESCRIPTION
## A reference to the issue / Description of it

Duplicate targeted terraform apply in core-vpc workflows

## How does this PR fix the problem?

This PR resolves the issue of the terraform apply command being executed twice in the `core-vpc `workflows. Specifically, the command `bash scripts/terraform-apply.sh terraform/environments/core-vpc -target=module.vpc` has been removed. This change ensures that terraform apply is only run once with the command `bash scripts/terraform-apply.sh terraform/environments/core-vpc`, eliminating redundant actions and improving the workflow's efficiency. The updated workflow is to verify that it functions correctly without the targeted terraform apply command with the new environment PR