### PR TITLE
Enhance Permissions for unit testing Cloudtrail and S3 Bucket deletion

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -199,7 +199,30 @@ data "aws_iam_policy_document" "member-access" {
     ]
     resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
   }
-
+  statement {
+    effect    = "Allow"
+    actions   = ["cloudtrail:DeleteTrail"]
+    resources = ["arn:aws:cloudtrail:*:*:trail/cloudtrail-test*"]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalAccount"
+      values = [
+        local.environment_management.account_ids["testing-test"]
+      ]
+    }
+  }
+  statement {
+    effect    = "Allow"
+    actions   = ["s3:DeleteObject"]
+    resources = ["arn:aws:s3:::cloudtrail-test*/*"]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalAccount"
+      values = [
+        local.environment_management.account_ids["testing-test"]
+      ]
+    }
+  }
   statement {
     effect = "Deny"
     actions = [


### PR DESCRIPTION
## A reference to the issue / Description of it

This PR adds necessary permissions to allow the unit test environment to successfully delete cloudtrail logs and S3 bucket. Without these permissions, unit tests are failing due to insufficient access

The added permissions are scoped to specially allow deletion of Cloudtrail logs and S3 Objects with a specific prefix and only on testing-test account. #7307 

## How does this PR fix the problem?

By granting required permissions, this PR enables the unit test environment to perform the necessary cleanup actions, ensuring test reliability. This address the current issue where unit tests are failing due to missing permissions.

## How has this been tested?

Testing these permission while testing unit test on testing test account

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
