### PR TITLE
create S3 bucket for storing AWS member account cost CSV files

### DIFF
--- a/terraform/modernisation-platform-account/s3.tf
+++ b/terraform/modernisation-platform-account/s3.tf
@@ -307,3 +307,39 @@ data "aws_iam_policy_document" "allow-state-access-from-root-account" {
     }
   }
 }
+
+module "cost-management-bucket" {
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=cadab519b10a7d28dfa3b77d407725db6b37614a" # v8.0.0
+  providers = {
+    aws.bucket-replication = aws.modernisation-platform-eu-west-1
+  }
+  bucket_policy       = [data.aws_iam_policy_document.cost_management_bucket_policy.json]
+  bucket_name         = "mp-cost-explorer-reports"
+  custom_kms_key      = aws_kms_key.s3_state_bucket.arn
+  replication_enabled = false
+  lifecycle_rule = [
+    {
+      id      = "main"
+      enabled = "Disabled"
+    }
+  ]
+  tags = local.tags
+}
+
+
+data "aws_iam_policy_document" "cost_management_bucket_policy" {
+  statement {
+    sid    = "AllowAdministratorAccessRole"
+    effect = "Allow"
+    actions = [
+      "s3:PutObject",
+      "s3:GetObject"
+    ]
+    resources = ["${module.cost-management-bucket.bucket.arn}/*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${local.environment_management.modernisation_platform_account_id}:role/github-actions"]
+    }
+  }
+}


### PR DESCRIPTION
## A reference to the issue / Description of it

This PR introduces a new S3 bucket to store CSV files that contain cost data for each AWS member account. #3683 

## How does this PR fix the problem?

Creates an S3 bucket named `mp-cost-explorer-reports` for storing cost-related CSV files.

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)
