### PR TITLE
Replace dynamodb kms key with multiregion

### DIFF
--- a/terraform/github/data.tf
+++ b/terraform/github/data.tf
@@ -20,6 +20,10 @@ data "aws_kms_key" "dynamodb_state_lock" {
   key_id = "alias/dynamodb-state-lock"
 }
 
+data "aws_kms_key" "dynamodb_state_lock_multi_region" {
+  key_id = "alias/dynamodb-state-lock-multi-region"
+}
+
 data "aws_kms_key" "environment_management" {
   key_id = "alias/environment-management"
 }

--- a/terraform/github/testing-ci.tf
+++ b/terraform/github/testing-ci.tf
@@ -56,6 +56,7 @@ data "aws_iam_policy_document" "testing_ci_policy" {
     resources = [
       data.aws_kms_key.s3_state_bucket.arn,
       data.aws_kms_key.dynamodb_state_lock.arn,
+      data.aws_kms_key.dynamodb_state_lock_multi_region.arn,
       data.aws_kms_key.environment_management.arn,
       data.aws_kms_key.environment_management_multi_region.arn,
       data.aws_kms_key.pagerduty.arn

--- a/terraform/modernisation-platform-account/dynamodb.tf
+++ b/terraform/modernisation-platform-account/dynamodb.tf
@@ -89,7 +89,7 @@ resource "aws_dynamodb_table" "state-lock" {
 
   server_side_encryption {
     enabled     = true
-    kms_key_arn = aws_kms_key.dynamo_encryption.arn
+    kms_key_arn = aws_kms_key.dynamo_encryption_multi_region.arn
   }
 
   point_in_time_recovery {


### PR DESCRIPTION
## A reference to the issue / Description of it

#7943 

## How does this PR fix the problem?

Replaces key used to encrypt DynamoDB state table with multi-region equivalent

## How has this been tested?

Will test through CI pipeline checks

## Deployment Plan / Instructions

Deploy through CI. A later PR will be required to schedule the old KMS key for deletion.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
