### PR TITLE
Issue/7689 - Reverts code-formatter.yml to its pre-graphql version to allow time to fix the branch issue & so prevent the workflow from failing.

### DIFF
--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -1,4 +1,4 @@
-
+---
 name: 'Format Code: ensure code formatting guidelines are met'
 
 on:
@@ -33,6 +33,7 @@ jobs:
           date=$(date +%Y_%m_%d)
           branch_name="date_$date"
           git checkout -b $branch_name
+
       - name: Run linter
         id: ml
         # You can override MegaLinter flavor used to have faster performances
@@ -53,81 +54,26 @@ jobs:
           YAML_PRETTIER_FILTER_REGEX_EXCLUDE: (.github/*)
           MARKDOWN_MARKDOWNLINT_FILTER_REGEX_EXCLUDE: (terraform/modules/.*/.*.md)
           REPORT_OUTPUT_FOLDER: none
-          
+
       - name: Check for changes
         run: |
-          # Show the status and diff before attempting to pull/push
-          echo "===== Git Status ====="
-          git status
-      
-          echo "===== Git Diff ====="
-          git diff
-          
           git add .
-          changes=$(git diff --staged --name-only)
+          git commit -m "Updates from GitHub Actions Format Code workflow" || true
+          branch_name=$(git branch --show-current)
+          changes=$(git diff origin/main...$branch_name --name-only)
           if [ -z "$changes" ]; then
             echo "No changes detected."
-            echo "Exiting workflow using status 0 without reporting an error"
-            exit 0
           else
             echo "Changes detected."
             echo "changes=true" >> $GITHUB_ENV
-            git diff --staged --name-only > changed_files.txt
           fi
-      - name: Store the current commit OID and branch name
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          # Store the current commit OID and branch name
-          commit_oid=$(git rev-parse HEAD)
-          branch_name=$(git branch --show-current)
-          # Fetch the repository ID using GitHub CLI
-          repo_id=$(gh api graphql -f query='
-          query {
-            repository(owner:"ministryofjustice", name:"modernisation-platform") {
-              id
-            }
-          }' --jq '.data.repository.id')
-          echo "Repository ID: $repo_id"
-          # Ensure that changed_files.txt is not empty
-          if [ ! -s changed_files.txt ]; then
-            echo "No files to commit."
-            exit 0
-          fi
-          # Prepare the list of changed files for commit
-          files_for_commit=$(jq -Rn '
-            [inputs | { "path": ., "contents": (inputs | @base64) }] 
-          ' < changed_files.txt)
-          echo "Files for commit: $files_for_commit"
-          # Create the GraphQL mutation payload
-          mutation_payload=$(jq -n --arg branch_name "$branch_name" --arg commit_oid "$commit_oid" --arg repo_id "$repo_id" --arg commit_message "Automated code formatting fixes" --argjson files_for_commit "$files_for_commit" '{
-            query: "mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { oid } } }",
-            variables: {
-              input: {
-                branch: {
-                  repositoryNameWithOwner: "ministryofjustice/modernisation-platform",
-                  branchName: $branch_name
-                },
-                message: {
-                  headline: $commit_message
-                },
-                fileChanges: {
-                  additions: $files_for_commit
-                },
-                expectedHeadOid: $commit_oid
-              }
-            }
-          }')
-          # Send the mutation request to GitHub's GraphQL API
-          curl -X POST -H "Authorization: bearer $GITHUB_TOKEN" \
-            -H "Content-Type: application/json" \
-            -d "$mutation_payload" https://api.github.com/graphql
-      - name: Push changes using GraphQL
+
+      - name: Push changes
         if: env.changes == 'true'
         run: |
           git config --global push.autoSetupRemote true
           git push
-          echo "Commit pushed successfully."
+
       - name: Create pull request
         if: env.changes == 'true'
         env:


### PR DESCRIPTION
Reverts the code formatter workflow to its pre-graphql version to allow time to fix the branch issue.

## A reference to the issue / Description of it

#7689 

## How does this PR fix the problem?

Workflow is failing and this reverts to the last known working state.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
