### PR TITLE
Add runbook for accessing OP & link to workflow dashboard

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -99,6 +99,7 @@ This documentation is for anyone interested in the Modernisation Platform and it
 
 ## Runbooks
 - [Accessing AWS accounts](runbooks/accessing-aws-accounts.html)
+- [Accessing the Observability Platform](runbooks/accessing-the-observability-platform.html)
 - [Adding a new team member to the Modernisation Platform](runbooks/adding-a-new-team-member.html)
 - [Adding collaborators](runbooks/adding-collaborators.html)
 - [Adding wider connectivity](runbooks/adding-wider-connectivity.html)

--- a/source/runbooks/accessing-the-observability-platform.html.md.erb
+++ b/source/runbooks/accessing-the-observability-platform.html.md.erb
@@ -1,0 +1,33 @@
+---
+owner_slack: "#modernisation-platform"
+title: Accessing the Observability Platform
+last_reviewed_on: 2024-07-01
+review_in: 6 months
+---
+
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-NXTCMQ7ZX6"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-NXTCMQ7ZX6');
+</script>
+
+# <%= current_page.data.title %>
+
+## How to access the Observability Platform
+
+To log in to the Observability Platform:
+
+1. Sign in to the [AWS access portal](https://moj.awsapps.com/start#/)
+1. Click on the `"Applications"` tab
+1. Click on `"[alpha] Observability Platform"`
+
+## Viewing Dashboards
+
+Once you have accessed Grafana you can navigate to our dashboards:
+
+1. Click on the *hamburger* menu icon in the top left corner
+1. Select `"Dashboards"`
+1. Finally click on the relevant dashboard of interest

--- a/source/user-guide/workflow-status.html.md.erb
+++ b/source/user-guide/workflow-status.html.md.erb
@@ -33,6 +33,8 @@ review_in: 3 months
 
 ### Modernisation Platform Tools & Checks
 
+Click [here](https://g-9d213fbc19.grafana-workspace.eu-west-2.amazonaws.com/d/l9nvX5wSk/modernisation-platform-workflow-stats?orgId=1) to view the MP Workflow Status Dashboard on the Observability Platform.
+
 | Workflow                                                                                                                                                                                  | Description & Link   |
 | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------| ---------------------|
 | ![Check Inactive Collaborators](https://github.com/ministryofjustice/modernisation-platform/actions/workflows/collaborator-inactivity-monitoring.yml/badge.svg)                           | [Checks for inactive collaborators and sends our email.](https://github.com/ministryofjustice/modernisation-platform/actions/workflows/collaborator-inactivity-monitoring.yml) |


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/7224

## How does this PR fix the problem?

I'm adding a link to the new Workflow Status dashboard on the Observability Platform to our current status page for workflows.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
