### PR TITLE
Trivy ignore AVD-AWS-0102 for subnet NACLs

### DIFF
--- a/terraform/modules/vpc-nacls/main.tf
+++ b/terraform/modules/vpc-nacls/main.tf
@@ -35,7 +35,7 @@ resource "aws_network_acl" "protected" {
   )
 }
 
-#tfsec:ignore:aws-vpc-no-excessive-port-access tfsec:ignore:aws-ec2-no-public-ingress-acl
+#trivy:ignore:AVD-AWS-0102
 resource "aws_network_acl_rule" "data_subnet_static_rules" {
   #checkov:skip=CKV_AWS_352:Verified - these rules are reasonable
   #checkov:skip=CKV_AWS_231:Allow ingress from 0.0.0.0:0 to port 3389 required
@@ -50,7 +50,7 @@ resource "aws_network_acl_rule" "data_subnet_static_rules" {
   to_port        = each.value.to_port != null ? each.value.to_port : null
 }
 
-#tfsec:ignore:aws-vpc-no-excessive-port-access tfsec:ignore:aws-ec2-no-public-ingress-acl
+#trivy:ignore:AVD-AWS-0102
 resource "aws_network_acl_rule" "private_subnet_static_rules" {
   #checkov:skip=CKV_AWS_352:Verified - these rules are reasonable
   #checkov:skip=CKV_AWS_231:Allow ingress from 0.0.0.0:0 to port 3389 required
@@ -65,7 +65,7 @@ resource "aws_network_acl_rule" "private_subnet_static_rules" {
   to_port        = each.value.to_port != null ? each.value.to_port : null
 }
 
-#tfsec:ignore:aws-vpc-no-excessive-port-access tfsec:ignore:aws-ec2-no-public-ingress-acl
+#trivy:ignore:AVD-AWS-0102
 resource "aws_network_acl_rule" "public_subnet_static_rules" {
   #checkov:skip=CKV_AWS_352:Verified - these rules are reasonable
   #checkov:skip=CKV_AWS_231:Allow ingress from 0.0.0.0:0 to port 3389 required
@@ -80,7 +80,7 @@ resource "aws_network_acl_rule" "public_subnet_static_rules" {
   to_port        = each.value.to_port != null ? each.value.to_port : null
 }
 
-#tfsec:ignore:aws-vpc-no-excessive-port-access tfsec:ignore:aws-ec2-no-public-ingress-acl
+#trivy:ignore:AVD-AWS-0102
 resource "aws_network_acl_rule" "public_subnet_internet_access_rules" {
   #checkov:skip=CKV_AWS_231:Verified - these rules are reasonable
   for_each       = local.public_access_acl_rules

--- a/terraform/modules/vpc-nacls/main.tf
+++ b/terraform/modules/vpc-nacls/main.tf
@@ -35,7 +35,7 @@ resource "aws_network_acl" "protected" {
   )
 }
 
-#trivy:ignore:AVD-AWS-0102
+# trivy:ignore:AVD-AWS-0102:NACL rule allows all ports by design
 resource "aws_network_acl_rule" "data_subnet_static_rules" {
   #checkov:skip=CKV_AWS_352:Verified - these rules are reasonable
   #checkov:skip=CKV_AWS_231:Allow ingress from 0.0.0.0:0 to port 3389 required
@@ -50,7 +50,7 @@ resource "aws_network_acl_rule" "data_subnet_static_rules" {
   to_port        = each.value.to_port != null ? each.value.to_port : null
 }
 
-#trivy:ignore:AVD-AWS-0102
+# trivy:ignore:AVD-AWS-0102:NACL rule allows all ports by design
 resource "aws_network_acl_rule" "private_subnet_static_rules" {
   #checkov:skip=CKV_AWS_352:Verified - these rules are reasonable
   #checkov:skip=CKV_AWS_231:Allow ingress from 0.0.0.0:0 to port 3389 required
@@ -65,7 +65,7 @@ resource "aws_network_acl_rule" "private_subnet_static_rules" {
   to_port        = each.value.to_port != null ? each.value.to_port : null
 }
 
-#trivy:ignore:AVD-AWS-0102
+# trivy:ignore:AVD-AWS-0102:NACL rule allows all ports by design
 resource "aws_network_acl_rule" "public_subnet_static_rules" {
   #checkov:skip=CKV_AWS_352:Verified - these rules are reasonable
   #checkov:skip=CKV_AWS_231:Allow ingress from 0.0.0.0:0 to port 3389 required
@@ -80,7 +80,7 @@ resource "aws_network_acl_rule" "public_subnet_static_rules" {
   to_port        = each.value.to_port != null ? each.value.to_port : null
 }
 
-#trivy:ignore:AVD-AWS-0102
+# trivy:ignore:AVD-AWS-0102:NACL rule allows all ports by design
 resource "aws_network_acl_rule" "public_subnet_internet_access_rules" {
   #checkov:skip=CKV_AWS_231:Verified - these rules are reasonable
   for_each       = local.public_access_acl_rules


### PR DESCRIPTION
## A reference to the issue / Description of it

Daily run of the Static Code Analysis job is failing...
https://github.com/ministryofjustice/modernisation-platform/actions/runs/11340947819/job/31538282534#step:4:3094

## How does this PR fix the problem?

Added an ignore on a few resources in the `vpc-nacls` module for `avd-aws-0102` as the rules are open to all ports by design.

As suggested, I've also removed the tfsec ignores as that is no longer in use.

## How has this been tested?

Status checks are passing.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
