### PR TITLE
Reschedule cost collection to run on second day to include full month's data

### DIFF
--- a/.github/workflows/upload-cost-explorer-to-s3.yml
+++ b/.github/workflows/upload-cost-explorer-to-s3.yml
@@ -1,8 +1,8 @@
 name: Upload Cost Explorer CSV to S3
 on:
   schedule:
-    # Runs on the first day of every month at 6:30 AM
-    - cron: '30 6 1 * *'
+    # Runs on the second day of every month at 6:30 AM
+    - cron: '30 6 2 * *'
   workflow_dispatch:
 env:
   AWS_REGION: "eu-west-2"


### PR DESCRIPTION
## A reference to the issue / Description of it

The cost collection script, running on the 1st of the month, was missing the data for the 1st day of the current month, leading to discrepancies in the reported costs.

## How does this PR fix the problem?

Running the script on the 2nd day allows AWS billing data from the 1st of the month to be finalized, ensuring that the script includes all costs, preventing discrepancies.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)
