### PR TITLE
Add issue template for providing Slack webhook information

### DIFF
--- a/.github/ISSUE_TEMPLATE/provide-slack-webhook-info.yml
+++ b/.github/ISSUE_TEMPLATE/provide-slack-webhook-info.yml
@@ -1,0 +1,48 @@
+name: "Provide Slack Webhook Information"
+description: "Submit Slack webhook URL and related information for environment JSON file change notifications."
+title: "Request to Integrate Slack Webhook for <Your Slack Channel Name>"
+labels: ["alerting"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Provide Slack Webhook Information
+
+        To set up notifications for changes in your `environments.json` file, please provide the following details about your Slack webhook URL stored in your AWS account.
+
+  - type: input
+    id: slack_channel_name
+    attributes:
+      label: "Slack Channel Name"
+      description: "Enter the name of the Slack channel where you want to receive notifications."
+      placeholder: "e.g., modernisation-platform"
+    validations:
+      required: true
+
+  - type: input
+    id: aws_account_name
+    attributes:
+      label: "AWS Account Name"
+      description: "Enter the name of the AWS account where the webhook URL secret is stored."
+      placeholder: "e.g., sprinkler-development"
+    validations:
+      required: true
+
+  - type: input
+    id: secret_name
+    attributes:
+      label: "Secret Name"
+      description: "Enter the name of the secret in AWS Secrets Manager where the Slack webhook URL is stored."
+      placeholder: "e.g., slack_webhook_url"
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional_information
+    attributes:
+      label: "Additional Information"
+      description: "Provide any additional details or context that may be relevant to this request."
+      placeholder: "e.g., Specific instructions or preferences..."
+    validations:
+      required: false


### PR DESCRIPTION
## A reference to the issue / Description of it

This PR adds a new issue template to the repository to help users provide Slack webhook information securely. The template guides users to enter the necessary details, such as the Slack channel name, AWS account name, and secret name, where the Slack webhook URL is stored. #7570 

## How does this PR fix the problem?

This PR resolves the problem by:
- Adding a structured issue template that collects all necessary information securely.
- Guiding users to store Slack webhook URLs in AWS Secrets Manager rather than in plaintext.
- Providing clear instructions on what information is needed and how to submit it.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
