### PR TITLE
Remove config to send `core-network-services` flow logs via data firehose

### DIFF
--- a/terraform/environments/core-network-services/locals.tf
+++ b/terraform/environments/core-network-services/locals.tf
@@ -17,7 +17,6 @@ locals {
   xsiam                          = jsondecode(data.aws_secretsmanager_secret_version.xsiam_secret_arn_version.secret_string)
   cloudwatch_log_buckets         = jsondecode(data.aws_secretsmanager_secret_version.core_logging_bucket_arns.secret_string)
   cloudwatch_generic_log_groups  = concat([module.firewall_logging.cloudwatch_log_group_name], [for key, value in module.vpc_inspection : value.fw_cloudwatch_name])
-  cloudwatch_vpc_flow_log_groups = concat([aws_cloudwatch_log_group.external_inspection.name, aws_cloudwatch_log_group.tgw_flowlog_group.name], [for key, value in module.vpc_inspection : value.vpc_cloudwatch_name])
 
   tags = {
     business-unit = "Platforms"

--- a/terraform/environments/core-network-services/logging.tf
+++ b/terraform/environments/core-network-services/logging.tf
@@ -1,11 +1,3 @@
-module "logging-vpc-flow-logs" {
-  source                     = "github.com/ministryofjustice/modernisation-platform-terraform-aws-data-firehose?ref=2e58c8fd0b43ca8461dfd0c8cc5f43a1a9c49987" #v1.1.0
-  for_each                   = local.is-production ? { "build" = true } : {}
-  cloudwatch_log_group_names = local.cloudwatch_vpc_flow_log_groups
-  destination_bucket_arn     = local.cloudwatch_log_buckets["vpc-flow-logs"]
-  tags                       = local.tags
-}
-
 module "logging-generic-logs" {
   source                     = "github.com/ministryofjustice/modernisation-platform-terraform-aws-data-firehose?ref=2e58c8fd0b43ca8461dfd0c8cc5f43a1a9c49987" #v1.1.0
   for_each                   = local.is-production ? { "build" = true } : {}


### PR DESCRIPTION
## A reference to the issue / Description of it

#7607

## How does this PR fix the problem?

Prior to sending logs directly to S3, this PR removes their streaming through an AWS Data Firehose

## How has this been tested?

Tested with local plan, will test through CI/CD pipeline

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
