### PR TITLE
fix broken internal document links

### DIFF
--- a/source/concepts/sdlc/sandbox-testing-environments.html.md.erb
+++ b/source/concepts/sdlc/sandbox-testing-environments.html.md.erb
@@ -18,7 +18,7 @@ review_in: 6 months
 
 This is a list of non core or member environments.  These environments are used for core platform development and testing work.
 
-Please note this does not include member development accounts which are given [sandbox access](../../user-guide/creating-environments.html#sandbox) to enable rapid development.
+Please note this does not include member development accounts which are given [sandbox access](../../user-guide/platform-user-roles.html#sandbox) to enable rapid development.
 
 ## Environments
 

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -71,6 +71,7 @@ This documentation is for anyone interested in the Modernisation Platform and it
 
 - [Auto-nuke](concepts/environments/auto-nuke.html)
 - [Instance Scheduling - automatically stop non-production instances overnight](concepts/environments/instance-scheduling.html)
+- [Platform user roles](user-guide/platform-user-roles.html)
 
 ### Networking
 - [Networking approach](concepts/networking/networking-approach.html)

--- a/source/runbooks/adding-collaborators.html.md.erb
+++ b/source/runbooks/adding-collaborators.html.md.erb
@@ -40,7 +40,7 @@ Under "reason" please put the name of the Modernisation Platform application tha
 
 Add the collaborators to the [collaborators.json](https://github.com/ministryofjustice/modernisation-platform/blob/main/collaborators.json) file.
 
-Valid access levels are `read-only` (read only access) and `developer` (read only plus additional permissions detailed [here](../user-guide/creating-environments.html#developer))
+Valid access levels are `read-only` (read only access) and `developer` (read only plus additional permissions detailed [here](../user-guide/platform-user-roles.html#developer))
 
 The modernisation-platform-account workflow will create the users when a pull request with these changes is merged.
 


### PR DESCRIPTION
Saw that my refactoring of the creating environments docs broke the internal links from some other pages.