### PR TITLE
Add Athena VPC endpoint

### DIFF
--- a/environments-networks/hmpps-development.json
+++ b/environments-networks/hmpps-development.json
@@ -32,6 +32,7 @@
     "bastion_linux": true,
     "additional_cidrs": [],
     "additional_endpoints": [
+      "com.amazonaws.eu-west-2.athena",
       "com.amazonaws.eu-west-2.email-smtp",
       "com.amazonaws.eu-west-2.execute-api",
       "com.amazonaws.eu-west-2.glue",


### PR DESCRIPTION
## A reference to the issue / Description of it

I am trying to set up a DMS validation job for some of the EM data (weve had issues with setting this up w Glue for large tables). To do so the DMS job (running in our VPC) needs to create some Athena tables to validate the parquet output.


## How does this PR fix the problem?

Adds a VPC endpoint for Athena in our account.

## How has this been tested?

n/a

## Deployment Plan / Instructions

n/a

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)


