### PR TITLE
EM: Add permissions to pull from ECR for different accounts

### DIFF
--- a/terraform/environments/core-shared-services/ecr_repos.tf
+++ b/terraform/environments/core-shared-services/ecr_repos.tf
@@ -1234,7 +1234,13 @@ module "create_a_data_task_ecr_repo" {
 
   pull_principals = [
     local.environment_management.account_ids["electronic-monitoring-data-development"],
-    local.environment_management.account_ids["analytical-platform-data-engineering-sandboxa"]
+    local.environment_management.account_ids["analytical-platform-data-engineering-sandboxa"],
+    local.environment_management.account_ids["electronic-monitoring-data-production"]
+  ]
+  
+  enable_retrieval_policy_for_lambdas = [
+    "arn:aws:lambda:eu-west-2:${local.environment_management.account_ids["electronic-monitoring-data-development"]}:function:*",
+    "arn:aws:lambda:eu-west-2:${local.environment_management.account_ids["electronic-monitoring-data-production"]}:function:*"
   ]
 
   # Tags


### PR DESCRIPTION
## A reference to the issue / Description of it

After some testing of pushing to the shared services create-a-data-task repo, we want to use some of the images in dev and prod for EM.

## How does this PR fix the problem?

Adds the lambda retrieval perms for lambdas in EM prod and dev, and gives pull perms to prod

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

n/a

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

no

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

