### PR TITLE
Fix terraform for `core-logging` bucket

### DIFF
--- a/terraform/environments/core-logging/cortex.tf
+++ b/terraform/environments/core-logging/cortex.tf
@@ -77,11 +77,6 @@ resource "aws_s3_bucket" "logging" {
   tags          = local.tags
 }
 
-resource "aws_s3_bucket_acl" "bucket_acl" {
-  bucket = aws_s3_bucket.logging.id
-  acl    = "private"
-}
-
 resource "aws_s3_bucket_lifecycle_configuration" "example" {
   bucket = aws_s3_bucket.logging.id
 


### PR DESCRIPTION
## A reference to the issue / Description of it

With an `s3_bucket_acl` resource the following error is triggered:

```
Error: creating S3 Bucket (core-logging-production20240819072032900200000003) ACL: operation error S3: PutBucketAcl, https response error StatusCode: 400, RequestID: 4MFM3A6M2JQS4W01, HostID: 1Kz5QOCX4wNzxBqnSkBn8iaTS0w/DxfbOaVnT1yfoCpefKI6KZoAOgRr6lXVv5xOsbgJ3FM7XwU=, api error AccessControlListNotSupported: The bucket does not allow ACLs
```

## How does this PR fix the problem?

Removes the `s3_bucket_acl` resource.

## How has this been tested?

Ran a local plan

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
