### PR TITLE
Update references for `environment_management` KMS to multi-region key

### DIFF
--- a/terraform/environments/secrets.tf
+++ b/terraform/environments/secrets.tf
@@ -4,7 +4,7 @@ resource "aws_secretsmanager_secret" "environment_management" {
   provider    = aws.modernisation-platform
   name        = "environment_management"
   description = "IDs for AWS-specific resources for environment management, such as organizational unit IDs"
-  kms_key_id  = aws_kms_key.environment_management.id
+  kms_key_id  = aws_kms_key.environment_management_multi_region.id
   policy      = data.aws_iam_policy_document.environment_management.json
   tags        = local.environments
   replica {

--- a/terraform/github/data.tf
+++ b/terraform/github/data.tf
@@ -24,7 +24,7 @@ data "aws_kms_key" "environment_management" {
   key_id = "alias/environment-management"
 }
 
-data "aws_kms_key" "environment_management" {
+data "aws_kms_key" "environment_management_multi_region" {
   key_id = "alias/environment-management-multi-region"
 }
 

--- a/terraform/github/data.tf
+++ b/terraform/github/data.tf
@@ -24,6 +24,10 @@ data "aws_kms_key" "environment_management" {
   key_id = "alias/environment-management"
 }
 
+data "aws_kms_key" "environment_management" {
+  key_id = "alias/environment-management-multi-region"
+}
+
 data "aws_kms_key" "pagerduty" {
   key_id = "alias/pagerduty-secret"
 }

--- a/terraform/github/testing-ci.tf
+++ b/terraform/github/testing-ci.tf
@@ -57,6 +57,7 @@ data "aws_iam_policy_document" "testing_ci_policy" {
       data.aws_kms_key.s3_state_bucket.arn,
       data.aws_kms_key.dynamodb_state_lock.arn,
       data.aws_kms_key.environment_management.arn,
+      data.aws_kms_key.environment_management_multi_region.arn,
       data.aws_kms_key.pagerduty.arn
     ]
   }


### PR DESCRIPTION
## A reference to the issue / Description of it

#7943 

## How does this PR fix the problem?

Updates terraform references to the `environment_management` KMS key from the single-region key to the multi-region key.

## How has this been tested?

It has not. Assuming CI tests pass, replacing one KMS key with another should be seamless.

## Deployment Plan / Instructions

Deploy through CI.

Once deployed and tested, old key can be removed and scheduled for deletion.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
