### PR TITLE
remove old account-local resolver logging

### DIFF
--- a/terraform/environments/core-vpc/locals.tf
+++ b/terraform/environments/core-vpc/locals.tf
@@ -17,7 +17,6 @@ locals {
 
   # Secrets used by Firehose resources which we only require for development & production VPCs.
   cloudwatch_log_buckets             = nonsensitive(jsondecode(data.aws_secretsmanager_secret_version.core_logging_bucket_arns.secret_string))
-  cloudwatch_r53_resolver_log_groups = local.is-production ? [for env in module.route_53_resolver_logs : env.r53_resolver_log_name] : []
 
   tags = {
     business-unit = "Platforms"

--- a/terraform/environments/core-vpc/logging.tf
+++ b/terraform/environments/core-vpc/logging.tf
@@ -1,11 +1,3 @@
-module "logging-r53-resolver" {
-  source                     = "github.com/ministryofjustice/modernisation-platform-terraform-aws-data-firehose?ref=2e58c8fd0b43ca8461dfd0c8cc5f43a1a9c49987" #v1.1.0
-  for_each                   = local.is-production ? { "build" = true } : {}
-  cloudwatch_log_group_names = local.cloudwatch_r53_resolver_log_groups
-  destination_bucket_arn     = local.cloudwatch_log_buckets["r53-resolver-logs"]
-  tags                       = local.tags
-}
-
 locals {
   resolver_query_log_config_names = toset(["core-logging-rlq-cloudwatch", "core-logging-rlq-s3"])
   vpc_ids                         = { for key, value in module.vpc : key => value["vpc_id"] }

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -108,14 +108,6 @@ module "vpc_nacls" {
   vpc_name         = each.key
 }
 
-module "route_53_resolver_logs" {
-  source      = "../../modules/r53-resolver-logs"
-  for_each    = { for key, value in module.vpc : key => value["vpc_id"] }
-  tags_common = local.tags
-  vpc_id      = each.value
-  vpc_name    = each.key
-}
-
 locals {
   non-tgw-vpc = flatten([
     for key, vpc in module.vpc : [


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/actions/runs/11055900092

## How does this PR fix the problem?

A VPC can only be associated with one type of log destination (EG, CloudWatch). This PR removes the legacy account-local logging.

## How has this been tested?

Tested with CI checks

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
