### PR TITLE
Add `ds-data` permissions to memberinfrastructureaccess role

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -77,6 +77,7 @@ data "aws_iam_policy_document" "member-access" {
       "ds:RestoreFromSnapshot",
       "ds:StartSchemaExtension",
       "ds:Update*",
+      "ds-data:*",
       "dynamodb:*",
       "ebs:*",
       "ec2:CreateVpc",


### PR DESCRIPTION
## A reference to the issue / Description of it

#8277 // [This](https://mojdt.slack.com/archives/C01A7QK5VM1/p1729175294137729) Slack conversation. 

## How does this PR fix the problem?

Adds requested permissions to role used by Terraform ahead of terraform support. Users of the GitHub OIDC access role will want this in place so that they can migrate their use across to Terraform once support becomes available

## How has this been tested?

Test through CI pipeline checks

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
