### PR TITLE
Add permissions for users to view console home widgets

### DIFF
--- a/terraform/modernisation-platform-account/iam.tf
+++ b/terraform/modernisation-platform-account/iam.tf
@@ -21,7 +21,8 @@ module "collaborators_group" {
 
   custom_group_policy_arns = [
     data.aws_iam_policy.ForceMFA.arn,
-    aws_iam_policy.collaborator_local_plan.arn
+    aws_iam_policy.collaborator_local_plan.arn,
+    aws_iam_policy.modernisation_account_limited_read.arn
   ]
 }
 
@@ -152,6 +153,18 @@ data "aws_iam_policy_document" "modernisation_account_limited_read" {
     effect    = "Deny"
     actions   = ["s3:*"]
     resources = ["arn:aws:s3:::*"]
+  }
+  statement {
+    sid    = "ViewConsoleHome"
+    effect = "Allow"
+    actions = [
+      "ec2:DescribeRegions",
+      "notifications:ListNotificationHubs",
+      "health:DescribeEventAggregates",
+      "cost-optimization-hub:ListEnrollmentStatuses",
+      "ce:GetCostAndUsage"
+    ]
+    resources = ["*"]
   }
 }
 resource "aws_iam_policy" "modernisation_account_limited_read" {


### PR DESCRIPTION
The AWS console home has widgets which display some data such as health and costs.

This gives permissions for users assuming the mp account read only role to view that data.

This will reduce the number of unauthorised API call alerts that we recieve every time a user assumes that role.

The read only policy is also being attached to the collaborator user group, this means that collaborators also have permissions to view these widgets, plus they no longer need to switch to a read only role in the same account.