### PR TITLE
ram policies to sandbox

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -621,6 +621,14 @@ data "aws_iam_policy_document" "sandbox_additional" {
       "organizations:Describe*",
       "organizations:List*",
       "quicksight:*",
+      "ram:Get*",
+      "ram:List*",
+      "ram:UpdateResourceShare",
+      "ram:DeleteResourceShare",
+      "ram:AssociateResourceShare",
+      "ram:DisassociateResourceShare",
+      "ram:GetResourceShares",
+      "ram:AssociateResourceSharePermission",
       "rds-db:*",
       "rds:*",
       "rds-data:*",
@@ -659,6 +667,18 @@ data "aws_iam_policy_document" "sandbox_additional" {
     resources = [
       "arn:aws:sso::${local.environment_management.aws_organizations_root_account_id}:application/ssoins-7535d9af4f41fb26/*" #tfsec:ignore:AWS099 tfsec:ignore:AWS097
     ]
+  }
+  statement {
+    sid = "AllowRamSharingofGlueResources"
+    actions = [
+       "ram:CreateResourceShare"
+    ]
+    resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
+    condition {
+       test     = "StringLikeIfExists
+       variable = "ram:RequestedResourceType"
+       values   = ["glue:Table", "glue:Database", "glue:Catalog"]
+    }
   }
 }
 

--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -671,13 +671,13 @@ data "aws_iam_policy_document" "sandbox_additional" {
   statement {
     sid = "AllowRamSharingofGlueResources"
     actions = [
-       "ram:CreateResourceShare"
+      "ram:CreateResourceShare"
     ]
     resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
     condition {
-       test     = "StringLikeIfExists
-       variable = "ram:RequestedResourceType"
-       values   = ["glue:Table", "glue:Database", "glue:Catalog"]
+      test     = "StringLikeIfExists"
+      variable = "ram:RequestedResourceType"
+      values   = ["glue:Table", "glue:Database", "glue:Catalog"]
     }
   }
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

To be able to create lake formation resource shares cross account, you need a number of ram permissions. I noticed there weren't any anywhere on here.

## How does this PR fix the problem?

 I've added the [minimum required for a lake formation admin](https://docs.aws.amazon.com/lake-formation/latest/dg/permissions-reference.html) to the sandbox account.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

n/a

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

no

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

