### PR TITLE
Remove firehose for firewall logging

### DIFF
--- a/terraform/environments/core-network-services/logging.tf
+++ b/terraform/environments/core-network-services/logging.tf
@@ -1,11 +1,3 @@
-module "logging-generic-logs" {
-  source                     = "github.com/ministryofjustice/modernisation-platform-terraform-aws-data-firehose?ref=2e58c8fd0b43ca8461dfd0c8cc5f43a1a9c49987" #v1.1.0
-  for_each                   = local.is-production ? { "build" = true } : {}
-  cloudwatch_log_group_names = local.cloudwatch_generic_log_groups
-  destination_bucket_arn     = local.core_logging_bucket_arns["generic-logs"]
-  tags                       = local.tags
-}
-
 locals {
   resolver_query_log_config_names = toset(["core-logging-rlq-cloudwatch", "core-logging-rlq-s3"])
   vpc_ids                         = { for key, value in module.vpc_inspection : key => value["vpc_id"] if key == "live_data" }


### PR DESCRIPTION
## A reference to the issue / Description of it

#7607

## How does this PR fix the problem?

As neither firehose nor direct-to-s3 are suitable methods to store logs for XSIAM consumption, this PR removes the existing method of populating the `core-generic-logs` S3 bucket.

## How has this been tested?

Tested with Terraform plan

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
