### PR TITLE
Adding Quicksight Admin policy for the new permission set

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -441,7 +441,65 @@ data "aws_iam_policy_document" "data_engineering_additional" {
   }
 }
 
+# quicksight administrator policy (IAM permissions needed to manage QuickSight subscription)
+# ref: https://docs.aws.amazon.com/quicksight/latest/user/iam-policy-examples.html#security_iam_conosole-administration
+resource "aws_iam_policy" "quicksight_administrator" {
+  provider = aws.workspace
+  name     = "quicksight_administrator_policy"
+  path     = "/"
+  policy   = data.aws_iam_policy_document.quicksight_administrator_additional.json
+}
 
+#tfsec:ignore:aws-iam-no-policy-wildcards
+data "aws_iam_policy_document" "quicksight_administrator_additional" {
+  #checkov:skip=CKV_AWS_108
+  #checkov:skip=CKV_AWS_109
+  #checkov:skip=CKV_AWS_111
+  #checkov:skip=CKV_AWS_110
+  #checkov:skip=CKV_AWS_356: Needs to access multiple resources
+  statement {
+    sid    = "QuickSightConsoleAdmin"
+    effect = "Allow"
+
+    actions = [
+      "quicksight:*",
+      "iam:AttachRolePolicy",
+      "iam:DetachRolePolicy",
+      "iam:ListAttachedRolePolicies",
+      "iam:GetPolicy",
+      "iam:CreatePolicyVersion",
+      "iam:DeletePolicyVersion",
+      "iam:GetPolicyVersion",
+      "iam:ListPolicyVersions",
+      "iam:DeleteRole",
+      "iam:CreateRole",
+      "iam:GetRole",
+      "iam:ListRoles",
+      "iam:CreatePolicy",
+      "iam:ListEntitiesForPolicy",
+      "iam:ListPolicies",
+      "s3:ListAllMyBuckets",
+      "athena:ListDataCatalogs",
+      "athena:GetDataCatalog",
+      "sso:DescribeApplication",
+      "sso:DescribeInstance",
+      "sso:CreateApplication",
+      "sso:PutApplicationAuthenticationMethod",
+      "sso:PutApplicationGrant",
+      "sso:DeleteApplication",
+      "sso:DescribeGroup",
+      "sso:SearchGroups",
+      "sso:GetProfile",
+      "sso:CreateApplicationAssignment",
+      "sso:DeleteApplicationAssignment",
+      "sso:ListInstances",
+      "sso:DescribeRegisteredRegions",
+      "organizations:DescribeOrganization",
+    ]
+
+    resources = ["*"]
+  }
+}
 
 # sandbox policy - member SSO and collaborators, development accounts only
 resource "aws_iam_policy" "sandbox" {


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/analytical-platform/issues/5289

QuickSight can't be fully managed in code. Specifically, adding and removing identity center groups requires manual intervention as terraform forces a destroy when groups are amended.

## How does this PR fix the problem?

This creates a policy that will eventually be utilised by a new permission set to carry out admin tasks in QS.

## How has this been tested?
The policy was copied from the AWS docs. Testing will take place after deployment

## Deployment Plan / Instructions

No special deployment instructions. There will be a follow-up two additional PRs. One that creates the permission set in `aws-root-account` and then amending of the json environment file and the rego tests that will assign the new permissions sets.

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
