### PR TITLE
Add kms:encrypt permissions to OIDC role

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -469,6 +469,7 @@ data "aws_iam_policy_document" "policy" {
       "kinesis:PutRecord",
       "kms:DescribeKey",
       "kms:Decrypt",
+      "kms:Encrypt",
       "kms:GenerateDataKey",
       "kms:CreateGrant",
       "logs:CreateLogGroup",


### PR DESCRIPTION
As per Slack request https://mojdt.slack.com/archives/C01A7QK5VM1/p1720426251369899 this PR adds the `kms:encrypt` permissions to the oidc role.