### PR TITLE
Replace state bucket and cur bucket KMS keys with multi-region key

### DIFF
--- a/terraform/modernisation-platform-account/s3.tf
+++ b/terraform/modernisation-platform-account/s3.tf
@@ -26,7 +26,7 @@ resource "aws_kms_alias" "s3_state_bucket_multi_region" {
 }
 
 resource "aws_kms_replica_key" "s3_state_bucket_multi_region_replica" {
-  description             = "AWS Secretsmanager CMK replica key"
+  description             = "AWS S3 bucket replica key"
   deletion_window_in_days = 30
   primary_key_arn         = aws_kms_key.s3_state_bucket_multi_region.arn
   provider                = aws.modernisation-platform-eu-west-1
@@ -122,8 +122,8 @@ module "state-bucket" {
   suffix_name                = "-terraform-state"
   replication_enabled        = true
   replication_region         = "eu-west-1"
-  custom_kms_key             = aws_kms_key.s3_state_bucket.arn
-  custom_replication_kms_key = aws_kms_key.s3_state_bucket_eu-west-1_replication.arn
+  custom_kms_key             = aws_kms_key.s3_state_bucket_multi_region.arn
+  custom_replication_kms_key = aws_kms_replica_key.s3_state_bucket_multi_region_replica.arn
   tags                       = local.tags
 
   lifecycle_rule = [
@@ -327,7 +327,7 @@ module "cost-management-bucket" {
   }
   bucket_policy       = [data.aws_iam_policy_document.cost_management_bucket_policy.json]
   bucket_name         = "mp-cost-explorer-reports"
-  custom_kms_key      = aws_kms_key.s3_state_bucket.arn
+  custom_kms_key      = aws_kms_key.s3_state_bucket_multi_region.arn
   replication_enabled = false
   lifecycle_rule = [
     {


### PR DESCRIPTION
## A reference to the issue / Description of it

#7943

## How does this PR fix the problem?

Replaces references to single-region KMS key with multi-region equivalent

## How has this been tested?

Tested through CI checks.

## Deployment Plan / Instructions

Deploy through CI. Once deployed, existing objects will need to be re-encrypted using new key prior to scheduling old key for deletion.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
