### PR TITLE
Send `live_data` flow logs go s3

### DIFF
--- a/terraform/environments/core-network-services/locals.tf
+++ b/terraform/environments/core-network-services/locals.tf
@@ -15,7 +15,7 @@ locals {
 
   # This local allows us to references the key / value pairs held in xsiam_secrets.
   xsiam                         = jsondecode(data.aws_secretsmanager_secret_version.xsiam_secret_arn_version.secret_string)
-  cloudwatch_log_buckets        = jsondecode(data.aws_secretsmanager_secret_version.core_logging_bucket_arns.secret_string)
+  cloudwatch_log_buckets        = nonsensitive(jsondecode(data.aws_secretsmanager_secret_version.core_logging_bucket_arns.secret_string))
   cloudwatch_generic_log_groups = concat([module.firewall_logging.cloudwatch_log_group_name], [for key, value in module.vpc_inspection : value.fw_cloudwatch_name])
 
   tags = {

--- a/terraform/environments/core-network-services/locals.tf
+++ b/terraform/environments/core-network-services/locals.tf
@@ -14,9 +14,9 @@ locals {
   is-production = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-production"
 
   # This local allows us to references the key / value pairs held in xsiam_secrets.
-  xsiam                          = jsondecode(data.aws_secretsmanager_secret_version.xsiam_secret_arn_version.secret_string)
-  cloudwatch_log_buckets         = jsondecode(data.aws_secretsmanager_secret_version.core_logging_bucket_arns.secret_string)
-  cloudwatch_generic_log_groups  = concat([module.firewall_logging.cloudwatch_log_group_name], [for key, value in module.vpc_inspection : value.fw_cloudwatch_name])
+  xsiam                         = jsondecode(data.aws_secretsmanager_secret_version.xsiam_secret_arn_version.secret_string)
+  cloudwatch_log_buckets        = jsondecode(data.aws_secretsmanager_secret_version.core_logging_bucket_arns.secret_string)
+  cloudwatch_generic_log_groups = concat([module.firewall_logging.cloudwatch_log_group_name], [for key, value in module.vpc_inspection : value.fw_cloudwatch_name])
 
   tags = {
     business-unit = "Platforms"

--- a/terraform/environments/core-network-services/vpc.tf
+++ b/terraform/environments/core-network-services/vpc.tf
@@ -9,15 +9,16 @@ locals {
 module "vpc_inspection" {
   for_each = local.networking
 
-  source                = "../../modules/vpc-inspection"
-  application_name      = local.application_name
-  fw_allowed_domains    = local.fqdn_firewall_rules.fw_allowed_domains
-  fw_home_net_ips       = local.fqdn_firewall_rules.fw_home_net_ips
-  fw_kms_arn            = data.aws_kms_key.general_shared.arn
-  fw_rules              = local.inline_firewall_rules
-  vpc_cidr              = each.value
-  vpc_flow_log_iam_role = aws_iam_role.vpc_flow_log.arn
-  transit_gateway_id    = aws_ec2_transit_gateway.transit-gateway.id
+  source                      = "../../modules/vpc-inspection"
+  application_name            = local.application_name
+  flow_log_s3_destination_arn = each.key == "live_data" ? local.cloudwatch_log_buckets["vpc-flow-logs"] : ""
+  fw_allowed_domains          = local.fqdn_firewall_rules.fw_allowed_domains
+  fw_home_net_ips             = local.fqdn_firewall_rules.fw_home_net_ips
+  fw_kms_arn                  = data.aws_kms_key.general_shared.arn
+  fw_rules                    = local.inline_firewall_rules
+  vpc_cidr                    = each.value
+  vpc_flow_log_iam_role       = aws_iam_role.vpc_flow_log.arn
+  transit_gateway_id          = aws_ec2_transit_gateway.transit-gateway.id
 
   # Tags
   tags_common = merge(


### PR DESCRIPTION
## A reference to the issue / Description of it

#7607

## How does this PR fix the problem?

Send flow logs from `live_data` egress VPC to S3 for Cortex XSIAM

## How has this been tested?

Ran local terraform plan

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
