### PR TITLE
Improve use of `firewall_policy` module

### DIFF
--- a/terraform/modules/firewall-policy/main.tf
+++ b/terraform/modules/firewall-policy/main.tf
@@ -68,22 +68,26 @@ resource "aws_networkfirewall_rule_group" "stateful" {
         }
       }
     }
-    rule_variables {
-      dynamic "ip_sets" {
-        for_each = var.ip_sets
-        content {
-          key = upper(ip_sets.key)
-          ip_set {
-            definition = tolist(ip_sets.value)
+    dynamic "rule_variables" {
+      for_each = length(var.ip_sets) > 0 || length(var.port_sets) > 0 ? [1] : []
+      content {
+        dynamic "ip_sets" {
+          for_each = var.ip_sets
+          content {
+            key = upper(ip_sets.key)
+            ip_set {
+              definition = tolist(ip_sets.value)
+            }
           }
         }
-      }
-      dynamic "port_sets" {
-        for_each = var.port_sets
-        content {
-          key = upper(port_sets.key)
-          port_set {
-            definition = tolist(port_sets.value)
+
+        dynamic "port_sets" {
+          for_each = var.port_sets
+          content {
+            key = upper(port_sets.key)
+            port_set {
+              definition = tolist(port_sets.value)
+            }
           }
         }
       }


### PR DESCRIPTION
## A reference to the issue / Description of it

When the firewall policy terraform is executed an empty `rule_variables` block is created regardless of if `ip_sets` or `port_sets` is populated.

## How does this PR fix the problem?

Wraps the `rule_variables {}` in a dynamic block, and creates it only when `ip_sets` or `port_sets` is supplied.

## How has this been tested?

Tested with local terraform plan

## Deployment Plan / Instructions

Non-functional deployment through CI; expect no changes.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
