### PR TITLE
ignore markdown files (e.g. README.md) for terraform deployment workflows

### DIFF
--- a/.github/workflows/bootstrap-sprinkler.yml
+++ b/.github/workflows/bootstrap-sprinkler.yml
@@ -6,8 +6,8 @@ on:
       - main
     paths:
       - 'terraform/environments/bootstrap/**'
-      - '!**.md'
       - 'terraform/modules/iam_baseline/**'
+      - '!**.md'
       - '.github/workflows/bootstrap-sprinkler.yml'
   workflow_dispatch:
 

--- a/.github/workflows/bootstrap-sprinkler.yml
+++ b/.github/workflows/bootstrap-sprinkler.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - 'terraform/environments/bootstrap/**'
+      - '!**.md'
       - 'terraform/modules/iam_baseline/**'
       - '.github/workflows/bootstrap-sprinkler.yml'
   workflow_dispatch:

--- a/.github/workflows/core-logging-deployment.yml
+++ b/.github/workflows/core-logging-deployment.yml
@@ -9,6 +9,7 @@ on:
       - 'terraform/environments/core-logging/**'
       - 'terraform/modules/vpc-hub/**'
       - 'terraform/modules/core-monitoring/**'
+      - '!**.md'
       - '.github/workflows/core-logging-deployment.yml'
       - '.github/workflows/reusable_terraform_plan_apply.yml'
   pull_request:
@@ -18,6 +19,7 @@ on:
       - 'terraform/environments/core-logging/**'
       - 'terraform/modules/vpc-hub/**'
       - 'terraform/modules/core-monitoring/**'
+      - '!**.md'
       - '.github/workflows/core-logging-deployment.yml'
       - '.github/workflows/reusable_terraform_plan_apply.yml'
   workflow_dispatch:

--- a/.github/workflows/core-network-services-deployment.yml
+++ b/.github/workflows/core-network-services-deployment.yml
@@ -10,6 +10,7 @@ on:
       - 'terraform/modules/vpc-hub/**'
       - 'terraform/modules/core-monitoring/**'
       - 'terraform/modules/firewall-policy/**'
+      - '!**.md'
       - '.github/workflows/core-network-services-deployment.yml'
       - '.github/workflows/reusable_terraform_plan_apply.yml'
   pull_request:
@@ -19,6 +20,7 @@ on:
       - 'terraform/environments/core-network-services/**'
       - 'terraform/modules/vpc-hub/**'
       - 'terraform/modules/core-monitoring/**'
+      - '!**.md'
       - '.github/workflows/core-network-services-deployment.yml'
       - '.github/workflows/reusable_terraform_plan_apply.yml'
   workflow_dispatch:

--- a/.github/workflows/core-security-deployment.yml
+++ b/.github/workflows/core-security-deployment.yml
@@ -9,6 +9,7 @@ on:
       - 'terraform/environments/core-security/**'
       - 'terraform/modules/vpc-hub/**'
       - 'terraform/modules/core-monitoring/**'
+      - '!**.md'
       - '.github/workflows/core-security-deployment.yml'
       - '.github/workflows/reusable_terraform_plan_apply.yml'
   pull_request:
@@ -18,6 +19,7 @@ on:
       - 'terraform/environments/core-security/**'
       - 'terraform/modules/vpc-hub/**'
       - 'terraform/modules/core-monitoring/**'
+      - '!**.md'
       - '.github/workflows/core-security-deployment.yml'
       - '.github/workflows/reusable_terraform_plan_apply.yml'
   workflow_dispatch:

--- a/.github/workflows/core-shared-services-deployment.yml
+++ b/.github/workflows/core-shared-services-deployment.yml
@@ -10,6 +10,7 @@ on:
       - 'terraform/modules/vpc-hub/**'
       - 'terraform/modules/core-monitoring/**'
       - 'terraform/modules/kms/**'
