### PR TITLE
More fixes for ssm params

### DIFF
--- a/terraform/environments/core-logging/cortex.tf
+++ b/terraform/environments/core-logging/cortex.tf
@@ -156,7 +156,7 @@ data "aws_iam_policy_document" "cortex_trust_policy" {
 
     principals {
       type        = "AWS"
-      identifiers = ["arn:aws:iam::${aws_ssm_parameter.cortex_account_id.value}:root"]
+      identifiers = ["arn:aws:iam::${aws_ssm_parameter.cortex_account_id.insecure_value}:root"]
       # Palo Alto Cortex AWS Account ID
       # Taken from https://docs-cortex.paloaltonetworks.com/r/Cortex-XDR/Cortex-XDR-Pro-Administrator-Guide/Create-an-Assumed-Role
     }

--- a/terraform/environments/core-logging/ssm.tf
+++ b/terraform/environments/core-logging/ssm.tf
@@ -1,7 +1,7 @@
 resource "aws_ssm_parameter" "cortex_account_id" {
   #checkov:skip=CKV2_AWS_34: "Parameter is not sensitive; account ID is publicly available."
   lifecycle {
-    ignore_changes = [value]
+    ignore_changes = [insecure_value]
   }
   provider       = aws.modernisation-platform
   description    = "Account ID for Palo Alto Cortex XSIAM cross-account role."
@@ -16,6 +16,7 @@ resource "aws_ssm_parameter" "core_logging_bucket_arns" {
   provider    = aws.modernisation-platform
   description = "Bucket ARNs in core-logging for Palo Alto Cortex XSIAM."
   name        = "core_logging_bucket_arns"
+  overwrite   = true
   type        = "String"
   insecure_value = jsonencode({
     for key in local.cortex_logging_buckets :


### PR DESCRIPTION
## A reference to the issue / Description of it

#7607

## How does this PR fix the problem?

SSM parameters can't be overwritten without `overwrite = true`. Once an SSM parameter has been created, the value can't be changed to `insecure_value` without this flag. I worked around it originally by deleting the parameters manually to recreate them, but this will allow us to continue to work programatically.

## How has this been tested?

Tested with local apply targeted at parameters.

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
