### PR TITLE
Adding lakeformation:get and put settings permissions to the data eng role

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -405,6 +405,8 @@ data "aws_iam_policy_document" "data_engineering_additional" {
       "glue:List*",
       "glue:BatchGetJobs",
       "glue:*Trigger",
+      "lakeformation:GetDataLakeSettings",
+      "lakeformation:PutDataLakeSettings",
       "lambda:PutRuntimeManagementConfig",
       "states:Describe*",
       "states:List*",
@@ -574,7 +576,7 @@ data "aws_iam_policy_document" "sandbox_additional" {
     resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
   }
   statement {
-    sid    = "sandboxSSOAllow"
+    sid = "sandboxSSOAllow"
     actions = [
       "sso:CreateApplicationAssignment"
     ]


### PR DESCRIPTION
## A reference to the issue / Description of it

The work this PR is a part of is being tracked here: 
https://github.com/ministryofjustice/analytical-platform/issues/4358

The problem:
In order to allow the process of sharing resources we have chosen, LakeFormation needs to be updated to `cross-account-sharing-version` 4. Ref: https://docs.aws.amazon.com/lake-formation/latest/dg/optimize-ram.html 
The ability to update the cross account sharing version isn't supported by terraform at present so this needs to be manually done.

## How does this PR fix the problem?

This gives the data engineering role enough permissions to make the update in the console once the Lake Formation has been bootstrapped in terraform. 

## How has this been tested?

The permission have been retrieved from CloudTrail

Testing can only happen post-deployment

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

This should be a zero-impact change.

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [X] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [X] Plan and discussed how it should be deployed to PROD (If needed)

