### PR TITLE
♻️  Pin observability_platform_tenant version to commit hash

### DIFF
--- a/terraform/environments/core-network-services/observability.tf
+++ b/terraform/environments/core-network-services/observability.tf
@@ -1,9 +1,6 @@
 module "observability_platform_tenant" {
-  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
-  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
-  source  = "ministryofjustice/observability-platform-tenant/aws"
-  version = "1.2.0"
+  source = "github.com/ministryofjustice/terraform-aws-observability-platform-tenant?ref=fbbe5c8282786bcc0a00c969fe598e14f12eea9b" # v1.2.0
 
   observability_platform_account_id = local.environment_management.account_ids["observability-platform-production"]
 


### PR DESCRIPTION
Refactor the observability_platform_tenant module to use the commit hash rather than version, removing the need for the checkov skips. 