### PR TITLE
bump one use of the firehose to assess impact of uncompressed logs

### DIFF
--- a/terraform/environments/core-network-services/logging.tf
+++ b/terraform/environments/core-network-services/logging.tf
@@ -7,7 +7,7 @@ module "logging-vpc-flow-logs" {
 }
 
 module "logging-generic-logs" {
-  source                     = "github.com/ministryofjustice/modernisation-platform-terraform-aws-data-firehose?ref=c734a2e83c8b034a07b6d11e1975c4f230f42ec4" #v1.0.0
+  source                     = "github.com/ministryofjustice/modernisation-platform-terraform-aws-data-firehose?ref=2e58c8fd0b43ca8461dfd0c8cc5f43a1a9c49987" #v1.1.0
   for_each                   = local.is-production ? { "build" = true } : {}
   cloudwatch_log_group_names = local.cloudwatch_generic_log_groups
   destination_bucket_arn     = local.cloudwatch_log_buckets["generic-logs"]


### PR DESCRIPTION
## A reference to the issue / Description of it

#7185

## How does this PR fix the problem?

The logs appear to be double-compressed; by the CloudWatch log group subscription filter, and by the delivery stream. This PR bumps the data firehose module to a version that supports uncompressed delivery streams.

If the behaviour is as expected - logs are parsed by Cortex XSIAM and successfully interpreted - a following PR will apply this to all other uses of the module.

## How has this been tested?

Tested with local plan

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
