### PR TITLE
added permissions to get & list AWS RAM share resources

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -142,6 +142,8 @@ data "aws_iam_policy_document" "member-access" {
       "organizations:List*",
       "oam:*",
       "quicksight:*",
+      "ram:Get*",
+      "ram:List*",
       "rds-db:*",
       "rds:*",
       "rds-data:*",


### PR DESCRIPTION
## A reference to the issue / Description of it

`analytical-platform-compute` accounts have a non-MP AWS Transit Gateway shared with them through Resource Access Manager. In order to correctly filter information on these shares through Terraform, IAM permissions are required for the `MemberInfrastructureAccess` role.

However, because there are other uses of RAM shares to provision general customer accounts, I haven't given blanket `ram:*` permissions in this PR.

## How does this PR fix the problem?

Allows member accounts to retrieve details of RAM shares for use in data calls.

## How has this been tested?

It has not been tested

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
