### PR TITLE
Enable NOMS VPN tunnel endpoint lifecycle control & health alerting

### DIFF
--- a/terraform/environments/core-network-services/vpn.tf
+++ b/terraform/environments/core-network-services/vpn.tf
@@ -11,36 +11,38 @@ resource "aws_customer_gateway" "this" {
 }
 
 resource "aws_vpn_connection" "this" {
-  for_each                             = local.vpn_attachments
-  transit_gateway_id                   = aws_ec2_transit_gateway.transit-gateway.id
-  customer_gateway_id                  = aws_customer_gateway.this[each.key].id
-  static_routes_only                   = try(each.value.static_routes_only, false)
-  type                                 = "ipsec.1"
-  tunnel1_dpd_timeout_action           = try(each.value.tunnel_dpd_timeout_action, null)
-  tunnel1_dpd_timeout_seconds          = try(each.value.tunnel_dpd_timeout_seconds, "30")
-  tunnel1_phase1_dh_group_numbers      = [try(each.value.tunnel_phase1_dh_group_numbers, null)]
-  tunnel1_phase1_encryption_algorithms = [try(each.value.tunnel_phase1_encryption_algorithms, null)]
-  tunnel1_phase1_integrity_algorithms  = [try(each.value.tunnel_phase1_integrity_algorithms, null)]
-  tunnel1_phase1_lifetime_seconds      = try(each.value.tunnel_phase1_lifetime_seconds, null)
-  tunnel1_phase2_dh_group_numbers      = [try(each.value.tunnel_phase2_dh_group_numbers, null)]
-  tunnel1_phase2_encryption_algorithms = [try(each.value.tunnel_phase2_encryption_algorithms, null)]
-  tunnel1_phase2_integrity_algorithms  = [try(each.value.tunnel_phase2_integrity_algorithms, null)]
-  tunnel1_phase2_lifetime_seconds      = try(each.value.tunnel_phase2_lifetime_seconds, null)
-  tunnel1_inside_cidr                  = try(each.value.tunnel1_inside_cidr, null)
-  tunnel1_startup_action               = try(each.value.tunnel_startup_action, null)
-  tunnel2_dpd_timeout_action           = try(each.value.tunnel_dpd_timeout_action, null)
-  tunnel2_dpd_timeout_seconds          = try(each.value.tunnel_dpd_timeout_seconds, "30")
-  tunnel2_phase1_dh_group_numbers      = [try(each.value.tunnel_phase1_dh_group_numbers, null)]
-  tunnel2_phase1_encryption_algorithms = [try(each.value.tunnel_phase1_encryption_algorithms, null)]
-  tunnel2_phase1_integrity_algorithms  = [try(each.value.tunnel_phase1_integrity_algorithms, null)]
-  tunnel2_phase1_lifetime_seconds      = try(each.value.tunnel_phase1_lifetime_seconds, null)
-  tunnel2_phase2_dh_group_numbers      = [try(each.value.tunnel_phase2_dh_group_numbers, null)]
-  tunnel2_phase2_encryption_algorithms = [try(each.value.tunnel_phase2_encryption_algorithms, null)]
-  tunnel2_phase2_integrity_algorithms  = [try(each.value.tunnel_phase2_integrity_algorithms, null)]
-  tunnel2_phase2_lifetime_seconds      = try(each.value.tunnel_phase2_lifetime_seconds, null)
-  tunnel2_inside_cidr                  = try(each.value.tunnel2_inside_cidr, null)
-  tunnel2_startup_action               = try(each.value.tunnel_startup_action, null)
-  remote_ipv4_network_cidr             = try(each.value.remote_ipv4_network_cidr, local.core-vpcs[each.value.modernisation_platform_vpc].cidr.subnet_sets["general"].cidr)
+  for_each                                = local.vpn_attachments
+  transit_gateway_id                      = aws_ec2_transit_gateway.transit-gateway.id
+  customer_gateway_id                     = aws_customer_gateway.this[each.key].id
+  static_routes_only                      = try(each.value.static_routes_only, false)
+  type                                    = "ipsec.1"
+  tunnel1_dpd_timeout_action              = try(each.value.tunnel_dpd_timeout_action, null)
+  tunnel1_dpd_timeout_seconds             = try(each.value.tunnel_dpd_timeout_seconds, "30")
+  tunnel1_phase1_dh_group_numbers         = [try(each.value.tunnel_phase1_dh_group_numbers, null)]
+  tunnel1_phase1_encryption_algorithms    = [try(each.value.tunnel_phase1_encryption_algorithms, null)]
+  tunnel1_phase1_integrity_algorithms     = [try(each.value.tunnel_phase1_integrity_algorithms, null)]
+  tunnel1_phase1_lifetime_seconds         = try(each.value.tunnel_phase1_lifetime_seconds, null)
+  tunnel1_phase2_dh_group_numbers         = [try(each.value.tunnel_phase2_dh_group_numbers, null)]
+  tunnel1_phase2_encryption_algorithms    = [try(each.value.tunnel_phase2_encryption_algorithms, null)]
+  tunnel1_phase2_integrity_algorithms     = [try(each.value.tunnel_phase2_integrity_algorithms, null)]
+  tunnel1_phase2_lifetime_seconds         = try(each.value.tunnel_phase2_lifetime_seconds, null)
+  tunnel1_inside_cidr                     = try(each.value.tunnel1_inside_cidr, null)
+  tunnel1_startup_action                  = try(each.value.tunnel_startup_action, null)
+  tunnel1_enable_tunnel_lifecycle_control = try(each.value.tunnel1_enable_tunnel_lifecycle_control, false)
+  tunnel2_dpd_timeout_action              = try(each.value.tunnel_dpd_timeout_action, null)
+  tunnel2_dpd_timeout_seconds             = try(each.value.tunnel_dpd_timeout_seconds, "30")
+  tunnel2_phase1_dh_group_numbers         = [try(each.value.tunnel_phase1_dh_group_numbers, null)]
+  tunnel2_phase1_encryption_algorithms    = [try(each.value.tunnel_phase1_encryption_algorithms, null)]
+  tunnel2_phase1_integrity_algorithms     = [try(each.value.tunnel_phase1_integrity_algorithms, null)]
+  tunnel2_phase1_lifetime_seconds         = try(each.value.tunnel_phase1_lifetime_seconds, null)
+  tunnel2_phase2_dh_group_numbers         = [try(each.value.tunnel_phase2_dh_group_numbers, null)]
+  tunnel2_phase2_encryption_algorithms    = [try(each.value.tunnel_phase2_encryption_algorithms, null)]
+  tunnel2_phase2_integrity_algorithms     = [try(each.value.tunnel_phase2_integrity_algorithms, null)]
+  tunnel2_phase2_lifetime_seconds         = try(each.value.tunnel_phase2_lifetime_seconds, null)
+  tunnel2_inside_cidr                     = try(each.value.tunnel2_inside_cidr, null)
+  tunnel2_startup_action                  = try(each.value.tunnel_startup_action, null)
+  tunnel2_enable_tunnel_lifecycle_control = try(each.value.tunnel2_enable_tunnel_lifecycle_control, false)
+  remote_ipv4_network_cidr                = try(each.value.remote_ipv4_network_cidr, local.core-vpcs[each.value.modernisation_platform_vpc].cidr.subnet_sets["general"].cidr)
 
   tunnel1_log_options {
     cloudwatch_log_options {

--- a/terraform/environments/core-network-services/vpn.tf
+++ b/terraform/environments/core-network-services/vpn.tf
@@ -127,6 +127,8 @@ resource "aws_cloudwatch_event_rule" "noms-vpn-event-rule" {
   name        = "noms-vpn-health-event-rule"
   description = "Check for any NOMS VPN related health events"
   event_pattern = jsonencode({
+    "source" : ["aws.health"],
+    "detail-type" : ["AWS Health Event"],
     "resources" = [
       aws_vpn_connection.this["NOMS-Transit-Live-VPN-VNG_1"].id,
       aws_vpn_connection.this["NOMS-Transit-Live-VPN-VNG_2"].id

--- a/terraform/environments/core-network-services/vpn.tf
+++ b/terraform/environments/core-network-services/vpn.tf
@@ -143,11 +143,12 @@ resource "aws_cloudwatch_event_target" "noms-vpn-event-target-sns" {
 }
 
 resource "aws_sns_topic" "noms-vpn-sns-topic" {
-  name = "noms_vpn_sns_topic"
+  name              = "noms_vpn_sns_topic"
+  kms_master_key_id = "alias/aws/sns"
 }
 
 module "core-networks-chatbot" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-aws-chatbot"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-aws-chatbot?ref=485d70f865876de922db6796d27b1f91fac25263" // v1.0.0
 
   slack_channel_id = "CDLAJTGRG" // #dba_alerts_prod
   sns_topic_arns   = ["arn:aws:sns:eu-west-2:${local.environment_management.account_ids[terraform.workspace]}:${aws_sns_topic.noms-vpn-sns-topic.name}"]

--- a/terraform/environments/core-network-services/vpn_attachments.json
+++ b/terraform/environments/core-network-services/vpn_attachments.json
@@ -33,7 +33,9 @@
     "tunnel2_inside_cidr": "169.254.22.128/30",
     "tunnel_dpd_timeout_action": "restart",
     "tunnel_dpd_timeout_seconds": "45",
-    "tunnel_startup_action": "start"
+    "tunnel_startup_action": "start",
+    "tunnel1_enable_tunnel_lifecycle_control": "true",
+    "tunnel2_enable_tunnel_lifecycle_control": "true"
   },
   "NOMS-Transit-Live-VPN-VNG_2": {
     "bgp_asn": "64522",
@@ -45,7 +47,9 @@
     "tunnel2_inside_cidr": "169.254.22.132/30",
     "tunnel_dpd_timeout_action": "restart",
     "tunnel_dpd_timeout_seconds": "45",
-    "tunnel_startup_action": "start"
+    "tunnel_startup_action": "start",
+    "tunnel1_enable_tunnel_lifecycle_control": "true",
+    "tunnel2_enable_tunnel_lifecycle_control": "true"
   },
   "Parole-Board-VPN": {
     "bgp_asn": "65535",


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/7833

## How does this PR fix the problem?

Enables tunnel endpoint lifecycle control for the NOMS VPN. Waiting on their approval to go ahead as running this is in will schedule an endpoint replacement at the point it is applied.

It also creates an eventbridge rule to monitor for any AWS health events relating to the NOMS VPN which will be sent to the  #dba_alerts_prod channel

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
