### PR TITLE
Remove random provider from `core-security`

### DIFF
--- a/terraform/environments/core-security/versions.tf
+++ b/terraform/environments/core-security/versions.tf
@@ -4,10 +4,6 @@ terraform {
       version = "~> 5.0"
       source  = "hashicorp/aws"
     }
-    random = {
-      version = "~> 3.0"
-      source  = "hashicorp/random"
-    }
   }
   required_version = "~> 1.0"
 }


### PR DESCRIPTION
`random` provider was required to successfully complete Terraform run after module requiring said provider was deleted.