### PR TITLE
adds elb:SetRulePriorities and ssm:SendCommand to the cicd role

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -445,6 +445,7 @@ data "aws_iam_policy_document" "policy" {
       "elasticfilesystem:Create*",
       "elasticfilesystem:Delete*",
       "elasticfilesystem:restore",
+      "elasticloadbalancing:SetRulePriorities",
       "glue:GetJobRuns",
       "glue:StartJobRun",
       "glue:GetJobs",
@@ -494,6 +495,7 @@ data "aws_iam_policy_document" "policy" {
       "ssm:PutParameter",
       "ssm:DescribeSessions",
       "ssm:ResumeSession",
+      "ssm:SendCommand",
       "ssm:StartSession",
       "ssm:TerminateSession"
     ]


### PR DESCRIPTION
## A reference to the issue / Description of it

Requested in the ask channel. 
**elasticloadbalancing:SetRulePriorities** - allows pipeline to tweak load balancer permissions - this allows us to put up a user-friendly message if an environment has been taken down out of hours
**ssm:SendCommand**-  allows us to run commands on EC2 instances, e.g. stop services cleanly for example

## How does this PR fix the problem?

{Please write here}

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
