### PR TITLE
Recreating the MP account runbook

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -111,7 +111,6 @@ This documentation is for anyone interested in the Modernisation Platform and it
 - [Backup and Restore of Terraform Statefile & EC2](runbooks/backup-restore-process.html)
 - [Changing environment (AWS account) details](runbooks/changing-environment-details.html)
 - [CloudWatch networking alarms](runbooks/cloudwatch-networking-alarms.html)
-- [Core Shared Services Account Setup](runbooks/core-shared-services-production.html)
 - [Creating Automated Terraform Documentation](user-guide/creating-automated-terraform-documentation.html)
 - [Creating new DNS zones](runbooks/creating-new-dns-zones.html)
 - [Creating new Private DNS zones](runbooks/creating-new-private-dns-zones.html)

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -134,6 +134,8 @@ This documentation is for anyone interested in the Modernisation Platform and it
 - [Modifying Service Control Policies (SCPs)](runbooks/modifying-scps.html)
 - [Querying CloudTrail logs with Athena](runbooks/using-athena.html)
 - [Querying VPC flow logs](runbooks/querying-vpc-flow-logs.html)
+- [Recreating the core-shared-services account](runbooks/recreate-core-shared-services-production.html)
+- [Recreating the modernisation-platform account](runbooks/recreate-modernisation-platform-account.html)
 - [Removing a team member from the Modernisation Platform](runbooks/removing-a-team-member.html)
 - [Reviewing Dependabot PRs](runbooks/reviewing-dependabot-prs.html)
 - [Reviewing MP Environments PRs](runbooks/reviewing-mp-environments-prs.html)

--- a/source/runbooks/recreate-core-shared-services-production.html.md.erb
+++ b/source/runbooks/recreate-core-shared-services-production.html.md.erb
@@ -52,7 +52,6 @@ Alternatively, this can be done as manual deployment:
 - Inform our members that the account has been recreated
 - Liaise with owning teams to validate any rebuilds
 
-
 ## References
 
 * [Accessing the AWS Console](https://user-guide.modernisation-platform.service.justice.gov.uk/user-guide/accessing-the-aws-console.html)

--- a/source/runbooks/recreate-core-shared-services-production.html.md.erb
+++ b/source/runbooks/recreate-core-shared-services-production.html.md.erb
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#modernisation-platform"
 title: Core Shared Services Account Setup
-last_reviewed_on: 2024-07-29
+last_reviewed_on: 2024-09-19
 review_in: 6 months
 ---
 

--- a/source/runbooks/recreate-modernisation-platform-account.html.md.erb
+++ b/source/runbooks/recreate-modernisation-platform-account.html.md.erb
@@ -1,0 +1,64 @@
+---
+owner_slack: "#modernisation-platform"
+title: Core Shared Services Account Setup
+last_reviewed_on: 2024-07-29
+review_in: 6 months
+---
+
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-NXTCMQ7ZX6"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-NXTCMQ7ZX6');
+</script>
+
+# <%= current_page.data.title %>
+
+## Overview
+
+The `Modernisation Platform` AWS account hosts resources used by other Modernisation Platform accounts.
+
+| Resource        | Description                                                                                                   |
+|-----------------|---------------------------------------------------------------------------------------------------------------|
+| S3              | Stores Terraform state files for Modernisation Platform accounts, account-local AWS Config info, cost reports |
+| DynamoDB        | Holds state locking table for Terraform                                                                       |
+| Secrets Manager | Stores values used by Modernisation Platform accounts                                                         |
+| IAM             | Contains accounts for external collaborators                                                                  |
+| KMS             | Encryption keys, some account local, but one used to secure PagerDuty secrets                                 |
+
+## Steps
+## 1. Account Creation 
+
+Configuration to create the `Modernisation Platform` account is stored in code in the [aws-root-account](https://github.com/ministryofjustice/aws-root-account/blob/main/management-account/terraform/organizations-accounts-platforms-and-architecture-modernisation-platform.tf) repository.
+
+To recreate the `Modernisation Platform` account, a person with appropriate access can run GitHub actions in [aws-root-account](https://github.com/ministryofjustice/aws-root-account/actions) repository.
+
+## 2. Deploy Modernisation Platform Resources
+
+Configuration of resources in the `Modernisation Platform` account is stored in code in [modernisation-platform](https://github.com/ministryofjustice/modernisation-platform/tree/main/terraform/modernisation-platform-account) repository.
+
+To recreate these resources you can run the [Terraform: modernisation-platform-account](https://github.com/ministryofjustice/modernisation-platform/actions/workflows/modernisation-platform-account.yml) action in GitHub.
+
+Alternatively, this can be done as manual deployment: 
+- Navigate to the `modernisation-platfom` repository and access the `terraform/modernisation-platform-account` directory
+- Run `terraform plan` in the default workspace
+- Using admin credentials, execute `terraform apply`
+
+## 3. Verify Resources
+
+- Log into the AWS Console for the `Modernisation Platform` account.
+- Verify that resources have been correctly configured.
+- Confirm that Modernisation Platform member accounts can retrieve information such as AWS Secrets Manager secret values.
+
+## 4. Notify customers
+
+- Inform Modernisation Platform team of rebuild process
+- Inform customers that account has been recreated
+- Work with customers to import cached Terraform statefile objects into S3
+
+## References
+
+* [Accessing the AWS Console](https://user-guide.modernisation-platform.service.justice.gov.uk/user-guide/accessing-the-aws-console.html)
+* [Disaster Recovery Process](https://user-guide.modernisation-platform.service.justice.gov.uk/runbooks/dr-process.html)

--- a/source/runbooks/recreate-modernisation-platform-account.html.md.erb
+++ b/source/runbooks/recreate-modernisation-platform-account.html.md.erb
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#modernisation-platform"
-title: Core Shared Services Account Setup
-last_reviewed_on: 2024-07-29
+title: Modernisation Platform Account Setup
+last_reviewed_on: 2024-09-19
 review_in: 6 months
 ---
 


### PR DESCRIPTION
## A reference to the issue / Description of it

#6761

## How does this PR fix the problem?

Adds a runbook detailing how to recreate the MP account and resources, along with some post-recreation steps.

The last part about reimporting state files isn't perfect; if the account was deleted the state files would go with them, but some state files will be locally cached by users who have run a terraform plan in their `./terraform` directory. In theory these could be manually restored.

## How has this been tested?

Will be tested when related story is in review

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
