### PR TITLE
Formatcode Bot update to use signed commits

### DIFF
--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -139,29 +139,28 @@ jobs:
 
           # Prepare the mutation payload
           mutation_payload=$(jq -n \
-            --arg branch_name $branch_name \
-            --arg commit_oid $commit_oid \
+            --arg branch_name "$branch_name" \
+            --arg commit_oid "$commit_oid" \
             --arg repo_id "$repo_id" \
-            --arg commit_message $commit_message \
-            --argjson files_for_commit "$(cat files_for_commit.json)" \
+            --arg commit_message "$commit_message" \
+            --argjson fileChanges "$(jq -c . < files_for_commit.json)" \
             '{
               query: "mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { oid } } }",
               variables: {
                 input: {
                   branch: {
-                    repositoryNameWithOwner: "ministryofjustice/modernisation-platform",
+                    repositoryNameWithOwner: $repo_id,
                     branchName: $branch_name
                   },
                   message: {
                     headline: $commit_message
                   },
-                  fileChanges: {
-                    additions: $files_for_commit.additions
-                  },
+                  fileChanges: $fileChanges,
                   expectedHeadOid: $commit_oid
                 }
               }
             }')
+            
           echo "Mutation Payload: $mutation_payload"    
       
           # Send the mutation request to GitHub's GraphQL API and capture the response

--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -1,10 +1,9 @@
-
 name: 'Format Code: ensure code formatting guidelines are met'
 
 on:
   workflow_dispatch: null
   schedule:
-    - cron: 45 4 * * 1-5
+    - cron: '45 4 * * 1-5'
 
 permissions:
   contents: write
@@ -82,23 +81,6 @@ jobs:
             cat changed_files.txt
           fi
 
-          # Prepare file additions for the GraphQL mutation
-          FILE_ADDITIONS="[]"
-
-          for FILE in $changed_files; do
-            if [[ -f "$FILE" ]]; then
-              # Encode the file content in base64
-              FILE_CONTENT=$(base64 "$FILE" | tr -d '\n')
-              
-              # Create a JSON object for the file addition
-              FILE_ADDITIONS+=("{
-                \"path\": \"$FILE\",
-                \"contents\": \"$FILE_CONTENT\"
-              }")
-            fi
-          done
-
-
       - name: Prepare the Changes for GraphQL
         run: |
           commit_oid=$(git rev-parse HEAD)
@@ -112,7 +94,7 @@ jobs:
             if [[ -f "$file" ]]; then
               # Add a newline to the end of the content
               file_content="$(cat "$file")"$'\n'
-    
+
               # Base64 encode the contents of the file
               base64_content=$(base64 -w 0 <<< "$file_content")
 
@@ -125,8 +107,12 @@ jobs:
           # Output the final JSON array
           echo "$files_for_commit" > files_for_commit.json
           cat files_for_commit.json
-  
-
+          
+          # Error handling for `jq` output
+          if ! jq . files_for_commit.json; then
+            echo "Error processing files_for_commit.json"
+            exit 1
+          fi
 
       - name: Commit changes via GraphQL
         env:
@@ -134,14 +120,19 @@ jobs:
         run: |
           commit_message="Automated code formatting fixes"
           files_for_commit="$(cat files_for_commit.json)"
-          jq . files_for_commit.json
-
+          
+          # Error handling for `jq` output
+          if ! jq . files_for_commit.json; then
+            echo "Error reading files_for_commit.json"
+            exit 1
+          fi
+      
           mutation_payload=$(jq -n \
             --arg branch_name $branch_name \
             --arg commit_oid $commit_oid \
             --arg repo_id "$repo_id" \
             --arg commit_message $commit_message \
-            --argjson files_for_commit "$(echo "$files_for_commit" | jq -c .)" \
+            --argjson files_for_commit "$(cat files_for_commit.json)" \
             '{
               query: "mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { oid } } }",
               variables: {
@@ -154,29 +145,30 @@ jobs:
                     headline: $commit_message
                   },
                   fileChanges: {
-                    additions: $files_for_commit
+                    additions: $files_for_commit.additions
                   },
                   expectedHeadOid: $commit_oid
                 }
               }
             }')
