### PR TITLE
Adds KMS encryption policy for CloudWatch Log groups

### DIFF
--- a/terraform/modules/kms/main.tf
+++ b/terraform/modules/kms/main.tf
@@ -128,6 +128,31 @@ data "aws_iam_policy_document" "kms-general" {
       ]
     }
   }
+  statement {
+    effect = "Allow"
+    
+    actions = [
+      "kms:Encrypt",
+      "kms:Decrypt",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:DescribeKey"
+    ]
+
+    resources = ["*"]
+
+    principals {
+      type = "Service"
+      identifiers = [
+        "logs.eu-west-2.amazonaws.com"
+      ]
+    }
+    condition {
+      test     = "ArnLike"
+      variable = "kms:EncryptionContext:aws:logs:arn"
+      values   = ["arn:aws:logs:eu-west-2:${data.aws_caller_identity.current.account_id}:*"]
+    }
+  }
 }
 
 data "aws_iam_policy_document" "combined-kms-general" {


### PR DESCRIPTION
## A reference to the issue / Description of it

#7870 
## How does this PR fix the problem?

This PR adds a policy to allow CloudWatch Logs to encrypt log data using a KMS key. It enhances the security of CloudWatch Log Groups by enabling encryption at rest and limits the use of the AWS KMS key to specified account.

## How has this been tested?

Tested in cooker.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
