### PR TITLE
Add aws chatbot permissions to `member-access` policy

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -36,6 +36,7 @@ data "aws_iam_policy_document" "member-access" {
       "autoscaling:*",
       "backup:*",
       "backup-storage:MountCapsule",
+      "chatbot:*",
       "cloudformation:*",
       "cloudfront:*",
       "cloudwatch:*",


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/6817

I'm adding unit tests to a new aws chatbot terraform module I've created. I was able to run these locally as an administrator but cannot via the testing pipeline and get the following error...

https://github.com/ministryofjustice/modernisation-platform-terraform-aws-chatbot/actions/runs/9988594516/job/27605429883?pr=1#step:6:152

## How does this PR fix the problem?

I'm looking to add `chatbot:*` permissions to the member access role. This will enable unit testing on the new module and also in future would allow members to consume the module and set up slack channel configs where required.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [X] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
