### PR TITLE
Allow optional streaming of R53 Resolver Query Logs to S3

### DIFF
--- a/terraform/modules/r53-resolver-logs/main.tf
+++ b/terraform/modules/r53-resolver-logs/main.tf
@@ -9,6 +9,19 @@ resource "aws_route53_resolver_query_log_config_association" "main" {
   resource_id                  = var.vpc_id
 }
 
+resource "aws_route53_resolver_query_log_config" "s3" {
+  count           = var.s3_destination_arn != "" ? 1 : 0
+  name            = format("%s-r53-resolver-logs-s3", var.vpc_name)
+  destination_arn = var.s3_destination_arn
+  tags            = var.tags_common
+}
+
+resource "aws_route53_resolver_query_log_config_association" "s3" {
+  count           = var.s3_destination_arn != "" ? 1 : 0
+  resolver_query_log_config_id = aws_route53_resolver_query_log_config.s3[0].id
+  resource_id                  = var.vpc_id
+}
+
 #tfsec:ignore:aws-cloudwatch-log-group-customer-key
 resource "aws_cloudwatch_log_group" "main" {
   #checkov:skip=CKV_AWS_158:"Standard encryption is enough"

--- a/terraform/modules/r53-resolver-logs/variables.tf
+++ b/terraform/modules/r53-resolver-logs/variables.tf
@@ -1,6 +1,12 @@
+variable "s3_destination_arn" {
+  type        = string
+  default     = ""
+  description = "S3 Bucket ARN to receive resolver logs"
+}
+
 variable "vpc_id" {
   type        = string
-  description = "VPC ID to turn on resolver logs"
+  description = "VPC ID to associate with resolver log query config"
 }
 
 variable "vpc_name" {


### PR DESCRIPTION
## A reference to the issue / Description of it

#7607

## How does this PR fix the problem?

Adds conditional resources to stream AWS Route53 Resolver Log Queries to S3

## How has this been tested?

Tested with local plan that both supplies and does not supply the variable to the module

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
