### PR TITLE
Add EM account access for AP ingestion scan ECR repo

### DIFF
--- a/terraform/environments/core-shared-services/ecr_repos.tf
+++ b/terraform/environments/core-shared-services/ecr_repos.tf
@@ -1115,14 +1115,25 @@ module "analytical_platform_ingestion_scan_ecr_repo" {
   pull_principals = [
     "arn:aws:iam::${local.environment_management.account_ids["analytical-platform-ingestion-development"]}:role/modernisation-platform-oidc-cicd",
     local.environment_management.account_ids["analytical-platform-ingestion-development"],
-    local.environment_management.account_ids["analytical-platform-ingestion-production"]
+    local.environment_management.account_ids["analytical-platform-ingestion-production"],
+    # Electronic monitoring data store accounts.
+    local.environment_management.account_ids["electronic-monitoring-data-development"],
+    local.environment_management.account_ids["electronic-monitoring-data-production"],
+    local.environment_management.account_ids["electronic-monitoring-data-test"]
   ]
 
   enable_retrieval_policy_for_lambdas = [
     "arn:aws:lambda:eu-west-2:${local.environment_management.account_ids["analytical-platform-ingestion-development"]}:function:scan*",
     "arn:aws:lambda:eu-west-2:${local.environment_management.account_ids["analytical-platform-ingestion-production"]}:function:scan*",
     "arn:aws:lambda:eu-west-2:${local.environment_management.account_ids["analytical-platform-ingestion-development"]}:function:definition-upload*",
-    "arn:aws:lambda:eu-west-2:${local.environment_management.account_ids["analytical-platform-ingestion-production"]}:function:definition-upload*"
+    "arn:aws:lambda:eu-west-2:${local.environment_management.account_ids["analytical-platform-ingestion-production"]}:function:definition-upload*",
+    # Electronic monitoring data store accounts.
+    "arn:aws:lambda:eu-west-2:${local.environment_management.account_ids["electronic-monitoring-data-development"]}:function:scan*",
+    "arn:aws:lambda:eu-west-2:${local.environment_management.account_ids["electronic-monitoring-data-production"]}:function:scan*",
+    "arn:aws:lambda:eu-west-2:${local.environment_management.account_ids["electronic-monitoring-data-test"]}:function:scan*",
+    "arn:aws:lambda:eu-west-2:${local.environment_management.account_ids["electronic-monitoring-data-development"]}:function:definition-upload*",
+    "arn:aws:lambda:eu-west-2:${local.environment_management.account_ids["electronic-monitoring-data-production"]}:function:definition-upload*",
+    "arn:aws:lambda:eu-west-2:${local.environment_management.account_ids["electronic-monitoring-data-test"]}:function:definition-upload*",
   ]
 
   # Tags


### PR DESCRIPTION
## A reference to the issue / Description of it

Electronic monitoring are going to be sent files from external suppliers that will need virus scanning before we do anything else with them. 

## How does this PR fix the problem?

The AP ingestion scan repo implements virus scanning for objects in S3 in a modular manner (i.e. no hard coded variables). As we need to add virus scanning of s3 objects into the Electronic Monitoring infrastructure, this PR is piggy backing on that code to add into our EM accounts.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.
Already deployed in AP accounts.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?
No
## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

n/a
