### PR TITLE
Set up prerequisites to push logs from `core-vpc` into `core-logging` S3 bucket

### DIFF
--- a/terraform/environments/core-logging/cortex.tf
+++ b/terraform/environments/core-logging/cortex.tf
@@ -132,7 +132,7 @@ resource "aws_secretsmanager_secret" "logging" {
   # checkov:skip=CKV2_AWS_57
   provider                = aws.modernisation-platform
   kms_key_id              = data.aws_kms_alias.secrets.target_key_id
-  name                    = "core-logging-bucket-arn"
+  name                    = "core_logging_bucket_arn"
   recovery_window_in_days = 0
   tags                    = local.tags
 }

--- a/terraform/environments/core-vpc/locals.tf
+++ b/terraform/environments/core-vpc/locals.tf
@@ -21,6 +21,8 @@ locals {
 
   # Secrets used by Firehose resources which we only require for development & production VPCs.
   xsiam = jsondecode(data.aws_secretsmanager_secret_version.xsiam_secret_arn_version.secret_string)
+  cloudwatch_log_groups = local.is-production ? [ for env in module.route_53_resolver_logs : env.r53_resolver_log_name ] : []
+  cloudwatch_logging_bucket = data.aws_secretsmanager_secret_version.core_logging_bucket_arn.secret_string
 
   tags = {
     business-unit = "Platforms"

--- a/terraform/environments/core-vpc/secrets.tf
+++ b/terraform/environments/core-vpc/secrets.tf
@@ -21,6 +21,15 @@ data "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {
   secret_id = data.aws_secretsmanager_secret.pagerduty_integration_keys.id
 }
 
+data "aws_secretsmanager_secret" "core_logging_bucket_arn" {
+  provider = aws.modernisation-platform
+  name     = "core_logging_bucket_arn"
+}
+
+data "aws_secretsmanager_secret_version" "core_logging_bucket_arn" {
+  provider  = aws.modernisation-platform
+  secret_id = data.aws_secretsmanager_secret.core_logging_bucket_arn.id
+}
 
 # Data for Firehose Endpoint URL & Key that are held in secrets manager.
 

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -85,7 +85,7 @@ locals {
 module "vpc" {
   for_each = local.vpcs[terraform.workspace]
 
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-member-vpc?ref=ddcd36b717b937bfa72b6245fd0410861aa40b36" # v2.3.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-member-vpc?ref=3094604aee5121f9794d60d3f27d21d6209e59d4" # v2.4.0
 
   subnet_sets = { for key, subnet in each.value.cidr.subnet_sets : key => subnet.cidr }
 


### PR DESCRIPTION
## A reference to the issue / Description of it

#7607 

## How does this PR fix the problem?

* Bumps the VPC module to `v2.4.0` which outputs the flow log group name
* Aligns the secret name better with existing secrets
* Creates data calls in `core-vpc` to get the bucket ARN
* Sets up a local (which needs expanding) to only retrieve log group names in `core-vpc-production`

## How has this been tested?

Tested with a local plan / `apply --refresh-only` to check the local values

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
