### PR TITLE
Create data calls and local values to associate production VPCs with …

### DIFF
--- a/terraform/environments/core-vpc/logging.tf
+++ b/terraform/environments/core-vpc/logging.tf
@@ -5,3 +5,32 @@ module "logging-r53-resolver" {
   destination_bucket_arn     = local.cloudwatch_log_buckets["r53-resolver-logs"]
   tags                       = local.tags
 }
+
+locals {
+  resolver_query_log_config_names = toset(["core-logging-rlq-cloudwatch", "core-logging-rlq-s3"])
+  vpc_ids                         = { for key, value in module.vpc : key => value["vpc_id"] }
+  rlq_ids                         = { for name, config in data.aws_route53_resolver_query_log_config.core_logging : name => config.id }
+  vpc_rlq_associations = merge([
+    for vpc_key, vpc_id in local.vpc_ids : {
+      for rlq_name, rlq_id in local.rlq_ids :
+      "${vpc_key}_${rlq_name}" => {
+        vpc_id = vpc_id
+        rlq_id = rlq_id
+      }
+    }
+  ]...)
+}
+
+data "aws_route53_resolver_query_log_config" "core_logging" {
+  for_each = local.resolver_query_log_config_names
+  filter {
+    name   = "Name"
+    values = [each.value]
+  }
+}
+
+resource "aws_route53_resolver_query_log_config_association" "core_logging" {
+  for_each                     = local.is-production ? local.vpc_rlq_associations : {}
+  resolver_query_log_config_id = each.value.rlq_id
+  resource_id                  = each.value.vpc_id
+}


### PR DESCRIPTION
## A reference to the issue / Description of it

#7607

## How does this PR fix the problem?

This PR does three things:

1. Create data objects for the RAM-shared `aws_route53_resolver_query_log_config` resources created and shared from `core-logging`
2. Create a set of local values which are combined to feed the `aws_route53_resolver_query_log_config_association` so that each VPC is associated with each resolver log query
3. Create the config associations in production only

## How has this been tested?

Tested with local terraform plan

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