+      - '!**.md'
       - '.github/workflows/core-shared-services-deployment.yml'
       - '.github/workflows/reusable_terraform_plan_apply.yml'
   pull_request:
@@ -19,6 +20,7 @@ on:
       - 'terraform/environments/core-shared-services/**'
       - 'terraform/modules/vpc-hub/**'
       - 'terraform/modules/core-monitoring/**'
+      - '!**.md'
       - '.github/workflows/core-shared-services-deployment.yml'
       - '.github/workflows/reusable_terraform_plan_apply.yml'
   workflow_run:

--- a/.github/workflows/core-vpc-development-deployment.yml
+++ b/.github/workflows/core-vpc-development-deployment.yml
@@ -19,6 +19,7 @@ on:
       - 'terraform/modules/vpc-nacls/**'
       - 'terraform/modules/ram-resource-share/**'
       - 'terraform/modules/core-vpc-tgw-routes/**'
+      - '!**.md'
   pull_request:
     branches:
       - main
@@ -36,6 +37,7 @@ on:
       - 'terraform/modules/vpc-nacls/**'
       - 'terraform/modules/ram-resource-share/**'
       - 'terraform/modules/core-vpc-tgw-routes/**'
+      - '!**.md'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/core-vpc-preproduction-deployment.yml
+++ b/.github/workflows/core-vpc-preproduction-deployment.yml
@@ -19,6 +19,7 @@ on:
       - 'terraform/modules/vpc-nacls/**'
       - 'terraform/modules/ram-resource-share/**'
       - 'terraform/modules/core-vpc-tgw-routes/**'
+      - '!**.md'
   pull_request:
     branches:
       - main
@@ -36,6 +37,7 @@ on:
       - 'terraform/modules/vpc-nacls/**'
       - 'terraform/modules/ram-resource-share/**'
       - 'terraform/modules/core-vpc-tgw-routes/**'
+      - '!**.md'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/core-vpc-production-deployment.yml
+++ b/.github/workflows/core-vpc-production-deployment.yml
@@ -19,6 +19,7 @@ on:
       - 'terraform/modules/vpc-nacls/**'
       - 'terraform/modules/ram-resource-share/**'
       - 'terraform/modules/core-vpc-tgw-routes/**'
+      - '!**.md'
   pull_request:
     branches:
       - main
@@ -36,6 +37,7 @@ on:
       - 'terraform/modules/vpc-nacls/**'
       - 'terraform/modules/ram-resource-share/**'
       - 'terraform/modules/core-vpc-tgw-routes/**'
+      - '!**.md'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/core-vpc-test-deployment.yml
+++ b/.github/workflows/core-vpc-test-deployment.yml
@@ -19,6 +19,7 @@ on:
       - 'terraform/modules/vpc-nacls/**'
       - 'terraform/modules/ram-resource-share/**'
       - 'terraform/modules/core-vpc-tgw-routes/**'
+      - '!**.md'
   pull_request:
     branches:
       - main
@@ -36,6 +37,7 @@ on:
       - 'terraform/modules/vpc-nacls/**'
       - 'terraform/modules/ram-resource-share/**'
       - 'terraform/modules/core-vpc-tgw-routes/**'
+      - '!**.md'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/modernisation-platform-account.yml
+++ b/.github/workflows/modernisation-platform-account.yml
@@ -4,6 +4,7 @@ on:
   push:
     paths:
       - 'terraform/modernisation-platform-account/**'
+      - '!**.md'
       - '.github/workflows/modernisation-platform-account.yml'
       - 'collaborators.json'
       - '.github/workflows/reusable_terraform_plan_apply.yml'
@@ -12,6 +13,7 @@ on:
   pull_request:
     paths:
       - 'terraform/modernisation-platform-account/**'
+      - '!**.md'
       - '.github/workflows/modernisation-platform-account.yml'
       - 'collaborators.json'
       - '.github/workflows/reusable_terraform_plan_apply.yml'

