### PR TITLE
New hosted zone for migration of legacy decisions.tribunals.gov.uk sites

### DIFF
--- a/terraform/environments/core-network-services/route53.tf
+++ b/terraform/environments/core-network-services/route53.tf
@@ -14,6 +14,7 @@ locals {
     ncas          = "neutral-citation-allocation.service.justice.gov.uk",
     pra-register  = "parental-responsibility-agreement.service.justice.gov.uk",
     tipstaff      = "tipstaff.service.justice.gov.uk",
+    tribunals     = "tribunals.gov.uk",
     wardship      = "wardship-agreements-register.service.justice.gov.uk"
   }
 


### PR DESCRIPTION
## A reference to the issue / Description of it

(https://tools.hmcts.net/jira/browse/RST-6829)

## How does this PR fix the problem?

Need to delegate the DNS records for the Legacy Tribunals Decisions websites in advance of the final migration to Modernisation Platform

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

This process has been followed for previous DNS migrations to the Cloud Platform.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

Existing DNS records saved in spreadsheet attached to above Jira ticket

## Checklist (check `x` in `[ ]` of list items)

- [y] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [y] Plan and discussed how it should be deployed to PROD

initially discussed with David Elliot (see email attached to Jira ticket)

## Additional comments (if any)

This PR should only create the new NS records for tribunals.gov.uk in the Modernisation Platform.
I need to discuss how the existing DNS records in the DSD account are created in the Modernisation Platform so that the NS in DSD can be delegated to this new NS.
