### PR TITLE
Revert "Optionally output firewall logs to S3 bucket"

### DIFF
--- a/terraform/modules/firewall-logging/main.tf
+++ b/terraform/modules/firewall-logging/main.tf
@@ -14,16 +14,6 @@ resource "aws_networkfirewall_logging_configuration" "main" {
       log_destination_type = "CloudWatchLogs"
       log_type             = "ALERT"
     }
-    dynamic "log_destination_config" {
-      for_each = var.s3_log_bucket != "" ? toset([var.s3_log_bucket]) : []
-      content {
-        log_destination = {
-          bucketName = log_destination_config.value
-        }
-        log_destination_type = "S3"
-        log_type             = "ALERT"
-      }
-    }
   }
 }
 

--- a/terraform/modules/firewall-logging/variables.tf
+++ b/terraform/modules/firewall-logging/variables.tf
@@ -7,11 +7,6 @@ variable "fw_arn" {
   description = "ARN of firewall for logging configuration"
   type        = string
 }
-variable "s3_log_bucket" {
-  description = "Optional ARN of an S3 bucket to ship logs to"
-  default     = ""
-  type        = string
-}
 
 variable "tags" {
   description = "A map of keys and values used to create resource metadata tags"


### PR DESCRIPTION
Manually testing showed this failed with an API message like so:

```
│ Error: adding NetworkFirewall Logging Configuration (arn:aws:network-firewall:eu-west-2:*:firewall/external-inspection): operation error Network Firewall: UpdateLoggingConfiguration, https response error StatusCode: 400, RequestID: 872a9584-6f39-4d07-9b0d-0cddfe3108c3, InvalidRequestException: Given logging configuration is unsupported.
```

However from a look at the CloudTrail logs it appears correct. I'd like to revert this PR then investigate with AWS tomorrow before recreating it correctly.