### PR TITLE
Fix Policy Permissions

### DIFF
--- a/terraform/environments/core-logging/observability.tf
+++ b/terraform/environments/core-logging/observability.tf
@@ -172,8 +172,6 @@ module "s3-moj-cur-reports-modplatform" {
 }
 
 data "aws_iam_policy_document" "moj_cur_bucket_replication_policy" {
-#checkov:skip=CKV_AWS_111:"Policy is directly related to the resource"
-#checkov:skip=CKV_AWS_356:"Policy is directly related to the resource"
   statement {
     sid    = "ReplicationPermissions"
     effect = "Allow"
@@ -195,21 +193,6 @@ data "aws_iam_policy_document" "moj_cur_bucket_replication_policy" {
       "s3:ReplicateTags"
     ]
     resources = ["${module.s3-moj-cur-reports-modplatform.bucket.arn}/*"]
-  }
-  statement {
-    sid    = "AllowS3ReplicationSourceRoleToUseTheKey"
-    effect = "Allow"
-    principals {
-      type = "AWS"
-        identifiers = [
-          "arn:aws:iam::${data.aws_organizations_organization.root_account.master_account_id}:role/moj-cur-reports-replication-role"
-        ]
-    }
-    actions = [
-      "kms:GenerateDataKey", 
-      "kms:Encrypt"
-    ]
-    resources = ["*"]
   }
 }
 
@@ -347,5 +330,20 @@ data "aws_iam_policy_document" "moj-cur-reports_kms" {
         "s3.amazonaws.com"
       ]
     }
+  }
+  statement {
+    sid    = "AllowS3ReplicationSourceRoleToUseTheKey"
+    effect = "Allow"
+    principals {
+      type = "AWS"
+        identifiers = [
+          "arn:aws:iam::${data.aws_organizations_organization.root_account.master_account_id}:role/moj-cur-reports-replication-role"
+        ]
+    }
+    actions = [
+      "kms:GenerateDataKey", 
+      "kms:Encrypt"
+    ]
+    resources = ["*"]
   }
 }


### PR DESCRIPTION
core-logging deployment workflow has [failed](https://github.com/ministryofjustice/modernisation-platform/actions/runs/11295859359/job/31419490253) deploying my latest PR https://github.com/ministryofjustice/modernisation-platform/pull/8250 which I believe was oversight on behalf where I combined some bucket permissions with some KMS permissions, this PR should rectify the issue.