### PR TITLE
Bump VPC module version to latest

### DIFF
--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -85,7 +85,7 @@ locals {
 module "vpc" {
   for_each = local.vpcs[terraform.workspace]
 
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-member-vpc?ref=3094604aee5121f9794d60d3f27d21d6209e59d4" # v2.4.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-member-vpc?ref=c0475531b5c9f45a78a94fea441cd9ce91ad3c59" # v2.5.0
 
   subnet_sets = { for key, subnet in each.value.cidr.subnet_sets : key => subnet.cidr }
 


### PR DESCRIPTION
## A reference to the issue / Description of it

#7607

## How does this PR fix the problem?

It's a precursory step to outputting logs to S3. By bumping the module version, a later PR can supply an attribute to create a flow log which outputs to S3

## How has this been tested?

Ran local terraform plan

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
