### PR TITLE
Remove deprecated secret used to store bucket ARNs

### DIFF
--- a/terraform/environments/core-logging/cortex.tf
+++ b/terraform/environments/core-logging/cortex.tf
@@ -254,24 +254,6 @@ data "aws_kms_alias" "secrets" {
   name     = "alias/secrets_key"
 }
 
-resource "aws_secretsmanager_secret" "logging" {
-  # checkov:skip=CKV2_AWS_57
-  provider                = aws.modernisation-platform
-  kms_key_id              = data.aws_kms_alias.secrets.target_key_id
-  name                    = "core_logging_bucket_arns"
-  recovery_window_in_days = 0
-  tags                    = local.tags
-}
-
-resource "aws_secretsmanager_secret_version" "logging" {
-  provider  = aws.modernisation-platform
-  secret_id = aws_secretsmanager_secret.logging.id
-  secret_string = jsonencode({
-    for key in local.cortex_logging_buckets :
-    key => aws_s3_bucket.logging[key].arn
-  })
-}
-
 resource "aws_iam_user" "cortex_xsiam_user" {
   #checkov:skip=CKV_AWS_273: This has been agreed by the TA that for this purpose an IAM user account can be used.
   name = "cortex_xsiam_user"

--- a/terraform/environments/core-logging/secrets.tf
+++ b/terraform/environments/core-logging/secrets.tf
@@ -20,14 +20,3 @@ data "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {
   provider  = aws.modernisation-platform
   secret_id = data.aws_secretsmanager_secret.pagerduty_integration_keys.id
 }
-
-# Get the ARNs of the logging buckets in `core-logging`
-data "aws_secretsmanager_secret" "core_logging_bucket_arns" {
-  provider = aws.modernisation-platform
-  name     = "core_logging_bucket_arns"
-}
-
-data "aws_secretsmanager_secret_version" "core_logging_bucket_arns" {
-  provider  = aws.modernisation-platform
-  secret_id = data.aws_secretsmanager_secret.core_logging_bucket_arns.id
-}

--- a/terraform/environments/core-network-services/secrets.tf
+++ b/terraform/environments/core-network-services/secrets.tf
@@ -21,17 +21,6 @@ data "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {
   secret_id = data.aws_secretsmanager_secret.pagerduty_integration_keys.id
 }
 
-# Get the ARNs of the logging buckets in `core-logging`
-data "aws_secretsmanager_secret" "core_logging_bucket_arns" {
-  provider = aws.modernisation-platform
-  name     = "core_logging_bucket_arns"
-}
-
-data "aws_secretsmanager_secret_version" "core_logging_bucket_arns" {
-  provider  = aws.modernisation-platform
-  secret_id = data.aws_secretsmanager_secret.core_logging_bucket_arns.id
-}
-
 # Environment logging secret KMS key
 resource "aws_kms_key" "environment_logging" {
   description             = "environment-logging"

--- a/terraform/environments/core-security/secrets.tf
+++ b/terraform/environments/core-security/secrets.tf
@@ -20,14 +20,3 @@ data "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {
   provider  = aws.modernisation-platform
   secret_id = data.aws_secretsmanager_secret.pagerduty_integration_keys.id
 }
-
-# Get the ARNs of the logging buckets in `core-logging`
-data "aws_secretsmanager_secret" "core_logging_bucket_arns" {
-  provider = aws.modernisation-platform
-  name     = "core_logging_bucket_arns"
-}
-
-data "aws_secretsmanager_secret_version" "core_logging_bucket_arns" {
-  provider  = aws.modernisation-platform
-  secret_id = data.aws_secretsmanager_secret.core_logging_bucket_arns.id
-}

--- a/terraform/environments/core-shared-services/secrets.tf
+++ b/terraform/environments/core-shared-services/secrets.tf
@@ -20,14 +20,3 @@ data "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {
   provider  = aws.modernisation-platform
   secret_id = data.aws_secretsmanager_secret.pagerduty_integration_keys.id
 }
-
-# Get the ARNs of the logging buckets in `core-logging`
-data "aws_secretsmanager_secret" "core_logging_bucket_arns" {
-  provider = aws.modernisation-platform
-  name     = "core_logging_bucket_arns"
-}
-
-data "aws_secretsmanager_secret_version" "core_logging_bucket_arns" {
-  provider  = aws.modernisation-platform
-  secret_id = data.aws_secretsmanager_secret.core_logging_bucket_arns.id
-}

--- a/terraform/environments/core-vpc/secrets.tf
+++ b/terraform/environments/core-vpc/secrets.tf
@@ -20,14 +20,3 @@ data "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {
   provider  = aws.modernisation-platform
   secret_id = data.aws_secretsmanager_secret.pagerduty_integration_keys.id
 }
-
-# Get the ARNs of the logging buckets in `core-logging`
-data "aws_secretsmanager_secret" "core_logging_bucket_arns" {
-  provider = aws.modernisation-platform
-  name     = "core_logging_bucket_arns"
-}
-
-data "aws_secretsmanager_secret_version" "core_logging_bucket_arns" {
-  provider  = aws.modernisation-platform
-  secret_id = data.aws_secretsmanager_secret.core_logging_bucket_arns.id
-}


### PR DESCRIPTION
## A reference to the issue / Description of it

#7607

## How does this PR fix the problem?

Previous PRs have replaced the use of an AWS Secrets Manager secret with an AWS SSM Parameter Store parameter. This secret is no longer necessary and can be safely removed.

## How has this been tested?

Tested with CI pipeline checks

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
