### PR TITLE
Create SSM Parameter to use in preference of secret store value for bucket ARNs

### DIFF
--- a/terraform/environments/core-logging/ssm.tf
+++ b/terraform/environments/core-logging/ssm.tf
@@ -4,9 +4,22 @@ resource "aws_ssm_parameter" "cortex_account_id" {
     ignore_changes = [value]
   }
   provider    = aws.modernisation-platform
-  description = "Account ID for Palo Alto XSIAM Cortex cross-account role."
+  description = "Account ID for Palo Alto Cortex XSIAM cross-account role."
   name        = "cortex_account_id"
   type        = "String"
   value       = "Placeholder"
   tags        = local.tags
+}
+
+resource "aws_ssm_parameter" "core_logging_bucket_arns" {
+  #checkov:skip=CKV2_AWS_34: "Parameter is not sensitive; bucket ARNs are stored here for programmatic retrieval."
+  provider    = aws.modernisation-platform
+  description = "Bucket ARNs in core-logging for Palo Alto Cortex XSIAM."
+  name        = "core_logging_bucket_arns"
+  type        = "String"
+  value = jsonencode({
+    for key in local.cortex_logging_buckets :
+    key => aws_s3_bucket.logging[key].arn
+  })
+  tags = local.tags
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

#7607 

## How does this PR fix the problem?

An AWS SSM Parameter is a more appropriate way to store non-sensitive information than an AWS Secrets Manager version.

This PR also harmonises the syntax in how we refer to Palo Alto Cortex XSIAM.

## How has this been tested?

Tested with local plan

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
