### PR TITLE
Create resolver query logs and new cloudwatch destination

### DIFF
--- a/terraform/environments/core-logging/r53_logs.tf
+++ b/terraform/environments/core-logging/r53_logs.tf
@@ -1,0 +1,36 @@
+resource "aws_route53_resolver_query_log_config" "s3" {
+  name            = format("%s-rlq-s3", local.application_name)
+  destination_arn = aws_s3_bucket.logging["r53-resolver-logs"].arn
+  tags            = local.tags
+}
+
+resource "aws_route53_resolver_query_log_config" "cloudwatch" {
+  name            = format("%s-rlq-cloudwatch", local.application_name)
+  destination_arn = aws_cloudwatch_log_group.r53_resolver_logs.arn
+  tags            = local.tags
+}
+
+#Temporarily unencrypted while I consider a suitable KMS policy
+resource "aws_cloudwatch_log_group" "r53_resolver_logs" {
+  name_prefix       = "r53-resolver-logs"
+  retention_in_days = 365
+  tags              = local.tags
+}
+
+locals {
+  resolver_query_log_configs = {
+    s3         = aws_route53_resolver_query_log_config.s3.arn
+    cloudwatch = aws_route53_resolver_query_log_config.cloudwatch.arn
+  }
+}
+
+resource "aws_ram_resource_share" "resolver_query_share" {
+  allow_external_principals = false
+  name                      = format("%s-resolver-log-query-share", local.application_name)
+}
+
+resource "aws_ram_resource_association" "resolver_query_share" {
+  for_each           = local.resolver_query_log_configs
+  resource_arn       = each.value
+  resource_share_arn = aws_ram_resource_share.resolver_query_share.id
+}


### PR DESCRIPTION
## A reference to the issue / Description of it

#7607

## How does this PR fix the problem?

Creates resolver log query configs and associates them with a new resource share.

This will allow the resource share to be distributed to the MP OU where it can be accepted and used to associate VPCs with said resolver log queries.

## How has this been tested?

Tested with local plan

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
