### PR TITLE
Add networking for emd-test env

### DIFF
--- a/environments-networks/hmpps-test.json
+++ b/environments-networks/hmpps-test.json
@@ -17,7 +17,8 @@
           "hmpps-oem-test",
           "hmpps-domain-services-test",
           "delius-core-test",
-          "oasys-national-reporting-test"
+          "oasys-national-reporting-test",
+          "electronic-monitoring-data-test"
         ]
       }
     }


### PR DESCRIPTION
## A reference to the issue / Description of it

electronic-monitoring-data-test has recently been added but required networking has not been added yet.

## How does this PR fix the problem?

This PR adds the required networking

## How has this been tested?

fully tried and documented process.

## Deployment Plan / Instructions

No

## Checklist (check `x` in `[ ]` of list items)

- [ X ] I have performed a self-review of my own code
- [ X ] All checks have passed
