### PR TITLE
Output flow logs from inspection VPC to S3

### DIFF
--- a/terraform/environments/core-network-services/firewall.tf
+++ b/terraform/environments/core-network-services/firewall.tf
@@ -73,6 +73,22 @@ resource "aws_flow_log" "external_inspection" {
   )
 }
 
+resource "aws_flow_log" "external_inspection_s3" {
+  log_destination          = local.cloudwatch_log_buckets["vpc-flow-logs"]
+  log_destination_type     = "s3"
+  log_format               = local.custom_vpc_flow_log_format
+  max_aggregation_interval = "60"
+  traffic_type             = "ALL"
+  vpc_id                   = aws_vpc.external_inspection.id
+
+  tags = merge(
+    local.tags,
+    {
+      Name = "external-inspection-vpc-flow-logs-s3"
+    }
+  )
+}
+
 ########################
 # Inspection VPC Subnets
 ########################


### PR DESCRIPTION
## A reference to the issue / Description of it

#7607

## How does this PR fix the problem?

Ensure flow logs are sent from `core-network-services` external-inspection (firewall) VPC to S3 for Cortex XSIAM ingestion

## How has this been tested?

Tested with local plan

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
