### PR TITLE
Use Bucket Name not ARN

### DIFF
--- a/terraform/environments/core-logging/observability.tf
+++ b/terraform/environments/core-logging/observability.tf
@@ -577,7 +577,7 @@ resource "aws_lambda_function" "cur_initializer" {
 }
 
 resource "aws_s3_bucket_notification" "cur_initializer_lambda_trigger" {
-  bucket = module.s3_moj_cur_reports_modplatform.bucket.arn
+  bucket = module.s3_moj_cur_reports_modplatform.bucket.id
 
   lambda_function {
     lambda_function_arn = aws_lambda_function.cur_initializer.arn


### PR DESCRIPTION
following on from PR https://github.com/ministryofjustice/modernisation-platform/pull/8301 which failed to deploy this PR updates the resources from the ARN to bucket name
