### PR TITLE
Add condition to only stream flow logs from production VPCs to S3

### DIFF
--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -91,7 +91,7 @@ module "vpc" {
 
   # VPC Flow Logs
   vpc_flow_log_iam_role       = aws_iam_role.vpc_flow_log.arn
-  flow_log_s3_destination_arn = local.cloudwatch_log_buckets["vpc-flow-logs"]
+  flow_log_s3_destination_arn = local.is-production ? local.cloudwatch_log_buckets["vpc-flow-logs"] : ""
 
   # Variables required for Firehose integration. We are not building this in all environments hence the "build_firehose" condition below.
   build_firehose                 = local.build_firehose


### PR DESCRIPTION
## A reference to the issue / Description of it

#7607

## How does this PR fix the problem?

As only production VPCs should be in scope, this adds a conditional check to ensure only production VPCs have logs streamed to S3

## How has this been tested?

Tested with local plan

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
