### PR TITLE
updated secret rotation runbook to remove old xsiam reference

### DIFF
--- a/source/runbooks/rotating-secrets.html.md.erb
+++ b/source/runbooks/rotating-secrets.html.md.erb
@@ -91,11 +91,3 @@ This runbook describes the process for rotating the **slack_webhook_url** secret
 6. Click `Edit` and replace the secret value with the new one and click `Save`
 7. Run the [Github resources Workflow](https://github.com/ministryofjustice/modernisation-platform/actions/workflows/terraform-github.yml) manually on the main branch. This will populate the GH secret with the value that you have just updated in AWS Secrets Manager. 
 8. Wait for another workflow to run which uses the secret to confirm that the new token has taken effect successfully. (The secrets status will show as *"Last used within the last week"*)
-
-### Cortex Xsiam User Access Key
-
-This runbook covers the rotation of the access key for the cortex_xsiam_user account in the Core Logging account.
-
-1. Email the Monitoring & Integration team via monitoring-and-integration-platform@justice.gov.uk to confirm a new key pair is being created which will need to be applied to their Cortex Xsiam system.
-2. Once they have responded confirming they are ready for the key, create a new one for the cortex_xsiam_user in the Core Logging account and email that to the named person who responded. This avoids the key being shared too widely.
-3. When the M&I team have confirmed the new key has been applied and the console shows it in use, delete the existing key.


### PR DESCRIPTION
## A reference to the issue / Description of it

#7607

## How does this PR fix the problem?

XSIAM uses a role now, not a secret/access key

## How has this been tested?

Via peer review

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
