### PR TITLE
Fix principal for `core-logging`

### DIFF
--- a/terraform/environments/core-logging/r53_logs.tf
+++ b/terraform/environments/core-logging/r53_logs.tf
@@ -12,6 +12,7 @@ resource "aws_route53_resolver_query_log_config" "cloudwatch" {
 
 #Temporarily unencrypted while I consider a suitable KMS policy
 resource "aws_cloudwatch_log_group" "r53_resolver_logs" {
+  #checkov:skip=CKV_AWS_158
   name_prefix       = "r53-resolver-logs"
   retention_in_days = 365
   tags              = local.tags
@@ -37,7 +38,7 @@ resource "aws_ram_resource_association" "resolver_query_share" {
 }
 
 resource "aws_ram_principal_association" "resolver_query_share" {
-  principal          = "${data.aws_organizations_organization.root_account.arn}/${local.environment_management.modernisation_platform_organisation_unit_id}"
+  principal          = replace("${data.aws_organizations_organization.root_account.arn}/${local.environment_management.modernisation_platform_organisation_unit_id}", "organization/", "ou/")
   resource_share_arn = aws_ram_resource_share.resolver_query_share.arn
 }
 


### PR DESCRIPTION
## A reference to the issue / Description of it

Principal supplied for `aws_ram_principal_association` is incorrectly formatted

## How does this PR fix the problem?

Adds a checkov skip for a cloudwatch group, and uses string manipulation to correctly present the ARN to association a RAM principal with a share.

## How has this been tested?

Tested with local terraform plan and compared ARN to AWS documentation.

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
