### PR TITLE
Point to v2.0.0 of aws chatbot module in `core-network-services`

### DIFF
--- a/terraform/environments/core-network-services/vpn.tf
+++ b/terraform/environments/core-network-services/vpn.tf
@@ -207,7 +207,7 @@ data "aws_iam_policy_document" "sns-kms" {
 }
 
 module "core-networks-chatbot" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-aws-chatbot?ref=485d70f865876de922db6796d27b1f91fac25263" // v1.0.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-aws-chatbot?ref=73280f80ce8a4557cec3a76ee56eb913452ca9aa" // v2.0.0
 
   slack_channel_id = "CDLAJTGRG" // #dba_alerts_prod
   sns_topic_arns   = ["arn:aws:sns:eu-west-2:${local.environment_management.account_ids[terraform.workspace]}:${aws_sns_topic.noms-vpn-sns-topic.name}"]


### PR DESCRIPTION
## A reference to the issue / Description of it

#7833

## How does this PR fix the problem?

Having merged https://github.com/ministryofjustice/modernisation-platform/pull/7848 I encountered an issue with deploying the aws chatbot config in core-network-services.

I've made a few changes to the module so that it uses non `awscc` resources and now it's behaving (i.e. building the config in the right region). ALso I had to update some SCP policies to get this going as well. Good news is that will help pave teh way if we decide to use chatbot elsewhere in our core accounts.

## How has this been tested?

Applied locally and worked. Now updating code so it's run in properly.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [X] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
