### PR TITLE
DSOS-2919: correct RD Licensing server prod subnet

### DIFF
--- a/terraform/environments/core-shared-services/ad-fixngo.tf
+++ b/terraform/environments/core-shared-services/ad-fixngo.tf
@@ -39,7 +39,7 @@ locals {
       #   instance_type             = "t3.large"
       #   key_name                  = "ad-fixngo-ec2-live"
       #   private_ip                = module.ad_fixngo_ip_addresses.mp_ip["ad-hmpp-dc-a"]
-      #   subnet_id                 = aws_subnet.live-data-additional["eu-west-2a"].id
+      #   subnet_id                 = module.vpc["live_data"].non_tgw_subnet_ids_map.private[0]
       #   vpc_security_group_name   = "ad_hmpp_dc_sg"
       #   tags = {
       #     server-type = "DomainController"
@@ -55,7 +55,7 @@ locals {
       #   instance_type             = "t3.large"
       #   key_name                  = "ad-fixngo-ec2-live"
       #   private_ip                = module.ad_fixngo_ip_addresses.mp_ip["ad-hmpp-dc-b"]
-      #   subnet_id                 = aws_subnet.live-data-additional["eu-west-2b"].id
+      #   subnet_id                 = module.vpc["live_data"].non_tgw_subnet_ids_map.private[1]
       #   vpc_security_group_name   = "ad_hmpp_dc_sg"
       #   tags = {
       #     server-type = "DomainController"
@@ -71,7 +71,7 @@ locals {
         instance_type             = "t3.medium"
         key_name                  = "ad-fixngo-ec2-live"
         private_ip                = module.ad_fixngo_ip_addresses.mp_ip["ad-hmpp-rdlic"]
-        subnet_id                 = aws_subnet.live-data-additional["eu-west-2c"].id
+        subnet_id                 = module.vpc["live_data"].non_tgw_subnet_ids_map.private[2]
         vpc_security_group_name   = "ad_hmpp_rdlic_sg"
         tags = {
           server-type = "RDLicensing"


### PR DESCRIPTION
## A reference to the issue / Description of it

New RD licence server cannot connect to Azure DCs

## How does this PR fix the problem?

Puts the RD licence server in the correct subnet.  With a bit of luck it will re-create the EC2 in one pass. If not, I'll comment out and add back in, in two PRs.

## How has this been tested?

Mirrors the devtest configuration which is working.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
