### PR TITLE
🛂 Add DynamoDB permissions to Data Engineering role

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -391,7 +391,7 @@ data "aws_iam_policy_document" "data_engineering_additional" {
       "dynamodb:DescribeTable",
       "dynamodb:GetItem",
       "dynamodb:PutItem",
-      "dynamodb:DeleteItem"
+      "dynamodb:DeleteItem",
       "glue:Batch*Partition",
       "glue:BatchDeleteTable",
       "glue:CreateDatabase",

--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -359,7 +359,7 @@ data "aws_iam_policy_document" "developer_additional" {
   }
 }
 
-# data engineerin policy (developer + glue + some athena)
+# data engineering policy (developer + glue + some athena)
 resource "aws_iam_policy" "data_engineering" {
   provider = aws.workspace
   name     = "data_engineering_policy"
@@ -388,6 +388,10 @@ data "aws_iam_policy_document" "data_engineering_additional" {
       "dms:StartReplicationTask",
       "dms:StopReplicationTask",
       "dms:ModifyReplicationTask",
+      "dynamodb:DescribeTable",
+      "dynamodb:GetItem",
+      "dynamodb:PutItem",
+      "dynamodb:DeleteItem"
       "glue:Batch*Partition",
       "glue:BatchDeleteTable",
       "glue:CreateDatabase",


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/analytical-platform/issues/5658

## How does this PR fix the problem?

Adds DynamoDB permissions as per https://developer.hashicorp.com/terraform/language/backend/s3#dynamodb-table-permissions

## How has this been tested?

It hasn't

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No, it an addition

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

Resource based policy for DynamoDB table created here https://github.com/ministryofjustice/analytical-platform/pull/5744

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk> 
