### PR TITLE
Update bucket policy to use correct condition

### DIFF
--- a/terraform/environments/core-logging/cortex.tf
+++ b/terraform/environments/core-logging/cortex.tf
@@ -54,10 +54,10 @@ data "aws_iam_policy_document" "logging-bucket" {
     }
 
     condition {
-      test     = "ForAnyValue:StringLike"
-      variable = "aws:PrincipalOrgPaths"
+      test     = "StringEquals"
+      variable = "aws:SourceOrgID"
       values = [
-        "${data.aws_organizations_organization.root_account.id}/*/${local.environment_management.modernisation_platform_organisation_unit_id}/*"
+        "${data.aws_organizations_organization.root_account.id}"
       ]
     }
   }
@@ -74,10 +74,10 @@ data "aws_iam_policy_document" "logging-bucket" {
     resources = [aws_s3_bucket.logging[each.key].arn]
 
     condition {
-      test     = "ForAnyValue:StringLike"
-      variable = "aws:PrincipalOrgPaths"
+      test     = "StringEquals"
+      variable = "aws:SourceOrgID"
       values = [
-        "${data.aws_organizations_organization.root_account.id}/*/${local.environment_management.modernisation_platform_organisation_unit_id}/*"
+        "${data.aws_organizations_organization.root_account.id}"
       ]
     }
   }

--- a/terraform/environments/core-logging/cortex.tf
+++ b/terraform/environments/core-logging/cortex.tf
@@ -57,7 +57,7 @@ data "aws_iam_policy_document" "logging-bucket" {
       test     = "StringEquals"
       variable = "aws:SourceOrgID"
       values = [
-        "${data.aws_organizations_organization.root_account.id}"
+        data.aws_organizations_organization.root_account.id
       ]
     }
   }
@@ -77,7 +77,7 @@ data "aws_iam_policy_document" "logging-bucket" {
       test     = "StringEquals"
       variable = "aws:SourceOrgID"
       values = [
-        "${data.aws_organizations_organization.root_account.id}"
+        data.aws_organizations_organization.root_account.id
       ]
     }
   }


### PR DESCRIPTION
## A reference to the issue / Description of it

#7607

## How does this PR fix the problem?

Because the bucket policy currently uses "aws:PrincipalOrgPaths" which is only for an IAM user, IAM role, federated user, or AWS account root user, flow logs can't be written into the bucket.

This PR switches to use a condition that scopes access only to our AWS Organization.

## How has this been tested?

Tested through local plan

## Deployment Plan / Instructions

Deploy through CI, then re-run failing VPC deployments.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
