### PR TITLE
Rebuild panda sandbox after nuke

### DIFF
--- a/environments/panda-cyber-appsec-lab.json
+++ b/environments/panda-cyber-appsec-lab.json
@@ -7,7 +7,8 @@
       "access": [
         {
           "sso_group_name": "panda-cyber-team",
-          "level": "sandbox"
+          "level": "sandbox",
+          "nuke": "rebuild"
         }
       ]
     }


### PR DESCRIPTION
## A reference to the issue / Description of it

panda-cyber-team have requested that their sandbox env is rebuilt after nuke now that they have some infra built by terraform

## How does this PR fix the problem?

Adds rebuild flag to json file

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
