### PR TITLE
Add detail on reopening account to runbook

### DIFF
--- a/source/runbooks/recreate-modernisation-platform-account.html.md.erb
+++ b/source/runbooks/recreate-modernisation-platform-account.html.md.erb
@@ -33,6 +33,8 @@ The `Modernisation Platform` AWS account hosts resources used by other Modernisa
 
 Configuration to create the `Modernisation Platform` account is stored in code in the [aws-root-account](https://github.com/ministryofjustice/aws-root-account/blob/main/management-account/terraform/organizations-accounts-platforms-and-architecture-modernisation-platform.tf) repository.
 
+If the account has been accidentally deleted less than 90 days ago you can refer to [this guidance](https://repost.aws/knowledge-center/reopen-aws-account).
+
 To recreate the `Modernisation Platform` account, a person with appropriate access can run GitHub actions in [aws-root-account](https://github.com/ministryofjustice/aws-root-account/actions) repository.
 
 ## 2. Deploy Modernisation Platform Resources


### PR DESCRIPTION
## A reference to the issue / Description of it

#6761 

## How does this PR fix the problem?

Adds a little extra detail on how to recover a closed account. It's possible that we might need to set a different alias to the account, but if we're in scope to reuse the alias then we're out of scope to recover the account and I can't see why we'd not recover the account.

## How has this been tested?

Checked link correctly refers to AWS guidance

## Deployment Plan / Instructions

N/A

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
