### PR TITLE
Revert workgroup KMS

### DIFF
--- a/terraform/environments/core-logging/observability.tf
+++ b/terraform/environments/core-logging/observability.tf
@@ -155,8 +155,7 @@ resource "aws_athena_workgroup" "mod_platform_cur_reports" {
     result_configuration {
       output_location = "s3://${module.s3_moj_cur_reports_modplatform.bucket.id}/workgroup/"
       encryption_configuration {
-        encryption_option = "SSE_KMS"
-        kms_key_arn       = aws_kms_alias.moj_cur_reports.arn
+        encryption_option = "SSE_S3"
       }
     }
   }

--- a/terraform/environments/core-logging/observability.tf
+++ b/terraform/environments/core-logging/observability.tf
@@ -155,7 +155,7 @@ resource "aws_athena_workgroup" "mod_platform_cur_reports" {
     result_configuration {
       output_location = "s3://${module.s3_moj_cur_reports_modplatform.bucket.id}/workgroup/"
       encryption_configuration {
-        encryption_option = "SSE_S3" 
+        encryption_option = "SSE_S3"
       }
     }
   }

--- a/terraform/environments/core-logging/observability.tf
+++ b/terraform/environments/core-logging/observability.tf
@@ -155,7 +155,7 @@ resource "aws_athena_workgroup" "mod_platform_cur_reports" {
     result_configuration {
       output_location = "s3://${module.s3_moj_cur_reports_modplatform.bucket.id}/workgroup/"
       encryption_configuration {
-        encryption_option = "SSE_S3"
+        encryption_option = "SSE_S3" 
       }
     }
   }


### PR DESCRIPTION
As PR reverts part of https://github.com/ministryofjustice/modernisation-platform/pull/8316/ where the KMS key was added to the Athena workgroup as I am now seeing errors when trying to run queries and want to rule this out as the cause.