### PR TITLE
Use SSM parameter to retrieve bucket ARNs

### DIFF
--- a/terraform/environments/core-logging/locals.tf
+++ b/terraform/environments/core-logging/locals.tf
@@ -12,8 +12,8 @@ locals {
 
   # This takes the name of the Terraform workspace (e.g. core-vpc-production), strips out the application name (e.g. core-vpc), and checks if
   # the string leftover is `-production`, if it isn't (e.g. core-vpc-non-production => -non-production) then it sets the var to false.
-  is-production          = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-production"
-  cloudwatch_log_buckets = nonsensitive(jsondecode(data.aws_secretsmanager_secret_version.core_logging_bucket_arns.secret_string))
+  is-production            = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-production"
+  core_logging_bucket_arns = jsondecode(aws_ssm_parameter.core_logging_bucket_arns.insecure_value)
 
   tags = {
     business-unit = "Platforms"

--- a/terraform/environments/core-logging/vpc.tf
+++ b/terraform/environments/core-logging/vpc.tf
@@ -21,7 +21,7 @@ module "vpc" {
 
   # VPC Flow Logs
   vpc_flow_log_iam_role       = aws_iam_role.vpc_flow_log.arn
-  flow_log_s3_destination_arn = each.key == "live_data" ? local.cloudwatch_log_buckets["vpc-flow-logs"] : ""
+  flow_log_s3_destination_arn = each.key == "live_data" ? local.core_logging_bucket_arns["vpc-flow-logs"] : ""
 
   # Transit Gateway ID
   transit_gateway_id = data.aws_ec2_transit_gateway.transit-gateway.id

--- a/terraform/environments/core-network-services/firewall.tf
+++ b/terraform/environments/core-network-services/firewall.tf
@@ -74,7 +74,7 @@ resource "aws_flow_log" "external_inspection" {
 }
 
 resource "aws_flow_log" "external_inspection_s3" {
-  log_destination          = local.cloudwatch_log_buckets["vpc-flow-logs"]
+  log_destination          = local.core_logging_bucket_arns["vpc-flow-logs"]
   log_destination_type     = "s3"
   log_format               = local.custom_vpc_flow_log_format
   max_aggregation_interval = "60"

--- a/terraform/environments/core-network-services/locals.tf
+++ b/terraform/environments/core-network-services/locals.tf
@@ -16,7 +16,7 @@ locals {
   # the string leftover is `-production`, if it isn't (e.g. core-vpc-non-production => -non-production) then it sets the var to false.
   is-production = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-production"
 
-  cloudwatch_log_buckets        = nonsensitive(jsondecode(data.aws_secretsmanager_secret_version.core_logging_bucket_arns.secret_string))
+  core_logging_bucket_arns = jsondecode(data.aws_ssm_parameter.core_logging_bucket_arns.insecure_value)
   cloudwatch_generic_log_groups = concat([module.firewall_logging.cloudwatch_log_group_name], [for key, value in module.vpc_inspection : value.fw_cloudwatch_name])
 
   tags = {

--- a/terraform/environments/core-network-services/logging.tf
+++ b/terraform/environments/core-network-services/logging.tf
@@ -2,7 +2,7 @@ module "logging-generic-logs" {
   source                     = "github.com/ministryofjustice/modernisation-platform-terraform-aws-data-firehose?ref=2e58c8fd0b43ca8461dfd0c8cc5f43a1a9c49987" #v1.1.0
   for_each                   = local.is-production ? { "build" = true } : {}
   cloudwatch_log_group_names = local.cloudwatch_generic_log_groups
-  destination_bucket_arn     = local.cloudwatch_log_buckets["generic-logs"]
+  destination_bucket_arn     = local.core_logging_bucket_arns["generic-logs"]
   tags                       = local.tags
 }
 

--- a/terraform/environments/core-network-services/monitoring.tf
+++ b/terraform/environments/core-network-services/monitoring.tf
@@ -152,7 +152,7 @@ resource "aws_flow_log" "tgw_flowlog" {
 }
 
 resource "aws_flow_log" "tgw_flowlog_s3" {
-  log_destination          = local.cloudwatch_log_buckets["vpc-flow-logs"]
+  log_destination          = local.core_logging_bucket_arns["vpc-flow-logs"]
   log_destination_type     = "s3"
   log_format               = local.custom_tgw_flow_log_format
   max_aggregation_interval = "60"

--- a/terraform/environments/core-network-services/vpc.tf
+++ b/terraform/environments/core-network-services/vpc.tf
@@ -11,7 +11,7 @@ module "vpc_inspection" {
 
   source                      = "../../modules/vpc-inspection"
   application_name            = local.application_name
-  flow_log_s3_destination_arn = each.key == "live_data" ? local.cloudwatch_log_buckets["vpc-flow-logs"] : ""
+  flow_log_s3_destination_arn = each.key == "live_data" ? local.core_logging_bucket_arns["vpc-flow-logs"] : ""
   fw_allowed_domains          = local.fqdn_firewall_rules.fw_allowed_domains
   fw_home_net_ips             = local.fqdn_firewall_rules.fw_home_net_ips
   fw_kms_arn                  = data.aws_kms_key.general_shared.arn

--- a/terraform/environments/core-security/locals.tf
+++ b/terraform/environments/core-security/locals.tf
@@ -10,7 +10,7 @@ locals {
   # This takes the name of the Terraform workspace (e.g. core-vpc-production), strips out the application name (e.g. core-vpc), and checks if
   # the string leftover is `-production`, if it isn't (e.g. core-vpc-non-production => -non-production) then it sets the var to false.
   is-production          = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-production"
-  cloudwatch_log_buckets = nonsensitive(jsondecode(data.aws_secretsmanager_secret_version.core_logging_bucket_arns.secret_string))
+  core_logging_bucket_arns = jsondecode(data.aws_ssm_parameter.core_logging_bucket_arns.insecure_value)
 
   tags = {
     business-unit = "Platforms"

--- a/terraform/environments/core-security/vpc.tf
+++ b/terraform/environments/core-security/vpc.tf
@@ -21,7 +21,7 @@ module "vpc" {
 
   # VPC Flow Logs
   vpc_flow_log_iam_role       = aws_iam_role.vpc_flow_log.arn
-  flow_log_s3_destination_arn = each.key == "live_data" ? local.cloudwatch_log_buckets["vpc-flow-logs"] : ""
+  flow_log_s3_destination_arn = each.key == "live_data" ? local.core_logging_bucket_arns["vpc-flow-logs"] : ""
 
   # Transit Gateway ID
   transit_gateway_id = data.aws_ec2_transit_gateway.transit-gateway.id

--- a/terraform/environments/core-shared-services/locals.tf
+++ b/terraform/environments/core-shared-services/locals.tf
@@ -45,7 +45,7 @@ locals {
     ]
   }
 
-  cloudwatch_log_buckets = nonsensitive(jsondecode(data.aws_secretsmanager_secret_version.core_logging_bucket_arns.secret_string))
+  core_logging_bucket_arns = jsondecode(data.aws_ssm_parameter.core_logging_bucket_arns.insecure_value)
 
   tags = {
     business-unit = "Platforms"

--- a/terraform/environments/core-shared-services/vpc.tf
+++ b/terraform/environments/core-shared-services/vpc.tf
@@ -33,7 +33,7 @@ module "vpc" {
 
   # VPC Flow Logs
   vpc_flow_log_iam_role       = aws_iam_role.vpc_flow_log.arn
-  flow_log_s3_destination_arn = each.key == "live_data" ? local.cloudwatch_log_buckets["vpc-flow-logs"] : ""
+  flow_log_s3_destination_arn = each.key == "live_data" ? local.core_logging_bucket_arns["vpc-flow-logs"] : ""
 
   # Transit Gateway ID
   transit_gateway_id = data.aws_ec2_transit_gateway.transit-gateway.id

--- a/terraform/environments/core-vpc/locals.tf
+++ b/terraform/environments/core-vpc/locals.tf
@@ -15,8 +15,7 @@ locals {
   is-development = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-development"
   is-live_data   = (substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-production") || (substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-preproduction")
 
-  # Secrets used by Firehose resources which we only require for development & production VPCs.
-  cloudwatch_log_buckets = nonsensitive(jsondecode(data.aws_secretsmanager_secret_version.core_logging_bucket_arns.secret_string))
+  core_logging_bucket_arns = jsondecode(data.aws_ssm_parameter.core_logging_bucket_arns.insecure_value)
 
   tags = {
     business-unit = "Platforms"

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -91,7 +91,7 @@ module "vpc" {
 
   # VPC Flow Logs
   vpc_flow_log_iam_role       = aws_iam_role.vpc_flow_log.arn
-  flow_log_s3_destination_arn = local.is-production ? local.cloudwatch_log_buckets["vpc-flow-logs"] : ""
+  flow_log_s3_destination_arn = local.is-production ? local.core_logging_bucket_arns["vpc-flow-logs"] : ""
 
   # Tags
   tags_common = local.tags


### PR DESCRIPTION
## A reference to the issue / Description of it

#7607

## How does this PR fix the problem?

We originally used AWS Secretsmanager to store values centrally that could be used by `core-*` accounts. However, AWS SSM Parameter Store is the more appropriate way to hold these values. This PR updates how we retrieve values relevant to storing Cortex XSIAM information.

## How has this been tested?

Tested through CI pipelines; no changes expected

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
