### PR TITLE
Allow events service to trigger SNS topic

### DIFF
--- a/terraform/environments/core-network-services/vpn.tf
+++ b/terraform/environments/core-network-services/vpn.tf
@@ -142,9 +142,43 @@ resource "aws_cloudwatch_event_target" "noms-vpn-event-target-sns" {
   arn       = aws_sns_topic.noms-vpn-sns-topic.arn
 }
 
-resource "aws_sns_topic" "noms-vpn-sns-topic" {
+resource "aws_sns_topic" "noms_vpn_sns_topic" {
   name              = "noms_vpn_sns_topic"
   kms_master_key_id = aws_kms_key.sns_kms_key.id
+}
+resource "aws_sns_topic_policy" "noms_vpn_sns_topic" {
+  arn    = aws_sns_topic.noms_vpn_sns_topic.arn
+  policy = data.aws_iam_policy_document.noms_vpn_sns_topic_policy.json
+}
+
+data "aws_iam_policy_document" "noms_vpn_sns_topic_policy" {
+  policy_id = "nomis vpn sns topic policy"
+
+  statement {
+    sid    = "Allow eventbrdige to publish messages to sns topic"
+    effect = "Allow"
+    actions = [
+      "SNS:Publish",
+    ]
+    resources = [
+      aws_sns_topic.test.arn,
+    ]
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceOwner"
+      values = [
+        local.environment_management.account_ids["core-network-services-production"]
+      ]
+    }
+    principals {
+      type = "Service"
+      identifiers = [
+        "events.amazonaws.com"
+      ]
+    }
+
+
+  }
 }
 
 resource "aws_kms_key" "sns_kms_key" {

--- a/terraform/environments/core-network-services/vpn.tf
+++ b/terraform/environments/core-network-services/vpn.tf
@@ -139,7 +139,7 @@ resource "aws_cloudwatch_event_rule" "noms-vpn-event-rule" {
 resource "aws_cloudwatch_event_target" "noms-vpn-event-target-sns" {
   rule      = aws_cloudwatch_event_rule.noms-vpn-event-rule.name
   target_id = "SendToSNS"
-  arn       = aws_sns_topic.noms-vpn-sns-topic.arn
+  arn       = aws_sns_topic.noms_vpn_sns_topic.arn
 }
 
 resource "aws_sns_topic" "noms_vpn_sns_topic" {
@@ -161,7 +161,7 @@ data "aws_iam_policy_document" "noms_vpn_sns_topic_policy" {
       "SNS:Publish",
     ]
     resources = [
-      aws_sns_topic.test.arn,
+      aws_sns_topic.noms_vpn_sns_topic.arn,
     ]
     condition {
       test     = "StringEquals"
@@ -244,7 +244,7 @@ module "core-networks-chatbot" {
   source = "github.com/ministryofjustice/modernisation-platform-terraform-aws-chatbot?ref=73280f80ce8a4557cec3a76ee56eb913452ca9aa" // v2.0.0
 
   slack_channel_id = "CDLAJTGRG" // #dba_alerts_prod
-  sns_topic_arns   = ["arn:aws:sns:eu-west-2:${local.environment_management.account_ids[terraform.workspace]}:${aws_sns_topic.noms-vpn-sns-topic.name}"]
+  sns_topic_arns   = ["arn:aws:sns:eu-west-2:${local.environment_management.account_ids[terraform.workspace]}:${aws_sns_topic.noms_vpn_sns_topic.name}"]
   tags             = local.tags
   application_name = local.application_name
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

I set up an alert to notify the #dba_alerts_prod channel when we receive health alerts related to the NOMIS VPN in the `core-network-services` account. However, this failed to work when we received an alert on Monday 23rd Sept (via email).

## How does this PR fix the problem?

Added an IAM policy to the SNS topic that specifically allows the events service to publish to the topic.

## How has this been tested?

Tested using a dummy eventbridge rule/sns topic with the new policy and it worked as inteneded.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
