### PR TITLE
Fix variable shadowing in utilities.rego to resolve Regal linting error

### DIFF
--- a/policies/collaborators/utilities.rego
+++ b/policies/collaborators/utilities.rego
@@ -2,7 +2,7 @@ package main
 
 import rego.v1
 
-has_field(object, field) if {
-	object[field]
-	object[field] != ""
+has_field(obj, field) if {
+	obj[field]
+	obj[field] != ""
 }

--- a/policies/environments/utilities.rego
+++ b/policies/environments/utilities.rego
@@ -2,7 +2,7 @@ package main
 
 import rego.v1
 
-has_field(object, field) if {
-	object[field]
-	object[field] != ""
+has_field(obj, field) if {
+	obj[field]
+	obj[field] != ""
 }

--- a/policies/member/utilities.rego
+++ b/policies/member/utilities.rego
@@ -2,7 +2,7 @@ package main
 
 import rego.v1
 
-has_field(object, field) if {
-	object[field]
-	object[field] != ""
+has_field(obj, field) if {
+	obj[field]
+	obj[field] != ""
 }

--- a/policies/networking/utilities.rego
+++ b/policies/networking/utilities.rego
@@ -2,7 +2,7 @@ package main
 
 import rego.v1
 
-has_field(object, field) if {
-	object[field]
-	object[field] != ""
+has_field(obj, field) if {
+	obj[field]
+	obj[field] != ""
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

The issue was related to a regal lint error in the utilities.rego file where the variable object was used, which conflicts with a built-in function in Rego. This shadowing of a built-in function caused linting issues, potentially leading to unexpected behavior in policy evaluation. The issue required renaming the variable to avoid conflict with the built-in object function in Rego. #7670 

https://github.com/ministryofjustice/modernisation-platform/actions/runs/10474087493/job/29007520608#step:5:37

## How does this PR fix the problem?

This PR fixes the issue where the variable name object was shadowing a built-in function in Rego. The object variable has been renamed to obj to avoid conflicts with the built-in object function, thereby resolving the var-shadows-builtin linting error reported by regal lint.

## How has this been tested?

This change was tested by running the `regal lint --format=github policies` command locally after the update. No errors were reported, confirming that the variable shadowing issue has been resolved.

Will this deployment impact the platform and / or services on it?

NO

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)