### PR TITLE
Increase OIDC role max_session_duration to 6 hours

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -401,7 +401,7 @@ module "github_oidc_role" {
   count                = length(compact(jsondecode(data.http.environments_file.response_body).github-oidc-team-repositories)) > 0 ? 1 : 0
   source               = "github.com/ministryofjustice/modernisation-platform-github-oidc-role?ref=62b8a16c73d8e4422cd81923e46948e8f4b5cf48" # v3.2.0
   github_repositories  = jsondecode(data.http.environments_file.response_body).github-oidc-team-repositories
-  max_session_duration = 14400
+  max_session_duration = 21600
   role_name            = "modernisation-platform-oidc-cicd"
   policy_jsons         = [data.aws_iam_policy_document.policy.json]
   tags                 = local.tags


### PR DESCRIPTION
## A reference to the issue / Description of it
#7707 
## How does this PR fix the problem?

This change ensures that the session duration aligns with the maximum runtime of jobs on GitHub-hosted runners, allowing for extended workflows without requiring re-authentication.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
