### PR TITLE
use correct syntax for time conditions

### DIFF
--- a/terraform/pagerduty/member-services-integrations.tf
+++ b/terraform/pagerduty/member-services-integrations.tf
@@ -2013,7 +2013,7 @@ resource "pagerduty_event_orchestration_service" "corporate-staff-rostering-prep
     rule {
       label = "Check if it's Saturday after 05:00 UTC"
       condition {
-        expression = "now.weekday() == 6 and now.hour() >= 5"
+        expression = "now in Sat 05:00:00 to 24:00:00"
       }
       actions {
         suppress = true
@@ -2022,25 +2022,16 @@ resource "pagerduty_event_orchestration_service" "corporate-staff-rostering-prep
     rule {
       label = "Check if it's Sunday"
       condition {
-        expression = "now.weekday() == 0"
+        expression = "now in Sun"
       }
       actions {
         suppress = true
       }
     }
     rule {
-      label = "Check if it's Monday before 06:00 UTC"
+      label = "Check if it's Monday before 06:05 UTC"
       condition {
-        expression = "now.weekday() == 1 and now.hour() < 6"
-      }
-      actions {
-        suppress = true
-      }
-    }
-    rule {
-      label = "Check if it's Monday 06:00 - 06:04 UTC"
-      condition {
-        expression = "now.weekday() == 1 and now.hour() == 6 and now.minute() < 5"
+        expression = "now in Mon 00:00:00 to 06:05:00"
       }
       actions {
         suppress = true


### PR DESCRIPTION
## A reference to the issue / Description of it

time based expressions for conditions don't seem to be well documented. This is a best guess 

## How does this PR fix the problem?

Should address syntax error where now. (dot) is not valid

## How has this been tested?

Hard to test without apply. If it keeps failing I'll use the PagerDuty curl code to figure it out instead

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

Nope, only impacting one alarm type at the moment

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
