### PR TITLE
Masking account number variables as they appear in logs.

### DIFF
--- a/.github/workflows/reusable_terraform_plan_apply.yml
+++ b/.github/workflows/reusable_terraform_plan_apply.yml
@@ -65,7 +65,6 @@ jobs:
           go-version: 1.21
           cache-dependency-path: "${{ inputs.working-directory }}/test/go.sum"
 
-
       - name: Set Account Number
         run: |
           ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< $ENVIRONMENT_MANAGEMENT)

--- a/.github/workflows/reusable_terraform_plan_apply.yml
+++ b/.github/workflows/reusable_terraform_plan_apply.yml
@@ -65,8 +65,12 @@ jobs:
           go-version: 1.21
           cache-dependency-path: "${{ inputs.working-directory }}/test/go.sum"
 
+
       - name: Set Account Number
-        run: echo "ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+        run: |
+          ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< $ENVIRONMENT_MANAGEMENT)
+          echo "::add-mask::$ACCOUNT_NUMBER"
+          echo ACCOUNT_NUMBER=$ACCOUNT_NUMBER >> $GITHUB_ENV
 
       - name: configure aws credentials
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2


### PR DESCRIPTION
This amends the 'Set Account Number' step in the reusable apply workflow to mask the account number variable as it appears in env output in subsequent steps.

## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform-security/issues/13

## How does this PR fix the problem?

Uses the ::add-mask:: statement to prevent modernisation platform account number appearing in the env output of workflow logs.

## How has this been tested?

This has been tested against the reusable workflow.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
