### PR TITLE
ses changes for user

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -296,6 +296,21 @@ data "aws_iam_policy_document" "developer_additional" {
   }
 
   statement {
+    sid = "sesAllow"
+    effect = "Allow"
+    principals {
+    type        = "Service"
+    identifiers = ["ses.amazonaws.com"]
+    }
+    actions = [
+      "kms:GenerateDataKey",
+      "kms:Decrypt"
+    ]
+    resources = ["*"]
+
+  }
+
+  statement {
     sid    = "lambdaAllow"
     effect = "Allow"
     actions = [


### PR DESCRIPTION
## A reference to the issue / Description of it

As part of user request 

Another KMS key request please. We're having problems now we've encrypted an SNS queue that SES uses to send event notifications to.
The SNS queue is encrypted using the HMPPS shared general key without issue, however SES can't send events to it. I think this is because SES also needs access to the KMS key. See point 3 here:
https://docs.aws.amazon.com/ses/latest/dg/configure-sns-notifications.html#configure-feedback-notifications-prerequisites
This is a little more urgent than the previous CloudWatch request. If you could please take a look.


## How does this PR fix the problem?

Adds the ses service to the decryption for KMS Keys

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
