### PR TITLE
Retrieve core-logging bucket arns for cortex through SSM

### DIFF
--- a/terraform/environments/core-network-services/ssm.tf
+++ b/terraform/environments/core-network-services/ssm.tf
@@ -1,0 +1,4 @@
+data "aws_ssm_parameter" "core_logging_bucket_arns" {
+  provider = aws.modernisation-platform
+  name     = "core_logging_bucket_arns"
+}

--- a/terraform/environments/core-security/ssm.tf
+++ b/terraform/environments/core-security/ssm.tf
@@ -1,0 +1,4 @@
+data "aws_ssm_parameter" "core_logging_bucket_arns" {
+  provider = aws.modernisation-platform
+  name     = "core_logging_bucket_arns"
+}

--- a/terraform/environments/core-shared-services/ssm.tf
+++ b/terraform/environments/core-shared-services/ssm.tf
@@ -64,3 +64,8 @@ resource "aws_ssm_document" "cross-account-single-patching-automation" {
 }
 DOC
 }
+
+data "aws_ssm_parameter" "core_logging_bucket_arns" {
+  provider = aws.modernisation-platform
+  name     = "core_logging_bucket_arns"
+}

--- a/terraform/environments/core-vpc/ssm.tf
+++ b/terraform/environments/core-vpc/ssm.tf
@@ -1,0 +1,4 @@
+data "aws_ssm_parameter" "core_logging_bucket_arns" {
+  provider = aws.modernisation-platform
+  name     = "core_logging_bucket_arns"
+}


### PR DESCRIPTION
## A reference to the issue / Description of it

#7607

## How does this PR fix the problem?

In order to replace the use of AWS Secret Manager, this PR allows accounts to retrieve the same information through an SSM Parameter. A following PR will remove the old secret and use the new parameter.

## How has this been tested?

Tested through CI checks

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
