### PR TITLE
Update dynamic variable for xsiam endpoint/secret in core-logging

### DIFF
--- a/terraform/environments/core-logging/firehose.tf
+++ b/terraform/environments/core-logging/firehose.tf
@@ -19,6 +19,6 @@ module "firehose_core_logging_vpcs" {
   common_attribute = "${local.application_name}-${each.key}"
   log_group_name   = each.value
   tags             = local.tags
-  xsiam_endpoint   = each.value == "live_data" ? local.xsiam["xsiam_prod_network_endpoint"] : local.xsiam["xsiam_preprod_network_endpoint"]
-  xsiam_secret     = each.value == "live_data" ? local.xsiam["xsiam_prod_network_secret"] : local.xsiam["xsiam_preprod_network_secret"]
+  xsiam_endpoint   = each.value == module.vpc["live_data"].vpc_cloudwatch_name ? local.xsiam["xsiam_prod_network_endpoint"] : local.xsiam["xsiam_preprod_network_endpoint"]
+  xsiam_secret     = each.value == module.vpc["live_data"].vpc_cloudwatch_name ? local.xsiam["xsiam_prod_network_secret"] : local.xsiam["xsiam_preprod_network_secret"]
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/7424

## How does this PR fix the problem?

I've updated the dynamic variable assignment for the xsiam endpoint/secret in core-logging as it was always evaluating to the false condition and providing the preprod values for prod.

## How has this been tested?
Local TF plan looks promising:
```
Terraform will perform the following actions:

  # module.firehose_core_logging_vpcs["live_data-vpc-flow-logs"].aws_kinesis_firehose_delivery_stream.delivery_stream will be updated in-place
  ~ resource "aws_kinesis_firehose_delivery_stream" "delivery_stream" {
        id             = "arn:aws:firehose:eu-west-2:624384546187:deliverystream/liv-log-delivery-stream-qex2oiu0"
        name           = "liv-log-delivery-stream-qex2oiu0"
        tags           = {
            "Name"          = "liv-log-delivery-stream-qex2oiu0"
            "application"   = "Modernisation Platform: core-logging-production"
            "business-unit" = "Platforms"
            "is-production" = "true"
            "owner"         = "Modernisation Platform: modernisation-platform@digital.justice.gov.uk"
        }
        # (5 unchanged attributes hidden)

      ~ http_endpoint_configuration {
          ~ access_key         = (sensitive value)
            name               = "liv-log-delivery-stream-endpoint--qex2oiu0"
          ~ url                = (sensitive value)
            # (5 unchanged attributes hidden)

            # (4 unchanged blocks hidden)
        }

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```



## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
