### PR TITLE
Remove logging to firehose via VPC module

### DIFF
--- a/terraform/environments/core-vpc/locals.tf
+++ b/terraform/environments/core-vpc/locals.tf
@@ -11,13 +11,9 @@ locals {
 
   # This takes the name of the Terraform workspace (e.g. core-vpc-production), strips out the application name (e.g. core-vpc), and checks if
   # the string leftover is `-production`, if it isn't (e.g. core-vpc-non-production => -non-production) then it sets the var to false.
-  is-production = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-production"
-  is-live_data  = (substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-production") || (substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-preproduction")
-
-  # This applies the same logic as above but to determine whether the environment is the development environment. Required for firehose resources.
+  is-production  = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-production"
   is-development = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-development"
-  # Determines if Firehose should be built in an environment.
-  build_firehose = anytrue([local.is-development, local.is-production]) ? true : false
+  is-live_data   = (substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-production") || (substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-preproduction")
 
   # Secrets used by Firehose resources which we only require for development & production VPCs.
   xsiam                              = jsondecode(data.aws_secretsmanager_secret_version.xsiam_secret_arn_version.secret_string)

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -84,7 +84,7 @@ locals {
 
 module "vpc" {
   for_each             = local.vpcs[terraform.workspace]
-  source               = "github.com/ministryofjustice/modernisation-platform-terraform-member-vpc?ref=c0475531b5c9f45a78a94fea441cd9ce91ad3c59" # v2.5.0
+  source               = "github.com/ministryofjustice/modernisation-platform-terraform-member-vpc?ref=0ba18bb790c4259512768ffb6db9c2852654b82f" # v3.0.0
   additional_endpoints = each.value.options.additional_endpoints
   subnet_sets          = { for key, subnet in each.value.cidr.subnet_sets : key => subnet.cidr }
   transit_gateway_id   = data.aws_ec2_transit_gateway.transit-gateway.id
@@ -92,11 +92,6 @@ module "vpc" {
   # VPC Flow Logs
   vpc_flow_log_iam_role       = aws_iam_role.vpc_flow_log.arn
   flow_log_s3_destination_arn = local.is-production ? local.cloudwatch_log_buckets["vpc-flow-logs"] : ""
-
-  # Variables required for Firehose integration. We are not building this in all environments hence the "build_firehose" condition below.
-  build_firehose                 = local.build_firehose
-  kinesis_endpoint_url           = local.is-production ? tostring(local.xsiam["xsiam_prod_network_endpoint"]) : tostring(local.xsiam["xsiam_preprod_network_endpoint"])
-  kinesis_endpoint_secret_string = local.is-production ? tostring(local.xsiam["xsiam_prod_network_secret"]) : tostring(local.xsiam["xsiam_preprod_network_secret"])
 
   # Tags
   tags_common = local.tags


### PR DESCRIPTION
## A reference to the issue / Description of it

#7607

## How does this PR fix the problem?

Bump modernisation-platform-terraform-member-vpc module to [latest tagged release](https://github.com/ministryofjustice/modernisation-platform-terraform-member-vpc/releases/tag/v3.0.0).

Removes configuration explicitly related to triggering firehose creation.

## How has this been tested?

Tested with local plan

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
