### PR TITLE
Resolve issues with log streaming module

### DIFF
--- a/terraform/environments/core-logging/cortex.tf
+++ b/terraform/environments/core-logging/cortex.tf
@@ -1,23 +1,5 @@
 data "aws_iam_policy_document" "logging-bucket" {
   statement {
-    sid     = "EnforceTLSv12orHigher"
-    effect  = "Deny"
-    actions = ["s3:*"]
-    resources = [
-      aws_s3_bucket.logging.arn,
-      "${aws_s3_bucket.logging.arn}/*"
-    ]
-    principals {
-      identifiers = ["*"]
-      type        = "AWS"
-    }
-    condition {
-      test     = "NumericLessThan"
-      variable = "s3:TlsVersion"
-      values   = [1.2]
-    }
-  }
-  statement {
     sid    = "AllowFirehosePutObject"
     effect = "Allow"
     principals {

--- a/terraform/environments/core-logging/cortex.tf
+++ b/terraform/environments/core-logging/cortex.tf
@@ -1,3 +1,4 @@
+# Because we can't use wildcards beyond "*" in a principal identifier
 data "aws_iam_policy_document" "logging-bucket" {
   statement {
     sid    = "AllowFirehosePutObject"

--- a/terraform/environments/core-logging/cortex.tf
+++ b/terraform/environments/core-logging/cortex.tf
@@ -19,7 +19,14 @@ data "aws_iam_policy_document" "logging-bucket" {
     condition {
       test     = "ForAnyValue:StringLike"
       variable = "aws:PrincipalOrgPaths"
-      values   = ["${data.aws_organizations_organization.root_account.id}/*/${local.environment_management.modernisation_platform_organisation_unit_id}/*"]
+      values = [
+        "${data.aws_organizations_organization.root_account.id}/*/${local.environment_management.modernisation_platform_organisation_unit_id}/*"
+      ]
+    }
+    condition {
+      test     = "ForAnyValue:StringLike"
+      variable = "aws:PrincipalArn"
+      values   = ["arn:aws:iam::*:role/firehose-to-s3*"]
     }
   }
 }

--- a/terraform/environments/core-logging/cortex.tf
+++ b/terraform/environments/core-logging/cortex.tf
@@ -21,16 +21,13 @@ data "aws_iam_policy_document" "logging-bucket" {
     sid    = "AllowFirehosePutObject"
     effect = "Allow"
     principals {
-      type        = "Service"
-      identifiers = ["firehose.amazonaws.com"]
+      type        = "AWS"
+      identifiers = ["*"]
     }
     actions = [
-      "s3:AbortMultipartUpload",
-      "s3:GetBucketLocation",
       "s3:GetObject",
-      "s3:ListBucket",
-      "s3:ListBucketMultipartUploads",
-      "s3:PutObject"
+      "s3:PutObject",
+      "s3:PutObjectAcl"
     ]
     resources = [
       aws_s3_bucket.logging.arn,
@@ -40,11 +37,6 @@ data "aws_iam_policy_document" "logging-bucket" {
       test     = "ForAnyValue:StringLike"
       variable = "aws:PrincipalOrgPaths"
       values   = ["${data.aws_organizations_organization.root_account.id}/*/${local.environment_management.modernisation_platform_organisation_unit_id}/*"]
-    }
-    condition {
-      test     = "ArnLike"
-      variable = "aws:SourceArn"
-      values   = ["arn:aws:firehose:*:*:*"]
     }
   }
 }
@@ -119,7 +111,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "logging" {
 
   rule {
     apply_server_side_encryption_by_default {
-      sse_algorithm = "aws:kms"
+      sse_algorithm = "AES256"
     }
   }
 }

--- a/terraform/environments/core-logging/cortex.tf
+++ b/terraform/environments/core-logging/cortex.tf
@@ -56,6 +56,7 @@ resource "aws_s3_bucket" "logging" {
   #  checkov:skip=CKV_AWS_18: Access logs not presently required
   #  checkov:skip=CKV_AWS_21: Versioning of log objects not required
   #  checkov:skip=CKV_AWS_144:Replication of log objects not required
+  #  checkov:skip=CKV_AWS_145:SSE Encryption OK as interim measure
   bucket_prefix = terraform.workspace
   tags          = local.tags
 }

--- a/terraform/environments/core-logging/cortex.tf
+++ b/terraform/environments/core-logging/cortex.tf
@@ -1,4 +1,5 @@
-# Because we can't use wildcards beyond "*" in a principal identifier
+# Because we can't use wildcards beyond "*" in a principal identifier, we use a policy condition to scope access only
+# to accounts in our OU, where the role matches the name created through the cloudwatch-firehose module
 data "aws_iam_policy_document" "logging-bucket" {
   statement {
     sid    = "AllowFirehosePutObject"

--- a/terraform/modules/cloudwatch-firehose/data.tf
+++ b/terraform/modules/cloudwatch-firehose/data.tf
@@ -80,7 +80,7 @@ data "aws_iam_policy_document" "firehose-role-policy" {
     ]
   }
   statement {
-    sid    = "FirehosPutLogs"
+    sid    = "FirehosePutLogs"
     effect = "Allow"
     actions = [
       "logs:PutLogEvents"

--- a/terraform/modules/cloudwatch-firehose/data.tf
+++ b/terraform/modules/cloudwatch-firehose/data.tf
@@ -57,13 +57,9 @@ data "aws_iam_policy_document" "firehose-role-policy" {
     sid    = "FirehoseToS3"
     effect = "Allow"
     actions = [
-      "s3:AbortMultipartUpload",
-      "s3:GetBucketLocation",
       "s3:GetObject",
-      "s3:ListBucket",
-      "s3:ListBucketMultipartUploads",
       "s3:PutObject",
-      "s3:PutObjectACL"
+      "s3:PutObjectAcl"
     ]
     resources = [
       var.destination_bucket_arn,

--- a/terraform/modules/cloudwatch-firehose/main.tf
+++ b/terraform/modules/cloudwatch-firehose/main.tf
@@ -59,6 +59,7 @@ resource "aws_kinesis_firehose_delivery_stream" "firehose-to-s3" {
     bucket_arn          = var.destination_bucket_arn
     buffering_size      = 64
     buffering_interval  = 60
+    compression_format  = "GZIP"
     role_arn            = aws_iam_role.firehose-to-s3.arn
     prefix              = "logs/!{timestamp:yyyy/MM/dd}/"
     error_output_prefix = "errors/!{firehose:error-output-type}/!{timestamp:yyyy/MM/dd}/"
@@ -72,7 +73,7 @@ resource "aws_kinesis_firehose_delivery_stream" "firehose-to-s3" {
     dynamic_partitioning_configuration {
       enabled = false
     }
-/*
+    /*
     processing_configuration {
       enabled = true
 
@@ -101,8 +102,9 @@ resource "aws_kinesis_firehose_delivery_stream" "firehose-to-s3" {
 }
 
 resource "aws_cloudwatch_log_group" "kinesis" {
-  name = "/aws/kinesisfirehose/cloudwatch-to-s3-${random_id.name.hex}"
-  tags = var.tags
+  name              = "/aws/kinesisfirehose/cloudwatch-to-s3-${random_id.name.hex}"
+  retention_in_days = 14
+  tags              = var.tags
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "cloudwatch-to-firehose" {

--- a/terraform/modules/cloudwatch-firehose/main.tf
+++ b/terraform/modules/cloudwatch-firehose/main.tf
@@ -85,6 +85,8 @@ resource "aws_kinesis_firehose_delivery_stream" "firehose-to-s3" {
 }
 
 resource "aws_cloudwatch_log_group" "kinesis" {
+  #  checkov:skip=CKV_AWS_338:Short life error logs don't need long term retention
+  #  checkov:skip=CKV_AWS_158:Default log encryption OK for short life error logs
   name              = "/aws/kinesisfirehose/cloudwatch-to-s3-${random_id.name.hex}"
   retention_in_days = 14
   tags              = var.tags

--- a/terraform/modules/cloudwatch-firehose/main.tf
+++ b/terraform/modules/cloudwatch-firehose/main.tf
@@ -22,8 +22,9 @@ resource "aws_iam_role" "firehose-to-s3" {
 }
 
 resource "aws_iam_policy" "firehose-to-s3" {
-  policy = data.aws_iam_policy_document.firehose-role-policy.json
-  tags   = var.tags
+  name_prefix = "firehose-to-s3"
+  policy      = data.aws_iam_policy_document.firehose-role-policy.json
+  tags        = var.tags
 }
 
 resource "aws_iam_policy_attachment" "firehose-to-s3" {
@@ -39,8 +40,9 @@ resource "aws_iam_role" "cloudwatch-to-firehose" {
 }
 
 resource "aws_iam_policy" "cloudwatch-to-firehose" {
-  policy = data.aws_iam_policy_document.cloudwatch-logs-role-policy.json
-  tags   = var.tags
+  name_prefix = "cloudwatch-to-firehose"
+  policy      = data.aws_iam_policy_document.cloudwatch-logs-role-policy.json
+  tags        = var.tags
 }
 
 resource "aws_iam_policy_attachment" "cloudwatch-to-firehose" {

--- a/terraform/modules/cloudwatch-firehose/main.tf
+++ b/terraform/modules/cloudwatch-firehose/main.tf
@@ -60,7 +60,7 @@ resource "aws_kinesis_firehose_delivery_stream" "firehose-to-s3" {
     buffering_size      = 64
     buffering_interval  = 60
     role_arn            = aws_iam_role.firehose-to-s3.arn
-    prefix              = "logs/!{partitionKeyFromQuery:logGroupName}/"
+    prefix              = "logs/!{timestamp:yyyy/MM/dd}/"
     error_output_prefix = "errors/!{firehose:error-output-type}/!{timestamp:yyyy/MM/dd}/"
 
     cloudwatch_logging_options {
@@ -70,9 +70,9 @@ resource "aws_kinesis_firehose_delivery_stream" "firehose-to-s3" {
     }
 
     dynamic_partitioning_configuration {
-      enabled = true
+      enabled = false
     }
-
+/*
     processing_configuration {
       enabled = true
 
@@ -88,7 +88,7 @@ resource "aws_kinesis_firehose_delivery_stream" "firehose-to-s3" {
         }
       }
     }
-
+*/
   }
 
   server_side_encryption {

--- a/terraform/modules/cloudwatch-firehose/main.tf
+++ b/terraform/modules/cloudwatch-firehose/main.tf
@@ -73,23 +73,6 @@ resource "aws_kinesis_firehose_delivery_stream" "firehose-to-s3" {
     dynamic_partitioning_configuration {
       enabled = false
     }
-    /*
-    processing_configuration {
-      enabled = true
-
-      processors {
-        type = "MetadataExtraction"
-        parameters {
-          parameter_name  = "JsonParsingEngine"
-          parameter_value = "JQ-1.6"
-        }
-        parameters {
-          parameter_name  = "MetadataExtractionQuery"
-          parameter_value = "{logGroupName:.logGroup}"
-        }
-      }
-    }
-*/
   }
 
   server_side_encryption {


### PR DESCRIPTION
## A reference to the issue / Description of it

#7607 

## How does this PR fix the problem?

* Updates S3 bucket policy so logs can be delivered
* Sets the S3 bucket to use AWS:SSE for simplicity (we can change this to KMS, but we'll need to consider access to the KMS key from other MP accounts, and the Cortex XSIAM AWS user)
* Resolves some discrepancies and outright errors in IAM policy documents in the module
* Improves policy naming
* Introduces a CloudWatch Log Group for data stream error logging 

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Tested with local terraform applies to `core-logging` and `core-vpc` sandbox workspace

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

The dynamic naming is still possible, but requires that logs be unzipped so that they can be dynamically parsed. As this isn't really a requirement for the customer, but just a nice-to-have I'll raise this as a backlog issue.

Further, there's still some more work to do with keeping the destination bucket name out of code; either storing it as a secret or accessing it with a remote state object, but I'll tackle that in a later PR.
