### PR TITLE
Put in the correct channel_id following discussion with Mark

### DIFF
--- a/terraform/pagerduty/member-services-integrations.tf
+++ b/terraform/pagerduty/member-services-integrations.tf
@@ -2052,7 +2052,7 @@ resource "pagerduty_service" "sprinkler-development" {
   alert_creation          = "create_alerts_and_incidents"
 }
 
-resource "pagerduty_event_orchestration" "monitor-sprinkler-integration" {
+resource ""pagerduty_event_orchestration" "monitor-sprinkler-integration""" {
   name        = "Monitor sprinkler for orchestration"
   description = "Integrates sprinkler-development account with PagerDuty"
   team        = pagerduty_team.modernisation_platform.id

--- a/terraform/pagerduty/member-services-integrations.tf
+++ b/terraform/pagerduty/member-services-integrations.tf
@@ -2053,7 +2053,6 @@ resource "pagerduty_service" "sprinkler-development" {
 }
 
 resource "pagerduty_event_orchestration" "monitor-sprinkler-integration" {
-  depends_on  = [pagerduty_team.modernisation_platform]
   name        = "Monitor sprinkler for orchestration"
   description = "Integrates sprinkler-development account with PagerDuty"
   team        = pagerduty_team.modernisation_platform.id

--- a/terraform/pagerduty/member-services-integrations.tf
+++ b/terraform/pagerduty/member-services-integrations.tf
@@ -1846,7 +1846,6 @@ resource "pagerduty_service" "cdpt-chaps" {
 
 resource "pagerduty_event_orchestration" "cdpt_chaps_cloudwatch" {
   name        = data.pagerduty_vendor.cloudwatch.name  
-  # = "Monitor sprinkler for cdpt_chaps"
   description = "Integrates with PagerDuty"
   team        = pagerduty_service_integration.cdpt_ifs_cloudwatch.integration_key
 }
@@ -2067,7 +2066,7 @@ resource "pagerduty_slack_connection" "sprinkler_connection" {
   source_id         = pagerduty_service.sprinkler-development.id
   source_type       = "service_reference"
   workspace_id      = local.slack_workspace_id
-  channel_id        = "C02PMCG8M1R"
+  channel_id        = "C02PFCG8M1R"
   notification_type = "responder"
   lifecycle {
   }

--- a/terraform/pagerduty/member-services-integrations.tf
+++ b/terraform/pagerduty/member-services-integrations.tf
@@ -2063,7 +2063,7 @@ resource "pagerduty_slack_connection" "sprinkler_connection" {
   source_id         = pagerduty_service.sprinkler-development.id
   source_type       = "service_reference"
   workspace_id      = local.slack_workspace_id
-  channel_id        = "C04QGQML68P"
+  channel_id        = "C02PMCG8M1R"
   notification_type = "responder"
   lifecycle {
   }

--- a/terraform/pagerduty/member-services-integrations.tf
+++ b/terraform/pagerduty/member-services-integrations.tf
@@ -1844,11 +1844,16 @@ resource "pagerduty_service" "cdpt-chaps" {
   alert_creation          = "create_alerts_and_incidents"
 }
 
-resource "pagerduty_service_integration" "cdpt_chaps_cloudwatch" {
-  name    = data.pagerduty_vendor.cloudwatch.name
-  service = pagerduty_service.cdpt-chaps.id
-  vendor  = data.pagerduty_vendor.cloudwatch.id
+resource "pagerduty_event_orchestration" "cdpt_chaps_cloudwatch" {
+  name        = data.pagerduty_vendor.cloudwatch.name  
+  # = "Monitor sprinkler for cdpt_chaps"
+  description = "Integrates with PagerDuty"
+  team        = pagerduty_service_integration.cdpt_ifs_cloudwatch.integration_key
 }
+#   name    = data.pagerduty_vendor.cloudwatch.name
+#   service = pagerduty_service.cdpt-chaps.id
+#   vendor  = data.pagerduty_vendor.cloudwatch.id
+# }
 
 resource "pagerduty_slack_connection" "chaps_slack" {
   source_id         = pagerduty_service.cdpt-chaps.id

--- a/terraform/pagerduty/member-services-integrations.tf
+++ b/terraform/pagerduty/member-services-integrations.tf
@@ -2052,7 +2052,7 @@ resource "pagerduty_service" "sprinkler-development" {
   alert_creation          = "create_alerts_and_incidents"
 }
 
-resource ""pagerduty_event_orchestration" "monitor-sprinkler-integration""" {
+resource "pagerduty_event_orchestration" "monitor-sprinkler-integration" {
   name        = "Monitor sprinkler for orchestration"
   description = "Integrates sprinkler-development account with PagerDuty"
   team        = pagerduty_team.modernisation_platform.id


### PR DESCRIPTION
This code, initially, sets up a different channel for Sprinkler. More importantly, however, is the change to cdpt_chaps_cloudwatch where the code has been amended to replace agerduty_service_integration with pagerduty_event_orchestration. This is to ensure that changes due to happen early next year will not impact us. We are currently testing this to make sure it has no impact on our services.

The code was also amended to put the low priority alarms code in place. Again this has been amended to fix an issue with the value.

The initial code has been left, commented out, so that we can reinstate if required. 

Also see request #5980 