### PR TITLE
New collaborator request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-collaborator.yml
+++ b/.github/ISSUE_TEMPLATE/new-collaborator.yml
@@ -94,8 +94,8 @@ body:
       label: Additional repository access
       description: Does this collaborator need `push` permissions for the following repositories?
       options:
-        - `modernisation-platform-environments`
-        - `modernisation-platform-ami-builds`
+        - modernisation-platform-environments
+        - modernisation-platform-ami-builds
     validations:
       required: false
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/new-collaborator.yml
+++ b/.github/ISSUE_TEMPLATE/new-collaborator.yml
@@ -104,8 +104,8 @@ body:
       label: Additional deployment approval access
       description: Does this collaborator need the ability to approve deployments through GitHub Actions?
       options:
-        - Yes
-        - No
+        - "Yes"
+        - "No"
     validations:
       required: false
   - type: textarea
@@ -113,7 +113,6 @@ body:
     attributes:
       label: Additional information
       description: Add any supporting information which relates to your request here.
-      placeholder: " "
       render: markdown
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/new-collaborator.yml
+++ b/.github/ISSUE_TEMPLATE/new-collaborator.yml
@@ -43,8 +43,8 @@ body:
       label: Collaborator email address
       description: Can you provide a valid email address for the new external collaborator?
       options:
-        - Yes
-        - No
+        - "Yes"
+        - "No"
     validations:
       required: true
   - type: input
@@ -94,8 +94,8 @@ body:
       label: Additional repository access
       description: Does this collaborator need `push` permissions for the following repositories?
       options:
-        - modernisation-platform-environments
-        - modernisation-platform-ami-builds
+        - "modernisation-platform-environments"
+        - "modernisation-platform-ami-builds"
     validations:
       required: false
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/new-collaborator.yml
+++ b/.github/ISSUE_TEMPLATE/new-collaborator.yml
@@ -1,0 +1,119 @@
+name: New Collaborator
+description: Add a Modernisation Platform collaborator.
+title: "New collaborator: "
+labels: ["collaborator"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please complete this issue to facilitate adding a new external collaborator.
+  - type: markdown
+    attributes:
+      value: "## Requestor details"
+  - type: input
+    id: requestor-name
+    attributes:
+      label: Requestor name
+      description: The full name of the person making this request.
+      placeholder: e.g., Bilbo Baggins
+    validations:
+      required: true
+  - type: input
+    id: requestor-slack
+    attributes:
+      label: Requestor Slack handle
+      description: The Slack handle of the person making this request.
+      placeholder: e.g., @bilbo-baggins
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: "## Collaborator details"
+  - type: input
+    id: collaborator-name
+    attributes:
+      label: Collaborator name
+      description: The full name of the new external collaborator.
+      placeholder: e.g., Frodo Baggins
+    validations:
+      required: true
+  - type: dropdown
+    id: collaborator-email
+    attributes:
+      label: Collaborator email address
+      description: Can you provide a valid email address for the new external collaborator?
+      options:
+        - Yes
+        - No
+    validations:
+      required: true
+  - type: input
+    id: collaborator-github
+    attributes:
+      label: Collaborator GitHub username
+      description: The GitHub username of the new external collaborator.
+      placeholder: e.g., Ffffrodo
+    validations:
+      required: true
+  - type: input
+    id: collaborator-application
+    attributes:
+      label: Collaborator requested application
+      description: The name of the Modernisation Platform application that new external collaborator requires access to.
+      placeholder: e.g., `rivendell`
+    validations:
+      required: true
+  - type: textarea
+    id: collaborator-account-access
+    attributes:
+      label: Collaborator required accounts and access levels
+      description: Which application accounts and access levels does the new external collaborator require?
+      placeholder: |
+        ```
+        {
+          "account-name": "rivendell-development",
+          "access": "ring-bearer"
+        },
+        ```
+      value: |        
+        ```
+        {
+          "account-name": "$account-$environment",
+          "access": "read-only"
+        },
+        ```
+      render: json
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: "## Additional information"
+  - type: dropdown
+    id: additional-repositories
+    attributes:
+      label: Additional repository access
+      description: Does this collaborator need `push` permissions for the following repositories?
+      options:
+        - `modernisation-platform-environments`
+        - `modernisation-platform-ami-builds`
+    validations:
+      required: false
+  - type: dropdown
+    id: additional-approve-deployments
+    attributes:
+      label: Additional deployment approval access
+      description: Does this collaborator need the ability to approve deployments through GitHub Actions?
+      options:
+        - Yes
+        - No
+    validations:
+      required: false
+  - type: textarea
+    id: additional-information
+    attributes:
+      label: Additional information
+      description: Add any supporting information which relates to your request here.
+      placeholder: " "
+      render: markdown
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/new-collaborator.yml
+++ b/.github/ISSUE_TEMPLATE/new-collaborator.yml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Please complete this issue to facilitate adding a new external collaborator.
+        Please complete this template to facilitate adding a new external collaborator.
   - type: markdown
     attributes:
       value: "## Requestor details"
@@ -88,16 +88,14 @@ body:
   - type: markdown
     attributes:
       value: "## Additional information"
-  - type: dropdown
+  - type: markdown
     id: additional-repositories
     attributes:
       label: Additional repository access
       description: Does this collaborator need `push` permissions for the following repositories?
-      options:
-        - "modernisation-platform-environments"
-        - "modernisation-platform-ami-builds"
-    validations:
-      required: false
+      value: |
+        - [ ] "modernisation-platform-environments"
+        - [ ] "modernisation-platform-ami-builds"
   - type: dropdown
     id: additional-approve-deployments
     attributes:

--- a/.github/ISSUE_TEMPLATE/new-collaborator.yml
+++ b/.github/ISSUE_TEMPLATE/new-collaborator.yml
@@ -89,11 +89,9 @@ body:
     attributes:
       value: "## Additional information"
   - type: markdown
-    id: additional-repositories
     attributes:
-      label: Additional repository access
-      description: Does this collaborator need `push` permissions for the following repositories?
       value: |
+        Does this collaborator need `push` permissions for the following repositories?
         - [ ] "modernisation-platform-environments"
         - [ ] "modernisation-platform-ami-builds"
   - type: dropdown


### PR DESCRIPTION
## A reference to the issue / Description of it

#7507

## How does this PR fix the problem?

Adds a standard template for requesting external collaborators

## How has this been tested?

Confirmed that this renders through the GitHub webpage [here](https://github.com/ministryofjustice/modernisation-platform/blob/feature/7507-collaborators/.github/ISSUE_TEMPLATE/new-collaborator.yml).

## Deployment Plan / Instructions

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

I will update the documentation once this PR is complete