### PR TITLE
Remove xsiam secret from `modernisation-platform-account`

### DIFF
--- a/terraform/modernisation-platform-account/secrets.tf
+++ b/terraform/modernisation-platform-account/secrets.tf
@@ -197,20 +197,6 @@ data "aws_secretsmanager_secret_version" "circleci" {
   secret_id = aws_secretsmanager_secret.circleci.id
 }
 
-# Secrets for the XIAM data transfers. Note that the secrets contained in here are provided by Technology Services and so cannot be rotated unless initiated by them.
-# Secrets should be manually set in the console.
-
-resource "aws_secretsmanager_secret" "xsiam_secrets" {
-  # checkov:skip=CKV2_AWS_57:Auto rotation not possible
-  name        = "xsiam_secrets"
-  description = "Secret that holds the preprod & prod XSIAM endpoint values & keys for the firewall inspection & vpc flow log transfers"
-  kms_key_id  = aws_kms_key.secrets_key.id
-  tags        = local.tags
-  replica {
-    region = local.replica_region
-  }
-}
-
 resource "aws_secretsmanager_secret" "gov_uk_notify_api_key" {
   # checkov:skip=CKV2_AWS_57:Auto rotation not possible
   name        = "gov_uk_notify_api_key"


### PR DESCRIPTION
## A reference to the issue / Description of it

#7607

## How does this PR fix the problem?

Now that XSIAM logs are being supplied via S3 instead of a Kinesis firehose http endpoint, this secret is no longer required.

## How has this been tested?

Ran local terraform plan, removed dependent objects from member accounts.

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
