### PR TITLE
Adding sso:CreateApplicationAssignment so can manage QS Groups via Console

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -571,6 +571,18 @@ data "aws_iam_policy_document" "sandbox_additional" {
     ]
     resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
   }
+  statement {
+    sid    = "sandboxSSOAllow"
+    actions = [
+      "sso:CreateApplicationAssignment"
+    ]
+    effect = "Allow"
+    # This allows the sandbox role to update QuickSight groups which are linked to Identity Center
+
+    resources = [
+      "arn:aws:sso::${local.environment_management.aws_organizations_root_account_id}:application/ssoins-7535d9af4f41fb26/*" #tfsec:ignore:AWS099 tfsec:ignore:AWS097
+    ]
+  }
 }
 
 # migration policy - member SSO and collaborators


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/analytical-platform/issues/4271

We need to be able to add additional Identity Center groups to QuickSight but doing so via Terraform results in attempt to replace the whole subscription:
https://github.com/ministryofjustice/modernisation-platform-environments/actions/runs/9990342858/job/27610845085?pr=7138#step:11:703

We are raising a bug ticket with the aws provider but in the meantime we need to add additional groups to enable testing.

## How does this PR fix the problem?

This SSO permission will allow us to add groups via the QuickSight admin console since the groupings are managed via Identity Center

## How has this been tested?

It hasn't. It needs to be tested post-deployment. The specific permission was identified after a cloudtrail search.

## Deployment Plan / Instructions

There shouldn't be any impact on deployment.

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [X] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [X] Plan and discussed how it should be deployed to PROD (If needed)

