### PR TITLE
Ensure production VPCs in all core account log to S3

### DIFF
--- a/terraform/environments/core-logging/vpc.tf
+++ b/terraform/environments/core-logging/vpc.tf
@@ -21,6 +21,7 @@ module "vpc" {
 
   # VPC Flow Logs
   vpc_flow_log_iam_role = aws_iam_role.vpc_flow_log.arn
+  flow_log_s3_destination_arn = each.key == "live_data" ? local.cloudwatch_log_buckets["vpc-flow-logs"] : ""
 
   # Transit Gateway ID
   transit_gateway_id = data.aws_ec2_transit_gateway.transit-gateway.id

--- a/terraform/environments/core-security/vpc.tf
+++ b/terraform/environments/core-security/vpc.tf
@@ -21,6 +21,7 @@ module "vpc" {
 
   # VPC Flow Logs
   vpc_flow_log_iam_role = aws_iam_role.vpc_flow_log.arn
+  flow_log_s3_destination_arn = each.key == "live_data" ? local.cloudwatch_log_buckets["vpc-flow-logs"] : ""
 
   # Transit Gateway ID
   transit_gateway_id = data.aws_ec2_transit_gateway.transit-gateway.id


### PR DESCRIPTION
## A reference to the issue / Description of it

#7607

## How does this PR fix the problem?

The `live_data` VPCs in these core accounts don't host any customer infrastructure, but are included in the scope of logging for consistency.

## How has this been tested?

Tested through CI pipeline

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