--- a/.github/workflows/new-environment.yml
+++ b/.github/workflows/new-environment.yml
@@ -9,6 +9,7 @@ on:
       - 'terraform/environments/*.tf'
       - 'environments/**.json'
       - 'terraform/environments/bootstrap/**'
+      - '!**.md'
   pull_request:
     branches:
       - main

--- a/.github/workflows/scheduled-baseline.yml
+++ b/.github/workflows/scheduled-baseline.yml
@@ -9,8 +9,8 @@ on:
     paths:
       - '.github/workflows/scheduled-baseline.yml'
       - 'terraform/environments/bootstrap/**'
-      - '!**.md'
       - 'terraform/modules/iam_baseline/**'
+      - '!**.md'
       - 'scripts/update-sso-permission-sets.sh'
   workflow_dispatch:
 

--- a/.github/workflows/scheduled-baseline.yml
+++ b/.github/workflows/scheduled-baseline.yml
@@ -9,6 +9,7 @@ on:
     paths:
       - '.github/workflows/scheduled-baseline.yml'
       - 'terraform/environments/bootstrap/**'
+      - '!**.md'
       - 'terraform/modules/iam_baseline/**'
       - 'scripts/update-sso-permission-sets.sh'
   workflow_dispatch:

--- a/.github/workflows/terraform-github.yml
+++ b/.github/workflows/terraform-github.yml
@@ -4,6 +4,7 @@ on:
   push:
     paths:
       - 'terraform/github/**'
+      - '!**.md'
       - '.github/workflows/terraform-github.yml'
       - 'environments/**.json'
       - '.github/workflows/reusable_terraform_plan_apply.yml'
@@ -12,6 +13,7 @@ on:
   pull_request:
     paths:
       - 'terraform/github/**'
+      - '!**.md'
       - '.github/workflows/terraform-github.yml'
       - 'environments/**.json'
       - '.github/workflows/reusable_terraform_plan_apply.yml'

--- a/.github/workflows/terraform-pagerduty.yml
+++ b/.github/workflows/terraform-pagerduty.yml
@@ -4,6 +4,7 @@ on:
   push:
     paths:
       - 'terraform/pagerduty/**'
+      - '!**.md'
       - '.github/workflows/terraform-pagerduty.yml'
       - '.github/workflows/reusable_terraform_plan_apply.yml'
     branches:
@@ -11,6 +12,7 @@ on:
   pull_request:
     paths:
       - 'terraform/pagerduty/**'
+      - '!**.md'
       - '.github/workflows/terraform-pagerduty.yml'
       - '.github/workflows/reusable_terraform_plan_apply.yml'
     branches:

--- a/.github/workflows/terraform-single-sign-on.yml
+++ b/.github/workflows/terraform-single-sign-on.yml
@@ -4,6 +4,7 @@ on:
   push:
     paths:
       - 'terraform/single-sign-on/**'
+      - '!**.md'
       - '.github/workflows/terraform-single-sign-on.yml'
       - '.github/workflows/reusable_terraform_plan_apply.yml'
     branches:
@@ -11,6 +12,7 @@ on:
   pull_request:
     paths:
       - 'terraform/single-sign-on/**'
+      - '!**.md'
       - '.github/workflows/terraform-single-sign-on.yml'
       - '.github/workflows/reusable_terraform_plan_apply.yml'
     branches:


### PR DESCRIPTION
## A reference to the issue / Description of it

No existing issue. The current github workflows for terraform deployment are triggered on changes within the terraform directories. This includes changes exclusively to `README.md` files, which won't affect the deployment, and shouldn't trigger the workflow.

## How does this PR fix the problem?

This PR adds a `- '!**.md'` condition to the `paths` argument for the triggering actions (see [including and excluding paths syntax](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-including-and-excluding-paths)). This means that changes to markdown files ending in `.md` (i.e. not `html.md.erb` files) will not trigger these deploy workflows.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation

## Additional comments (if any)

{Please write here}
