### PR TITLE
Add Lakeformation policies to sandbox role

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -614,6 +614,7 @@ data "aws_iam_policy_document" "sandbox_additional" {
       "kinesis:*",
       "kms:*",
       "lambda:*",
+      "lakeformation:*",
       "logs:*",
       "mgn:*",
       "mgh:*",


### PR DESCRIPTION
## A reference to the issue / Description of it

We are trying to set up lakeformation, and testing in our dev account with sandbox roles and noticed we have no permissions in there to do anything lf related. Some of these are already in the[ data engineering policy.](https://github.com/ministryofjustice/modernisation-platform/blob/0ce2becd9b8ac56935812ae776933057d510cd03/terraform/environments/bootstrap/single-sign-on/policies.tf#L413-L423)

## How does this PR fix the problem?

Add lakeformation:* to sandbox policy

## How has this been tested?

n/a

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

no

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

