### PR TITLE
Add Role and Policy for S3 Upload

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/collaborators.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/collaborators.tf
@@ -215,3 +215,28 @@ module "collaborator_fleet_manager_role" {
 data "aws_iam_policy" "fleet_manager" {
   name = "fleet_manager_policy"
 }
+
+# s3-upload role for collaborators
+module "collaborator_s3_upload_role" {
+  # checkov:skip=CKV_TF_1:
+
+  count  = local.account_data.account-type == "member" ? 1 : 0
+  source = "github.com/terraform-aws-modules/terraform-aws-iam//modules/iam-assumable-role?ref=de95e21a3bc51cd3a44b3b95a4c2f61000649ebb" # v5.39.1
+
+  trusted_role_arns = [
+    local.modernisation_platform_account.id
+  ]
+
+  create_role       = true
+  role_name         = "s3-upload"
+  role_requires_mfa = true
+
+  custom_role_policy_arns = [
+    data.aws_iam_policy.s3_upload.arn
+  ]
+  number_of_custom_role_policy_arns = 1
+}
+
+data "aws_iam_policy" "s3_upload" {
+  name = "s3_upload_policy"
+}

--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -1330,3 +1330,26 @@ data "aws_iam_policy_document" "fleet-manager-document" {
     resources = ["*"]
   }
 }
+
+resource "aws_iam_policy" "s3_upload_policy" {
+  provider = aws.workspace
+  name     = "s3_upload_policy"
+  path     = "/"
+  policy   = data.aws_iam_policy_document.s3_upload_policy_document.json
+}
+
+#tfsec:ignore:aws-iam-no-policy-wildcards
+data "aws_iam_policy_document" "s3_upload_policy_document" {
+  statement {
+    sid    = "AllowS3Upload"
+    effect = "Allow"
+    actions = [
+      "s3:PutObject",
+      "s3:ListBucket"
+    ]
+    resources = [
+      ""arn:aws:s3:::mod-platform-image-artefact-bucket20230203091453221500000001",
+      "arn:aws:s3:::mod-platform-image-artefact-bucket20230203091453221500000001/*"
+    ]
+  }
+}

--- a/terraform/environments/core-shared-services/s3.tf
+++ b/terraform/environments/core-shared-services/s3.tf
@@ -56,7 +56,8 @@ data "aws_iam_policy_document" "bucket_policy" {
       "s3:PutObject",
       "s3:PutObjectTagging",
       "s3:DeleteObject",
-      "s3:ListBucket"
+      "s3:ListBucket",
+      "s3:GetBucketOwnershipControls"
     ]
 
     resources = [


### PR DESCRIPTION
## A reference to the issue / Description of it

This PR introduces a new IAM role and policy that enables the user to list and upload objects to the `mod-platform-image-artefact-bucket20230203091453221500000001` in the `core-shared-services` account. The role provides necessary permissions for S3 operations specific to this bucket. #7800 

## How does this PR fix the problem?

The newly created IAM role and policy address the requirement to allow specific users to upload and list objects in the test-bucket of the `core-shared-services` account. This ensures secure and limited access by restricting permissions to the necessary actions (s3:ListBucket, s3:PutObject) and to the specific bucket


## How has this been tested?

I tested the solution by assuming the newly created role (s3-upload-role) using test-user-1

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
