### PR TITLE
Adding LakeFormation Actions that Queries Permissions Assigned to User

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -415,6 +415,7 @@ data "aws_iam_policy_document" "data_engineering_additional" {
       "lakeformation:ListLakeFormationOptIns",
       "lakeformation:CreateLakeFormationOptIn",
       "lakeformation:DeleteLakeFormationOptIn",
+      "lakeformation:lakeformation:GetDataAccess",
       "states:Describe*",
       "states:List*",
       "states:Stop*",


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/analytical-platform/issues/4461

Users need a way to check their LakeFormation permissions in order to query Athena

## How does this PR fix the problem?

Adds the iam action that allows looking up the right permissions in LakeFormation
ref: https://docs.aws.amazon.com/lake-formation/latest/dg/access-control-underlying-data.html

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Tested post-apply

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

This should not impact operational services.

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [ ] All checks have passed
- [X] I have made corresponding changes to the documentation
- [X] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
