### PR TITLE
Remove firehose logging of vpc flow logs

### DIFF
--- a/terraform/environments/core-vpc/logging.tf
+++ b/terraform/environments/core-vpc/logging.tf
@@ -5,11 +5,3 @@ module "logging-r53-resolver" {
   destination_bucket_arn     = local.cloudwatch_log_buckets["r53-resolver-logs"]
   tags                       = local.tags
 }
-
-module "logging-vpc-flow-logs" {
-  source                     = "github.com/ministryofjustice/modernisation-platform-terraform-aws-data-firehose?ref=2e58c8fd0b43ca8461dfd0c8cc5f43a1a9c49987" #v1.1.0
-  for_each                   = local.is-production ? { "build" = true } : {}
-  cloudwatch_log_group_names = local.cloudwatch_vpc_flow_log_groups
-  destination_bucket_arn     = local.cloudwatch_log_buckets["vpc-flow-logs"]
-  tags                       = local.tags
-}


### PR DESCRIPTION
## A reference to the issue / Description of it

#7607 

## How does this PR fix the problem?

Remove streaming of flow logs through aws data firehose. A following PR will instate logging directly to S3

## How has this been tested?

Tested with local PR

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
