### PR TITLE
Fix regal liniting errors

### DIFF
--- a/policies/collaborators/collaborators.rego
+++ b/policies/collaborators/collaborators.rego
@@ -1,4 +1,4 @@
-package main
+package policies.collaborators
 
 import rego.v1
 

--- a/policies/collaborators/collaborators_test.rego
+++ b/policies/collaborators/collaborators_test.rego
@@ -1,4 +1,5 @@
-package main
+package policies.collaborators
+
 
 import rego.v1
 

--- a/policies/collaborators/utilities.rego
+++ b/policies/collaborators/utilities.rego
@@ -1,4 +1,4 @@
-package main
+package policies.collaborators
 
 import rego.v1
 

--- a/policies/environments/environment-definitions.rego
+++ b/policies/environments/environment-definitions.rego
@@ -1,4 +1,4 @@
-package main
+package policies.environments
 
 import rego.v1
 

--- a/policies/environments/environment-definitions_test.rego
+++ b/policies/environments/environment-definitions_test.rego
@@ -1,4 +1,4 @@
-package main
+package policies.environments
 
 import rego.v1
 

--- a/policies/environments/expected.rego
+++ b/policies/environments/expected.rego
@@ -1,4 +1,4 @@
-package main
+package policies.environments
 
 import rego.v1
 

--- a/policies/environments/utilities.rego
+++ b/policies/environments/utilities.rego
@@ -1,4 +1,4 @@
-package main
+package policies.environments
 
 import rego.v1
 

--- a/policies/member/environment-definitions.rego
+++ b/policies/member/environment-definitions.rego
@@ -1,4 +1,4 @@
-package main
+package policies.member
 
 import rego.v1
 

--- a/policies/member/environment-definitions_test.rego
+++ b/policies/member/environment-definitions_test.rego
@@ -1,4 +1,4 @@
-package main
+package policies.member
 
 import rego.v1
 

--- a/policies/member/utilities.rego
+++ b/policies/member/utilities.rego
@@ -1,4 +1,4 @@
-package main
+package policies.member
 
 import rego.v1
 

--- a/policies/networking/core-vpc.rego
+++ b/policies/networking/core-vpc.rego
@@ -1,4 +1,4 @@
-package main
+package policies.networking
 
 import rego.v1
 

--- a/policies/networking/core-vpc_test.rego
+++ b/policies/networking/core-vpc_test.rego
@@ -1,4 +1,4 @@
-package main
+package policies.networking
 
 import rego.v1
 

--- a/policies/networking/expected.rego
+++ b/policies/networking/expected.rego
@@ -1,4 +1,4 @@
-package main
+package policies.networking
 
 import rego.v1
 

--- a/policies/networking/utilities.rego
+++ b/policies/networking/utilities.rego
@@ -1,4 +1,4 @@
-package main
+package policies.networking
 
 import rego.v1
 


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/actions/runs/10717883396

The latest version of regal has introduced some stricter rules on pckage naming conventions. See .. https://docs.styra.com/regal/rules/idiomatic/directory-package-mismatch

## How does this PR fix the problem?

I've updated all the package definitions to match the directory structure as suggested.

## How has this been tested?

I ran regal linting locally and it passed.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
