### PR TITLE
added link to issues page to adding-collaborators docs page

### DIFF
--- a/source/runbooks/adding-collaborators.html.md.erb
+++ b/source/runbooks/adding-collaborators.html.md.erb
@@ -25,6 +25,8 @@ To enable collaborators to use the Modernisation Platform we need to give them t
 - Access to the relevant AWS accounts
 - Access to be able to approve deployments (if needed)
 
+You can request that a collaborator be added through the [New Collaborator](https://github.com/ministryofjustice/modernisation-platform/issues/new/choose) issue template.
+
 ## Access to our GitHub repositories
 
 In order to create infrastructure, collaborators will need to have `push` permissions to the following repositories:


### PR DESCRIPTION
## A reference to the issue / Description of it

#7507

## How does this PR fix the problem?

Points people reading our docs at the template to add a new collaborator.

## How has this been tested?

Checked that the link was correct

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
