### PR TITLE
fix: Refactor ECR repository IAM policy document

### DIFF
--- a/terraform/modules/app-ecr-repo/main.tf
+++ b/terraform/modules/app-ecr-repo/main.tf
@@ -28,35 +28,43 @@ resource "aws_ecr_repository" "ecr_repo" {
 }
 
 data "aws_iam_policy_document" "ecr_repo_policy" {
-  statement {
-    sid    = "AllowPush"
-    effect = "Allow"
-    actions = [
-      "ecr:CompleteLayerUpload",
-      "ecr:BatchCheckLayerAvailability",
-      "ecr:PutImage",
-      "ecr:InitiateLayerUpload",
-      "ecr:UploadLayerPart",
-      "ecr:DescribeImages"
-    ]
-    principals {
-      type        = "AWS"
-      identifiers = var.push_principals
+  dynamic "statement" {
+    for_each = length(var.push_principals) > 0 ? [1] : []
+
+    content {
+      sid    = "AllowPush"
+      effect = "Allow"
+      actions = [
+        "ecr:CompleteLayerUpload",
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:PutImage",
+        "ecr:InitiateLayerUpload",
+        "ecr:UploadLayerPart",
+        "ecr:DescribeImages"
+      ]
+      principals {
+        type        = "AWS"
+        identifiers = var.push_principals
+      }
     }
   }
 
-  statement {
-    sid    = "AllowPull"
-    effect = "Allow"
-    actions = [
-      "ecr:GetDownloadUrlForLayer",
-      "ecr:BatchGetImage",
-      "ecr:DescribeRepositories",
-      "ecr:ListImages"
-    ]
-    principals {
-      type        = "AWS"
-      identifiers = var.pull_principals
+  dynamic "statement" {
+    for_each = length(var.pull_principals) > 0 ? [1] : []
+
+    content {
+      sid    = "AllowPull"
+      effect = "Allow"
+      actions = [
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:BatchGetImage",
+        "ecr:DescribeRepositories",
+        "ecr:ListImages"
+      ]
+      principals {
+        type        = "AWS"
+        identifiers = var.pull_principals
+      }
     }
   }
 


### PR DESCRIPTION
Refactor the IAM policy document for the ECR repository in the `main.tf` file. The policy document now dynamically generates the statements for allowing push and pull actions based on the `push_principals` and `pull_principals` variables.

## A reference to the issue / Description of it

{Please write here}

## How does this PR fix the problem?

{Please write here}

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
