### PR TITLE
Create core-billing account

### DIFF
--- a/environments/core-billing.json
+++ b/environments/core-billing.json
@@ -1,0 +1,16 @@
+{
+  "account-type": "core",
+  "environments": [
+    {
+      "name": "production",
+      "access": []
+    }
+  ],
+  "tags": {
+    "application": "modernisation-platform",
+    "business-unit": "Platforms",
+    "infrastructure-support": "modernisation-platform@digital.justice.gov.uk",
+    "owner": "Modernisation Platform: modernisation-platform@digital.justice.gov.uk"
+  },
+  "github-oidc-team-repositories": [""]
+}

--- a/policies/environments/expected.rego
+++ b/policies/environments/expected.rego
@@ -23,6 +23,7 @@ expected :=
     "cica-tariff",
     "contract-work-administration",
     "cooker",
+    "core-billing",
     "core-logging",
     "core-network-services",
     "core-sandbox",


### PR DESCRIPTION
This PR creates a new environment name `core-billing` to help investigate better ways to display and dissect our platform costs as per issue #7169 