### PR TITLE
adding the ability to tag glue resources

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -408,6 +408,8 @@ data "aws_iam_policy_document" "data_engineering_additional" {
       "glue:List*",
       "glue:BatchGetJobs",
       "glue:*Trigger",
+      "glue:TagResource",
+      "glue:UntagResource",
       "lakeformation:GetDataLakeSettings",
       "lakeformation:PutDataLakeSettings",
       "lambda:PutRuntimeManagementConfig",


### PR DESCRIPTION
## A reference to the issue / Description of it

As part of the ask channel request 
Madhu Kadiri
  13:36
Ref:- "https://mojdt.slack.com/archives/C01A7QK5VM1/p1728640192868709"
Hi, When I enabled "glue:TagResource" in the policy associated to the role "arn:iam::976799291502:role/glue-notebook-role-tf", it hasn't fixed the issue. I see this is to be enabled at user-level (IAM-Role>> "AWSReservedSSO_modernisation-platform-data-eng_e01f956b5b720d1f").
Could someone eligible, update the relevant policy associated to the above role to 'allow' >>
"glue:TagResource",
"glue:UntagResource"



Madhu Kadiri
Ref: Glue Notebook Session:
%iam_role arn:aws:iam::976799291502:role/glue-notebook-role-tf
Hi, I am using jupyter-notebook to run glue pyspark script on my local machine using the above mentioned IAM role.

## How does this PR fix the problem?

amended the IAM role so that glue resources can be tagged and untagged

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
