### PR TITLE
OIDC Role - Increase Max Session Duration from 1 to 2 hours

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -399,7 +399,7 @@ resource "aws_iam_policy" "member-access-us-east" {
 # Github OIDC role
 module "github_oidc_role" {
   count                = length(compact(jsondecode(data.http.environments_file.response_body).github-oidc-team-repositories)) > 0 ? 1 : 0
-  source               = "github.com/ministryofjustice/modernisation-platform-github-oidc-role?ref=c3bde7c787038ff5536bfb1b73781072edbb74da" # v3.0.0
+  source               = "github.com/ministryofjustice/modernisation-platform-github-oidc-role?ref=62b8a16c73d8e4422cd81923e46948e8f4b5cf48" # v3.2.0
   github_repositories  = jsondecode(data.http.environments_file.response_body).github-oidc-team-repositories
   max_session_duration = 7200
   role_name            = "modernisation-platform-oidc-cicd"

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -401,7 +401,7 @@ module "github_oidc_role" {
   count                = length(compact(jsondecode(data.http.environments_file.response_body).github-oidc-team-repositories)) > 0 ? 1 : 0
   source               = "github.com/ministryofjustice/modernisation-platform-github-oidc-role?ref=c3bde7c787038ff5536bfb1b73781072edbb74da" # v3.0.0
   github_repositories  = jsondecode(data.http.environments_file.response_body).github-oidc-team-repositories
-  max_session_duration = "7200"
+  max_session_duration = 7200
   role_name            = "modernisation-platform-oidc-cicd"
   policy_jsons         = [data.aws_iam_policy_document.policy.json]
   tags                 = local.tags

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -401,9 +401,9 @@ module "github_oidc_role" {
   count                = length(compact(jsondecode(data.http.environments_file.response_body).github-oidc-team-repositories)) > 0 ? 1 : 0
   source               = "github.com/ministryofjustice/modernisation-platform-github-oidc-role?ref=c3bde7c787038ff5536bfb1b73781072edbb74da" # v3.0.0
   github_repositories  = jsondecode(data.http.environments_file.response_body).github-oidc-team-repositories
+  max_session_duration = "7200"
   role_name            = "modernisation-platform-oidc-cicd"
   policy_jsons         = [data.aws_iam_policy_document.policy.json]
-  max_session_duration = 7200
   tags                 = local.tags
 }
 

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -398,12 +398,13 @@ resource "aws_iam_policy" "member-access-us-east" {
 
 # Github OIDC role
 module "github_oidc_role" {
-  count               = length(compact(jsondecode(data.http.environments_file.response_body).github-oidc-team-repositories)) > 0 ? 1 : 0
-  source              = "github.com/ministryofjustice/modernisation-platform-github-oidc-role?ref=c3bde7c787038ff5536bfb1b73781072edbb74da" # v3.0.0
-  github_repositories = jsondecode(data.http.environments_file.response_body).github-oidc-team-repositories
-  role_name           = "modernisation-platform-oidc-cicd"
-  policy_jsons        = [data.aws_iam_policy_document.policy.json]
-  tags                = local.tags
+  count                = length(compact(jsondecode(data.http.environments_file.response_body).github-oidc-team-repositories)) > 0 ? 1 : 0
+  source               = "github.com/ministryofjustice/modernisation-platform-github-oidc-role?ref=c3bde7c787038ff5536bfb1b73781072edbb74da" # v3.0.0
+  github_repositories  = jsondecode(data.http.environments_file.response_body).github-oidc-team-repositories
+  role_name            = "modernisation-platform-oidc-cicd"
+  policy_jsons         = [data.aws_iam_policy_document.policy.json]
+  max_session_duration = 7200
+  tags                 = local.tags
 }
 
 #tfsec:ignore:aws-iam-no-policy-wildcards


### PR DESCRIPTION
## A reference to the issue / Description of it

Issue raised in the ask-channel due to OIDC role time outs in for GitHub Actions :  https://mojdt.slack.com/archives/C01A7QK5VM1/p1723642741120779

## How does this PR fix the problem?

This PR sets the `max_sessions_duration` to 2 hours (7200 seconds) from the default 1 hour (3600 seconds)

## How has this been tested?

un-tested at present but will apply to sprinkler

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No impact expected. 

## Checklist (check `x` in `[ ]` of list items)

- [ X ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
