### PR TITLE
Add new job for JSON change notifications via Slack and email

### DIFF
--- a/.github/workflows/new-environment.yml
+++ b/.github/workflows/new-environment.yml
@@ -24,6 +24,8 @@ env:
   TF_IN_AUTOMATION: true
   AWS_REGION: "eu-west-2"
   ENVIRONMENT_MANAGEMENT: ${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENTS }}
+  API_KEY: ${{ secrets.GOV_UK_NOTIFY_API_KEY }}
+  TEMPLATE_ID: "c529aa7e-685a-4907-90dd-ab93fc4791ef"
 
 permissions:
   id-token: write # This is required for requesting the JWT
@@ -207,6 +209,48 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
         if: ${{ failure() }}
+  environment_json_changes_notification:
+    runs-on: ubuntu-latest
+    if: github.event.ref == 'refs/heads/main'
+    needs: [delegate-access]
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          fetch-depth: 0
+      - name: Get modified JSON files
+        id: environment_json_changes
+        run: |
+          files=$(git diff --name-only --diff-filter=M @^ -- 'environments/*.json' | uniq | sed 's#environments/##' | base64 )
+          echo "files=$files" >> $GITHUB_OUTPUT
+      - name: Install Python
+        if: steps.environment_json_changes.outputs.files != ''
+        uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1
+        with:
+          python-version: '3.10'
+      - name: Install the client
+        if: steps.environment_json_changes.outputs.files != ''
+        run: pip install notifications-python-client
+      - name: Send notification to Slack
+        if: steps.environment_json_changes.outputs.files != ''
+        run: |
+          DECODED_FILES=$(echo ${{ steps.environment_json_changes.outputs.files }} | base64 --decode)
+          for file in $DECODED_FILES; do
+          FILE_PATH="https://github.com/${GITHUB_REPO}/blob/main/environments/${file}"
+          PAYLOAD=$(cat <<EOF
+          {
+            "text": "The JSON file [${file}](${FILE_PATH}) has been changed."
+          }
+          EOF
+          )
+          curl -X POST -H 'Content-type: application/json' --data "$PAYLOAD" "$SLACK_WEBHOOK_URL_MODERNISATION_PLATFORM_UPDATE"
+          done
+        env:
+          SLACK_WEBHOOK_URL_MODERNISATION_PLATFORM_UPDATE: ${{ secrets.SLACK_WEBHOOK_URL_MODERNISATION_PLATFORM_UPDATE }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+      - name: Send notification to Email
+        run: |
+          DECODED_FILES=$(echo ${{ steps.environment_json_changes.outputs.files }} | base64 --decode)
+          python ./scripts/json-changes-notifier.py $DECODED_FILES
   remove-default-vpc:
     runs-on: ubuntu-latest
     if: github.event.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/new-environment.yml
+++ b/.github/workflows/new-environment.yml
@@ -209,48 +209,6 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
         if: ${{ failure() }}
-  environment_json_changes_notification:
-    runs-on: ubuntu-latest
-    if: github.event.ref == 'refs/heads/main'
-    needs: [delegate-access]
-    steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-        with:
-          fetch-depth: 0
-      - name: Get modified JSON files
-        id: environment_json_changes
-        run: |
-          files=$(git diff --name-only --diff-filter=M @^ -- 'environments/*.json' | uniq | sed 's#environments/##' | base64 )
-          echo "files=$files" >> $GITHUB_OUTPUT
-      - name: Install Python
-        if: steps.environment_json_changes.outputs.files != ''
-        uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1
-        with:
-          python-version: '3.10'
-      - name: Install the client
-        if: steps.environment_json_changes.outputs.files != ''
-        run: pip install notifications-python-client
-      - name: Send notification to Slack
-        if: steps.environment_json_changes.outputs.files != ''
-        run: |
-          DECODED_FILES=$(echo ${{ steps.environment_json_changes.outputs.files }} | base64 --decode)
-          for file in $DECODED_FILES; do
-          FILE_PATH="https://github.com/${GITHUB_REPO}/blob/main/environments/${file}"
-          PAYLOAD=$(cat <<EOF
-          {
-            "text": "The JSON file [${file}](${FILE_PATH}) has been changed."
-          }
-          EOF
-          )
-          curl -X POST -H 'Content-type: application/json' --data "$PAYLOAD" "$SLACK_WEBHOOK_URL_MODERNISATION_PLATFORM_UPDATE"
-          done
-        env:
-          SLACK_WEBHOOK_URL_MODERNISATION_PLATFORM_UPDATE: ${{ secrets.SLACK_WEBHOOK_URL_MODERNISATION_PLATFORM_UPDATE }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-      - name: Send notification to Email
-        run: |
-          DECODED_FILES=$(echo ${{ steps.environment_json_changes.outputs.files }} | base64 --decode)
-          python ./scripts/json-changes-notifier.py $DECODED_FILES
   remove-default-vpc:
     runs-on: ubuntu-latest
     if: github.event.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
@@ -404,6 +362,48 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
         if: ${{ failure() }}
+  environment_json_changes_notification:
+    runs-on: ubuntu-latest
+    if: github.event.ref == 'refs/heads/main'
+    needs: [single-sign-on]
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          fetch-depth: 0
+      - name: Get modified JSON files
+        id: environment_json_changes
+        run: |
+          files=$(git diff --name-only --diff-filter=M @^ -- 'environments/*.json' | uniq | sed 's#environments/##' | base64 )
+          echo "files=$files" >> $GITHUB_OUTPUT
+      - name: Install Python
+        if: steps.environment_json_changes.outputs.files != ''
+        uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1
+        with:
+          python-version: '3.10'
+      - name: Install the client
+        if: steps.environment_json_changes.outputs.files != ''
+        run: pip install notifications-python-client
+      - name: Send notification to Slack
+        if: steps.environment_json_changes.outputs.files != ''
+        run: |
+          DECODED_FILES=$(echo ${{ steps.environment_json_changes.outputs.files }} | base64 --decode)
+          for file in $DECODED_FILES; do
+          FILE_PATH="https://github.com/${GITHUB_REPO}/blob/main/environments/${file}"
+          PAYLOAD=$(cat <<EOF
+          {
+            "text": "The JSON file [${file}](${FILE_PATH}) has been changed."
+          }
+          EOF
+          )
+          curl -X POST -H 'Content-type: application/json' --data "$PAYLOAD" "$SLACK_WEBHOOK_URL_MODERNISATION_PLATFORM_UPDATE"
+          done
+        env:
+          SLACK_WEBHOOK_URL_MODERNISATION_PLATFORM_UPDATE: ${{ secrets.SLACK_WEBHOOK_URL_MODERNISATION_PLATFORM_UPDATE }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+      - name: Send notification to Email
+        run: |
+          DECODED_FILES=$(echo ${{ steps.environment_json_changes.outputs.files }} | base64 --decode)
+          python ./scripts/json-changes-notifier.py $DECODED_FILES
   member-bootstrap:
     runs-on: ubuntu-latest
     if: github.event.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'

--- a/scripts/json-changes-notifier.py
+++ b/scripts/json-changes-notifier.py
@@ -1,0 +1,39 @@
+import json
+import os
+import sys
+from notifications_python_client.notifications import NotificationsAPIClient
+
+# Function to retrieve email from JSON file
+def get_email(json_file_name):
+    # Construct the path to the JSON file
+    json_file = os.path.join("environments", f"{json_file_name}")
+    # Check if the JSON file exists
+    if not os.path.exists(json_file):
+        return None
+    # Open and read the JSON file
+    with open(json_file, 'r') as f:
+        json_file_data = json.load(f)
+    # Retrieve the email address from JSON data
+    return json_file_data.get("tags", {}).get("infrastructure-support")
+
+# Main function to send notifications
+def main(file_names):
+    # Retrieve API key and template ID from environment variables
+    api_key = os.environ["API_KEY"]
+    template_id = os.environ["TEMPLATE_ID"]
+    # Create a NotificationsAPIClient instance
+    client = NotificationsAPIClient(api_key=api_key)
+    # Iterate over each JSON file name provided as arguments
+    for json_file_name in file_names:
+        email_address=get_email(json_file_name)
+        print(f"Email sending to: {email_address}")
+        # Send email notification using NotificationsAPIClient
+        notification = client.send_email_notification(
+            template_id=template_id,
+            email_address=email_address,
+            personalisation={"file_name": json_file_name}
+        )
+
+if __name__ == "__main__":
+    file_names = sys.argv[1:]
+    main(file_names)


### PR DESCRIPTION
## A reference to the issue / Description of it

This PR introduces a new job and Python script to facilitate timely notifications via Slack and email whenever changes occur in JSON files within the `environments` folder. #7402 

## How does this PR fix the problem?

Previously, there was no automated mechanism to notify users about changes in JSON files within the `environments` repository. This PR addresses the issue by:
- Establishing a systematic approach to monitor and notify changes.
- Enhancing responsiveness and ensuring users are promptly informed about critical updates.

## How has this been tested?

Sent test notifications to MP Slack channel and Executed script with mock JSON file changes.

Will this deployment impact the platform and / or services on it?

NO

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)