### PR TITLE
Add lambda UpdateFunctionCode permission to OIDC role

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -486,6 +486,7 @@ data "aws_iam_policy_document" "policy" {
       "kms:Encrypt",
       "kms:GenerateDataKey",
       "kms:CreateGrant",
+      "lambda:UpdateFunctionCode",
       "logs:CreateLogGroup",
       "logs:DescribeLogGroups",
       "logs:DescribeResourcePolicies",


### PR DESCRIPTION
Following on from request / issue in raised in the [ask-channel](https://mojdt.slack.com/archives/C01A7QK5VM1/p1721921991134449?thread_ts=1720087038.002219&cid=C01A7QK5VM1) this PR adds the `lambda:UpdateFunctionCode` to the OIDC role.