### PR TITLE
🛂 Allow role assumption of Analytical Platform Terraform state for Data Engineering

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -453,6 +453,13 @@ data "aws_iam_policy_document" "data_engineering_additional" {
     actions   = ["iam:PassRole"]
     resources = ["arn:aws:iam::${local.environment_management.account_ids["analytical-platform-data-production"]}:role/data-first-data-science", "arn:aws:iam::${local.environment_management.account_ids["electronic-monitoring-data-production"]}:role/glue-notebook-role-tf"]
   }
+
+  statement {
+    sid       = "AllowAssumeAnalyticalPlatformDataEngineeringStateAccessRole"
+    effect    = "Allow"
+    actions   = ["sts:AssumeRole"]
+    resources = ["arn:aws:iam::${local.environment_management.account_ids["analytical-platform-management-production"]}:role/data-engineering-state-access"]
+  }
 }
 
 # quicksight administrator policy (IAM permissions needed to manage QuickSight subscription)


### PR DESCRIPTION
## A reference to the issue / Description of it

Is part of https://github.com/ministryofjustice/analytical-platform/issues/5658

## How does this PR fix the problem?

Adds `sts:AssumeRole` for `arn:aws:iam::${local.environment_management.account_ids["analytical-platform-management-production"]}:role/data-engineering-state-access`

## How has this been tested?

It hasn't

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No, its an addition

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

The role being assumed is scoped to specific AWS accounts https://github.com/ministryofjustice/analytical-platform/pull/5782
