### PR TITLE
Send flow logs to S3

### DIFF
--- a/terraform/environments/core-vpc/locals.tf
+++ b/terraform/environments/core-vpc/locals.tf
@@ -21,7 +21,7 @@ locals {
 
   # Secrets used by Firehose resources which we only require for development & production VPCs.
   xsiam                              = jsondecode(data.aws_secretsmanager_secret_version.xsiam_secret_arn_version.secret_string)
-  cloudwatch_log_buckets             = jsondecode(data.aws_secretsmanager_secret_version.core_logging_bucket_arns.secret_string)
+  cloudwatch_log_buckets             = nonsensitive(jsondecode(data.aws_secretsmanager_secret_version.core_logging_bucket_arns.secret_string))
   cloudwatch_r53_resolver_log_groups = local.is-production ? [for env in module.route_53_resolver_logs : env.r53_resolver_log_name] : []
   cloudwatch_vpc_flow_log_groups     = local.is-production ? [for key, value in module.vpc : value.vpc_flow_log] : []
 

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -83,27 +83,20 @@ locals {
 }
 
 module "vpc" {
-  for_each = local.vpcs[terraform.workspace]
-
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-member-vpc?ref=c0475531b5c9f45a78a94fea441cd9ce91ad3c59" # v2.5.0
-
-  subnet_sets = { for key, subnet in each.value.cidr.subnet_sets : key => subnet.cidr }
-
+  for_each             = local.vpcs[terraform.workspace]
+  source               = "github.com/ministryofjustice/modernisation-platform-terraform-member-vpc?ref=c0475531b5c9f45a78a94fea441cd9ce91ad3c59" # v2.5.0
   additional_endpoints = each.value.options.additional_endpoints
-
-  transit_gateway_id = data.aws_ec2_transit_gateway.transit-gateway.id
+  subnet_sets          = { for key, subnet in each.value.cidr.subnet_sets : key => subnet.cidr }
+  transit_gateway_id   = data.aws_ec2_transit_gateway.transit-gateway.id
 
   # VPC Flow Logs
-  vpc_flow_log_iam_role = aws_iam_role.vpc_flow_log.arn
+  vpc_flow_log_iam_role       = aws_iam_role.vpc_flow_log.arn
+  flow_log_s3_destination_arn = local.cloudwatch_log_buckets["vpc-flow-logs"]
 
   # Variables required for Firehose integration. We are not building this in all environments hence the "build_firehose" condition below.
-
-  build_firehose = local.build_firehose
-
-  kinesis_endpoint_url = local.is-production ? tostring(local.xsiam["xsiam_prod_network_endpoint"]) : tostring(local.xsiam["xsiam_preprod_network_endpoint"])
-
+  build_firehose                 = local.build_firehose
+  kinesis_endpoint_url           = local.is-production ? tostring(local.xsiam["xsiam_prod_network_endpoint"]) : tostring(local.xsiam["xsiam_preprod_network_endpoint"])
   kinesis_endpoint_secret_string = local.is-production ? tostring(local.xsiam["xsiam_prod_network_secret"]) : tostring(local.xsiam["xsiam_preprod_network_secret"])
-
 
   # Tags
   tags_common = local.tags


### PR DESCRIPTION
## A reference to the issue / Description of it

#7607

## How does this PR fix the problem?

Adds statement to build flow log that outputs to S3 bucket in `core-logging`.

Cleans up formatting of terraform for `module.vpc` a bit.

## How has this been tested?

Tested with local plan and CI pipeline

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
