### PR TITLE
Declare oidc github team repos per app env

### DIFF
--- a/environments/delius-core.json
+++ b/environments/delius-core.json
@@ -1,9 +1,12 @@
 {
   "account-type": "member",
-  "codeowners": ["hmpps-migration"],
+  "codeowners": [
+    "hmpps-migration"
+  ],
   "environments": [
     {
       "name": "development",
+      "github-oidc-team-repositories": ["ministryofjustice/hmpps-delius-operational-automation"],
       "access": [
         {
           "github_slug": "hmpps-migration",
@@ -86,10 +89,10 @@
     "owner": "probation-webops@digital.justice.gov.uk"
   },
   "github-oidc-team-repositories": [
-    "ministryofjustice/hmpps-delius-operational-automation",
-    "ministryofjustice/hmpps-openldap-container",
-    "ministryofjustice/hmpps-delius-docker-images",
-    "ministryofjustice/hmpps-pwm",
-    "ministryofjustice/ndelius-um"
-  ]
+      "ministryofjustice/hmpps-delius-operational-automation",
+      "ministryofjustice/hmpps-openldap-container",
+      "ministryofjustice/hmpps-delius-docker-images",
+      "ministryofjustice/hmpps-pwm",
+      "ministryofjustice/ndelius-um"
+    ]
 }

--- a/environments/delius-core.json
+++ b/environments/delius-core.json
@@ -6,7 +6,13 @@
   "environments": [
     {
       "name": "development",
-      "github-oidc-team-repositories": ["ministryofjustice/hmpps-delius-operational-automation"],
+      "github-oidc-team-repositories": [
+        "ministryofjustice/hmpps-delius-operational-automation",
+        "ministryofjustice/hmpps-openldap-container",
+        "ministryofjustice/hmpps-pwm",
+        "ministryofjustice/ndelius-um",
+        "ministryofjustice/hmpps-delius-docker-images"
+      ],
       "access": [
         {
           "github_slug": "hmpps-migration",
@@ -29,6 +35,10 @@
     },
     {
       "name": "test",
+      "github-oidc-team-repositories": [
+        "ministryofjustice/hmpps-delius-operational-automation",
+        "ministryofjustice/hmpps-openldap-container"
+      ],
       "access": [
         {
           "github_slug": "hmpps-migration",
@@ -47,6 +57,10 @@
     },
     {
       "name": "preproduction",
+      "github-oidc-team-repositories": [
+        "ministryofjustice/hmpps-delius-operational-automation",
+        "ministryofjustice/hmpps-openldap-container"
+      ],
       "access": [
         {
           "github_slug": "hmpps-migration",
@@ -65,6 +79,10 @@
     },
     {
       "name": "production",
+      "github-oidc-team-repositories": [
+        "ministryofjustice/hmpps-delius-operational-automation",
+        "ministryofjustice/hmpps-openldap-container"
+      ],
       "access": [
         {
           "github_slug": "hmpps-migration",
@@ -87,12 +105,5 @@
     "business-unit": "HMPPS",
     "infrastructure-support": "probation-webops@digital.justice.gov.uk",
     "owner": "probation-webops@digital.justice.gov.uk"
-  },
-  "github-oidc-team-repositories": [
-      "ministryofjustice/hmpps-delius-operational-automation",
-      "ministryofjustice/hmpps-openldap-container",
-      "ministryofjustice/hmpps-delius-docker-images",
-      "ministryofjustice/hmpps-pwm",
-      "ministryofjustice/ndelius-um"
-    ]
+  }
 }

--- a/environments/sprinkler.json
+++ b/environments/sprinkler.json
@@ -35,8 +35,7 @@
           "nuke": "rebuild"
         }
       ],
-      "additional_reviewers": ["astrobinson"],
-      "github-oidc-team-repositories": ["modernisation-platform-environments"]
+      "additional_reviewers": ["astrobinson"]
     }
   ],
   "tags": {

--- a/environments/sprinkler.json
+++ b/environments/sprinkler.json
@@ -35,7 +35,8 @@
           "nuke": "rebuild"
         }
       ],
-      "additional_reviewers": ["astrobinson"]
+      "additional_reviewers": ["astrobinson"],
+      "github-oidc-team-repositories": ["modernisation-platform-environments"]
     }
   ],
   "tags": {

--- a/policies/environments/environment-definitions.rego
+++ b/policies/environments/environment-definitions.rego
@@ -117,11 +117,6 @@ deny contains msg if {
 }
 
 deny contains msg if {
-  not has_field(input, "github-oidc-team-repositories")
-  msg := sprintf("`%v` is missing the `github-oidc-team-repositories` key", [input.filename])
-}
-
-deny contains msg if {
   not regex.match(`^\S+@\S+$`, input.tags["infrastructure-support"])
  msg := sprintf("`%v` infrastructure-support value is not a valid email address", [input.filename])
 }

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -4,7 +4,7 @@ locals {
   environments = jsondecode(data.http.environments_file.response_body).environments
   github_repositories = [
     for environment in local.environments :
-    environment.github-oidc-team-repositories
+    lookup(environment, "github-oidc-team-repositories", [])
     if environment.name == local.application_environment
   ]
 }

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -363,7 +363,7 @@ resource "aws_iam_policy" "member-access-us-east" {
 module "github_oidc_role" {
   count               = length(compact(jsondecode(data.http.environments_file.response_body).github-oidc-team-repositories)) > 0 ? 1 : 0
   source              = "github.com/ministryofjustice/modernisation-platform-github-oidc-role?ref=c3bde7c787038ff5536bfb1b73781072edbb74da" # v3.0.0
-  github_repositories = jsondecode(data.http.environments_file.response_body).github-oidc-team-repositories
+  github_repositories = distinct(concat(jsondecode(data.http.environments_file.response_body).github-oidc-team-repositories[local.application_environment]), jsondecode(data.http.environments_file.response_body).github-oidc-team-repositories["all"])
   role_name           = "modernisation-platform-oidc-cicd"
   policy_jsons        = [data.aws_iam_policy_document.policy.json]
   tags                = local.tags

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -363,7 +363,7 @@ resource "aws_iam_policy" "member-access-us-east" {
 module "github_oidc_role" {
   count               = length(compact(jsondecode(data.http.environments_file.response_body).github-oidc-team-repositories)) > 0 ? 1 : 0
   source              = "github.com/ministryofjustice/modernisation-platform-github-oidc-role?ref=c3bde7c787038ff5536bfb1b73781072edbb74da" # v3.0.0
-  github_repositories = distinct(concat(jsondecode(data.http.environments_file.response_body).github-oidc-team-repositories[local.application_environment]), jsondecode(data.http.environments_file.response_body).github-oidc-team-repositories["all"])
+  github_repositories = distinct(concat(jsondecode(data.http.environments_file.response_body).github-oidc-team-repositories[local.application_environment], jsondecode(data.http.environments_file.response_body).github-oidc-team-repositories["all"]))
   role_name           = "modernisation-platform-oidc-cicd"
   policy_jsons        = [data.aws_iam_policy_document.policy.json]
   tags                = local.tags

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -363,7 +363,12 @@ resource "aws_iam_policy" "member-access-us-east" {
 module "github_oidc_role" {
   count               = length(compact(jsondecode(data.http.environments_file.response_body).github-oidc-team-repositories)) > 0 ? 1 : 0
   source              = "github.com/ministryofjustice/modernisation-platform-github-oidc-role?ref=c3bde7c787038ff5536bfb1b73781072edbb74da" # v3.0.0
-  github_repositories = distinct(concat(jsondecode(data.http.environments_file.response_body).github-oidc-team-repositories[local.application_environment], jsondecode(data.http.environments_file.response_body).github-oidc-team-repositories["all"]))
+  # github_repositories = distinct(concat(jsondecode(data.http.environments_file.response_body).github-oidc-team-repositories[local.application_environment], jsondecode(data.http.environments_file.response_body).github-oidc-team-repositories["all"]))
+  github_repositories = [
+    for environment in jsondecode(data.http.environments_file.response_body).environments :
+    environment.github-oidc-team-repositories
+    if environment.name == local.application_environment
+  ]
   role_name           = "modernisation-platform-oidc-cicd"
   policy_jsons        = [data.aws_iam_policy_document.policy.json]
   tags                = local.tags


### PR DESCRIPTION
## A reference to the issue / Description of it

Currently, adding repos to the `github-oidc-team-repositories` allows access to all accounts via the member-oidc role.
In certain use cases such as just pushing an image to ECR, we'd rather the account has only access to dev - especially where the repo might not be _purely_ under the control of the environment owning team (eg a supplier or detached development team).

## How does this PR fix the problem?
By allowing repos to be specified per account:
```
  "github-oidc-team-repositories": {
    "all": [
      "ministryofjustice/hmpps-delius-operational-automation",
      "ministryofjustice/hmpps-openldap-container",
    ],
    "development": [
      "ministryofjustice/hmpps-delius-docker-images",
      "ministryofjustice/hmpps-pwm",
      "ministryofjustice/ndelius-um"
    ]
  }
```
This would therefore only give access to development from the `ministryofjustice/hmpps-delius-docker-images` for example.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
