### PR TITLE
Add test to validate email address in json files

### DIFF
--- a/policies/environments/environment-definitions.rego
+++ b/policies/environments/environment-definitions.rego
@@ -120,3 +120,8 @@ deny contains msg if {
   not has_field(input, "github-oidc-team-repositories")
   msg := sprintf("`%v` is missing the `github-oidc-team-repositories` key", [input.filename])
 }
+
+deny contains msg if {
+  not regex.match(`^\S+@\S+$`, input.tags["infrastructure-support"])
+ msg := sprintf("`%v` infrastructure-support value is not a valid email address", [input.filename])
+}

--- a/policies/environments/environment-definitions_test.rego
+++ b/policies/environments/environment-definitions_test.rego
@@ -53,3 +53,7 @@ test_unexpected_access_assignment if {
 test_unexpected_nuke if {
   deny["`example.json` uses an unexpected nuke value: got `incorrect-value`, expected one of: include, exclude, rebuild"] with input as { "filename": "example.json", "environments": [{"access": [{"nuke": "incorrect-value"}]}]}
 }
+
+test_invalid_email if {
+  deny["`example.json` infrastructure-support tag value is not a valid email address"] with input as { "filename": "example.json", "tags": { "infrastructure-support": "not-a-valid-email-address" } }
+}

--- a/policies/environments/environment-definitions_test.rego
+++ b/policies/environments/environment-definitions_test.rego
@@ -43,11 +43,11 @@ test_business_units_character if {
 }
 
 test_unexpected_access if {
-  deny["`example.json` uses an unexpected access level: got `incorrect-access`, expected one of: view-only, developer, sandbox, administrator, migration, instance-management, read-only, security-audit, data-engineer, reporting-operations, mwaa-user, powerbi-user"] with input as { "filename": "example.json", "environments": [{"access": [{"level": "incorrect-access"}]}]}
+  deny["`example.json` uses an unexpected access level: got `incorrect-access`, expected one of: administrator, data-engineer, developer, instance-access, instance-management, migration, mwaa-user, read-only, reporting-operations, sandbox, security-audit, view-only, powerbi-user, fleet-manager"] with input as { "filename": "example.json", "environments": [{"access": [{"level": "incorrect-access"}]}]}
 }
 
 test_unexpected_access_assignment if {
-  deny["`example.json` uses an unexpected access assignment: got `powerbi-user`, but `example` is not an analytical platform or sprinkler account"] with input as { "filename": "example.json", "environments": [{"access": [{"level": "powerbi-user"}]}]}
+  deny["`example.json` uses `powerbi-user` access level but is not an analytical platform or sprinkler account"] with input as { "filename": "example.json", "environments": [{"access": [{"level": "powerbi-user"}]}]}
 }
 
 test_unexpected_nuke if {
@@ -55,5 +55,5 @@ test_unexpected_nuke if {
 }
 
 test_invalid_email if {
-  deny["`example.json` infrastructure-support tag value is not a valid email address"] with input as { "filename": "example.json", "tags": { "infrastructure-support": "not-a-valid-email-address" } }
+  deny["`example.json` infrastructure-support value is not a valid email address"] with input as { "filename": "example.json", "tags": { "infrastructure-support": "not-a-valid-email-address" } }
 }

--- a/source/user-guide/creating-environments.html.md.erb
+++ b/source/user-guide/creating-environments.html.md.erb
@@ -195,7 +195,7 @@ Here are some examples of the environments JSON file that the Modernisation Plat
 - the `name` key and `access` object are required, see: [Another example](#another-example)
 - `github_action_reviewer` is an optional true/false for each team listed and determines if the team should be the approver for GitHub action runs.
 - the `nuke` key is optional and is only read if the `access.level` is `sandbox`.
-- `tags` should be an object of the mandatory tags defined in the MoJ [Tagging Guidance](https://ministryofjustice.github.io/technical-guidance/documentation/standards/documenting-infrastructure-owners.html#tagging-your-infrastructure). You can omit `is-production` as we infer this from the environment name.
+- `tags` should be an object of the mandatory tags defined in the MoJ [Tagging Guidance](https://ministryofjustice.github.io/technical-guidance/documentation/standards/documenting-infrastructure-owners.html#tagging-your-infrastructure). You can omit `is-production` as we infer this from the environment name. Note that the `infrastructure-support` tag must contain a valid email address.
 
 ### Blank example
 
@@ -265,7 +265,7 @@ An JSON definition for a nonsensical application called [`glados`](https://en.wi
   "tags": {
     "application": "GLaDOS",
     "business-unit": "Platforms",
-    "infrastructure-support": "",
+    "infrastructure-support": "aperture-science@digital.justice.gov.uk",
     "owner": "GLaDOS (Genetic Lifeform and Disk Operating System): aperture-science@digital.justice.gov.uk"
   },
   "github-oidc-team-repositories": [""],


### PR DESCRIPTION
## A reference to the issue / Description of it
https://mojdt.slack.com/archives/C013RM6MFFW/p1719306860238849?thread_ts=1719306746.916439&cid=C013RM6MFFW

## How does this PR fix the problem?

I've added a test to check for a valid email address format in the `infrastructure-support` tag in application.json files

## How has this been tested?

Example output tested locally before and after updating the field with a valid email:

```
❯ ./scripts/tests/validate/run-opa-tests.sh
PASS - Environment files check
PASS - Environment network files check

8 tests, 8 passed, 0 warnings, 0 failures, 0 exceptions

408 tests, 408 passed, 0 warnings, 0 failures, 0 exceptions

120 tests, 120 passed, 0 warnings, 0 failures, 0 exceptions
FAIL - - main - `environments/panda-cyber-appsec-lab.json` infrastructure-support value is not a valid email address

1200 tests, 1199 passed, 0 warnings, 1 failure, 0 exceptions
❯ ./scripts/tests/validate/run-opa-tests.sh
PASS - Environment files check
PASS - Environment network files check

8 tests, 8 passed, 0 warnings, 0 failures, 0 exceptions

408 tests, 408 passed, 0 warnings, 0 failures, 0 exceptions

120 tests, 120 passed, 0 warnings, 0 failures, 0 exceptions

1200 tests, 1200 passed, 0 warnings, 0 failures, 0 exceptions
```

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
