### PR TITLE
DPR2-1170: Add iam:UpdateAssumeRolePolicy to DPR circle_ci role

### DIFF
--- a/terraform/environments/digital-prison-reporting/iam.tf
+++ b/terraform/environments/digital-prison-reporting/iam.tf
@@ -248,6 +248,7 @@ data "aws_iam_policy_document" "circleci_iam_policy" {
       "glue:DeleteTrigger",
       "glue:GetConnection",
       "iam:TagRole",
+      "iam:UpdateAssumeRolePolicy",
       "scheduler:CreateSchedule",
       "scheduler:DeleteSchedule",
       "scheduler:UpdateSchedule",


### PR DESCRIPTION
## A reference to the issue / Description of it

The error below was encountered by the DPR circle-ci role while trying to update an IAM role:
```
╷
│ Error: updating IAM Role (dpr-start-establishments-development-role) assume role policy: operation error IAM: UpdateAssumeRolePolicy, https response error StatusCode: 403, RequestID: f0c92f6c-6cc1-4c16-845f-75bd9c3ce3cd, api error AccessDenied: User: arn:aws:sts::771283872747:assumed-role/circleci_iam_role/circleci-oidc-session is not authorized to perform: iam:UpdateAssumeRolePolicy on resource: role dpr-start-establishments-development-role because no identity-based policy allows the iam:UpdateAssumeRolePolicy action
```
https://app.circleci.com/pipelines/github/ministryofjustice/digital-prison-reporting-domains/1380/workflows/16f920cd-c430-4716-a2ce-f08d6bcc4cf5/jobs/4234

## How does this PR fix the problem?

This PR adds the `iam:UpdateAssumeRolePolicy` action to the DPR circle_ci role.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Link to the failing pipeline is
https://app.circleci.com/pipelines/github/ministryofjustice/digital-prison-reporting-domains/1380/workflows/16f920cd-c430-4716-a2ce-f08d6bcc4cf5/jobs/4234

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

N/A

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed) - N/A

## Additional comments (if any)

N/A
