### PR TITLE
Add custom key to s3 bucket

### DIFF
--- a/terraform/environments/core-logging/observability.tf
+++ b/terraform/environments/core-logging/observability.tf
@@ -121,6 +121,7 @@ module "s3-moj-cur-reports-modplatform" {
   versioning_enabled  = true
   ownership_controls  = "BucketOwnerEnforced"
   replication_enabled = false
+  custom_kms_key      = aws_kms_key.moj-cur-reports.arn
   bucket_policy       = [data.aws_iam_policy_document.moj_cur_bucket_replication_policy.json]
   providers = {
     aws.bucket-replication = aws


### PR DESCRIPTION
As part of ticket https://github.com/ministryofjustice/modernisation-platform/issues/7169 this PR adds the KMS key to the cur-reports-buckets for encryption. 
