### PR TITLE
DPR2-1127: Add glue:getConnection to DPR SSO

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -281,6 +281,7 @@ data "aws_iam_policy_document" "developer_additional" {
       "kinesisanalytics:List*",
       "kinesisanalytics:Describe*",
       "kinesisanalytics:DiscoverInputSchema",
+      "glue:GetConnection",
       "glue:GetConnections"
     ]
     resources = ["*"]
@@ -1130,6 +1131,7 @@ data "aws_iam_policy_document" "reporting-operations" {
       "glue:GetJobRuns",
       "glue:StartTrigger",
       "glue:StopTrigger",
+      "glue:GetConnection",
       "glue:GetConnections",
       "logs:DescribeLogStreams",
       "logs:GetLogEvents",


### PR DESCRIPTION
Add glue:getConnection to DPR SSO so problems with connection details can be debugged.

## A reference to the issue / Description of it

Developer and Operations roles need to be able to view the details of glue connections via AWS CLI or console to debug issues with the connection configuration. Currently we get this error message:
```
aws glue get-connection --name dpr-dps-activities-connection

An error occurred (AccessDeniedException) when calling the GetConnection operation: User: arn:aws:sts::203591025782:assumed-role/AWSReservedSSO_mp-reporting-operations_e480d2547978b388/tom-ogle-moj@digital.justice.gov.uk is not authorized to perform: glue:GetConnection on resource: arn:aws:glue:eu-west-2:203591025782:catalog because no identity-based policy allows the glue:GetConnection action
```

## How does this PR fix the problem?

Adds `glue:GetConnection` so roles can view the details of a glue connection.

## How has this been tested?

Tested on Sandbox/Dev Environment and can be reproduced by attempting to access a glue connection in higher environments, e.g. `aws glue get-connection --name dpr-dps-activities-connection`

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

N/A
