### PR TITLE
Add access for `electronic-monitoring-data` accounts  ITHC

### DIFF
--- a/environments/electronic-monitoring-data.json
+++ b/environments/electronic-monitoring-data.json
@@ -35,6 +35,18 @@
         {
           "sso_group_name": "hmpps-electronic-monitoring-data-store",
           "level": "migration"
+        },
+        {
+          "sso_group_name": "hmpps-electronic-monitoring-data-store-appsec-202410",
+          "level": "read-only"
+        },
+        {
+          "sso_group_name": "hmpps-electronic-monitoring-data-store-appsec-202410",
+          "level": "view-only"
+        },
+        {
+          "sso_group_name": "hmpps-electronic-monitoring-data-store-appsec-202410",
+          "level": "security-audit"
         }
       ]
     }


### PR DESCRIPTION
## A reference to the issue / Description of it
Electronic monitoring are having an internal ITHC being conducted on our infrastructure and therefore need to grant access to the team performing the ITHC

## How does this PR fix the problem?
This PR gives the following access to the [hmpps-electronic-monitoring-data-store-appsec-202410](https://github.com/orgs/ministryofjustice/teams/hmpps-electronic-monitoring-data-store-appsec-202410/members) team in our prod account.

* `read-only`
* `view-only`
* `security-audit`


## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

n/a

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

no

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

n/a