### PR TITLE
Log R53 resolver queries for `core-logging`

### DIFF
--- a/terraform/environments/core-logging/locals.tf
+++ b/terraform/environments/core-logging/locals.tf
@@ -12,7 +12,7 @@ locals {
 
   # This takes the name of the Terraform workspace (e.g. core-vpc-production), strips out the application name (e.g. core-vpc), and checks if
   # the string leftover is `-production`, if it isn't (e.g. core-vpc-non-production => -non-production) then it sets the var to false.
-  is-production = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-production"
+  is-production          = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-production"
   cloudwatch_log_buckets = nonsensitive(jsondecode(data.aws_secretsmanager_secret_version.core_logging_bucket_arns.secret_string))
 
   tags = {

--- a/terraform/environments/core-logging/logging.tf
+++ b/terraform/environments/core-logging/logging.tf
@@ -1,0 +1,28 @@
+locals {
+  resolver_query_log_config_names = toset(["core-logging-rlq-cloudwatch", "core-logging-rlq-s3"])
+  vpc_ids                         = { for key, value in module.vpc : key => value["vpc_id"] if key == "live_data" }
+  rlq_ids                         = { for name, config in data.aws_route53_resolver_query_log_config.core_logging : name => config.id }
+  vpc_rlq_associations = merge([
+    for vpc_key, vpc_id in local.vpc_ids : {
+      for rlq_name, rlq_id in local.rlq_ids :
+      "${vpc_key}_${rlq_name}" => {
+        vpc_id = vpc_id
+        rlq_id = rlq_id
+      }
+    }
+  ]...)
+}
+
+data "aws_route53_resolver_query_log_config" "core_logging" {
+  for_each = local.resolver_query_log_config_names
+  filter {
+    name   = "Name"
+    values = [each.value]
+  }
+}
+
+resource "aws_route53_resolver_query_log_config_association" "core_logging" {
+  for_each                     = local.is-production ? local.vpc_rlq_associations : {}
+  resolver_query_log_config_id = each.value.rlq_id
+  resource_id                  = each.value.vpc_id
+}

--- a/terraform/environments/core-logging/vpc.tf
+++ b/terraform/environments/core-logging/vpc.tf
@@ -20,7 +20,7 @@ module "vpc" {
   gateway = "transit"
 
   # VPC Flow Logs
-  vpc_flow_log_iam_role = aws_iam_role.vpc_flow_log.arn
+  vpc_flow_log_iam_role       = aws_iam_role.vpc_flow_log.arn
   flow_log_s3_destination_arn = each.key == "live_data" ? local.cloudwatch_log_buckets["vpc-flow-logs"] : ""
 
   # Transit Gateway ID


### PR DESCRIPTION
## A reference to the issue / Description of it

#7607

## How does this PR fix the problem?

Adds config to log resolver queries to CloudWatch & S3 in `core-logging`

## How has this been tested?

Tested with local plan

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
