### PR TITLE
Fix internal link on runbook page

### DIFF
--- a/source/runbooks/integration-with-protective-monitoring.html.md.erb
+++ b/source/runbooks/integration-with-protective-monitoring.html.md.erb
@@ -58,7 +58,7 @@ Each Data Firehose resource has an endpoint & key that is obtained from a common
 
 ## Known Maintenance Requirements
 
-- The user access key for the IAM account needs to be rotated every 6 months and the new value shared with the SecOps team. See the runbook page for [Rotating Secrets](rotating-secrets.html.md.erb) for further information.
+- The user access key for the IAM account needs to be rotated every 6 months and the new value shared with the SecOps team. See the runbook page for [Rotating Secrets](rotating-secrets.html) for further information.
 
 ## Known Contacts:
 


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/actions/runs/9853367257/job/27203750215

## How does this PR fix the problem?

Cleans up a link to an internal page

## How has this been tested?


## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
