### PR TITLE
🧹 Tidy up the new story template

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-story-template.yml
+++ b/.github/ISSUE_TEMPLATE/new-story-template.yml
@@ -14,11 +14,11 @@ body:
       placeholder: "As a… [who is the user?] 
               I need/want/expect to… [what does the user want to do?]
               So that… [why does the user want to do this?] "
-      value: "As a…  
+      value: "As a 
 
-              I need/want/expect to… 
+              I need/want/expect to 
 
-              So that…"
+              So that"
     validations:
       required: true
   - type: textarea
@@ -47,28 +47,11 @@ body:
     validations:
       required: false
   - type: textarea
-    id: proposal-unknowns
-    attributes:
-      description: Assumptions, Hypothesis, Questions, Unknowns
-      label: Proposal / Unknowns
-      value:
-        "### Hypothesis 
-        If we... [do a thing]
-        Then... [this will happ]
-
-        ### Proposal
-        A proposal that is something testable, don't worry whether it works or not, it's a place for ideas. 
-
-        ### Unknowns
-        Potential pitfalls that could cause the story to expand beyond its original scope. Ideally this section will remain blank."
-    validations:
-      required: false
-  - type: textarea
     id: dod
     attributes:
       description: Please clearly and concisely detail the Definition of Done. (example optional checklist below)
       label: Definition of Done
-      value:
+      placeholder:
 
         Example
         - [ ] Documentation has been written / updated
@@ -80,6 +63,9 @@ body:
         - [ ] Another team member has reviewed 
 
         - [ ] Tests are green
+      value:
+        - [ ] First outcome
+        - [ ] Second outcome
     validations:
       required: true
   - type: markdown


### PR DESCRIPTION
## A reference to the issue / Description of it

The new user story template could do with a bit of polish.

## How does this PR fix the problem?

We very, very rarely use the `Assumptions/Hypothesis/Questions/Unknowns` section. Any information that could be placed here could just as easily be placed in the `Additional Information` section.

Also removed elipses from the user story placeholder because these are irritating to delete every time you raise a story.

## How has this been tested?

It has not been tested

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

I'll check the template works once it's in `main` and revert this PR if the template is broken.
