### PR TITLE
Update policies.tf to add glue crawler permissions

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -403,6 +403,7 @@ data "aws_iam_policy_document" "data_engineering_additional" {
       "glue:List*",
       "glue:BatchGetJobs",
       "glue:*Trigger",
+      "glue:*Crawler",
       "lambda:PutRuntimeManagementConfig",
       "states:Describe*",
       "states:List*",


### PR DESCRIPTION
## A reference to the issue / Description of it

Using a glue crawler inconsistent struct schemas in Athena

## How does this PR fix the problem?

Adds permissions to create a Glue crawler

## How has this been tested?

Tested using a Glue crawler in sandbox, but haven't tested how the impact of these permissons...

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

Will add permissions to users

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
