### PR TITLE
Amended name on pagerduty_event_orchestration cdpt_ifs_cloudwatch to …

### DIFF
--- a/terraform/pagerduty/member-services-integrations.tf
+++ b/terraform/pagerduty/member-services-integrations.tf
@@ -1802,7 +1802,7 @@ resource "pagerduty_service" "cdpt-ifs" {
 }
 
 resource "pagerduty_event_orchestration" "cdpt_ifs_cloudwatch" {
-  name        = data.pagerduty_vendor.cloudwatch.name
+  name        = "cdpt_ifs_cloudwatch orchestration integration"
   description = "Integrates with PagerDuty"
   team        = pagerduty_team.modernisation_platform_members.id
 }


### PR DESCRIPTION
…another name

There was an error in a previous release that was unhappy with the name being used. This will correct that error and ensure the PR passes smoothly.

See #5980 