### PR TITLE
Issue 7689 - Bug fixes from testing.

### DIFF
--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -67,6 +67,8 @@ jobs:
           changes=$(git diff --staged --name-only)
           if [ -z "$changes" ]; then
             echo "No changes detected."
+            echo "Exiting workflow using status 1 without reporting an error"
+            exit 1
           else
             echo "Changes detected."
             echo "changes=true" >> $GITHUB_ENV

--- a/terraform/environments/sprinkler/locals.tf
+++ b/terraform/environments/sprinkler/locals.tf
@@ -20,9 +20,9 @@ locals {
 
   )
 
-  environment       = "sandbox"
+  environment     = "sandbox"
   vpc_name        = var.networking[0].business-unit
-  subnet_set        = var.networking[0].set
+  subnet_set      = var.networking[0].set
   vpc_all         = "${local.vpc_name}-${local.environment}"
   subnet_set_name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}"
 


### PR DESCRIPTION
Triggers an "exit 1" of the workflow if no changes are found. This is to prevent the pushing of a commit that is behind the remote which will error. Also removes some formatting changes in sprinkler locals that were used to test the linter.

## A reference to the issue / Description of it

#7689 

## How does this PR fix the problem?

See above.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
