### PR TITLE
Update scripts to use TF_ENV for environment removal from account names

### DIFF
--- a/.github/workflows/core-vpc-development-deployment.yml
+++ b/.github/workflows/core-vpc-development-deployment.yml
@@ -53,6 +53,7 @@ defaults:
 env:
   AWS_REGION: "eu-west-2"
   ENVIRONMENT_MANAGEMENT: ${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENTS }}
+  TF_ENV: "development"
 jobs:
   core-vpc-development-deployment-plan-apply:
     uses: ./.github/workflows/reusable_terraform_plan_apply.yml

--- a/.github/workflows/core-vpc-preproduction-deployment.yml
+++ b/.github/workflows/core-vpc-preproduction-deployment.yml
@@ -45,7 +45,7 @@ on:
 env:
   AWS_REGION: "eu-west-2"
   ENVIRONMENT_MANAGEMENT: ${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENTS }}
-  
+  TF_ENV: "preproduction"
 permissions:
   id-token: write # This is required for requesting the JWT
   contents: read # This is required for actions/checkout

--- a/.github/workflows/core-vpc-production-deployment.yml
+++ b/.github/workflows/core-vpc-production-deployment.yml
@@ -53,7 +53,7 @@ defaults:
 env:
   AWS_REGION: "eu-west-2"
   ENVIRONMENT_MANAGEMENT: ${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENTS }}
-
+  TF_ENV: "production"
 jobs:
   core-vpc-production-deployment-plan-apply:
     uses: ./.github/workflows/reusable_terraform_plan_apply.yml

--- a/.github/workflows/core-vpc-test-deployment.yml
+++ b/.github/workflows/core-vpc-test-deployment.yml
@@ -51,7 +51,7 @@ defaults:
 env:
   AWS_REGION: "eu-west-2"
   ENVIRONMENT_MANAGEMENT: ${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENTS }}
-
+  TF_ENV: "test"
 jobs:
   core-vpc-test-deployment-plan-apply:
     uses: ./.github/workflows/reusable_terraform_plan_apply.yml

--- a/scripts/get-applications-and-run-ram.sh
+++ b/scripts/get-applications-and-run-ram.sh
@@ -9,7 +9,7 @@ echo "[+] environments-networks accounts to run RAM share on: ${accounts}"
 
 if [ ! -z "${accounts}" ]; then
   for account in ${accounts}; do
-    application=`echo ${account} | sed -e "s/-${TF_ENV}\$//g"`
+    application="${account%-${environment}}"
     echo "[+] *********************************************"
     echo "[+] Starting up RAM association for account ${account} of application ${application}"
     networking_file="./terraform/environments/${application}/networking.auto.tfvars.json"

--- a/scripts/get-applications-and-run-ram.sh
+++ b/scripts/get-applications-and-run-ram.sh
@@ -9,7 +9,7 @@ echo "[+] environments-networks accounts to run RAM share on: ${accounts}"
 
 if [ ! -z "${accounts}" ]; then
   for account in ${accounts}; do
-    application=`echo ${account} | sed -e "s/-${environment}//g"`
+    application=`echo ${account} | sed -e "s/-${TF_ENV}\$//g"`
     echo "[+] *********************************************"
     echo "[+] Starting up RAM association for account ${account} of application ${application}"
     networking_file="./terraform/environments/${application}/networking.auto.tfvars.json"


### PR DESCRIPTION
## A reference to the issue / Description of it

#7580 

## Changes Made

- Added `TF_ENV` variable to all core workflows.
- Updated the script to remove the environment suffix from the account name using the `TF_ENV` variable.
- Ensured proper handling of potential trailing newlines or spaces in the `TF_ENV` variable to avoid mismatches.

## How does this PR fix the problem?

Previously, the script failed to remove the environment suffix correctly due to potential hidden characters or mismatches in the environment variable. This inconsistency could lead to errors in account identification and subsequent operations. By introducing `TF_ENV` and sanitizing its input, we ensure the correct suffix removal and improve the reliability of our workflows.


## How has this been tested?

Tested the script locally

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
