### PR TITLE
set rule for suppress-at-weekend pagerduty alarms

### DIFF
--- a/terraform/pagerduty/member-services-integrations.tf
+++ b/terraform/pagerduty/member-services-integrations.tf
@@ -1971,6 +1971,19 @@ resource "pagerduty_event_orchestration_service" "default" {
       label = "Set the default priority to P5 so breaches appear in the PagerDuty UI"
       actions {
         priority = data.pagerduty_priority.p5.id
+        route_to = "suppress-at-weekend"
+      }
+    }
+  }
+  set {
+    id = "suppress-at-weekend"
+    rule {
+      label = "Suppress incidents starting with trainab- on Saturday after 05:00, all of Sunday or Monday before 06:05 (UTC)"
+      condition {
+        expression = "event.summary matches regex '^trainab-' and ((now.weekday() == 6 and now.hour >= 5) or now.weekday() == 0 or (now.weekday() == 1 and (now.hour < 6 or (now.hour == 6 and now.minute < 5))))"
+      }
+      actions {
+        suppress = true
       }
     }
   }


### PR DESCRIPTION
## A reference to the issue / Description of it

Suppress CSR training server endpoint running alarms over the weekend as these instances are turned off - what happens currently is these alarms ALWAYS fire over the weekend... 

## How does this PR fix the problem?

Adds condition to pagerduty_event_orchestration_service for alarms summary beginning with trainab-http- and only for the corporate-staff-rostering-preproduction service in PagerDuty

## How has this been tested?

Should just work but have checked everything pretty thoroughly, also the number of changes is minimal

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
