### PR TITLE
Deleted expired collaborator accounts.

### DIFF
--- a/collaborators.json
+++ b/collaborators.json
@@ -315,16 +315,6 @@
       ]
     },
     {
-      "username": "richard.stubbs",
-      "github-username": "rs87099",
-      "accounts": [
-        {
-          "account-name": "nomis-development",
-          "access": "instance-management"
-        }
-      ]
-    },
-    {
       "username": "joehyland.deeson",
       "github-username": "joe-hd",
       "accounts": [
@@ -361,36 +351,6 @@
         {
           "account-name": "nomis-test",
           "access": "instance-management"
-        }
-      ]
-    },
-    {
-      "username": "carl.last",
-      "github-username": "carldevcap",
-      "accounts": [
-        {
-          "account-name": "oasys-development",
-          "access": "s3-upload"
-        }
-      ]
-    },
-    {
-      "username": "martin.hiorns",
-      "github-username": "martinhiorns-capita",
-      "accounts": [
-        {
-          "account-name": "oasys-development",
-          "access": "s3-upload"
-        }
-      ]
-    },
-    {
-      "username": "morgan.boniface",
-      "github-username": "morgan-boniface",
-      "accounts": [
-        {
-          "account-name": "oasys-development",
-          "access": "s3-upload"
         }
       ]
     }


### PR DESCRIPTION
## A reference to the issue / Description of it

Removes four inactive collaborator accounts as per tickets #8178, #8179, #8180 and #8181 

IAM accounts have already been removed via the console.

## How does this PR fix the problem?

As per document https://user-guide.modernisation-platform.service.justice.gov.uk/runbooks/adding-collaborators.html#access-to-be-able-to-approve-deployments

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
