### PR TITLE
Fixes issue whereby wrong xsiam endpoint & secret were used for core-security & core-shared-services.

### DIFF
--- a/terraform/environments/core-security/firehose.tf
+++ b/terraform/environments/core-security/firehose.tf
@@ -18,6 +18,6 @@ module "firehose_core_security_vpcs" {
   common_attribute = "${local.application_name}-${each.key}"
   log_group_name   = each.value
   tags             = local.tags
-  xsiam_endpoint   = each.value == "live_data" ? local.xsiam["xsiam_prod_network_endpoint"] : local.xsiam["xsiam_preprod_network_endpoint"]
-  xsiam_secret     = each.value == "live_data" ? local.xsiam["xsiam_prod_network_secret"] : local.xsiam["xsiam_preprod_network_secret"]
+  xsiam_endpoint   = each.value == module.vpc["live_data"].vpc_cloudwatch_name ? local.xsiam["xsiam_prod_network_endpoint"] : local.xsiam["xsiam_preprod_network_endpoint"]
+  xsiam_secret     = each.value == module.vpc["live_data"].vpc_cloudwatch_name ? local.xsiam["xsiam_prod_network_secret"] : local.xsiam["xsiam_preprod_network_secret"]
 }

--- a/terraform/environments/core-shared-services/firehose.tf
+++ b/terraform/environments/core-shared-services/firehose.tf
@@ -19,6 +19,6 @@ module "firehose_core_logging_vpcs" {
   common_attribute = "${local.application_name}-${each.key}"
   log_group_name   = each.value
   tags             = local.tags
-  xsiam_endpoint   = each.value == "live_data" ? local.xsiam["xsiam_prod_network_endpoint"] : local.xsiam["xsiam_preprod_network_endpoint"]
-  xsiam_secret     = each.value == "live_data" ? local.xsiam["xsiam_prod_network_secret"] : local.xsiam["xsiam_preprod_network_secret"]
+  xsiam_endpoint   = each.value == module.vpc["live_data"].vpc_cloudwatch_name ? local.xsiam["xsiam_prod_network_endpoint"] : local.xsiam["xsiam_preprod_network_endpoint"]
+  xsiam_secret     = each.value == module.vpc["live_data"].vpc_cloudwatch_name ? local.xsiam["xsiam_prod_network_secret"] : local.xsiam["xsiam_preprod_network_secret"]
 }


### PR DESCRIPTION
Fixes a bug whereby the condition test was not picking up the correct element of vpc_logs and so was defaulting to nonprod.

## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/7424

## How does this PR fix the problem?

The element used for test was incomplete and so resolving to the values for preprod.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

PR tests show correct plan. Change has already been applied to core-logging and this repeats that approach.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No impact on other services.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