-  
-          # Send the mutation request to GitHub's GraphQL API
-          curl -X POST -H "Authorization: bearer $GITHUB_TOKEN" \
+      
+          # Send the mutation request to GitHub's GraphQL API and capture the response
+          RESPONSE=$(curl -X POST -H "Authorization: bearer $GITHUB_TOKEN" \
             -H "Content-Type: application/json" \
-            -d "$mutation_payload" https://api.github.com/graphql
-
-                # Parse the commit OID from the response
-                COMMIT_OID=$(echo "$RESPONSE" | jq -r '.data.createCommitOnBranch.commit.oid')
-
-                # Check if the commit was successfully created
-                if [ "$COMMIT_OID" != "null" ]; then
-                  echo "Commit successfully created with OID: $COMMIT_OID"
-                else
-                  echo "Error creating commit: $RESPONSE"
-                fi
-
+            -d "$mutation_payload" https://api.github.com/graphql)
+      
+          # Parse the commit OID from the response
+          COMMIT_OID=$(echo "$RESPONSE" | jq -r '.data.createCommitOnBranch.commit.oid')
+      
+          # Check if the commit was successfully created
+          if [ "$COMMIT_OID" != "null" ]; then
+            echo "Commit successfully created with OID: $COMMIT_OID"
+          else
+            echo "Error creating commit: $RESPONSE"
+          fi
         
+
+          
 
       # - name: Create pull request
       #   if: env.changes == 'true'

--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -177,16 +177,14 @@ jobs:
           else
             echo "Error creating commit: $RESPONSE"
           fi
-        
 
-
-      # - name: Create pull request
-      #   if: env.changes == 'true'
-      #   env:
-      #     GH_TOKEN: ${{ github.token }}
-      #   run: |
-      #     pr_title="GitHub Actions Code Formatter workflow"
-      #     pr_body="This pull request includes updates from the GitHub Actions Code Formatter workflow. Please review the changes and merge if everything looks good."
-      #     pr_head="${{ github.repository_owner }}:${branch_name}"
-      #     pr_base="main"
-      #     gh pr create --title "$pr_title" --body "$pr_body" --head "$pr_head" --base "$pr_base" --label "code quality"
+      - name: Create pull request
+        if: env.changes == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          pr_title="GitHub Actions Code Formatter workflow"
+          pr_body="This pull request includes updates from the GitHub Actions Code Formatter workflow. Please review the changes and merge if everything looks good."
+          pr_head="${{ github.repository_owner }}:${branch_name}"
+          pr_base="main"
+          gh pr create --title "$pr_title" --body "$pr_body" --head "$pr_head" --base "$pr_base" --label "code quality"

--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -126,7 +126,18 @@ jobs:
             echo "Error reading files_for_commit.json"
             exit 1
           fi
-      
+
+          # Output the final JSON array
+          echo "$files_for_commit" > files_for_commit.json
+          cat files_for_commit.json  # Check the contents for validity
+
+          # Validate the JSON before proceeding
+          if ! jq empty files_for_commit.json; then
+            echo "Invalid JSON in files_for_commit.json"
+            exit 1
+          fi
+
+          # Prepare the mutation payload
           mutation_payload=$(jq -n \
             --arg branch_name $branch_name \
             --arg commit_oid $commit_oid \
@@ -151,6 +162,7 @@ jobs:
                 }
               }
             }')
