### PR TITLE
Add LDAP CLI repo to delius-core oidc repos

### DIFF
--- a/environments/delius-core.json
+++ b/environments/delius-core.json
@@ -98,6 +98,7 @@
   },
   "github-oidc-team-repositories": [
     "ministryofjustice/hmpps-delius-operational-automation",
+    "ministryofjustice/hmpps-ldap-automation-cli",
     "ministryofjustice/hmpps-openldap-container",
     "ministryofjustice/hmpps-delius-docker-images",
     "ministryofjustice/hmpps-pwm",


### PR DESCRIPTION
Adds the `ministryofjustice/hmpps-ldap-automation-cli` repo to the `delius-core` environment OIDC list. 