### PR TITLE
Fix KMS access for logs service

### DIFF
--- a/terraform/environments/core-logging/observability.tf
+++ b/terraform/environments/core-logging/observability.tf
@@ -398,7 +398,7 @@ data "aws_iam_policy_document" "moj-cur-reports_kms" {
     }
   }
   statement {
-    sid     = "Allow AWS S3 service to use key"
+    sid     = "Allow AWS S3 & Logs service to use key"
     effect  = "Allow"
     actions = [
       "kms:Encrypt*",
@@ -413,7 +413,8 @@ data "aws_iam_policy_document" "moj-cur-reports_kms" {
     principals {
       type = "Service"
       identifiers = [
-        "s3.amazonaws.com"
+        "s3.amazonaws.com",
+        "logs.amazonaws.com"
       ]
     }
   }


### PR DESCRIPTION
following the failed deployment of `core-logging` from PR https://github.com/ministryofjustice/modernisation-platform/pull/8286 this PR fixes the KMS access by adding AWS logs service principal to the KMS key.

failed deployment run: https://github.com/ministryofjustice/modernisation-platform/actions/runs/11440085982/job/31825154636