### PR TITLE
Add placeholder value to `cortex_account_id` parameter

### DIFF
--- a/terraform/environments/core-logging/ssm.tf
+++ b/terraform/environments/core-logging/ssm.tf
@@ -7,6 +7,6 @@ resource "aws_ssm_parameter" "cortex_account_id" {
   description = "Account ID for Palo Alto XSIAM Cortex cross-account role."
   name        = "cortex_account_id"
   type        = "String"
-  value       = ""
+  value       = "Placeholder"
   tags        = local.tags
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

#7607

## How does this PR fix the problem?

SSM parameter requires a minimum amount of content to meet validation constraints:

> Error: creating SSM Parameter (cortex_account_id): operation error SSM: PutParameter, https response error StatusCode: 400, RequestID: 895a8634-9acd-4f68-af9b-e8e5329604c8, api error ValidationException: 1 validation error detected: Value at 'value' failed to satisfy constraint: Member must have length greater than or equal to 1

## How has this been tested?

Tested with local plan.

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
