### PR TITLE
update secure baselines version to the latest

### DIFF
--- a/terraform/environments/bootstrap/secure-baselines/main.tf
+++ b/terraform/environments/bootstrap/secure-baselines/main.tf
@@ -6,7 +6,7 @@ data "aws_kms_key" "cloudtrail_key" {
 
 #trivy:ignore:AVD-AWS-0136
 module "baselines" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=47f42fd469a17e749814acafb4bc2e59396881b6" # v7.6.3
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=672806679936c8e5da29234fe6f23411f8b45eba" # v7.6.3
 
   providers = {
     # Default and replication regions

--- a/terraform/environments/bootstrap/secure-baselines/main.tf
+++ b/terraform/environments/bootstrap/secure-baselines/main.tf
@@ -6,7 +6,7 @@ data "aws_kms_key" "cloudtrail_key" {
 
 #trivy:ignore:AVD-AWS-0136
 module "baselines" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=672806679936c8e5da29234fe6f23411f8b45eba" # v7.6.3
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=672806679936c8e5da29234fe6f23411f8b45eba" # v7.6.4
 
   providers = {
     # Default and replication regions

--- a/terraform/modernisation-platform-account/baselines.tf
+++ b/terraform/modernisation-platform-account/baselines.tf
@@ -18,7 +18,7 @@ locals {
 # Secure baselines (GuardDuty, Config, SecurityHub, etc)
 #trivy:ignore:AVD-AWS-0136 trivy:ignore:AVD-AWS-0132
 module "baselines-modernisation-platform" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=672806679936c8e5da29234fe6f23411f8b45eba" # v7.6.3
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=672806679936c8e5da29234fe6f23411f8b45eba" # v7.6.4
   providers = {
     # Default and replication regions
     aws                    = aws.modernisation-platform-eu-west-2

--- a/terraform/modernisation-platform-account/baselines.tf
+++ b/terraform/modernisation-platform-account/baselines.tf
@@ -18,7 +18,7 @@ locals {
 # Secure baselines (GuardDuty, Config, SecurityHub, etc)
 #trivy:ignore:AVD-AWS-0136 trivy:ignore:AVD-AWS-0132
 module "baselines-modernisation-platform" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=47f42fd469a17e749814acafb4bc2e59396881b6" # v7.6.3
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=672806679936c8e5da29234fe6f23411f8b45eba" # v7.6.3
   providers = {
     # Default and replication regions
     aws                    = aws.modernisation-platform-eu-west-2


### PR DESCRIPTION
## A reference to the issue / Description of it

As part of [New Cloud watch alarms](https://github.com/ministryofjustice/modernisation-platform/issues/7450)
#7450

i have done a new release for the secure baselines that removes the NAT alarms. as these are no longer required for the moment

## How does this PR fix the problem?

update to new release

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

tested in sprinkler

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
