### PR TITLE
LASB-2244: Updated crime apps access level for MLRA

### DIFF
--- a/environments/mlra.json
+++ b/environments/mlra.json
@@ -10,7 +10,7 @@
         },
         {
           "github_slug": "laa-crime-apps-team",
-          "level": "developer"
+          "level": "data-engineering"
         }
       ]
     },
@@ -23,7 +23,7 @@
         },
         {
           "github_slug": "laa-crime-apps-team",
-          "level": "developer"
+          "level": "data-engineering"
         }
       ]
     },
@@ -36,7 +36,7 @@
         },
         {
           "github_slug": "laa-crime-apps-team",
-          "level": "developer"
+          "level": "data-engineering"
         }
       ]
     },
@@ -49,7 +49,7 @@
         },
         {
           "github_slug": "laa-crime-apps-team",
-          "level": "developer"
+          "level": "data-engineering"
         }
       ]
     }

--- a/environments/mlra.json
+++ b/environments/mlra.json
@@ -10,7 +10,7 @@
         },
         {
           "github_slug": "laa-crime-apps-team",
-          "level": "data-engineering"
+          "level": "data-engineer"
         }
       ]
     },
@@ -23,7 +23,7 @@
         },
         {
           "github_slug": "laa-crime-apps-team",
-          "level": "data-engineering"
+          "level": "data-engineer"
         }
       ]
     },
@@ -36,7 +36,7 @@
         },
         {
           "github_slug": "laa-crime-apps-team",
-          "level": "data-engineering"
+          "level": "data-engineer"
         }
       ]
     },
@@ -49,7 +49,7 @@
         },
         {
           "github_slug": "laa-crime-apps-team",
-          "level": "data-engineering"
+          "level": "data-engineer"
         }
       ]
     }


### PR DESCRIPTION
## A reference to the issue / Description of it

Permissions required for Crime apps team to use AWS Glue (for Athena)

## How does this PR fix the problem?

Add `data-engineer` access for the crime apps team.

## How has this been tested?

N/A


## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

