### PR TITLE
ARN of key required to encrypt cloudwatch log group

### DIFF
--- a/terraform/environments/core-logging/r53_logs.tf
+++ b/terraform/environments/core-logging/r53_logs.tf
@@ -35,7 +35,7 @@ resource "aws_ram_principal_association" "resolver_query_share" {
 }
 
 resource "aws_cloudwatch_log_group" "r53_resolver_logs" {
-  kms_key_id        = aws_kms_key.r53_resolver_logs.id
+  kms_key_id        = aws_kms_key.r53_resolver_logs.arn
   name_prefix       = "r53-resolver-logs"
   retention_in_days = 365
   tags              = local.tags


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/actions/runs/11069352259/job/30757178006

ARN, not ID,of KMS key is required to encrypt a CloudWatch Log Group

## How does this PR fix the problem?

Amends argument attribute supplied to encrypt Log Group

## How has this been tested?

Applied key through CLI, tested against Terraform Plan without and with updated reference to attribute.

## Deployment Plan / Instructions

No functional changes

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
