### PR TITLE
 Feature 7514 - make kms key replicas

### DIFF
--- a/terraform/environments/core-logging/athena.tf
+++ b/terraform/environments/core-logging/athena.tf
@@ -4,7 +4,7 @@ data "aws_caller_identity" "mod-platform" {
 
 data "aws_kms_alias" "environment_management" {
   provider = aws.modernisation-platform
-  name     = "alias/environment-management"
+  name     = "alias/environment-management-multi-region"
 }
 
 #S3 Bucket for Athena temp SQL queries 

--- a/terraform/environments/core-logging/cortex.tf
+++ b/terraform/environments/core-logging/cortex.tf
@@ -164,7 +164,7 @@ resource "aws_sqs_queue_policy" "logging" {
 
 data "aws_kms_alias" "secrets" {
   provider = aws.modernisation-platform
-  name     = "alias/secrets_key"
+  name     = "alias/secrets-key-multi-region"
 }
 
 resource "aws_secretsmanager_secret" "logging" {

--- a/terraform/environments/secrets.tf
+++ b/terraform/environments/secrets.tf
@@ -81,6 +81,18 @@ resource "aws_kms_alias" "environment_management_multi_region" {
   target_key_id = aws_kms_key.environment_management_multi_region.id
 }
 
+resource "aws_kms_replica_key" "environment_management_multi_region_replica" {
+  description             = "AWS Secretsmanager CMK replica key"
+  deletion_window_in_days = 30
+  primary_key_arn         = aws_kms_key.environment_management_multi_region.arn
+  provider                = aws.modernisation-platform-eu-west-1
+}
+
+resource "aws_kms_alias" "environment_management_multi_region_replica" {
+  name          = "alias/environment-management-multi-region-replica"
+  target_key_id = aws_kms_replica_key.environment_management_multi_region_replica.id
+}
+
 data "aws_iam_policy_document" "kms_environment_management" {
 
   # checkov:skip=CKV_AWS_111: "policy is directly related to the resource"

--- a/terraform/github/data.tf
+++ b/terraform/github/data.tf
@@ -13,17 +13,17 @@ data "aws_caller_identity" "modernisation_platform" {
 }
 
 data "aws_kms_key" "s3_state_bucket" {
-  key_id = "alias/s3-state-bucket"
+  key_id = "alias/s3-state-bucket-multi-region"
 }
 
 data "aws_kms_key" "dynamodb_state_lock" {
-  key_id = "alias/dynamodb-state-lock"
+  key_id = "alias/dynamodb-state-lock-multi-region"
 }
 
 data "aws_kms_key" "environment_management" {
-  key_id = "alias/environment-management"
+  key_id = "alias/environment-management-multi-region"
 }
 
 data "aws_kms_key" "pagerduty" {
-  key_id = "alias/pagerduty-secret"
+  key_id = "alias/pagerduty-secret-multi-region"
 }

--- a/terraform/modernisation-platform-account/dynamodb.tf
+++ b/terraform/modernisation-platform-account/dynamodb.tf
@@ -32,6 +32,18 @@ resource "aws_kms_alias" "dynamo_encryption_multi_region" {
   target_key_id = aws_kms_key.dynamo_encryption_multi_region.id
 }
 
+resource "aws_kms_replica_key" "dynamo_encryption_multi_region_replica" {
+  description             = "AWS Secretsmanager CMK replica key"
+  deletion_window_in_days = 30
+  primary_key_arn         = aws_kms_key.dynamo_encryption_multi_region.arn
+  provider                = aws.modernisation-platform-eu-west-1
+}
+
+resource "aws_kms_alias" "dynamo_encryption_multi_region_replica" {
+  name          = "alias/dynamo-encryption-multi-region-replica"
+  target_key_id = aws_kms_replica_key.dynamo_encryption_multi_region_replica.id
+}
+
 data "aws_iam_policy_document" "dynamo_encryption" {
 
   # checkov:skip=CKV_AWS_109: "Key policy requires asterisk resource"

--- a/terraform/modernisation-platform-account/s3.tf
+++ b/terraform/modernisation-platform-account/s3.tf
@@ -25,6 +25,18 @@ resource "aws_kms_alias" "s3_state_bucket_multi_region" {
   target_key_id = aws_kms_key.s3_state_bucket_multi_region.id
 }
 
+resource "aws_kms_replica_key" "s3_state_bucket_multi_region_replica" {
+  description             = "AWS Secretsmanager CMK replica key"
+  deletion_window_in_days = 30
+  primary_key_arn         = aws_kms_key.s3_state_bucket_multi_region.arn
+  provider                = aws.modernisation-platform-eu-west-1
+}
+
+resource "aws_kms_alias" "s3_state_bucket_multi_region_replica" {
+  name          = "alias/s3-state-bucket-multi-region-replica"
+  target_key_id = aws_kms_replica_key.s3_state_bucket_multi_region_replica.id
+}
+
 data "aws_iam_policy_document" "kms_state_bucket" {
   # checkov:skip=CKV_AWS_111: "policy is directly related to the resource"
   # checkov:skip=CKV_AWS_356: "policy is directly related to the resource"

--- a/terraform/modernisation-platform-account/secrets.tf
+++ b/terraform/modernisation-platform-account/secrets.tf
@@ -76,7 +76,7 @@ resource "aws_secretsmanager_secret" "slack_webhook_url" {
   # checkov:skip=CKV2_AWS_57:Auto rotation not possible
   name        = "slack_webhook_url"
   description = "Slack channel modernisation-platform-notifications webhook url for sending notifications to slack"
-  kms_key_id  = aws_kms_key.secrets_key.id
+  kms_key_id  = aws_kms_key.secrets_key_multi_region.id
   tags        = local.tags
   replica {
     region = local.replica_region
@@ -87,7 +87,7 @@ resource "aws_secretsmanager_secret" "slack_webhook_url_modernisation_platform_u
   # checkov:skip=CKV2_AWS_57:Auto rotation not possible
   name        = "slack_webhook_url_modernisation_platform_update"
   description = "Slack channel modernisation-platform-update webhook url for sending notifications to slack"
-  kms_key_id  = aws_kms_key.secrets_key.id
+  kms_key_id  = aws_kms_key.secrets_key_multi_region.id
   tags        = local.tags
   replica {
     region = local.replica_region
@@ -101,7 +101,7 @@ resource "aws_secretsmanager_secret" "github_ci_user_pat" {
   # checkov:skip=CKV2_AWS_57:Auto rotation not possible
   name        = "github_ci_user_pat"
   description = "GitHub CI user PAT used for generated resources in GitHub via Terraform"
-  kms_key_id  = aws_kms_key.secrets_key.id
+  kms_key_id  = aws_kms_key.secrets_key_multi_region.id
   tags        = local.tags
   replica {
     region = local.replica_region
@@ -115,7 +115,7 @@ resource "aws_secretsmanager_secret" "github_ci_user_environments_repo_pat" {
   # checkov:skip=CKV2_AWS_57:Auto rotation not possible
   name        = "github_ci_user_environments_repo_pat"
   description = "This PAT token is used in reusable pipelines of the modernisation-platform-environments repository. This is so that the CI user can post comments in PRs, e.g. tf plan/apply output. Expires on Tue, Apr 9 2024."
-  kms_key_id  = aws_kms_key.secrets_key.id
+  kms_key_id  = aws_kms_key.secrets_key_multi_region.id
   tags        = local.tags
   replica {
     region = local.replica_region
@@ -129,7 +129,7 @@ resource "aws_secretsmanager_secret" "github_ci_user_password" {
   # checkov:skip=CKV2_AWS_57:Auto rotation not possible
   name        = "github_ci_user_password"
   description = "GitHub CI user password"
-  kms_key_id  = aws_kms_key.secrets_key.id
+  kms_key_id  = aws_kms_key.secrets_key_multi_region.id
   tags        = local.tags
   replica {
     region = local.replica_region
@@ -141,7 +141,7 @@ resource "aws_secretsmanager_secret" "nuke_account_blocklist" {
   # checkov:skip=CKV2_AWS_57:Auto rotation not possible
   name        = "nuke_account_blocklist"
   description = "Account IDs to be excluded from auto-nuke. AWS-Nuke (https://github.com/rebuy-de/aws-nuke) requires at least one Account ID to be present in this blocklist, while it is recommended to add every production account to this blocklist."
-  kms_key_id  = aws_kms_key.secrets_key.id
+  kms_key_id  = aws_kms_key.secrets_key_multi_region.id
   tags        = local.tags
   replica {
     region = local.replica_region
@@ -153,7 +153,7 @@ resource "aws_secretsmanager_secret" "nuke_account_ids" {
   # checkov:skip=CKV2_AWS_57:Auto rotation not possible
   name        = "nuke_account_ids"
   description = "Account IDs to be auto-nuked on weekly basis. CAUTION: Any account ID you add here will be automatically nuked! This secret is used by GitHub actions job nuke.yml inside the environments repo, to find the Account IDs to be nuked."
-  kms_key_id  = aws_kms_key.secrets_key.id
+  kms_key_id  = aws_kms_key.secrets_key_multi_region.id
   tags        = local.tags
   replica {
     region = local.replica_region
@@ -174,7 +174,7 @@ resource "aws_secretsmanager_secret" "circleci" {
   # checkov:skip=CKV2_AWS_57:Auto rotation not possible
   name        = "mod-platform-circleci"
   description = "CircleCI organisation ID for ministryofjustice, used for OIDC IAM policies"
-  kms_key_id  = aws_kms_key.secrets_key.id
+  kms_key_id  = aws_kms_key.secrets_key_multi_region.id
 
   replica {
     region = local.replica_region
@@ -204,7 +204,7 @@ resource "aws_secretsmanager_secret" "xsiam_secrets" {
   # checkov:skip=CKV2_AWS_57:Auto rotation not possible
   name        = "xsiam_secrets"
   description = "Secret that holds the preprod & prod XSIAM endpoint values & keys for the firewall inspection & vpc flow log transfers"
-  kms_key_id  = aws_kms_key.secrets_key.id
+  kms_key_id  = aws_kms_key.secrets_key_multi_region.id
   tags        = local.tags
   replica {
     region = local.replica_region
@@ -215,7 +215,7 @@ resource "aws_secretsmanager_secret" "gov_uk_notify_api_key" {
   # checkov:skip=CKV2_AWS_57:Auto rotation not possible
   name        = "gov_uk_notify_api_key"
   description = "API key for accessing the GOV.UK Notify service for sending email notifications"
-  kms_key_id  = aws_kms_key.secrets_key.id
+  kms_key_id  = aws_kms_key.secrets_key_multi_region.id
   tags        = local.tags
   replica {
     region = local.replica_region
@@ -226,7 +226,7 @@ resource "aws_secretsmanager_secret" "slack_webhooks" {
   # checkov:skip=CKV2_AWS_57:Auto rotation not possible
   name        = "slack_webhooks"
   description = "Used for sending notifications to specified Slack channels when environment JSON files are modified"
-  kms_key_id  = aws_kms_key.secrets_key.id
+  kms_key_id  = aws_kms_key.secrets_key_multi_region.id
   tags        = local.tags
   replica {
     region = local.replica_region

--- a/terraform/pagerduty/kms.tf
+++ b/terraform/pagerduty/kms.tf
@@ -20,3 +20,15 @@ resource "aws_kms_alias" "pagerduty_multi_region" {
   name          = "alias/pagerduty-secret-multi-region"
   target_key_id = aws_kms_key.pagerduty_multi_region.id
 }
+
+resource "aws_kms_replica_key" "pagerduty_multi_region_replica" {
+  description             = "AWS Secretsmanager CMK replica key"
+  deletion_window_in_days = 30
+  primary_key_arn         = aws_kms_key.pagerduty_multi_region.arn
+  provider                = aws.modernisation-platform-eu-west-1
+}
+
+resource "aws_kms_alias" "pagerduty_multi_region_replica" {
+  name          = "alias/pagerduty-secret-multi-region-replica"
+  target_key_id = aws_kms_replica_key.pagerduty_multi_region_replica.id
+}


### PR DESCRIPTION
## A reference to the issue / Description of it

#7514

## How does this PR fix the problem?

The PR adds the multi region replica keys below and also resources that where using the non multi region keys now use the new ones below

- secrets-key-multi-region
- environment-management-multi-region
- s3-state-bucket-multi-region
- pagerduty-secret-multi-region
- dynamodb-state-lock-multi-region


## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Local Terraform Plan

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
