### PR TITLE
Migrate Tag Protection from `github_repository_tag_protection` to `github_repository_ruleset`

### DIFF
--- a/terraform/github/modules/repository/main.tf
+++ b/terraform/github/modules/repository/main.tf
@@ -76,9 +76,43 @@ resource "github_branch_protection" "default" {
   }
 }
 
-resource "github_repository_tag_protection" "default" {
-  repository = github_repository.default.id
-  pattern    = "*"
+resource "github_repository_ruleset" "default" {
+  repository  = github_repository.default.id
+  name        = "Tag Protection Ruleset"
+  enforcement = "active"
+  target      = "tag"
+
+  conditions {
+    ref_name {
+      include = ["~ALL"]
+      exclude = []
+    }
+  }
+
+  bypass_actors {
+    actor_id    = 1
+    actor_type  = "OrganizationAdmin"
+    bypass_mode = "always"
+  }
+
+  bypass_actors {
+    actor_id    = 2
+    actor_type  = "RepositoryRole"
+    bypass_mode = "always"
+  }
+
+  bypass_actors {
+    actor_id    = 5
+    actor_type  = "RepositoryRole"
+    bypass_mode = "always"
+  }
+
+  rules {
+    creation            = true
+    update              = true
+    deletion            = true
+    required_signatures = true
+  }
 }
 
 # Secrets


### PR DESCRIPTION
## A reference to the issue / Description of it

#7687 

## How does this PR fix the problem?

The migration to `github_repository_ruleset` addresses the deprecation of `github_repository_tag_protection` and ensures that tag protection is applied in accordance with GitHub’s updated standards. This change is necessary to maintain tag protection functionality in our repositories.

## How has this been tested?

This change has been tested on the `modernisation-platform` repository. The updated module was applied successfully, and tag protection rules were verified to ensure they were correctly implemented as specified. No issues were encountered during testing.

Will this deployment impact the platform and / or services on it?

NO

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)