### PR TITLE
Restrict kms:CreateGrant permissions for oidc role

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -509,7 +509,6 @@ data "aws_iam_policy_document" "policy" {
       "kms:Decrypt",
       "kms:Encrypt",
       "kms:GenerateDataKey",
-      "kms:CreateGrant",
       "lambda:UpdateFunctionCode",
       "logs:CreateLogGroup",
       "logs:DescribeLogGroups",
@@ -545,6 +544,21 @@ data "aws_iam_policy_document" "policy" {
     ]
     resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
   }
+
+ statement {
+    effect = "Allow"
+    actions = [
+      "kms:CreateGrant",
+    ]
+
+ resources = ["arn:aws:kms:eu-west-2:${local.environment_management.account_ids["core-shared-services-production"]}:alias/rds-*"]
+    condition {
+      test     = "Bool"
+      variable = "kms:GrantIsForAWSResource"
+      values   = ["true"]
+    }
+  }
+
 }
 
 # MemberInfrastructureBedrockEuCentral

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -557,8 +557,13 @@ data "aws_iam_policy_document" "policy" {
       variable = "kms:GrantIsForAWSResource"
       values   = ["true"]
     }
+   # Further limit to operations that involve the RDS service only
+    condition {
+      test     = "StringEquals"
+      variable = "kms:ViaService"
+      values   = ["rds.eu-west-2.amazonaws.com"]
+    }
   }
-
 }
 
 # MemberInfrastructureBedrockEuCentral

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -548,7 +548,7 @@ data "aws_iam_policy_document" "policy" {
  statement {
     effect = "Allow"
     actions = [
-      "kms:CreateGrant",
+      "kms:CreateGrant"
     ]
 
  resources = ["arn:aws:kms:eu-west-2:${local.environment_management.account_ids["core-shared-services-production"]}:alias/rds-*"]


### PR DESCRIPTION
## A reference to the issue / Description of it

Restrict kms:CreateGrant permissions for oidc role #6845 
## How does this PR fix the problem?

Implements a restriction on the kms:CreateGrant action to ensure that grants can only be created for AWS resources and not to external IAM users, roles, or services. Following the principle of least privilege, I've  tightened the conditions even further by restricting the kms:CreateGrant action only to RDS-related operations.
## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
