### PR TITLE
Create PagerDuty Service/Integration for Security Hub

### DIFF
--- a/terraform/pagerduty/aws.tf
+++ b/terraform/pagerduty/aws.tf
@@ -18,6 +18,7 @@ resource "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {
   secret_id = aws_secretsmanager_secret.pagerduty_integration_keys.id
   secret_string = jsonencode({
     core_alerts_cloudwatch          = pagerduty_service_integration.core_alerts_cloudwatch.integration_key,
+    security_hub                    = pagerduty_service_integration.security_hub.integration_key,
     ddos_cloudwatch                 = pagerduty_service_integration.ddos_cloudwatch.integration_key,
     tgw_cloudwatch                  = pagerduty_service_integration.tgw_cloudwatch.integration_key,
     networking_cloudwatch           = pagerduty_service_integration.networking_cloudwatch.integration_key,


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/8076

## How does this PR fix the problem?

Builds a dedicated PagerDuty service/integration for Security Hub findings which will be linked to the newly created `modernisation-platform-security-hub-alerts` Slack channel.

After a chat with Dave we felt it best to create a dedicated channel as the alerts will be quite noisy for a while and it will be easier to separate them from our other alerts while we look to tune the findings that Security Hub is flagging.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [X] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
