### PR TITLE
Add secret value for slack webhook to send failures to

### DIFF
--- a/terraform/github/repositories.tf
+++ b/terraform/github/repositories.tf
@@ -249,9 +249,10 @@ module "modernisation-platform-environments" {
   required_checks = ["run-opa-policy-tests"]
   secrets = {
     # Terraform GitHub token for the CI/CD user
-    TERRAFORM_GITHUB_TOKEN                               = data.aws_secretsmanager_secret_version.github_ci_user_token.secret_string
     MODERNISATION_PLATFORM_CI_USER_ENVIRONMENTS_REPO_PAT = data.aws_secretsmanager_secret_version.github_ci_user_environments_repo_pat_token.secret_string
     MODERNISATION_PLATFORM_ACCOUNT_ID                    = local.modernisation_platform_account
+    SLACK_WEBHOOK_URL = data.aws_secretsmanager_secret_version.slack_webhook_url.secret_string
+    TERRAFORM_GITHUB_TOKEN                               = data.aws_secretsmanager_secret_version.github_ci_user_token.secret_string
     TESTING_AWS_ACCESS_KEY_ID                            = local.testing_ci_iam_user_keys.AWS_ACCESS_KEY_ID
     TESTING_AWS_SECRET_ACCESS_KEY                        = local.testing_ci_iam_user_keys.AWS_SECRET_ACCESS_KEY
   }


### PR DESCRIPTION
## A reference to the issue / Description of it

#7395 

## How does this PR fix the problem?

Adds the slack webhook url as a repository secret to the environments repo

## How has this been tested?

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
