### PR TITLE
Allow VPC flow logs to be written directly to Cortex buckets

### DIFF
--- a/terraform/environments/core-logging/cortex.tf
+++ b/terraform/environments/core-logging/cortex.tf
@@ -81,6 +81,24 @@ data "aws_iam_policy_document" "logging-bucket" {
       ]
     }
   }
+  statement {
+    sid     = "EnforceTLSv12orHigher"
+    effect  = "Deny"
+    actions = ["s3:*"]
+    resources = [
+      aws_s3_bucket.logging[each.key].arn,
+      "${aws_s3_bucket.logging[each.key].arn}/*"
+    ]
+    principals {
+      identifiers = ["*"]
+      type        = "AWS"
+    }
+    condition {
+      test     = "NumericLessThan"
+      variable = "s3:TlsVersion"
+      values   = [1.2]
+    }
+  }
 }
 
 data "aws_iam_policy_document" "logging-sqs" {


### PR DESCRIPTION
## A reference to the issue / Description of it

#7607

## How does this PR fix the problem?

Adds bucket policy statements allowing `delivery.logs.amazonaws.com` service to write to the buckets. This is a precursor to enabling VPC flow logs to be written directly to the buckets, instead of via an AWS Data Stream / kinesis firehose.

You can see the AWS guidance on policies here: https://docs.aws.amazon.com/prescriptive-guidance/latest/patterns/configure-vpc-flow-logs-for-centralization-across-aws-accounts.html#configure-vpc-flow-logs-for-centralization-across-aws-accounts-additional

## How has this been tested?

Tested through PR checks & by peer review

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
