### PR TITLE
DSOS-2919: build azure.noms.root RD Licensing server

### DIFF
--- a/terraform/environments/core-shared-services/ad-fixngo.tf
+++ b/terraform/environments/core-shared-services/ad-fixngo.tf
@@ -113,22 +113,22 @@ locals {
           Patching    = "ad-nonlive-eu-west-2b"
         }
       }
-      # ad-azure-rdlic = {
-      #   ami_name                  = "hmpps_windows_server_2022_release_2024-02-02T00-00-04.569Z"
-      #   availability_zone         = "eu-west-2c"
-      #   iam_instance_profile_role = "ad-fixngo-ec2-nonlive-role"
-      #   instance_type             = "t3.medium"
-      #   key_name                  = "ad-fixngo-ec2-nonlive"
-      #   private_ip                = module.ad_fixngo_ip_addresses.mp_ip["ad-azure-rdlic"]
-      #   subnet_id                 = module.vpc["non_live_data"].non_tgw_subnet_ids_map.private[2]
-      #   vpc_security_group_name   = "ad_azure_rdlic_sg"
-      #   tags = {
-      #     server-type = "RDLicensing"
-      #     domain-name = "azure.noms.root"
-      #     description = "remote desktop licensing server for FixNGo azure.noms.root domain"
-      #     Patching    = "rdlic-nonlive-eu-west-2c"
-      #   }
-      # }
+      ad-azure-rdlic = {
+        ami_name                  = "hmpps_windows_server_2022_release_2024-08-02T00-00-40.717Z"
+        availability_zone         = "eu-west-2c"
+        iam_instance_profile_role = "ad-fixngo-ec2-nonlive-role"
+        instance_type             = "t3.medium"
+        key_name                  = "ad-fixngo-ec2-nonlive"
+        private_ip                = module.ad_fixngo_ip_addresses.mp_ip["ad-azure-rdlic"]
+        subnet_id                 = module.vpc["non_live_data"].non_tgw_subnet_ids_map.private[2]
+        vpc_security_group_name   = "ad_azure_rdlic_sg"
+        tags = {
+          server-type = "RDLicensing"
+          domain-name = "azure.noms.root"
+          description = "remote desktop licensing server for FixNGo azure.noms.root domain"
+          Patching    = "rdlic-nonlive-eu-west-2c"
+        }
+      }
     }
 
     ec2_iam_roles = {


### PR DESCRIPTION
## A reference to the issue / Description of it

Cannot complete migration of Azure FixNGo estate without migrating Remote Desktop Licensing server.

## How does this PR fix the problem?

Builds a new 2022 licensing server (Azure is 2012) co-located with the Domain Controllers. Needs to be alongside DCs as the licenses are shared across the domain. This PR is for DevTest (azure.noms.root), a subsequent PR will build a licensing server for prod (azure.hmpp.root) if all goes well.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Powershell code for configuring the server has been tested in member account (hmpps-domain-services)

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
