### PR TITLE
Adds AVD-GIT-0004 to trivyignore.

### DIFF
--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -39,6 +39,7 @@ vulnerabilities:
 
 misconfigurations:
 - id: AVD-GIT-0001
+- id: AVD-GIT-0004
 - id: AVD-AWS-0031
 - id: AVD-AWS-0039
 - id: AVD-AWS-0057

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -39,6 +39,7 @@ vulnerabilities:
 
 misconfigurations:
 - id: AVD-GIT-0001
+# Added AVD-GIT-0004 as Modernisation Platform Environments does not currently use signed commits. 
 - id: AVD-GIT-0004
 - id: AVD-AWS-0031
 - id: AVD-AWS-0039


### PR DESCRIPTION
Adds AVD-GIT-0004 which adds an ignore for signed commits not being set for modernisation-platform-environments.

## A reference to the issue / Description of it

The repository modernisation-platform-environments does not have "require signed commits" enabled for the main branch. This adds the required ignore as it is failing the test as evidenced here - https://github.com/ministryofjustice/modernisation-platform/actions/runs/11287877020

## How does this PR fix the problem?

See above.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
