### PR TITLE
Fix policy arn AmazonGrafanaAthenaAccess

### DIFF
--- a/terraform/environments/core-logging/observability.tf
+++ b/terraform/environments/core-logging/observability.tf
@@ -52,7 +52,7 @@ data "aws_iam_policy_document" "grafana_athena_policy" {
 # Attach AmazonGrafanaAthenaAccess policy
 resource "aws_iam_role_policy_attachment" "grafana_athena_attachment" {
   role       = aws_iam_role.grafana_athena.id
-  policy_arn = "arn:aws:iam::aws:policy/AmazonGrafanaAthenaAccess"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonGrafanaAthenaAccess"
 }
 
 # S3 bucket for Grafana Athena query results


### PR DESCRIPTION
incorrect arn specified updating from `arn:aws:iam::aws:policy/AmazonGrafanaAthenaAccess` to `arn:aws:iam::aws:policy/service-role/AmazonGrafanaAthenaAccess`
