### PR TITLE
Associate R53 Resolver QLC RAM share across MP OU

### DIFF
--- a/terraform/environments/core-logging/locals.tf
+++ b/terraform/environments/core-logging/locals.tf
@@ -4,6 +4,7 @@ data "aws_caller_identity" "modernisation-platform" {
 
 data "aws_organizations_organization" "root_account" {}
 
+
 locals {
   application_name           = "core-logging"
   environment_management     = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)

--- a/terraform/environments/core-logging/r53_logs.tf
+++ b/terraform/environments/core-logging/r53_logs.tf
@@ -27,6 +27,7 @@ locals {
 resource "aws_ram_resource_share" "resolver_query_share" {
   allow_external_principals = false
   name                      = format("%s-resolver-log-query-share", local.application_name)
+  tags                      = local.tags
 }
 
 resource "aws_ram_resource_association" "resolver_query_share" {
@@ -34,3 +35,9 @@ resource "aws_ram_resource_association" "resolver_query_share" {
   resource_arn       = each.value
   resource_share_arn = aws_ram_resource_share.resolver_query_share.id
 }
+
+resource "aws_ram_principal_association" "resolver_query_share" {
+  principal          = "${data.aws_organizations_organization.root_account.arn}/${local.environment_management.modernisation_platform_organisation_unit_id}"
+  resource_share_arn = aws_ram_resource_share.resolver_query_share.arn
+}
+


### PR DESCRIPTION
## A reference to the issue / Description of it

#7607

## How does this PR fix the problem?

Adds a terraform resource to share the new RAM Shares with accounts in the MP OU. They will still need to accept the share to make use of it.

This is somewhat different to how we carry out shares in the `modules/ram-principal-association` module which share resources on a per-account basis.

## How has this been tested?

Tested with local plan

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
