### PR TITLE
:wrench: Add S3 Permissions to DataEngineeringAllow

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -435,7 +435,8 @@ data "aws_iam_policy_document" "data_engineering_additional" {
       "states:Start*",
       "states:RedriveExecution",
       "s3:PutBucketNotificationConfiguration",
-      "s3:GetBucketOwnershipControls"
+      "s3:GetBucketOwnershipControls",
+      "s3:PutObjectAcl"
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
## A reference to the issue / Description of it

This seeks to resolve [this](https://github.com/ministryofjustice/data-platform-support/issues/707) issue. And the approach mirrors that taken further up in the ticket in this PR. 

## How does this PR fix the problem?

Adds missing S3 permission highlighted in ticket.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

It hasn't been tested

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No, it is an additional IAM action

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
