### PR TITLE
make rules shorter

### DIFF
--- a/terraform/pagerduty/member-services-integrations.tf
+++ b/terraform/pagerduty/member-services-integrations.tf
@@ -2074,108 +2074,27 @@ resource "pagerduty_event_orchestration_service" "hmpps-domain-services-test" {
   set {
     id = "weekend-and-overnite-check"
     rule {
-      label = "Check if it's Saturday"
+      label = "Check if it's Saturday or Sunday"
       condition {
-        expression = "now in Sat 00:00:00 to 23:59:59 Etc/UTC"
+        expression = "now in Sat,Sun 00:00:00 to 23:59:59 Etc/UTC"
       }
       actions {
         suppress = true
       }
     }
     rule {
-      label = "Check if it's Sunday"
+      label = "Check if it's during the week before 05:05 UTC"
       condition {
-        expression = "now in Sun 00:00:00 to 23:59:59 Etc/UTC"
+        expression = "now in Mon,Tue,Wed,Thu,Fri 00:00:00 to 05:04:59 Etc/UTC"
       }
       actions {
         suppress = true
       }
     }
     rule {
-      label = "Check if it's Monday before 05:05 UTC"
+      label = "Check if it's during the week after 20:10 UTC"
       condition {
-        expression = "now in Mon 00:00:00 to 05:04:59 Etc/UTC"
-      }
-      actions {
-        suppress = true
-      }
-    }
-    rule {
-      label = "Check if it's Monday after 20:10 UTC"
-      condition {
-        expression = "now in Mon 20:10:00 to 23:59:59 Etc/UTC"
-      }
-      actions {
-        suppress = true
-      }
-    }
-    rule {
-      label = "Check if it's Tuesday before 05:05 UTC"
-      condition {
-        expression = "now in Tue 00:00:00 to 05:04:59 Etc/UTC"
-      }
-      actions {
-        suppress = true
-      }
-    }
-    rule {
-      label = "Check if it's Tuesday after 20:10 UTC"
-      condition {
-        expression = "now in Tue 20:10:00 to 23:59:59 Etc/UTC"
-      }
-      actions {
-        suppress = true
-      }
-    }
-    rule {
-      label = "Check if it's Wednesday before 05:05 UTC"
-      condition {
-        expression = "now in Wed 00:00:00 to 05:04:59 Etc/UTC"
-      }
-      actions {
-        suppress = true
-      }
-    }
-    rule {
-      label = "Check if it's Wednesday after 20:10 UTC"
-      condition {
-        expression = "now in Wed 20:10:00 to 23:59:59 Etc/UTC"
-      }
-      actions {
-        suppress = true
-      }
-    }
-    rule {
-      label = "Check if it's Thursday before 05:05 UTC"
-      condition {
-        expression = "now in Thu 00:00:00 to 05:04:59 Etc/UTC"
-      }
-      actions {
-        suppress = true
-      }
-    }
-    rule {
-      label = "Check if it's Thursday after 20:10 UTC"
-      condition {
-        expression = "now in Thu 20:10:00 to 23:59:59 Etc/UTC"
-      }
-      actions {
-        suppress = true
-      }
-    }
-    rule {
-      label = "Check if it's Friday before 05:05 UTC"
-      condition {
-        expression = "now in Fri 00:00:00 to 05:04:59 Etc/UTC"
-      }
-      actions {
-        suppress = true
-      }
-    }
-    rule {
-      label = "Check if it's Friday after 20:10 UTC"
-      condition {
-        expression = "now in Fri 20:10:00 to 23:59:59 Etc/UTC"
+        expression = "now in Mon,Tue,Wed,Thu,Fri 20:10:00 to 23:59:59 Etc/UTC"
       }
       actions {
         suppress = true
@@ -2216,108 +2135,27 @@ resource "pagerduty_event_orchestration_service" "hmpps-domain-services-preprodu
   set {
     id = "weekend-and-overnite-check"
     rule {
-      label = "Check if it's Saturday"
+      label = "Check if it's Saturday or Sunday"
       condition {
-        expression = "now in Sat 00:00:00 to 23:59:59 Etc/UTC"
+        expression = "now in Sat,Sun 00:00:00 to 23:59:59 Etc/UTC"
       }
       actions {
         suppress = true
       }
     }
     rule {
-      label = "Check if it's Sunday"
+      label = "Check if it's during the week before 05:05 UTC"
       condition {
-        expression = "now in Sun 00:00:00 to 23:59:59 Etc/UTC"
+        expression = "now in Mon,Tue,Wed,Thu,Fri 00:00:00 to 05:04:59 Etc/UTC"
       }
       actions {
         suppress = true
       }
     }
     rule {
-      label = "Check if it's Monday before 05:05 UTC"
+      label = "Check if it's during the week after 20:10 UTC"
       condition {
-        expression = "now in Mon 00:00:00 to 05:04:59 Etc/UTC"
-      }
-      actions {
-        suppress = true
-      }
-    }
-    rule {
-      label = "Check if it's Monday after 20:10 UTC"
-      condition {
-        expression = "now in Mon 20:10:00 to 23:59:59 Etc/UTC"
-      }
-      actions {
-        suppress = true
-      }
-    }
-    rule {
-      label = "Check if it's Tuesday before 05:05 UTC"
-      condition {
-        expression = "now in Tue 00:00:00 to 05:04:59 Etc/UTC"
-      }
-      actions {
-        suppress = true
-      }
-    }
-    rule {
-      label = "Check if it's Tuesday after 20:10 UTC"
-      condition {
-        expression = "now in Tue 20:10:00 to 23:59:59 Etc/UTC"
-      }
-      actions {
-        suppress = true
-      }
-    }
-    rule {
-      label = "Check if it's Wednesday before 05:05 UTC"
-      condition {
-        expression = "now in Wed 00:00:00 to 05:04:59 Etc/UTC"
-      }
-      actions {
-        suppress = true
-      }
-    }
-    rule {
-      label = "Check if it's Wednesday after 20:10 UTC"
-      condition {
-        expression = "now in Wed 20:10:00 to 23:59:59 Etc/UTC"
-      }
-      actions {
-        suppress = true
-      }
-    }
-    rule {
-      label = "Check if it's Thursday before 05:05 UTC"
-      condition {
-        expression = "now in Thu 00:00:00 to 05:04:59 Etc/UTC"
-      }
-      actions {
-        suppress = true
-      }
-    }
-    rule {
-      label = "Check if it's Thursday after 20:10 UTC"
-      condition {
-        expression = "now in Thu 20:10:00 to 23:59:59 Etc/UTC"
-      }
-      actions {
-        suppress = true
-      }
-    }
-    rule {
-      label = "Check if it's Friday before 05:05 UTC"
-      condition {
-        expression = "now in Fri 00:00:00 to 05:04:59 Etc/UTC"
-      }
-      actions {
-        suppress = true
-      }
-    }
-    rule {
-      label = "Check if it's Friday after 20:10 UTC"
-      condition {
-        expression = "now in Fri 20:10:00 to 23:59:59 Etc/UTC"
+        expression = "now in Mon,Tue,Wed,Thu,Fri 20:10:00 to 23:59:59 Etc/UTC"
       }
       actions {
         suppress = true


### PR DESCRIPTION
## A reference to the issue / Description of it

PagerDuty API seems to have some size issues for requests

## How does this PR fix the problem?

Reduces the number of rules, assuming it's a header issue for their PUT endpoint

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Pagerduty have tests?

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

Apply and cross fingers

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
