### PR TITLE
🌐 Add Platforms General shared VPC to Analytical Platform Ingestion

### DIFF
--- a/environments-networks/platforms-development.json
+++ b/environments-networks/platforms-development.json
@@ -4,6 +4,7 @@
       "general": {
         "cidr": "10.26.16.0/21",
         "accounts": [
+          "analytical-platform-ingestion-development",
           "example-development",
           "data-platform-development",
           "data-platform-apps-and-tools-development",

--- a/environments-networks/platforms-production.json
+++ b/environments-networks/platforms-production.json
@@ -4,6 +4,7 @@
       "general": {
         "cidr": "10.27.96.0/21",
         "accounts": [
+          "analytical-platform-ingestion-production",
           "long-term-storage-production",
           "data-platform-apps-and-tools-production",
           "data-platform-production",

--- a/policies/networking/expected.rego
+++ b/policies/networking/expected.rego
@@ -49,6 +49,7 @@ expected :=
       "general": {
         "cidr": "10.26.16.0/21",
         "accounts": [
+          "analytical-platform-ingestion-development",
           "example-development",
           "data-platform-development",
           "data-platform-apps-and-tools-development",
@@ -388,6 +389,7 @@ expected :=
       "general": {
         "cidr": "10.27.96.0/21",
         "accounts": [
+          "analytical-platform-ingestion-production",
           "data-platform-production",
           "long-term-storage-production",
           "data-platform-apps-and-tools-production",

--- a/terraform/environments/analytical-platform-ingestion/networking.auto.tfvars.json
+++ b/terraform/environments/analytical-platform-ingestion/networking.auto.tfvars.json
@@ -1,8 +1,8 @@
 {
   "networking": [
     {
-      "business-unit": "",
-      "set": "",
+      "business-unit": "platforms",
+      "set": "general",
       "application": "analytical-platform-ingestion"
     }
   ]


### PR DESCRIPTION
## A reference to the issue / Description of it

Is part of https://github.com/ministryofjustice/analytical-platform/issues/5175

https://mojdt.slack.com/archives/C01A7QK5VM1/p1727263917973289

## How does this PR fix the problem?

Adds `analytical-platform-ingestion` to what I think is the right places based on `data-platform`

## How has this been tested?

It hasn't been tested

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)
