### PR TITLE
Assumable role for Cortex XSIAM

### DIFF
--- a/terraform/environments/core-logging/ssm.tf
+++ b/terraform/environments/core-logging/ssm.tf
@@ -1,0 +1,12 @@
+resource "aws_ssm_parameter" "cortex_account_id" {
+  #checkov:skip=CKV2_AWS_34: "Parameter is not sensitive; account ID is publicly available."
+  lifecycle {
+    ignore_changes = [value]
+  }
+  provider    = aws.modernisation-platform
+  description = "Account ID for Palo Alto XSIAM Cortex cross-account role."
+  name        = "cortex_account_id"
+  type        = "String"
+  value       = ""
+  tags        = local.tags
+}

--- a/terraform/environments/core-logging/versions.tf
+++ b/terraform/environments/core-logging/versions.tf
@@ -12,6 +12,10 @@ terraform {
       version = "~> 2.0"
       source  = "hashicorp/archive"
     }
+    random = {
+      version = "~> 3.0"
+      source  = "hashicorp/random"
+    }
   }
   required_version = "~> 1.0"
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

#7607 

## How does this PR fix the problem?

Creates an assumable role that can be used by Palo Alto Cortex XSIAM in line with their documented guidelines. I deliberately haven't attached the `Security Audit` managed policy as this isn't currently being used by the Cortex user, and provides access to the account which we may not prefer to offer.

## How has this been tested?

Tested with CI pipeline. I expect that this will fail because - at present - there is no value for the account ID SSM parameter. This will be added manually once the parameter has been created

## Deployment Plan / Instructions

Deploy through CI. Potentially re-run after populating SSM parameter.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
