### PR TITLE
Restricts kms:CreateGrant permissions for Github OIDC role

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -433,6 +433,12 @@ data "aws_iam_policy_document" "policy" {
       "codebuild:StartBuild",
       "codebuild:BatchGetBuilds",
       "codepipeline:StartPipelineExecution",
+      "datasync:Create*",
+      "datasync:Delete*",
+      "datasync:Describe*",
+      "datasync:List*",
+      "datasync:StartTaskExecution",
+      "datasync:*Tag*",
       "dms:StartReplicationTask",
       "dms:StopReplicationTask",
       "dms:TestConnection",
@@ -445,12 +451,6 @@ data "aws_iam_policy_document" "policy" {
       "ds:DescribeDirectories",
       "dynamodb:GetItem",
       "dynamodb:PutItem",
-      "datasync:Create*",
-      "datasync:Delete*",
-      "datasync:Describe*",
-      "datasync:List*",
-      "datasync:*Tag*",
-      "datasync:StartTaskExecution",
       "ecs:*Service*",
       "ecs:*Task*",
       "ecs:*Tag*",
@@ -508,7 +508,6 @@ data "aws_iam_policy_document" "policy" {
       "kms:DescribeKey",
       "kms:Decrypt",
       "kms:Encrypt",
-      "kms:CreateGrant",
       "kms:GenerateDataKey",
       "lambda:UpdateFunctionCode",
       "logs:CreateLogGroup",
@@ -544,6 +543,19 @@ data "aws_iam_policy_document" "policy" {
       "ssm:TerminateSession"
     ]
     resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
+  }
+   statement {
+    effect = "Allow"
+    actions = [
+      "kms:CreateGrant"
+    ]
+
+ resources = ["arn:aws:kms:eu-west-2:${local.environment_management.account_ids["core-shared-services-production"]}:key/*"]
+    condition {
+      test     = "Bool"
+      variable = "kms:GrantIsForAWSResource"
+      values   = ["true"]
+    }
   }
 }
 


### PR DESCRIPTION
## A reference to the issue / Description of it

Restrict kms:CreateGrant permissions for oidc role #6845 
This permission is required for copying snapshots encrypted with a shared KMS key in the core-shared-services account.
## How does this PR fix the problem?

Implements a restriction on the kms:CreateGrant action to ensure that grants can only be created for AWS resources and not to external IAM users, roles, or services. 

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
