### PR TITLE
Baselines Update

### DIFF
--- a/terraform/environments/bootstrap/secure-baselines/main.tf
+++ b/terraform/environments/bootstrap/secure-baselines/main.tf
@@ -6,7 +6,7 @@ data "aws_kms_key" "cloudtrail_key" {
 
 #trivy:ignore:AVD-AWS-0136
 module "baselines" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=2b4010fdcb5dfb78683e5fdf2dfb98aa17917e4f" # v7.3.5
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=2240c9d1752109001a8d2fe66a57cef6c56dd3f0" # v7.4.1
 
   providers = {
     # Default and replication regions


### PR DESCRIPTION
## A reference to the issue / Description of it

Releasing changes to aws backup vault and backup notifications. 

https://github.com/ministryofjustice/modernisation-platform-terraform-baselines/releases/tag/v7.4.1


## How does this PR fix the problem?

Created backup vault lock for production accounts.
Changed SNS topics and notifications to only build in eu-west-2 for backup failures (only region we use for it)
Created notifications for backup vault meddling
Created variable for non prod backup retention, with a default value (will not impact users unless called)

## How has this been tested?

Deployed to cooker and long term storage accounts

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)


