### PR TITLE
DSOS-2919: add rd licensing firewall rules part2

### DIFF
--- a/terraform/environments/core-network-services/cidr-ranges.tf
+++ b/terraform/environments/core-network-services/cidr-ranges.tf
@@ -87,6 +87,9 @@ locals {
     ad-hmpp-dc-a          = "10.27.136.5/32" # see https://github.com/ministryofjustice/modernisation-platform/issues/5970
     ad-hmpp-dc-b          = "10.27.137.5/32" # and https://dsdmoj.atlassian.net/wiki/x/3oCKGAE
     ad-hmpp-rdlic         = "10.27.138.6/32" # ditto
+    ad-azure-dc-a         = "10.20.104.5/32" # ditto
+    ad-azure-dc-b         = "10.20.106.5/32" # ditto
+    ad-azure-rdlic        = "10.20.108.6/32" # ditto
   }
 
   all_cidr_ranges = merge(

--- a/terraform/environments/core-network-services/firewall-rules/live_data_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/live_data_rules.json
@@ -40,5 +40,12 @@
     "destination_ip": "${dom1-dcs}",
     "destination_port": "$DOMAIN_CONTROLLER_UDP",
     "protocol": "UDP"
+  },
+  "azure_prod_to_mp_ad_azure_rdlic_TCP": {
+    "action": "PASS",
+    "source_ip": "$AZURE_PROD",
+    "destination_ip": "$AD_HMPP_RD_LICENSING",
+    "destination_port": "$RD_LICENSING_TCP",
+    "protocol": "TCP"
   }
 }

--- a/terraform/environments/core-network-services/firewall-rules/non_live_data_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/non_live_data_rules.json
@@ -1,0 +1,51 @@
+{
+  "mp_ad_azure_dc_to_azure_devtest_TCP": {
+    "action": "PASS",
+    "source_ip": "$AD_AZURE_DCS",
+    "destination_ip": "$AZURE_DEVTEST",
+    "destination_port": "$DOMAIN_CONTROLLER_TCP",
+    "protocol": "TCP"
+  },
+  "mp_ad_azure_dc_to_azure_devtest_UDP": {
+    "action": "PASS",
+    "source_ip": "$AD_AZURE_DCS",
+    "destination_ip": "$AZURE_DEVTEST",
+    "destination_port": "$DOMAIN_CONTROLLER_UDP",
+    "protocol": "UDP"
+  },
+  "azure_devtest_to_mp_ad_azure_dcs_TCP": {
+    "action": "PASS",
+    "source_ip": "$AZURE_DEVTEST",
+    "destination_ip": "$AD_AZURE_DCS",
+    "destination_port": "$DOMAIN_CONTROLLER_TCP",
+    "protocol": "TCP"
+  },
+  "azure_devtest_to_mp_ad_azure_dcs_UDP": {
+    "action": "PASS",
+    "source_ip": "$AZURE_DEVTEST",
+    "destination_ip": "$AD_AZURE_DCS",
+    "destination_port": "$DOMAIN_CONTROLLER_UDP",
+    "protocol": "UDP"
+  },
+  "mp_ad_azure_rdlic_to_azure_devtest_TCP": {
+    "action": "PASS",
+    "source_ip": "$AD_AZURE_RD_LICENSING",
+    "destination_ip": "$AZURE_DEVTEST",
+    "destination_port": "$DOMAIN_CONTROLLER_TCP",
+    "protocol": "TCP"
+  },
+  "mp_ad_azure_rdlic_to_azure_devtest_UDP": {
+    "action": "PASS",
+    "source_ip": "$AD_AZURE_RD_LICENSING",
+    "destination_ip": "$AZURE_DEVTEST",
+    "destination_port": "$DOMAIN_CONTROLLER_UDP",
+    "protocol": "UDP"
+  },
+  "azure_devtest_to_mp_ad_azure_rdlic_TCP": {
+    "action": "PASS",
+    "source_ip": "$AZURE_DEVTEST",
+    "destination_ip": "$AD_AZURE_RD_LICENSING",
+    "destination_port": "$RD_LICENSING_TCP",
+    "protocol": "TCP"
+  }
+}

--- a/terraform/environments/core-network-services/firewall-rules/sets.json
+++ b/terraform/environments/core-network-services/firewall-rules/sets.json
@@ -3,6 +3,10 @@
     "IP_SET_EXAMPLE": ["1.1.1.1/32", "1.0.0.1/32"],
     "AD_HMPP_DCS": ["${ad-hmpp-dc-a}", "${ad-hmpp-dc-b}"],
     "AD_HMPP_RD_LICENSING": ["${ad-hmpp-rdlic}"],
+    "AD_AZURE_DCS": ["${ad-azure-dc-a}", "${ad-azure-dc-b}"],
+    "AD_AZURE_RD_LICENSING": ["${ad-azure-rdlic}"],
+    "AZURE_PROD": ["${noms-live-vnet}", "${noms-mgmt-live-vnet}", "${noms-live-dr-vnet}", "${noms-mgmt-live-dr-vnet}"],
+    "AZURE_DEVTEST": ["${noms-test-vnet}", "${noms-mgmt-vnet}"],
     "DATA_ENGINEERING": [
       "${data-engineering-dev}",
       "${data-engineering-prod}",

--- a/terraform/environments/core-network-services/locals.tf
+++ b/terraform/environments/core-network-services/locals.tf
@@ -38,9 +38,10 @@ locals {
   preproduction_rules   = fileexists("./firewall-rules/preproduction_rules.json") ? jsondecode(templatefile("./firewall-rules/preproduction_rules.json", local.all_cidr_ranges)) : {}
   production_rules      = fileexists("./firewall-rules/production_rules.json") ? jsondecode(templatefile("./firewall-rules/production_rules.json", local.all_cidr_ranges)) : {}
   live_data_rules       = fileexists("./firewall-rules/live_data_rules.json") ? jsondecode(templatefile("./firewall-rules/live_data_rules.json", local.all_cidr_ranges)) : {}
+  non_live_data_rules   = fileexists("./firewall-rules/non_live_data_rules.json") ? jsondecode(templatefile("./firewall-rules/non_live_data_rules.json", local.all_cidr_ranges)) : {}
   fqdn_firewall_rules   = fileexists("./firewall-rules/fqdn_rules.json") ? jsondecode(file("./firewall-rules/fqdn_rules.json")) : {}
   inline_firewall_rules = fileexists("./firewall-rules/inline_rules.json") ? jsondecode(templatefile("./firewall-rules/inline_rules.json", local.all_cidr_ranges)) : {}
-  firewall_rules        = merge(local.development_rules, local.test_rules, local.preproduction_rules, local.production_rules, local.live_data_rules)
+  firewall_rules        = merge(local.development_rules, local.test_rules, local.preproduction_rules, local.production_rules, local.live_data_rules, local.non_live_data_rules)
   firewall_sets         = fileexists("./firewall-rules/sets.json") ? jsondecode(templatefile("./firewall-rules/sets.json", local.all_cidr_ranges)) : {}
 
   vpn_attachments = fileexists("./vpn_attachments.json") ? jsondecode(file("./vpn_attachments.json")) : {}


### PR DESCRIPTION
## A reference to the issue / Description of it

Follow on from https://github.com/ministryofjustice/modernisation-platform/pull/7737

The non-live RemoteDesktop Licensing server isn't working due to some connectivity issues.


## How does this PR fix the problem?

Adds the non-live Domain Controller and Licence servers firewall rules. These sit in the non-live VNET so additional terraform also required.
Also allows the Azure FixNGo estate to use the licenses on the new prod license server

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

n/a

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
