### PR TITLE
Encrypt Route53 Resolver Logs

### DIFF
--- a/terraform/environments/core-logging/r53_logs.tf
+++ b/terraform/environments/core-logging/r53_logs.tf
@@ -50,6 +50,9 @@ resource "aws_kms_key" "r53_resolver_logs" {
 }
 
 data "aws_iam_policy_document" "r53_resolver_logs_kms" {
+  #checkov:skip=CKV_AWS_109:"Policy is directly related to the resource"
+  #checkov:skip=CKV_AWS_111:"Policy is directly related to the resource"
+  #checkov:skip=CKV_AWS_356:"Policy is directly related to the resource"
   statement {
     sid    = "Allow management access of the key to the logging account"
     effect = "Allow"

--- a/terraform/environments/core-logging/r53_logs.tf
+++ b/terraform/environments/core-logging/r53_logs.tf
@@ -45,6 +45,7 @@ resource "aws_kms_key" "r53_resolver_logs" {
   description         = "KMS key used to encrypt R53 Resolver Logs CloudWatch log group"
   enable_key_rotation = true
   multi_region        = true
+  policy              = data.aws_iam_policy_document.r53_resolver_logs_kms.json
   tags                = local.tags
 }
 

--- a/terraform/environments/core-logging/r53_logs.tf
+++ b/terraform/environments/core-logging/r53_logs.tf
@@ -1,3 +1,10 @@
+locals {
+  resolver_query_log_configs = {
+    s3         = aws_route53_resolver_query_log_config.s3.arn
+    cloudwatch = aws_route53_resolver_query_log_config.cloudwatch.arn
+  }
+}
+
 resource "aws_route53_resolver_query_log_config" "s3" {
   name            = format("%s-rlq-s3", local.application_name)
   destination_arn = aws_s3_bucket.logging["r53-resolver-logs"].arn
@@ -8,21 +15,6 @@ resource "aws_route53_resolver_query_log_config" "cloudwatch" {
   name            = format("%s-rlq-cloudwatch", local.application_name)
   destination_arn = aws_cloudwatch_log_group.r53_resolver_logs.arn
   tags            = local.tags
-}
-
-#Temporarily unencrypted while I consider a suitable KMS policy
-resource "aws_cloudwatch_log_group" "r53_resolver_logs" {
-  #checkov:skip=CKV_AWS_158
-  name_prefix       = "r53-resolver-logs"
-  retention_in_days = 365
-  tags              = local.tags
-}
-
-locals {
-  resolver_query_log_configs = {
-    s3         = aws_route53_resolver_query_log_config.s3.arn
-    cloudwatch = aws_route53_resolver_query_log_config.cloudwatch.arn
-  }
 }
 
 resource "aws_ram_resource_share" "resolver_query_share" {
@@ -42,3 +34,55 @@ resource "aws_ram_principal_association" "resolver_query_share" {
   resource_share_arn = aws_ram_resource_share.resolver_query_share.arn
 }
 
+resource "aws_cloudwatch_log_group" "r53_resolver_logs" {
+  kms_key_id        = aws_kms_key.r53_resolver_logs.id
+  name_prefix       = "r53-resolver-logs"
+  retention_in_days = 365
+  tags              = local.tags
+}
+
+resource "aws_kms_key" "r53_resolver_logs" {
+  description         = "KMS key used to encrypt R53 Resolver Logs CloudWatch log group"
+  enable_key_rotation = true
+  multi_region        = true
+  tags                = local.tags
+}
+
+data "aws_iam_policy_document" "r53_resolver_logs_kms" {
+  statement {
+    sid    = "Allow management access of the key to the logging account"
+    effect = "Allow"
+    actions = [
+      "kms:*"
+    ]
+    resources = [
+      "*"
+    ]
+    principals {
+      type = "AWS"
+      identifiers = [
+        data.aws_caller_identity.current.account_id
+      ]
+    }
+  }
+  statement {
+    sid    = "Allow AWS Log service to use key"
+    effect = "Allow"
+    actions = [
+      "kms:Encrypt*",
+      "kms:Decrypt*",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:Describe*"
+    ]
+    resources = [
+      "*"
+    ]
+    principals {
+      type = "Service"
+      identifiers = [
+        "logs.amazonaws.com"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## A reference to the issue / Description of it

#7607

## How does this PR fix the problem?

Adds a KMS key and policy to encrypt the Route53 Resolver CloudWatch logs.

Guidance on key policy taken from [here](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html#cmk-permissions).

## How has this been tested?

Tested with local plan, also tested against `trivy` and `checkov` locally.

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
