### PR TITLE
Incorrect team used. Copied from the service in the code below

### DIFF
--- a/terraform/pagerduty/member-services-integrations.tf
+++ b/terraform/pagerduty/member-services-integrations.tf
@@ -1847,7 +1847,7 @@ resource "pagerduty_service" "cdpt-chaps" {
 resource "pagerduty_event_orchestration" "cdpt_chaps_cloudwatch" {
   name        = data.pagerduty_vendor.cloudwatch.name  
   description = "Integrates with PagerDuty"
-  team        = pagerduty_service.cdpt-chaps.id
+  team        = pagerduty_team.modernisation_platform.id
 }
 #   name    = data.pagerduty_vendor.cloudwatch.name
 #   service = pagerduty_service.cdpt-chaps.id

--- a/terraform/pagerduty/member-services-integrations.tf
+++ b/terraform/pagerduty/member-services-integrations.tf
@@ -1847,7 +1847,7 @@ resource "pagerduty_service" "cdpt-chaps" {
 resource "pagerduty_event_orchestration" "cdpt_chaps_cloudwatch" {
   name        = data.pagerduty_vendor.cloudwatch.name  
   description = "Integrates with PagerDuty"
-  team        = pagerduty_service_integration.cdpt_ifs_cloudwatch.integration_key
+  team        = pagerduty_service.cdpt-chaps.id
 }
 #   name    = data.pagerduty_vendor.cloudwatch.name
 #   service = pagerduty_service.cdpt-chaps.id
@@ -1860,7 +1860,7 @@ resource "pagerduty_slack_connection" "chaps_slack" {
   workspace_id      = local.slack_workspace_id
   channel_id        = "CQQDV9N4R"
   notification_type = "responder"
-  config {
+    config {
     events = [
       "incident.triggered",
       "incident.acknowledged",


### PR DESCRIPTION
See comments from #7976 

The apply failed due to an incorrect team name in the code. This has been amended in this call.

Applies to request #5980 