### PR TITLE
add http://*.csr.service.justice.gov.uk to AWS firewall allow list

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/fqdn_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/fqdn_rules.json
@@ -24,7 +24,8 @@
     "ccms-opa.dev.legalservices.gov.uk",
     "ccms-opa.uat.legalservices.gov.uk",
     "ccms-opa.stg.legalservices.gov.uk",
-    "ccms-opa.legalservices.gov.uk"
+    "ccms-opa.legalservices.gov.uk",
+    ".csr.service.justice.gov.uk"
   ],
   "fw_home_net_ips": ["10.26.0.0/16", "10.27.0.0/16"]
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

Need to allow traffic out via the http allow list to *.csr.service.justice.gov.uk

## How does this PR fix the problem?

This is the only http endpoint we're trying to monitor from within AWS

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Consulted the oracle that is the mod-platform team

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

Can't think how it would

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
