### PR TITLE
🛂 Allow CICA UAT on-prem to dev

### DIFF
--- a/terraform/environments/core-network-services/cidr-ranges.tf
+++ b/terraform/environments/core-network-services/cidr-ranges.tf
@@ -93,6 +93,8 @@ locals {
     cica-aws-uat-b      = "10.12.110.0/24"
     cica-aws-uat-data-a = "10.12.20.0/24"
     cica-aws-uat-data-b = "10.12.120.0/24"
+    cica-onprem-uat     = "192.168.4.0/24"
+    cica-onprem-prod    = "10.2.30.0/24"
 
 
 

--- a/terraform/environments/core-network-services/firewall-rules/development_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/development_rules.json
@@ -516,5 +516,19 @@
     "destination_ip": "${cica-aws-uat-a}",
     "destination_port": "ANY",
     "protocol": "TCP"
+  },
+  "cica_tariff_dev_to_cica_onprem_uat": {
+    "action": "PASS",
+    "source_ip": "${cica-development}",
+    "destination_ip": "${cica-onprem-uat}",
+    "destination_port": "ANY",
+    "protocol": "TCP"
+  },
+  "cica_onprem_uat_to_cica_tariff_dev": {
+    "action": "PASS",
+    "source_ip": "${cica-onprem-uat}",
+    "destination_ip": "${cica-development}",
+    "destination_port": "ANY",
+    "protocol": "TCP"
   }
 }


### PR DESCRIPTION
Allow traffic from CICA UAT on-prem to MP Dev.

## A reference to the issue / Description of it

Allow connectivity from CICA UAT VLAN to Dev environment. Adds CICA on-prem ranges to cidr-ranges.tf and creates firewall rule to allow traffic.

## How does this PR fix the problem?

CICA firewall is being configured to allow routes from on-premise across VPN and Transit Gateway to Modernisation Platform. This  PR will allow testing of this connectivity.

## How has this been tested?

Previous PR for allowing Dev traffic to CICA AWS has been tested and connectivity confirmed.


## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
