### PR TITLE
Creating the backup failure topic only in production and London region

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/notifications.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/notifications.tf
@@ -1,30 +1,41 @@
+locals {
+  is_production      = can(regex("production|default", terraform.workspace))
+  existing_topic_name = try(data.aws_sns_topic.existing_topic[0].name, null)
+  # backup_topic_name   = try(data.aws_sns_topic.backup_vault_failure_topic[0].name, null)
+}
+
+data "aws_region" "current" {}
 
 # Data source to get the ARN of an existing SNS topic
 data "aws_sns_topic" "existing_topic" {
-  name = "backup_failure_topic"
+  count = (local.is_production && data.aws_region.current.name == "eu-west-2") ? 1 : 0
+  name  = "backup_failure_topic"
+
 }
 
-data "aws_sns_topic" "backup_vault_failure_topic" {
-  name = "backup_vault_failure_topic"
-}
+# data "aws_sns_topic" "backup_vault_failure_topic" {
+#    count = (local.is_production && data.aws_region.current.name == "eu-west-2") ? 1 : 0
+#    name  = "backup_vault_failure_topic"
+
+# }
 
 # Link the sns topics to the pagerduty service
 module "pagerduty_core_alerts" {
   count = (local.account_data.account-type != "member-unrestricted") ? 1 : 0
   depends_on = [
-    data.aws_sns_topic.existing_topic, data.aws_sns_topic.backup_vault_failure_topic
+    data.aws_sns_topic.existing_topic
   ]
   source                    = "github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration?ref=0179859e6fafc567843cd55c0b05d325d5012dc4" # v2.0.0
-  sns_topics                = [data.aws_sns_topic.existing_topic.name, data.aws_sns_topic.backup_vault_failure_topic.name]
+  sns_topics                = compact([local.existing_topic_name])
   pagerduty_integration_key = local.pagerduty_integration_keys["core_alerts_cloudwatch"]
 }
 
 # Cloudwatch metric alarm required for errors
 resource "aws_cloudwatch_metric_alarm" "aws_backup_has_errors" {
-  count             = local.account_data.account-type != "member-unrestricted" ? 1 : 0
+  count = (local.is_production && data.aws_region.current.name == "eu-west-2") ? 1 : 0
   alarm_name        = "aws-backup-failed"
   alarm_description = "AWS Backup, everything has failed. Please check logs"
-  alarm_actions     = [data.aws_sns_topic.existing_topic.arn]
+  alarm_actions     = [data.aws_sns_topic.existing_topic[0].arn]
 
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
@@ -41,39 +52,40 @@ resource "aws_cloudwatch_metric_alarm" "aws_backup_has_errors" {
 
 }
 
-data "aws_cloudwatch_log_group" "cloudtrail" {
-  name = "cloudtrail"
-}
-resource "aws_cloudwatch_log_metric_filter" "backup_vault_lock_changes" {
-  name           = "BackupVaultLockChanges"
-  pattern        = "{($.eventSource = \"backup.amazonaws.com\") && (($.eventName = \"PutBackupVaultLockConfiguration\") || ($.eventName = \"DeleteBackupVaultLockConfiguration\") || ($.eventName = \"ChangeBackupVaultLockConfiguration\") || ($.eventName = \"PutBackupVaultAccessPolicy\"))}"
-  log_group_name = data.aws_cloudwatch_log_group.cloudtrail.name
+# data "aws_cloudwatch_log_group" "cloudtrail" {
+#   name = "cloudtrail"
+# }
+# resource "aws_cloudwatch_log_metric_filter" "backup_vault_lock_changes" {
+#     count        = (local.is_production && data.aws_region.current.name == "eu-west-2") ? 1 : 0
+#   name           = "BackupVaultLockChanges"
+#   pattern        = "{($.eventSource = \"backup.amazonaws.com\") && (($.eventName = \"PutBackupVaultLockConfiguration\") || ($.eventName = \"DeleteBackupVaultLockConfiguration\") || ($.eventName = \"ChangeBackupVaultLockConfiguration\") || ($.eventName = \"PutBackupVaultAccessPolicy\"))}"
+#   log_group_name = data.aws_cloudwatch_log_group.cloudtrail.name
 
-  metric_transformation {
-    name      = "CallCount"
-    namespace = "CustomMetrics"
-    value     = "1"
-  }
-}
+#   metric_transformation {
+#     name      = "CallCount"
+#     namespace = "CustomMetrics"
+#     value     = "1"
+#   }
+# }
 
-resource "aws_cloudwatch_metric_alarm" "backup_vault_config_alarm" {
-  # count             = local.account_data.account_type != "member-unrestricted" ? 1 : 0
-  alarm_name        = "backup-vault-config-change"
-  alarm_description = "Alarm when there are changes to Backup Vault configurations. Please check logs"
-  alarm_actions     = [data.aws_sns_topic.backup_vault_failure_topic.arn]
+# resource "aws_cloudwatch_metric_alarm" "backup_vault_config_alarm" {
+#   count             = (local.is_production && data.aws_region.current.name == "eu-west-2") ? 1 : 0
+#   alarm_name        = "backup-vault-config-change"
+#   alarm_description = "Alarm when there are changes to Backup Vault configurations. Please check logs"
+#   alarm_actions     = [data.aws_sns_topic.backup_vault_failure_topic[0].arn]
 
-  comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "1"
-  metric_name         = "CallCount"
-  namespace           = "CustomMetrics"
-  period              = "10"
-  statistic           = "Sum"
-  threshold           = "1"
-  treat_missing_data  = "notBreaching"
+#   comparison_operator = "GreaterThanOrEqualToThreshold"
+#   evaluation_periods  = "1"
+#   metric_name         = "CallCount"
+#   namespace           = "CustomMetrics"
+#   period              = "10"
+#   statistic           = "Sum"
+#   threshold           = "1"
+#   treat_missing_data  = "notBreaching"
 
 
-  depends_on = [aws_cloudwatch_log_metric_filter.backup_vault_lock_changes]
-}
+#   depends_on = [aws_cloudwatch_log_metric_filter.backup_vault_lock_changes]
+# }
 
 # Keys for pagerduty
 data "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {


### PR DESCRIPTION
## A reference to the issue / Description of it

#7265 

## How does this PR fix the problem?

Integrates with recent updates made to the baseline module: https://github.com/ministryofjustice/modernisation-platform-terraform-baselines/pull/495

Only applying the changes to the existing topic first.

## How has this been tested?

Tested in cooker. 

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
