### PR TITLE
use correct channel id for nomis_alarms_non_prod

### DIFF
--- a/terraform/pagerduty/member-services-integrations.tf
+++ b/terraform/pagerduty/member-services-integrations.tf
@@ -2043,9 +2043,9 @@ locals {
     hmpps-oem-test                          = { slack_channel_id = "C07J1QBJXC3" } # hmpps_oem_alarms_non_prod
     hmpps-oem-preproduction                 = { slack_channel_id = "C07J1QBJXC3" } # hmpps_oem_alarms_non_prod
     hmpps-oem-production                    = { slack_channel_id = "C07JEHTH95F" } # hmpps_oem_alarms_prod
-    nomis-development                       = { slack_channel_id = "C07HFLM47QX" } # nomis_alarms_non_prod
-    nomis-test                              = { slack_channel_id = "C07HFLM47QX" } # nomis_alarms_non_prod
-    nomis-preproduction                     = { slack_channel_id = "C07HFLM47QX" } # nomis_alarms_non_prod
+    nomis-development                       = { slack_channel_id = "C07HW4A8K19" } # nomis_alarms_non_prod
+    nomis-test                              = { slack_channel_id = "C07HW4A8K19" } # nomis_alarms_non_prod
+    nomis-preproduction                     = { slack_channel_id = "C07HW4A8K19" } # nomis_alarms_non_prod
     nomis-production                        = { slack_channel_id = "C07HFLM47QX" } # nomis_alarms_prod
     nomis-combined-reporting-test           = { slack_channel_id = "C07JE9TL03T" } # nomis_combined_reporting_alarms_non_prod
     nomis-combined-reporting-preproduction  = { slack_channel_id = "C07JE9TL03T" } # nomis_combined_reporting_alarms_non_prod


### PR DESCRIPTION
## A reference to the issue / Description of it

Supplied wrong slack channel Id for non-prod alarms

## How does this PR fix the problem?

Uses correct slack channel ID

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Should just work now that the channel is correct, can test manually using pagerduty as well

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

Nope

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
