### PR TITLE
Send `core-shared-services` flow logs to S3

### DIFF
--- a/terraform/environments/core-shared-services/locals.tf
+++ b/terraform/environments/core-shared-services/locals.tf
@@ -48,6 +48,8 @@ locals {
   # This local allows us to references the key / value pairs held in xsiam_secrets.
   xsiam = jsondecode(data.aws_secretsmanager_secret_version.xsiam_secret_arn_version.secret_string)
 
+  cloudwatch_log_buckets = nonsensitive(jsondecode(data.aws_secretsmanager_secret_version.core_logging_bucket_arns.secret_string))
+
   tags = {
     business-unit = "Platforms"
     application   = "Modernisation Platform: ${terraform.workspace}"

--- a/terraform/environments/core-shared-services/secrets.tf
+++ b/terraform/environments/core-shared-services/secrets.tf
@@ -32,3 +32,14 @@ data "aws_secretsmanager_secret_version" "xsiam_secret_arn_version" {
   provider  = aws.modernisation-platform
   secret_id = data.aws_secretsmanager_secret.xsiam_secret_arn.id
 }
+
+# Get the ARNs of the logging buckets in `core-logging`
+data "aws_secretsmanager_secret" "core_logging_bucket_arns" {
+  provider = aws.modernisation-platform
+  name     = "core_logging_bucket_arns"
+}
+
+data "aws_secretsmanager_secret_version" "core_logging_bucket_arns" {
+  provider  = aws.modernisation-platform
+  secret_id = data.aws_secretsmanager_secret.core_logging_bucket_arns.id
+}

--- a/terraform/environments/core-shared-services/vpc.tf
+++ b/terraform/environments/core-shared-services/vpc.tf
@@ -32,7 +32,8 @@ module "vpc" {
   gateway = "transit"
 
   # VPC Flow Logs
-  vpc_flow_log_iam_role = aws_iam_role.vpc_flow_log.arn
+  vpc_flow_log_iam_role       = aws_iam_role.vpc_flow_log.arn
+  flow_log_s3_destination_arn = each.key == "live_data" ? local.cloudwatch_log_buckets["vpc-flow-logs"] : ""
 
   # Transit Gateway ID
   transit_gateway_id = data.aws_ec2_transit_gateway.transit-gateway.id


### PR DESCRIPTION
## A reference to the issue / Description of it

#7607

## How does this PR fix the problem?

As our `live_data` VPC holds production infrastructure, we should send flow logs to S3 for XSIAM

## How has this been tested?

Tested with local plan

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
