### PR TITLE
Update baselines module to v7.7.0

### DIFF
--- a/terraform/environments/bootstrap/secure-baselines/main.tf
+++ b/terraform/environments/bootstrap/secure-baselines/main.tf
@@ -6,7 +6,7 @@ data "aws_kms_key" "cloudtrail_key" {
 
 #trivy:ignore:AVD-AWS-0136
 module "baselines" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=672806679936c8e5da29234fe6f23411f8b45eba" # v7.6.4
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=7a44478e0f15d0158cb06a2e8ab8f95448a796cd" # v7.7.0
 
   providers = {
     # Default and replication regions

--- a/terraform/modernisation-platform-account/baselines.tf
+++ b/terraform/modernisation-platform-account/baselines.tf
@@ -18,7 +18,7 @@ locals {
 # Secure baselines (GuardDuty, Config, SecurityHub, etc)
 #trivy:ignore:AVD-AWS-0136 trivy:ignore:AVD-AWS-0132
 module "baselines-modernisation-platform" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=672806679936c8e5da29234fe6f23411f8b45eba" # v7.6.4
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=7a44478e0f15d0158cb06a2e8ab8f95448a796cd" # v7.7.0
   providers = {
     # Default and replication regions
     aws                    = aws.modernisation-platform-eu-west-2


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/7437

## How does this PR fix the problem?

Points baselines module to latest version v7.7.0 which includes teh alerting for when admin role is assumed across MP.

## How has this been tested?

The module update was tested locally for core-shared-services to test the alerting.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
