### PR TITLE
Update baselines module to v7.6.3

### DIFF
--- a/terraform/environments/bootstrap/secure-baselines/main.tf
+++ b/terraform/environments/bootstrap/secure-baselines/main.tf
@@ -6,7 +6,7 @@ data "aws_kms_key" "cloudtrail_key" {
 
 #trivy:ignore:AVD-AWS-0136
 module "baselines" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=69767e7878f7393eb95a54f9e532064457b7976a" # v7.6.2
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=47f42fd469a17e749814acafb4bc2e59396881b6" # v7.6.3
 
   providers = {
     # Default and replication regions

--- a/terraform/modernisation-platform-account/baselines.tf
+++ b/terraform/modernisation-platform-account/baselines.tf
@@ -18,7 +18,7 @@ locals {
 # Secure baselines (GuardDuty, Config, SecurityHub, etc)
 #trivy:ignore:AVD-AWS-0136 trivy:ignore:AVD-AWS-0132
 module "baselines-modernisation-platform" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=69767e7878f7393eb95a54f9e532064457b7976a" # v7.6.2
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=47f42fd469a17e749814acafb4bc2e59396881b6" # v7.6.3
   providers = {
     # Default and replication regions
     aws                    = aws.modernisation-platform-eu-west-2


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/7309 - adding `securityhub-alarms` unit tests

## How does this PR fix the problem?

Updates baseline to latest tag v7.6.3 

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

tested locally and in sprinkler as per workflows below. Zero changes to infrastructure as expected.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [X] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
