### PR TITLE
Allow KMS:CreateGrant for the EM accounts in the OIDC

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -552,7 +552,12 @@ data "aws_iam_policy_document" "policy" {
       "kms:CreateGrant"
     ]
 
-    resources = ["arn:aws:kms:eu-west-2:${local.environment_management.account_ids["core-shared-services-production"]}:key/*"]
+    resources = [
+      "arn:aws:kms:eu-west-2:${local.environment_management.account_ids["core-shared-services-production"]}:key/*",
+      "arn:aws:kms:eu-west-2:${local.environment_management.account_ids["electronic-monitoring-data-development"]}:key/*",
+      "arn:aws:kms:eu-west-2:${local.environment_management.account_ids["electronic-monitoring-data-test"]}:key/*",
+      "arn:aws:kms:eu-west-2:${local.environment_management.account_ids["electronic-monitoring-data-production"]}:key/*"
+    ]
     condition {
       test     = "Bool"
       variable = "kms:GrantIsForAWSResource"


### PR DESCRIPTION
## Failing github action to automate lambda code updates

## How does this PR fix the problem?

Action currently fails to update lambda code as doesnt have perms to create a grant for kms keys in our account, this adds those permissions

## How has this been tested?

Please describe the tests that you ran: n/a

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

no

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
