### PR TITLE
Revert "Add flow logs from transit gateway to s3"

### DIFF
--- a/terraform/environments/core-network-services/locals.tf
+++ b/terraform/environments/core-network-services/locals.tf
@@ -5,9 +5,7 @@ data "aws_caller_identity" "modernisation-platform" {
 data "aws_organizations_organization" "root_account" {}
 
 locals {
-  application_name = "core-network-services"
-  # Custom VPC flow log statement
-  custom_flow_log_format     = "$${version} $${account-id} $${interface-id} $${srcaddr} $${dstaddr} $${srcport} $${dstport} $${protocol} $${packets} $${bytes} $${start} $${end} $${action} $${log-status} $${vpc-id} $${subnet-id} $${instance-id} $${tcp-flags} $${type} $${pkt-srcaddr} $${pkt-dstaddr} $${region} $${az-id} $${sublocation-type} $${sublocation-id} $${pkt-src-aws-service} $${pkt-dst-aws-service} $${flow-direction} $${traffic-path}"
+  application_name           = "core-network-services"
   environment_management     = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
   pagerduty_integration_keys = jsondecode(data.aws_secretsmanager_secret_version.pagerduty_integration_keys.secret_string)
 

--- a/terraform/environments/core-network-services/monitoring.tf
+++ b/terraform/environments/core-network-services/monitoring.tf
@@ -151,21 +151,6 @@ resource "aws_flow_log" "tgw_flowlog" {
   tags                          = local.tags
 }
 
-resource "aws_flow_log" "tgw_flowlog_s3" {
-  log_destination               = local.cloudwatch_log_buckets["vpc-flow-logs"]
-  log_destination_type          = "s3"
-  log_format                    = local.custom_flow_log_format
-  max_aggregation_interval      = "60"
-  traffic_type                  = "ALL"
-  transit_gateway_attachment_id = aws_ec2_transit_gateway.transit-gateway.id
-  tags = merge(
-    local.tags,
-    {
-      Name = "${aws_vpc.external_inspection.id}-vpc-flow-logs-s3"
-    }
-  )
-}
-
 resource "aws_cloudwatch_metric_alarm" "firewall-traffic-drop-alarm" {
   alarm_name          = "firewall-traffic-dropped"
   comparison_operator = "GreaterThanOrEqualToThreshold"


### PR DESCRIPTION
Reverts ministryofjustice/modernisation-platform#8015

```
Error: creating Flow Log (tgw-053d9dd7f1222a554): operation error EC2: CreateFlowLogs, https response error StatusCode: 400, RequestID: 3689b02c-625d-4d13-93f1-7d72da130de7, api error InvalidParameter: Invalid Resource id tgw-************ for resource-type TransitGatewayAttachment
```

This looks like a provider issue; you can see from my PR that I specified the transit gateway id, not an attachment ID. I'll raise an issue on the AWS Provider repository and refactor this branch to merge in a selection of attachments.