### PR TITLE
Optionally output firewall logs to S3 bucket

### DIFF
--- a/terraform/modules/firewall-logging/main.tf
+++ b/terraform/modules/firewall-logging/main.tf
@@ -14,6 +14,16 @@ resource "aws_networkfirewall_logging_configuration" "main" {
       log_destination_type = "CloudWatchLogs"
       log_type             = "ALERT"
     }
+    dynamic "log_destination_config" {
+      for_each = var.s3_log_bucket != "" ? toset([var.s3_log_bucket]) : []
+      content {
+        log_destination = {
+          bucketName = log_destination_config.value
+        }
+        log_destination_type = "S3"
+        log_type             = "ALERT"
+      }
+    }
   }
 }
 

--- a/terraform/modules/firewall-logging/variables.tf
+++ b/terraform/modules/firewall-logging/variables.tf
@@ -7,6 +7,11 @@ variable "fw_arn" {
   description = "ARN of firewall for logging configuration"
   type        = string
 }
+variable "s3_log_bucket" {
+  description = "Optional ARN of an S3 bucket to ship logs to"
+  default     = ""
+  type        = string
+}
 
 variable "tags" {
   description = "A map of keys and values used to create resource metadata tags"


### PR DESCRIPTION
## A reference to the issue / Description of it

#7607

## How does this PR fix the problem?

Allows optional output of firewall logs to S3

## How has this been tested?

Tested only through a terraform plan - unclear if we can supply `ALERT` logs to two destinations at present.

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
