### PR TITLE
Sets correct endpoint for non-live-data firehose transfers in core-network-services.

### DIFF
--- a/terraform/environments/core-network-services/firehose.tf
+++ b/terraform/environments/core-network-services/firehose.tf
@@ -21,8 +21,8 @@ module "firehose_firewalls" {
   common_attribute = "${local.application_name}-${each.key}"
   log_group_name   = each.value
   tags             = local.tags
-  xsiam_endpoint   = each.value != "non_live_data" ? tostring(local.xsiam["xsiam_prod_firewall_endpoint"]) : tostring(local.xsiam["xsiam_preprod_firewall_endpoint"])
-  xsiam_secret     = each.value != "non_live_data" ? tostring(local.xsiam["xsiam_prod_firewall_secret"]) : tostring(local.xsiam["xsiam_preprod_firewall_secret"])
+  xsiam_endpoint   = each.value != module.vpc_inspection["non_live_data"].fw_cloudwatch_name ? tostring(local.xsiam["xsiam_prod_firewall_endpoint"]) : tostring(local.xsiam["xsiam_preprod_firewall_endpoint"])
+  xsiam_secret     = each.value != module.vpc_inspection["non_live_data"].fw_cloudwatch_name ? tostring(local.xsiam["xsiam_prod_firewall_secret"]) : tostring(local.xsiam["xsiam_preprod_firewall_secret"])
 }
 
 # A 2nd call of the module which will generate the firehose streams for the firewall vpc flow logs.
@@ -34,6 +34,6 @@ module "firehose_vpcs" {
   common_attribute = "${local.application_name}-${each.key}"
   log_group_name   = each.value
   tags             = local.tags
-  xsiam_endpoint   = each.value != "non_live_data" ? tostring(local.xsiam["xsiam_prod_network_endpoint"]) : tostring(local.xsiam["xsiam_preprod_network_endpoint"])
-  xsiam_secret     = each.value != "non_live_data" ? tostring(local.xsiam["xsiam_prod_network_secret"]) : tostring(local.xsiam["xsiam_preprod_network_secret"])
+  xsiam_endpoint   = each.value != module.vpc_inspection["non_live_data"].vpc_cloudwatch_name ? tostring(local.xsiam["xsiam_prod_network_endpoint"]) : tostring(local.xsiam["xsiam_preprod_network_endpoint"])
+  xsiam_secret     = each.value != module.vpc_inspection["non_live_data"].vpc_cloudwatch_name ? tostring(local.xsiam["xsiam_prod_network_secret"]) : tostring(local.xsiam["xsiam_preprod_network_secret"])
 }


### PR DESCRIPTION
Fixes an issue whereby the condition test wasn't correctly identifying non-live-data logs and so applying the prod endpoints. 

## A reference to the issue / Description of it

Resolves additional issues arising from the work to fix the bugs identified in https://github.com/ministryofjustice/modernisation-platform/issues/7424

## How does this PR fix the problem?

The existing condition was not correctly resolving and so defaulting to using the prod endpoints.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Applies the same approach to the issues found in core-shared-services, logging and security. See PRs https://github.com/ministryofjustice/modernisation-platform/pull/7433 and https://github.com/ministryofjustice/modernisation-platform/pull/7431

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No services will be impacted.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
