### PR TITLE
Update NOMIS vpn sns topic access policy

### DIFF
--- a/terraform/environments/core-network-services/vpn.tf
+++ b/terraform/environments/core-network-services/vpn.tf
@@ -155,10 +155,17 @@ data "aws_iam_policy_document" "noms_vpn_sns_topic_policy" {
   policy_id = "nomis vpn sns topic policy"
 
   statement {
-    sid    = "Allow eventbrdige to publish messages to sns topic"
+    sid    = "Allow topic owner to manage sns topic"
     effect = "Allow"
     actions = [
-      "SNS:Publish",
+      "sns:Publish",
+      "sns:RemovePermission",
+      "sns:SetTopicAttributes",
+      "sns:DeleteTopic",
+      "sns:ListSubscriptionsByTopic",
+      "sns:GetTopicAttributes",
+      "sns:AddPermission",
+      "sns:Subscribe"
     ]
     resources = [
       aws_sns_topic.noms_vpn_sns_topic.arn,
@@ -171,13 +178,27 @@ data "aws_iam_policy_document" "noms_vpn_sns_topic_policy" {
       ]
     }
     principals {
+      type = "AWS"
+      identifiers = [
+        "*"
+      ]
+    }
+  }
+  statement {
+    sid    = "Allow eventbridge to publish messages to sns topic"
+    effect = "Allow"
+    actions = [
+      "sns:Publish",
+    ]
+    resources = [
+      aws_sns_topic.noms_vpn_sns_topic.arn,
+    ]
+    principals {
       type = "Service"
       identifiers = [
         "events.amazonaws.com"
       ]
     }
-
-
   }
 }
 


### PR DESCRIPTION
## A reference to the issue / Description of it

Health alerts relating to the NOMIS VPN were still not successfully triggering the associated SNS topic.

## How does this PR fix the problem?

Having made some manual changes, tested it and spoken to AWS support I've updated the policy to be less specific (condition statement removed).


## How has this been tested?

Local TF plan works and manual changes have been tested previously.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
