### PR TITLE
Update baselines to v7.9.0 to enable Security Hub alerting

### DIFF
--- a/terraform/environments/bootstrap/secure-baselines/main.tf
+++ b/terraform/environments/bootstrap/secure-baselines/main.tf
@@ -6,7 +6,7 @@ data "aws_kms_key" "cloudtrail_key" {
 
 #trivy:ignore:AVD-AWS-0136
 module "baselines" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=9d62fce5d0493e7da26f08c6331c627c4ae2ddfb" # v7.7.1
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=55841c7044d20fafd756a06961d0690bf7607c1c" # v7.9.0
 
   providers = {
     # Default and replication regions
@@ -71,4 +71,22 @@ module "baselines" {
 
   # Regions to enable IMDSv2 in
   enabled_imdsv2_regions = local.enabled_baseline_regions
+
+  # Pass in pagerduty integration key for security hub alerts
+  pagerduty_integration_key = local.pagerduty_integration_keys["security_hub"]
+}
+
+# Keys for pagerduty
+data "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {
+  secret_id = data.aws_secretsmanager_secret.pagerduty_integration_keys.id
+}
+
+# Get the map of pagerduty integration keys
+data "aws_secretsmanager_secret" "pagerduty_integration_keys" {
+  name = "pagerduty_integration_keys"
+}
+
+# Keys for pagerduty
+locals {
+  pagerduty_integration_keys = jsondecode(data.aws_secretsmanager_secret_version.pagerduty_integration_keys.secret_string)
 }

--- a/terraform/modernisation-platform-account/baselines.tf
+++ b/terraform/modernisation-platform-account/baselines.tf
@@ -18,7 +18,7 @@ locals {
 # Secure baselines (GuardDuty, Config, SecurityHub, etc)
 #trivy:ignore:AVD-AWS-0136 trivy:ignore:AVD-AWS-0132
 module "baselines-modernisation-platform" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=9d62fce5d0493e7da26f08c6331c627c4ae2ddfb" # v7.7.1
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=55841c7044d20fafd756a06961d0690bf7607c1c" # v7.9.0
   providers = {
     # Default and replication regions
     aws                    = aws.modernisation-platform-eu-west-2
@@ -71,5 +71,8 @@ module "baselines-modernisation-platform" {
 
   # Regions to enable IMDSv2 in
   enabled_imdsv2_regions = local.enabled_baseline_regions
+
+  # Pass in pagerduty integration key for security hub alerts
+  pagerduty_integration_key = local.pagerduty_integration_keys["security_hub"]
 }
 


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/8076

## How does this PR fix the problem?

Updates baselines module to `v7.9.0` which enables Security Hub findings to be sent to the [`#modernisation-platform-security-hub-alerts`](https://moj.enterprise.slack.com/archives/C07SNBJBVC6) Slack channel.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Tested locally on sprinkler and in status checks for this PR.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
