### PR TITLE
🛂 Add `TransitGatewayVpcAttachment` permissions

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -116,6 +116,7 @@ data "aws_iam_policy_document" "member-access" {
       "ec2:*Spot*",
       "ec2:*InternetGateway*",
       "ec2:*NatGateway*",
+      "ec2:*TransitGatewayVpcAttachment*",
       "ecr-public:*",
       "ecr:*",
       "ecs:*",


### PR DESCRIPTION
## A reference to the issue / Description of it

I'm trying to attach PTTP TGW to VPCs in Analytical Platform Compute

```
Error: creating EC2 Transit Gateway VPC Attachment: operation error EC2: CreateTransitGatewayVpcAttachment, https response error StatusCode: 403, RequestID: 3f1bc303-b5bf-49b6-a35f-ba966858ab85, api error UnauthorizedOperation: You are not authorized to perform this operation. User: arn:aws:sts::381491960855:assumed-role/MemberInfrastructureAccess/aws-go-sdk-1719441876290007039 is not authorized to perform: ec2:CreateTransitGatewayVpcAttachment on resource: arn:aws:ec2:eu-west-2:381491960855:vpc/vpc-01001d7ad4d285e59 because no identity-based policy allows the ec2:CreateTransitGatewayVpcAttachment action.
```

## How does this PR fix the problem?

Adds permissions for TGW attachments

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Additive permissions

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

I will add `aws_ec2_transit_gateway_vpc_attachment` to the plan evaluator

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

There doesn't seem to be a precedent for adding permissions, one has to choose between either

```json
"ec2:CreateTransitGatewayVpcAttachment",
"ec2:DeleteTransitGatewayVpcAttachment",
"ec2:ModifyTransitGatewayVpcAttachment",
"ec2:DescribeTransitGatewayVpcAttachments"
```
or
```json
"ec2:*TransitGatewayVpcAttachment*"
```