### PR TITLE
Minor changes to mention not using codeowners when creating environments

### DIFF
--- a/source/user-guide/creating-environments.html.md.erb
+++ b/source/user-guide/creating-environments.html.md.erb
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#modernisation-platform"
 title: Creating environments in the Modernisation Platform
-last_reviewed_on: 2024-03-20
+last_reviewed_on: 2024-07-18
 review_in: 6 months
 ---
 
@@ -189,8 +189,8 @@ Here are some examples of the environments JSON file that the Modernisation Plat
 ### Schema
 
 - `account-type` determines if this is a core modernisation platform account or a user member account.
-- `isolated-network` is an optional field which can be set to 'true' if you require an isolated environment with no internet or shared network connectivity.
-- `codeowners` is an optional list of GitHub slugs if you want specific teams to review code changes before they are released into environments.
+- `isolated-network` is an optional field which can be set to 'true' if you require an isolated environment with no internet or shared network connectivity. Again this is **NOT** generally used. Compare the [Blank example](#blank-example) with [Another example](#another-example) below, to see it is unused.
+- `codeowners` is an ***optional*** list of GitHub slugs if you want specific teams to review code changes before they are released into environments. It is **NOT** generally used. Compare the [Blank example](#blank-example) with [Another example](#another-example) below, to see it is unused. 
 - `environments` should be an array of objects for environments required. If the environment is `production`, retention periods, backup frequency, and similar will be different compared to non-production environments.
 - the `name` key and `access` object are required, see: [Another example](#another-example)
 - `github_action_reviewer` is an optional true/false for each team listed and determines if the team should be the approver for GitHub action runs.

--- a/source/user-guide/creating-environments.html.md.erb
+++ b/source/user-guide/creating-environments.html.md.erb
@@ -189,7 +189,7 @@ Here are some examples of the environments JSON file that the Modernisation Plat
 ### Schema
 
 - `account-type` determines if this is a core modernisation platform account or a user member account.
-- `isolated-network` is an optional field which can be set to 'true' if you require an isolated environment with no internet or shared network connectivity. Again this is **NOT** generally used. Compare the [Blank example](#blank-example) with [Another example](#another-example) below, to see it is unused.
+- `isolated-network` is an optional field which can be set to 'true' if you require an isolated environment with no internet or shared network connectivity.
 - `codeowners` is an ***optional*** list of GitHub slugs if you want specific teams to review code changes before they are released into environments. It is **NOT** generally used. Compare the [Blank example](#blank-example) with [Another example](#another-example) below, to see it is unused. 
 - `environments` should be an array of objects for environments required. If the environment is `production`, retention periods, backup frequency, and similar will be different compared to non-production environments.
 - the `name` key and `access` object are required, see: [Another example](#another-example)


### PR DESCRIPTION
The instructions on the [Creating environments in the Modernisation Platform](https://user-guide.modernisation-platform.service.justice.gov.uk/user-guide/creating-environments.html#creating-environments-in-the-modernisation-platform) were showing codeowners in the "blank eample" json but not in the "another example" json code.

It is not generally used and caused an issue with one environment that was built using these instructions. This has since been corrected in New account process incorrectly populates codeowners file
[#7430](https://github.com/ministryofjustice/modernisation-platform/issues/7430).

To ensure it does not happen again a little bit of text has been added to not it is not required and can be ignored. It points to the two pieces of json shown below.