### PR TITLE
DPR2-1170: Add scheduler roles to circleci_iam_policy

### DIFF
--- a/terraform/environments/digital-prison-reporting/iam.tf
+++ b/terraform/environments/digital-prison-reporting/iam.tf
@@ -247,7 +247,12 @@ data "aws_iam_policy_document" "circleci_iam_policy" {
       "glue:DeleteTable",
       "glue:DeleteTrigger",
       "glue:GetConnection",
-      "iam:TagRole"
+      "iam:TagRole",
+      "scheduler:CreateSchedule",
+      "scheduler:DeleteSchedule",
+      "scheduler:UpdateSchedule",
+      "scheduler:TagSchedule",
+      "scheduler:UntagSchedule"
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
## A reference to the issue / Description of it

There were errors encountered by the `circle_ci` role when creating an `EventBridge` scheduler:
```
│ Error: creating AWS EventBridge Scheduler Schedule (dpr-start-establishments-development): operation error Scheduler: CreateSchedule, https response error StatusCode: 403, RequestID: bae15e8c-3f7a-4e14-9c1a-cd900ae14b37, api error AccessDeniedException: User: arn:aws:sts::771283872747:assumed-role/circleci_iam_role/circleci-oidc-session is not authorized to perform: scheduler:CreateSchedule on resource: arn:aws:scheduler:eu-west-2:771283872747:schedule/default/dpr-start-establishments-development because no identity-based policy allows the scheduler:CreateSchedule action
```
https://app.circleci.com/pipelines/github/ministryofjustice/digital-prison-reporting-domains/1370/workflows/290d4cf6-6deb-4f24-b2f1-8172d8b1a374/jobs/4187

## How does this PR fix the problem?

This adds the actions below to the `circle_ci` role:
- scheduler:CreateSchedule
- scheduler:DeleteSchedule
- scheduler:UpdateSchedule
- scheduler:TagSchedule
- scheduler:UntagSchedule

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

A pipeline which shows the failure is at:
https://app.circleci.com/pipelines/github/ministryofjustice/digital-prison-reporting-domains/1370/workflows/290d4cf6-6deb-4f24-b2f1-8172d8b1a374/jobs/4187

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed) N/A

## Additional comments (if any)

N/A
