### PR TITLE
Add Object and Bucket level Resources

### DIFF
--- a/terraform/environments/core-logging/observability.tf
+++ b/terraform/environments/core-logging/observability.tf
@@ -192,7 +192,10 @@ data "aws_iam_policy_document" "moj_cur_bucket_replication_policy" {
       "s3:ReplicateObject",
       "s3:ReplicateTags"
     ]
-    resources = ["${module.s3-moj-cur-reports-modplatform.bucket.arn}/*"]
+    resources = [
+      module.s3-moj-cur-reports-modplatform.bucket.arn,
+      "${module.s3-moj-cur-reports-modplatform.bucket.arn}/*"
+    ]
   }
 }
 


### PR DESCRIPTION
This PR updates the S3 bucket policy for the `moj-cur-reports-modplatform` bucket to resolve a MalformedPolicy error.

The issue stemmed from using object-level actions on bucket-level resources. The policy now correctly defines both the bucket-level ARN (`"arn:aws:s3:::moj-cur-reports-modplatform"`) and the object-level ARN (`"arn:aws:s3:::moj-cur-reports-modplatform/*"`), ensuring that:

- **Bucket-level** actions like `s3:ListBucket` and `s3:PutBucketVersioning` are applied to the bucket ARN.
- **Object-level** actions like `s3:ReplicateObject` and `s3:GetObjectVersionTagging` are applied to the object ARN.