+          echo "Mutation Payload: $mutation_payload"    
       
           # Send the mutation request to GitHub's GraphQL API and capture the response
           RESPONSE=$(curl -X POST -H "Authorization: bearer $GITHUB_TOKEN" \
@@ -158,7 +170,7 @@ jobs:
             -d "$mutation_payload" https://api.github.com/graphql)
       
           # Parse the commit OID from the response
-          COMMIT_OID=$(echo "$RESPONSE" | jq -r '.data.createCommitOnBranch.commit.oid')
+          COMMIT_OID=$(echo "$RESPONSE" | jq -r ".data.createCommitOnBranch.commit.oid")
       
           # Check if the commit was successfully created
           if [ "$COMMIT_OID" != "null" ]; then
@@ -168,7 +180,6 @@ jobs:
           fi
         
 
-          
 
       # - name: Create pull request
       #   if: env.changes == 'true'

--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -1,4 +1,4 @@
----
+
 name: 'Format Code: ensure code formatting guidelines are met'
 
 on:
@@ -30,9 +30,13 @@ jobs:
 
       - name: Create new branch
         run: |
-          date=$(date +%Y_%m_%d)
-          branch_name="date_$date"
+          date=$(date +%Y_%m_%d_%H_%M)
+          branch_name="code_formatter_$date"
           git checkout -b $branch_name
+          echo "branch_name=$branch_name" >> $GITHUB_ENV
+          # Push the empty branch to remote
+          git push -u origin $branch_name 
+
 
       - name: Run linter
         id: ml
@@ -54,34 +58,133 @@ jobs:
           YAML_PRETTIER_FILTER_REGEX_EXCLUDE: (.github/*)
           MARKDOWN_MARKDOWNLINT_FILTER_REGEX_EXCLUDE: (terraform/modules/.*/.*.md)
           REPORT_OUTPUT_FOLDER: none
-
+          
       - name: Check for changes
         run: |
+          # Show the status and diff before attempting to pull/push
+          echo "===== Git Status & Diff ====="
+          git status
+          git diff
+
+          echo "===== Git Add ====="
           git add .
-          git commit -m "Updates from GitHub Actions Format Code workflow" || true
-          branch_name=$(git branch --show-current)
-          changes=$(git diff origin/main...$branch_name --name-only)
+          changes=$(git diff --staged --name-only)
+
           if [ -z "$changes" ]; then
             echo "No changes detected."
+            echo "Exiting workflow using status 1 without reporting an error"
+            exit 0
           else
             echo "Changes detected."
             echo "changes=true" >> $GITHUB_ENV
+            git diff --staged --name-only > changed_files.txt
+            echo "List Files"
+            cat changed_files.txt
           fi
 
-      - name: Push changes
-        if: env.changes == 'true'
-        run: |
-          git config --global push.autoSetupRemote true
-          git push
+          # Prepare file additions for the GraphQL mutation
+          FILE_ADDITIONS="[]"
 
-      - name: Create pull request
-        if: env.changes == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
+          for FILE in $changed_files; do
+            if [[ -f "$FILE" ]]; then
+              # Encode the file content in base64
+              FILE_CONTENT=$(base64 "$FILE" | tr -d '\n')
+              
+              # Create a JSON object for the file addition
+              FILE_ADDITIONS+=("{
+                \"path\": \"$FILE\",
+                \"contents\": \"$FILE_CONTENT\"
+              }")
+            fi
+          done
+
+
+      - name: Prepare the Changes for GraphQL
         run: |
-          pr_title="GitHub Actions Code Formatter workflow"
-          pr_body="This pull request includes updates from the GitHub Actions Code Formatter workflow. Please review the changes and merge if everything looks good."
-          branch_name=$(git branch --show-current)
-          pr_head="${{ github.repository_owner }}:${branch_name}"
-          pr_base="main"
-          gh pr create --title "$pr_title" --body "$pr_body" --head "$pr_head" --base "$pr_base" --label "code quality"
+          commit_oid=$(git rev-parse HEAD)
+          echo "commit_oid=$commit_oid" >> $GITHUB_ENV
+
+          # Initialize an empty JSON object for the additions
+          files_for_commit='{"additions": []}'
+
+          # Read the changed files from changed_files.txt
+          while IFS= read -r file; do
+            if [[ -f "$file" ]]; then
+              # Add a newline to the end of the content
+              file_content="$(cat "$file")"$'\n'
+    
+              # Base64 encode the contents of the file
+              base64_content=$(base64 -w 0 <<< "$file_content")
+
+              # Construct a JSON object for this file and append it to the additions array
+              files_for_commit=$(echo "$files_for_commit" | jq --arg path "$file" --arg content "$base64_content" \
+              '.additions += [{ "path": $path, "contents": $content }]')
+            fi
+          done < changed_files.txt
+
+          # Output the final JSON array
+          echo "$files_for_commit" > files_for_commit.json
+          cat files_for_commit.json
+  
+
+
+      - name: Commit changes via GraphQL
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          commit_message="Automated code formatting fixes"
+          files_for_commit="$(cat files_for_commit.json)"
+          jq . files_for_commit.json
+
+          mutation_payload=$(jq -n \
+            --arg branch_name $branch_name \
+            --arg commit_oid $commit_oid \
+            --arg repo_id "$repo_id" \
+            --arg commit_message $commit_message \
+            --argjson files_for_commit "$(echo "$files_for_commit" | jq -c .)" \
+            '{
+              query: "mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { oid } } }",
+              variables: {
+                input: {
+                  branch: {
+                    repositoryNameWithOwner: "ministryofjustice/modernisation-platform",
+                    branchName: $branch_name
+                  },
+                  message: {
+                    headline: $commit_message
+                  },
+                  fileChanges: {
+                    additions: $files_for_commit
+                  },
+                  expectedHeadOid: $commit_oid
+                }
+              }
+            }')
+  
+          # Send the mutation request to GitHub's GraphQL API
+          curl -X POST -H "Authorization: bearer $GITHUB_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "$mutation_payload" https://api.github.com/graphql
+
+                # Parse the commit OID from the response
+                COMMIT_OID=$(echo "$RESPONSE" | jq -r '.data.createCommitOnBranch.commit.oid')
+
+                # Check if the commit was successfully created
+                if [ "$COMMIT_OID" != "null" ]; then
+                  echo "Commit successfully created with OID: $COMMIT_OID"
+                else
+                  echo "Error creating commit: $RESPONSE"
+                fi
+
+        
+
+      # - name: Create pull request
+      #   if: env.changes == 'true'
+      #   env:
+      #     GH_TOKEN: ${{ github.token }}
+      #   run: |
+      #     pr_title="GitHub Actions Code Formatter workflow"
+      #     pr_body="This pull request includes updates from the GitHub Actions Code Formatter workflow. Please review the changes and merge if everything looks good."
+      #     pr_head="${{ github.repository_owner }}:${branch_name}"
+      #     pr_base="main"
+      #     gh pr create --title "$pr_title" --body "$pr_body" --head "$pr_head" --base "$pr_base" --label "code quality"

--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -149,7 +149,7 @@ jobs:
               variables: {
                 input: {
                   branch: {
-                    repositoryNameWithOwner: $repo_id,
+                    repositoryNameWithOwner: "ministryofjustice/modernisation-platform",
                     branchName: $branch_name
                   },
                   message: {
@@ -160,7 +160,7 @@ jobs:
                 }
               }
             }')
-            
+
           echo "Mutation Payload: $mutation_payload"    
       
           # Send the mutation request to GitHub's GraphQL API and capture the response

--- a/terraform/environments/sprinkler/locals.tf
+++ b/terraform/environments/sprinkler/locals.tf
@@ -20,7 +20,7 @@ locals {
 
   )
 
-  environment     = "sandbox"
+  environment     =   "sandbox"
   vpc_name        = var.networking[0].business-unit
   subnet_set      = var.networking[0].set
   vpc_all         = "${local.vpc_name}-${local.environment}"


### PR DESCRIPTION
## A reference to the issue / Description of it

Full details in [Issue-7689](https://github.com/ministryofjustice/modernisation-platform/issues/7689)

## How does this PR fix the problem?

This PR updates the formate code workflow to use signed commits

## How has this been tested?

tested here https://github.com/ministryofjustice/modernisation-platform/actions/runs/11069022570

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No impact is expected.

## Checklist (check `x` in `[ ]` of list items)

- [ X ] I have performed a self-review of my own code
- [ X ] All checks have passed
- [ ] I have made corresponding changes to the documentation

