### PR TITLE
Adds aws account number redaction from ARNs listed in plan & apply log output.

### DIFF
--- a/scripts/redact-output.sh
+++ b/scripts/redact-output.sh
@@ -6,4 +6,6 @@ sed -e 's/AWS_SECRET_ACCESS_KEY".*/<REDACTED>/g' \
     -e 's/AWS_ACCESS_KEY_ID".*/<REDACTED>/g' \
     -e 's/$AWS_SECRET_ACCESS_KEY".*/<REDACTED>/g' \
     -e 's/$AWS_ACCESS_KEY_ID".*/<REDACTED>/g' \
-    -e 's/\[id=.*\]/\[id=<REDACTED>\]/g'
+    -e 's/\[id=.*\]/\[id=<REDACTED>\]/g' \
+    -e 's/::[0-9]\{12\}:/::REDACTED:/g' \
+    -e 's/:[0-9]\{12\}:/:REDACTED:/g'


### PR DESCRIPTION

## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform-security/issues/13

## How does this PR fix the problem?

Redacts account numbers from ARNs in workflow logs.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

This change has already been applied in modernisation-platform-environments.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
