### PR TITLE
Add secrets for Slack webhook URL, and GOV.UK Notify API key

### DIFF
--- a/terraform/modernisation-platform-account/secrets.tf
+++ b/terraform/modernisation-platform-account/secrets.tf
@@ -211,4 +211,14 @@ resource "aws_secretsmanager_secret" "xsiam_secrets" {
   }
 }
 
+resource "aws_secretsmanager_secret" "gov_uk_notify_api_key" {
+  # checkov:skip=CKV2_AWS_57:Auto rotation not possible
+  name        = "gov_uk_notify_api_key"
+  description = "API key for accessing the GOV.UK Notify service for sending email notifications"
+  kms_key_id  = aws_kms_key.secrets_key.id
+  tags        = local.tags
+  replica {
+    region = local.replica_region
+  }
+}
 

--- a/terraform/modernisation-platform-account/secrets.tf
+++ b/terraform/modernisation-platform-account/secrets.tf
@@ -83,6 +83,17 @@ resource "aws_secretsmanager_secret" "slack_webhook_url" {
   }
 }
 
+resource "aws_secretsmanager_secret" "slack_webhook_url_modernisation_platform_update" {
+  # checkov:skip=CKV2_AWS_57:Auto rotation not possible
+  name        = "slack_webhook_url_modernisation_platform_update"
+  description = "Slack channel modernisation-platform-update webhook url for sending notifications to slack"
+  kms_key_id  = aws_kms_key.secrets_key.id
+  tags        = local.tags
+  replica {
+    region = local.replica_region
+  }
+}
+
 # Github CI user PAT
 # Not adding a secret version as this url is generated in Github cannot be added programatically
 # Secret should be manually set in the console.


### PR DESCRIPTION
This PR adds secrets for a `Slack webhook URL`, and a `GOV.UK Notify API key`, necessary for integrating with Slack notifications, and sending notifications through GOV.UK Notify. #7402 