### PR TITLE
Update references to KMS key from single-region to multi-region

### DIFF
--- a/terraform/pagerduty/aws.tf
+++ b/terraform/pagerduty/aws.tf
@@ -6,7 +6,7 @@ resource "aws_secretsmanager_secret" "pagerduty_integration_keys" {
   # checkov:skip=CKV2_AWS_57:Auto rotation not possible
   # checkov:skip=CKV_AWS_149:No requirement currently to encrypt this secret with customer-managed KMS key
   description = "Pager Duty integration keys"
-  kms_key_id  = aws_kms_key.pagerduty.id
+  kms_key_id  = aws_kms_key.pagerduty_multi_region.id
   name        = "pagerduty_integration_keys"
   policy      = data.aws_iam_policy_document.pagerduty_secret.json
   tags        = local.tags
@@ -105,7 +105,7 @@ resource "aws_secretsmanager_secret" "pagerduty_token" {
   # checkov:skip=CKV2_AWS_57:Auto rotation not possible
   name        = "pagerduty_token"
   description = "PagerDuty api token, used by PagerDuty Terraform to manage most PagerDuty resources"
-  kms_key_id  = aws_kms_key.pagerduty.id
+  kms_key_id  = aws_kms_key.pagerduty_multi_region.id
   tags        = local.tags
   replica {
     region = local.replica_region
@@ -118,7 +118,7 @@ resource "aws_secretsmanager_secret" "pagerduty_token" {
 resource "aws_secretsmanager_secret" "pagerduty_user_token" {
   # checkov:skip=CKV2_AWS_57:Auto rotation not possible
   name        = "pagerduty_userapi_token"
-  kms_key_id  = aws_kms_key.pagerduty.id
+  kms_key_id  = aws_kms_key.pagerduty_multi_region.id
   description = "PagerDuty api user level token, used to link services to Slack channels.  A valid PD and Slack user needed (to authorise against a slack user), needed in addition to the org level token"
   tags        = local.tags
   replica {


### PR DESCRIPTION
## A reference to the issue / Description of it

#7943 

## How does this PR fix the problem?

Updates the Pagerduty terraform to refer to the multi-region KMS key

## How has this been tested?

It has not. Assuming CI tests pass, replacing one KMS key with another should be seamless.

## Deployment Plan / Instructions

Deploy through CI.
Once deployed and tested, old key can be removed and scheduled for deletion.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
