### PR TITLE
exclude nuke for contract-work-administration

### DIFF
--- a/environments/contract-work-administration.json
+++ b/environments/contract-work-administration.json
@@ -6,7 +6,7 @@
       "access": [
         {
           "github_slug": "laa-aws-infrastructure",
-          "level": "sandbox"
+          "level": "sandbox",
           "nuke": "exclude"
         },
         {

--- a/environments/contract-work-administration.json
+++ b/environments/contract-work-administration.json
@@ -7,6 +7,7 @@
         {
           "github_slug": "laa-aws-infrastructure",
           "level": "sandbox"
+          "nuke": "exclude"
         },
         {
           "github_slug": "laa-cwa-developer",


### PR DESCRIPTION
as per Slack request https://mojdt.slack.com/archives/C01A7QK5VM1/p1720445686062709 this PR excludes `contract-work-administration-development` from the nuke run.