### PR TITLE
Add AWS_REGION Environment Variable

### DIFF
--- a/.github/workflows/core-vpc-development-deployment.yml
+++ b/.github/workflows/core-vpc-development-deployment.yml
@@ -50,6 +50,9 @@ defaults:
   run:
     shell: bash
 
+env:
+  AWS_REGION: "eu-west-2"
+
 jobs:
   core-vpc-development-deployment-plan-apply:
     uses: ./.github/workflows/reusable_terraform_plan_apply.yml

--- a/.github/workflows/core-vpc-preproduction-deployment.yml
+++ b/.github/workflows/core-vpc-preproduction-deployment.yml
@@ -43,11 +43,8 @@ on:
   workflow_dispatch:
 
 env:
-  TF_IN_AUTOMATION: true
-  TF_ENV: "preproduction"
   AWS_REGION: "eu-west-2"
-  ENVIRONMENT_MANAGEMENT: ${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENTS }}
-
+  
 permissions:
   id-token: write # This is required for requesting the JWT
   contents: read # This is required for actions/checkout

--- a/.github/workflows/core-vpc-production-deployment.yml
+++ b/.github/workflows/core-vpc-production-deployment.yml
@@ -50,6 +50,9 @@ defaults:
   run:
     shell: bash
 
+env:
+  AWS_REGION: "eu-west-2"
+
 jobs:
   core-vpc-production-deployment-plan-apply:
     uses: ./.github/workflows/reusable_terraform_plan_apply.yml

--- a/.github/workflows/core-vpc-test-deployment.yml
+++ b/.github/workflows/core-vpc-test-deployment.yml
@@ -48,6 +48,9 @@ defaults:
   run:
     shell: bash
 
+env:
+  AWS_REGION: "eu-west-2"
+
 jobs:
   core-vpc-test-deployment-plan-apply:
     uses: ./.github/workflows/reusable_terraform_plan_apply.yml


### PR DESCRIPTION
## A reference to the issue / Description of it

This PR adds the `AWS_REGION` environment variable to the pipeline configuration to prevent failures due to the missing variable.

## How does this PR fix the problem?

By including the `AWS_REGION` environment variable, the pipeline will now have access to the required region information, preventing errors that were caused by its absence.