### PR TITLE
Remove provider from `core-shared-services`

### DIFF
--- a/terraform/environments/core-shared-services/versions.tf
+++ b/terraform/environments/core-shared-services/versions.tf
@@ -4,10 +4,6 @@ terraform {
       version = "~> 5.0"
       source  = "hashicorp/aws"
     }
-    random = {
-      version = "~> 3.0"
-      source  = "hashicorp/random"
-    }
   }
   required_version = "~> 1.0"
 }


### PR DESCRIPTION
As the `random` provider is no longer required by any objects in configuration or state, this PR removes it.