### PR TITLE
Fix broken internal link by updating hash from `github-team-slug` to `sso-group-name`

### DIFF
--- a/source/runbooks/adding-collaborators.html.md.erb
+++ b/source/runbooks/adding-collaborators.html.md.erb
@@ -17,7 +17,7 @@ review_in: 6 month
 # <%= current_page.data.title %>
 
 Collaborators are defined as GitHub users which are not part of the `ministryofjustice` GitHub organisation.
-Users who are part of the organisation are added to the platform by joining a [GitHub team](../user-guide/creating-environments.html#github-team-slug).
+Users who are part of the organisation are added to the platform by joining a [GitHub team](../user-guide/creating-environments.html#sso-group-name).
 
 To enable collaborators to use the Modernisation Platform we need to give them the following access:
 

--- a/source/user-guide/accessing-the-aws-console.html.md.erb
+++ b/source/user-guide/accessing-the-aws-console.html.md.erb
@@ -18,7 +18,7 @@ review_in: 6 months
 
 You can view your infrastructure via the AWS console, you will also need access to the AWS console to create and configure your [AWS Credentials (access keys)](getting-aws-credentials.html)
 
-To have access to your infrastructure you will need to be a member of the GitHub team specified when the [environment was created](./creating-environments.html#github-team-slug)
+To have access to your infrastructure you will need to be a member of the GitHub team specified when the [environment was created](./creating-environments.html#sso-group-name)
 
 ## Logging in
 

--- a/source/user-guide/getting-aws-credentials.html.md.erb
+++ b/source/user-guide/getting-aws-credentials.html.md.erb
@@ -20,7 +20,7 @@ _NB. This page is relevant to Ministry of Justice employees. External collaborat
 
 You can obtain temporary AWS credentials to use the AWS CLI or other command line tools.
 
-To have access to your AWS credentials you will need to be a member of the GitHub team specified when the [environment was created](./creating-environments.html#github-team-slug)
+To have access to your AWS credentials you will need to be a member of the GitHub team specified when the [environment was created](./creating-environments.html#sso-group-name)
 
 Note - you do not need to obtain AWS credentials to deploy infrastructure, this is done via GitHub Workflows (see [deploying your infrastructure](deploying-your-infrastructure.html)).
 


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/actions/runs/10261428738/job/28389157737

## How does this PR fix the problem?

This PR fixes the problem by correcting the internal link in the documentation. The original link pointed to a hash (`github-team-slug`) that did not exist, causing an error. By updating the hash to `sso-group-name`, which exists, the link now correctly points to the intended section, resolving the error.


## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
