### PR TITLE
Issue/17 - Sets require_signed_commits = true for all MP managed repos except modernisation-platform-environments.

### DIFF
--- a/terraform/github/modules/repository/main.tf
+++ b/terraform/github/modules/repository/main.tf
@@ -59,7 +59,7 @@ resource "github_branch_protection" "default" {
   pattern        = "main"
   enforce_admins = true
   #tfsec:ignore:github-branch_protections-require_signed_commits
-  require_signed_commits = false
+  require_signed_commits = var.name == "modernisation-platform-environments" ? false : true
 
   required_status_checks {
     strict   = false


### PR DESCRIPTION
Enforces signed commits for all MP managed repositories except modernisation-platform-environments.

## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform-security/issues/17

## How does this PR fix the problem?

Sets the require_signed_commits field to true for all modules except modernisation-platform-environments.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
