### PR TITLE
Correct reference to firewall log group

### DIFF
--- a/terraform/environments/core-network-services/logging.tf
+++ b/terraform/environments/core-network-services/logging.tf
@@ -29,7 +29,7 @@ resource "aws_route53_resolver_query_log_config_association" "core_logging" {
 
 module "stream_firewall_logs" {
   source                     = "github.com/ministryofjustice/modernisation-platform-terraform-aws-data-firehose?ref=cebe39c438390ffb5355827ec9469cfe9b09c22c" # v1.2.1
-  cloudwatch_log_group_names = [module.vpc_inspection["live_data"].fw_cloudwatch_name, aws_cloudwatch_log_group.external_inspection.name]
+  cloudwatch_log_group_names = [module.vpc_inspection["live_data"].fw_cloudwatch_name, module.firewall_logging.cloudwatch_log_group_name]
   destination_http_endpoint  = data.aws_ssm_parameter.cortex_xsiam_endpoint.value
   tags                       = local.tags
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

#7607

## How does this PR fix the problem?

Incorrect CW Log Group was being applied to data stream

## How has this been tested?

Tested through CI pipeline

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
