### PR TITLE
Remove slack notification step from environment_json_changes job

### DIFF
--- a/.github/workflows/new-environment.yml
+++ b/.github/workflows/new-environment.yml
@@ -383,23 +383,6 @@ jobs:
       - name: Install the client
         if: steps.environment_json_changes.outputs.files != ''
         run: pip install notifications-python-client
-      - name: Send notification to Slack
-        if: steps.environment_json_changes.outputs.files != ''
-        run: |
-          DECODED_FILES=$(echo ${{ steps.environment_json_changes.outputs.files }} | base64 --decode)
-          for file in $DECODED_FILES; do
-          FILE_PATH="https://github.com/${GITHUB_REPO}/blob/main/environments/${file}"
-          PAYLOAD=$(cat <<EOF
-          {
-            "text": "The JSON file [${file}](${FILE_PATH}) has been changed."
-          }
-          EOF
-          )
-          curl -X POST -H 'Content-type: application/json' --data "$PAYLOAD" "$SLACK_WEBHOOK_URL_MODERNISATION_PLATFORM_UPDATE"
-          done
-        env:
-          SLACK_WEBHOOK_URL_MODERNISATION_PLATFORM_UPDATE: ${{ secrets.SLACK_WEBHOOK_URL_MODERNISATION_PLATFORM_UPDATE }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
       - name: Send notification to Email
         if: steps.environment_json_changes.outputs.files != ''
         run: |


### PR DESCRIPTION
## A reference to the issue / Description of it

https://mojdt.slack.com/archives/C013RM6MFFW/p1721725689918789

## How does this PR fix the problem?

Remove the Slack notification step from the environment_json_changes job so that users are not notified in the MP update channel.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
