### PR TITLE
DPR2-1170: Add scheduler:GetSchedule and other required perms to DPR …

### DIFF
--- a/terraform/environments/digital-prison-reporting/iam.tf
+++ b/terraform/environments/digital-prison-reporting/iam.tf
@@ -253,7 +253,11 @@ data "aws_iam_policy_document" "circleci_iam_policy" {
       "scheduler:DeleteSchedule",
       "scheduler:UpdateSchedule",
       "scheduler:TagSchedule",
-      "scheduler:UntagSchedule"
+      "scheduler:UntagSchedule",
+      "scheduler:GetSchedule",
+      "scheduler:ListSchedules",
+      "scheduler:TagResource",
+      "scheduler:UntagResource"
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
…circle_ci role

## A reference to the issue / Description of it

The DPR circle_ci role failed to aply changes due to the error below:
```
Error: reading AWS EventBridge Scheduler Schedule (default/dpr-start-establishments-development): operation error Scheduler: GetSchedule, https response error StatusCode: 403, RequestID: fd02efd7-3168-4d9a-be6d-afd7998cb0c8, api error AccessDeniedException: User: arn:aws:sts::771283872747:assumed-role/circleci_iam_role/circleci-oidc-session is not authorized to perform: scheduler:GetSchedule on resource: arn:aws:scheduler:eu-west-2:771283872747:schedule/default/dpr-start-establishments-development because no identity-based policy allows the scheduler:GetSchedule action
```
https://app.circleci.com/pipelines/github/ministryofjustice/digital-prison-reporting-domains/1380/workflows/e140624a-b4a9-4f79-b6c0-faa668023362/jobs/4236

## How does this PR fix the problem?

This PR adds the actions required to make the terraform apply succeed.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

The job which reproduces the issue is
https://app.circleci.com/pipelines/github/ministryofjustice/digital-prison-reporting-domains/1380/workflows/e140624a-b4a9-4f79-b6c0-faa668023362/jobs/4236

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

None

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed) - N/A

## Additional comments (if any)

{Please write here}
