### PR TITLE
add check requirements function

### DIFF
--- a/scripts/account-deletion/delete-accounts.sh
+++ b/scripts/account-deletion/delete-accounts.sh
@@ -1,5 +1,26 @@
 #!/bin/bash
 
+# Check required programs are installed
+check_requirements() {
+   local required_programs=("terraform" "jq")
+   local missing =0
+
+   for program in "${required_programs[@]}"; do
+        if ! command -v "$program" &> /dev/null; then
+            echo "Error: $program is not installed."
+            missing=1
+        fi
+    done
+   
+   if [ $missing -eq 1 ]; then
+        echo "Please install the missing programs and try again."
+        exit 1
+    else
+        echo "All required programs are installed."
+    fi
+}
+
+check_requirements
 
 # Define script names
 script1="./delete-tf-state.sh"


### PR DESCRIPTION
## A reference to the issue / Description of it

Having spoken to @Khatraf who recently ran through the account deletion process - she didn't have jq installed which is required in one of the scripts so it failed part-way through.

## How does this PR fix the problem?

I've added a small function to check the requirements for the script. Esssentially it checks that `terraform` and `jq` are installed and cancels the run if they are not.

## How has this been tested?

Tested locally. When I put in dummy package names I got the following result:

```
 ./delete-accounts.sh
Error: terrafom is not installed.
Error: j is not installed.
Please install the missing programs and try again.
```
But it runs through successfully when set to the proper names and the requirements are installed.

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [X] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
