### PR TITLE
add hosting-migrations team to codeowners

### DIFF
--- a/environments/hmpps-domain-services.json
+++ b/environments/hmpps-domain-services.json
@@ -1,6 +1,6 @@
 {
   "account-type": "member",
-  "codeowners": ["studio-webops"],
+  "codeowners": ["hosting-migrations", "studio-webops"],
   "environments": [
     {
       "name": "development",

--- a/environments/hmpps-oem.json
+++ b/environments/hmpps-oem.json
@@ -1,6 +1,6 @@
 {
   "account-type": "member",
-  "codeowners": ["studio-webops", "hmpps-migration", "hmpps-dba"],
+  "codeowners": ["hosting-migrations", "studio-webops", "hmpps-migration", "hmpps-dba"],
   "environments": [
     {
       "name": "development",

--- a/environments/nomis-combined-reporting.json
+++ b/environments/nomis-combined-reporting.json
@@ -1,6 +1,6 @@
 {
   "account-type": "member",
-  "codeowners": ["studio-webops"],
+  "codeowners": ["hosting-migrations", "studio-webops"],
   "environments": [
     {
       "name": "development",

--- a/environments/nomis-data-hub.json
+++ b/environments/nomis-data-hub.json
@@ -1,6 +1,6 @@
 {
   "account-type": "member",
-  "codeowners": ["studio-webops"],
+  "codeowners": ["hosting-migrations", "studio-webops"],
   "environments": [
     {
       "name": "development",

--- a/environments/nomis.json
+++ b/environments/nomis.json
@@ -1,6 +1,6 @@
 {
   "account-type": "member",
-  "codeowners": ["studio-webops"],
+  "codeowners": ["hosting-migrations", "studio-webops"],
   "environments": [
     {
       "name": "development",

--- a/environments/oasys-national-reporting.json
+++ b/environments/oasys-national-reporting.json
@@ -1,6 +1,6 @@
 {
   "account-type": "member",
-  "codeowners": ["studio-webops"],
+  "codeowners": ["hosting-migrations", "studio-webops"],
   "environments": [
     {
       "name": "development",

--- a/environments/oasys.json
+++ b/environments/oasys.json
@@ -1,6 +1,6 @@
 {
   "account-type": "member",
-  "codeowners": ["studio-webops"],
+  "codeowners": ["hosting-migrations", "studio-webops"],
   "environments": [
     {
       "name": "development",


### PR DESCRIPTION
## A reference to the issue / Description of it

hosting-migrations was not added as a codeowner to all environments changed in #7895.

## How does this PR fix the problem?

The team was not added to the `codeowners` key in some of the JSON files. As this acts as an override, the new team was not added as a codeowner. This PR adds the team to the `codeowners` key where applicable.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

N/A

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No.

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [X] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

N/A
