### PR TITLE
🛂 Add `route53resolver` permissions

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -156,6 +156,7 @@ data "aws_iam_policy_document" "member-access" {
       "rds:*",
       "rds-data:*",
       "route53:*",
+      "route53resolver:*",
       "s3:*",
       "secretsmanager:*",
       "ses:*",


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/analytical-platform/issues/5175

Trying to create a Route53 resolver endpoint and getting

```
│ Error: creating Route53 Resolver Endpoint: operation error Route53Resolver: CreateResolverEndpoint, https response error StatusCode: 400, RequestID: b76acb63-a66e-42d1-a060-36ef595f6fcb, AccessDeniedException: User: arn:aws:sts::***:assumed-role/MemberInfrastructureAccess/aws-go-sdk-1729718246063734309 is not authorized to perform: route53resolver:CreateResolverEndpoint on resource: arn:aws:route53resolver:eu-west-2:***:resolver-endpoint/ because no identity-based policy allows the route53resolver:CreateResolverEndpoint action
│ 
│   with module.connected_vpc_outbound_route53_resolver_endpoint.aws_route53_resolver_endpoint.this[0],
│   on .terraform/modules/connected_vpc_outbound_route53_resolver_endpoint/modules/resolver-endpoints/main.tf line 6, in resource "aws_route53_resolver_endpoint" "this":
│    6: resource "aws_route53_resolver_endpoint" "this" {
```

Source: https://github.com/ministryofjustice/modernisation-platform-environments/actions/runs/11488263685/job/31974680725?pr=8440#step:10:22

## How does this PR fix the problem?

Adds `route53resolver` permissions

## How has this been tested?

It hasn't

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No, it's an addition

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

N/A

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk> 