### PR TITLE
🛂 CICA Development FW rules

### DIFF
--- a/terraform/environments/core-network-services/cidr-ranges.tf
+++ b/terraform/environments/core-network-services/cidr-ranges.tf
@@ -82,6 +82,20 @@ locals {
     hmpps-preproduction-general-private-subnets = "10.27.0.0/22"
     hmpps-production-general-private-subnets    = "10.27.10.0/22"
 
+    # cica cidr ranges
+    cica-aws-ss-a       = "10.10.10.0/24"
+    cica-aws-ss-b       = "10.10.110.0/24"
+    cica-aws-dev-a      = "10.11.10.0/24"
+    cica-aws-dev-b      = "10.11.110.0/24"
+    cica-aws-dev-data-a = "10.11.20.0/24"
+    cica-aws-dev-data-b = "10.11.120.0/24"
+    cica-aws-uat-a      = "10.12.10.0/24"
+    cica-aws-uat-b      = "10.12.110.0/24"
+    cica-aws-uat-data-a = "10.12.20.0/24"
+    cica-aws-uat-data-b = "10.12.120.0/24"
+
+
+
     mojo-end-user-devices = "10.0.0.0/8"
     dom1-dcs              = "10.0.0.0/8"
     ad-hmpp-dc-a          = "10.27.136.5/32" # see https://github.com/ministryofjustice/modernisation-platform/issues/5970

--- a/terraform/environments/core-network-services/firewall-rules/development_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/development_rules.json
@@ -495,5 +495,26 @@
     "destination_ip": "${moj-smtp-relay2}",
     "destination_port": "587",
     "protocol": "TCP"
+  },
+  "cica_aws_uat_a_to_cica_tariff_dev": {
+    "action": "PASS",
+    "source_ip": "${cica-aws-uat-a}",
+    "destination_ip": "${cica-development}",
+    "destination_port": "ANY",
+    "protocol": "TCP"
+  },
+  "cica_aws_uat_a_to_cica_tariff_dev_icmp": {
+    "action": "PASS",
+    "source_ip": "${cica-aws-uat-a}",
+    "destination_ip": "${cica-development}",
+    "destination_port": "ANY",
+    "protocol": "ICMP"
+  },
+  "cica_tariff_dev_to_cica_aws_uat_a": {
+    "action": "PASS",
+    "source_ip": "${cica-development}",
+    "destination_ip": "${cica-aws-uat-a}",
+    "destination_port": "ANY",
+    "protocol": "TCP"
   }
 }


### PR DESCRIPTION
Allow CICA Dev inbound and outbound to CICA AWS UAT.

## A reference to the issue / Description of it

Initial firewall rules to allow CICA Tariff on MP to reach CICA AWS

## How does this PR fix the problem?

Allows Inbound and Outbound rules on FW, so that CICA AWS can reach Tariff on mod platform across TGW.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

This is a WIP and will be the initial test of connectivity

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
