### PR TITLE
Create `modernisation-platform-terraform-aws-data-firehose` repository

### DIFF
--- a/terraform/github/locals.tf
+++ b/terraform/github/locals.tf
@@ -54,7 +54,6 @@ locals {
 
   # Security engineers performing reviews on the platform or member accounts
   security = [
-    "joelefejuku",
     "isaacthomasMOJ"
   ]
 

--- a/terraform/github/repositories.tf
+++ b/terraform/github/repositories.tf
@@ -378,3 +378,18 @@ module "modernisation-platform-terraform-aws-chatbot" {
   ]
   secrets = nonsensitive(local.testing_ci_iam_user_keys)
 }
+
+module "modernisation-platform-terraform-aws-data-firehose" {
+  source      = "./modules/repository"
+  name        = "modernisation-platform-terraform-aws-data-firehose"
+  type        = "module"
+  description = "Module for creating AWS Data Streams to stream logs from CloudWatch Log Groups."
+  topics = [
+    "aws",
+    "cloudwatch",
+    "kinesis-data-streams",
+    "module",
+    "terraform"
+  ]
+  secrets = nonsensitive(local.testing_ci_iam_user_keys)
+}

--- a/terraform/github/repositories.tf
+++ b/terraform/github/repositories.tf
@@ -223,7 +223,6 @@ module "terraform-module-ec2-instance" {
   secrets = nonsensitive(local.testing_ci_iam_user_keys)
 }
 
-
 module "terraform-module-lambda-function" {
   source      = "./modules/repository"
   name        = "modernisation-platform-terraform-lambda-function"


### PR DESCRIPTION
## A reference to the issue / Description of it

#7607 

## How does this PR fix the problem?

This will allow us to migrate code from our `modules/cloudwatch-firehose` to an independent module which can be used both by ourselves and other teams such as `analytical-platform` and `cloud-platform`.

## How has this been tested?

Tested with local plan

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

