### PR TITLE
Add test account to the electronic-monitoring-data account

### DIFF
--- a/environments/electronic-monitoring-data.json
+++ b/environments/electronic-monitoring-data.json
@@ -17,6 +17,15 @@
       ]
     },
     {
+      "name": "test",
+      "access": [
+        {
+          "sso_group_name": "hmpps-electronic-monitoring-data-store",
+          "level": "data-engineer"
+        }
+      ]
+    },
+    {
       "name": "production",
       "access": [
         {


### PR DESCRIPTION
## A reference to the issue / Description of it
Electronic monitoring are going to be receiving data from external suppliers who will be pushing data to an S3 bucket. We want to test and ensure this connection is secure outside of our Production account.

## How does this PR fix the problem?
It creates a test account where we can test suppliers sending dummy data before promoting to Prod.

We then have an action to exclude spinning up most infra in our test account as many things won't be needed.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Not tested, just eyeballed config file update against other accounts.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

Original account request > https://github.com/ministryofjustice/modernisation-platform/issues/5833