### PR TITLE
cica-tariff networking

### DIFF
--- a/environments-networks/cica-preproduction.json
+++ b/environments-networks/cica-preproduction.json
@@ -3,7 +3,9 @@
     "subnet_sets": {
       "general": {
         "cidr": "10.27.88.0/21",
-        "accounts": []
+        "accounts": [
+          "cica-tariff-preproduction"
+        ]
       }
     }
   },

--- a/environments-networks/cica-production.json
+++ b/environments-networks/cica-production.json
@@ -3,7 +3,9 @@
     "subnet_sets": {
       "general": {
         "cidr": "10.27.80.0/21",
-        "accounts": []
+        "accounts": [
+          "cica-tariff-production"
+        ]
       }
     }
   },

--- a/environments-networks/cica-test.json
+++ b/environments-networks/cica-test.json
@@ -3,7 +3,9 @@
     "subnet_sets": {
       "general": {
         "cidr": "10.26.112.0/21",
-        "accounts": []
+        "accounts": [
+          "cica-tariff-test"
+        ]
       }
     }
   },

--- a/policies/networking/expected.rego
+++ b/policies/networking/expected.rego
@@ -301,6 +301,7 @@ expected :=
       "general": {
         "cidr": "10.26.112.0/21",
         "accounts": [
+          "cica-tariff-test"
         ]
       }
     },
@@ -367,6 +368,7 @@ expected :=
       "general": {
         "cidr": "10.27.80.0/21",
         "accounts": [
+          "cica-tariff-production"
         ]
       }
     },
@@ -374,6 +376,7 @@ expected :=
       "general": {
         "cidr": "10.27.88.0/21",
         "accounts": [
+          "cica-tariff-preproduction"
         ]
       }
     },


### PR DESCRIPTION
## A reference to the issue / Description of it

Change the cica tariff environments to add networking. cica-tariff-development was in place on cica-development.json so I added it to cica-preproduction, production and test.
