### PR TITLE
Adds additional read permissions to the collaborator role s3-upload.

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -1367,7 +1367,9 @@ data "aws_iam_policy_document" "s3_upload_policy_document" {
     effect = "Allow"
     actions = [
       "s3:PutObject",
-      "s3:ListBucket"
+      "s3:ListBucket",
+      "s3:GetObject",
+      "s3:ListBucketVersions"
     ]
     resources = [
       data.aws_s3_bucket.mod_platform_artefact.arn,

--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -1366,10 +1366,10 @@ data "aws_iam_policy_document" "s3_upload_policy_document" {
     sid    = "AllowS3Upload"
     effect = "Allow"
     actions = [
-      "s3:PutObject",
-      "s3:ListBucket",
       "s3:GetObject",
-      "s3:ListBucketVersions"
+      "s3:ListBucket",
+      "s3:ListBucketVersions",
+      "s3:PutObject"
     ]
     resources = [
       data.aws_s3_bucket.mod_platform_artefact.arn,


### PR DESCRIPTION

## A reference to the issue / Description of it

Adds permissions to list s3 objects for s3-upload. This is the result of collaborator feedback on using the role and has been requested by the product team.

## How does this PR fix the problem?

See above.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- x ] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
