### PR TITLE
Add conftest verify

### DIFF
--- a/.github/workflows/opa-policies.yml
+++ b/.github/workflows/opa-policies.yml
@@ -8,11 +8,13 @@ on:
     paths:
       - '**.json'
       - '**.rego'
+      - 'scripts/tests/validate/run-opa-tests.sh'
   merge_group:
     types: [checks_requested]
     paths:
       - '**.json'
       - '**.rego'
+      - 'scripts/tests/validate/run-opa-tests.sh'
 
 permissions:
   contents: read

--- a/policies/collaborators/collaborators_test.rego
+++ b/policies/collaborators/collaborators_test.rego
@@ -29,5 +29,5 @@ test_empty_values if {
 }
 
 test_unexpected_access if {
-  deny["`example.json` uses an unexpected access: got `incorrect-access`, expected one of: read-only, developer, security-audit, sandbox, migration, instance-management"] with input as { "filename": "example.json", "users": [{"accounts": [{"access": "incorrect-access"}]}] }
+  deny["`example.json` uses an unexpected access: got `incorrect-access`, expected one of: read-only, developer, security-audit, sandbox, migration, instance-management, fleet-manager"] with input as { "filename": "example.json", "users": [{"accounts": [{"access": "incorrect-access"}]}] }
 }

--- a/policies/networking/core-vpc_test.rego
+++ b/policies/networking/core-vpc_test.rego
@@ -38,10 +38,6 @@ test_missing_options_keys if {
   deny["`example.json` is missing the `dns_zone_extend` key"] with input as { "filename": "example.json", "options": {} }
 }
 
-test_no_nacl if {
-  deny["`example.json` is missing the `nacl` key"] with input as { "filename": "example.json" }
-}
-
 test_cidr_types if {
   deny["`example.json` invalid subnet_sets type - must be a object"] with input as { "filename": "example.json", "cidr": {"subnet_sets": ""} }
 }

--- a/scripts/tests/validate/run-opa-tests.sh
+++ b/scripts/tests/validate/run-opa-tests.sh
@@ -74,6 +74,9 @@ verify-tests(){
   line
   echo "Verify OPA tests"
   conftest verify -p policies/environments
+  conftest verify -p policies/networking
+  conftest verify -p policies/member
+  conftest verify -p policies/collaborators
 }
 
 main() {


### PR DESCRIPTION
## A reference to the issue / Description of it

conftest verify is not run on the workflow, so new OPA tests can be added or old ones amended without they themselves being tested.

## How does this PR fix the problem?

This runs the conftest verify command to make sure the rego tests are themselves tested before running.

Also improved the output so that it is more readable.

![Screenshot 2024-06-28 at 14 07 02](https://github.com/ministryofjustice/modernisation-platform/assets/24830854/c6241b87-1cb3-431d-a5cc-1e67ea7942e3)

## How has this been tested?

Tested locally

## Deployment Plan / Instructions

No impact

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
