### PR TITLE
Bump baselines release to `v7.9.2`

### DIFF
--- a/terraform/environments/bootstrap/secure-baselines/main.tf
+++ b/terraform/environments/bootstrap/secure-baselines/main.tf
@@ -6,7 +6,7 @@ data "aws_kms_key" "cloudtrail_key" {
 
 #trivy:ignore:AVD-AWS-0136
 module "baselines" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=55841c7044d20fafd756a06961d0690bf7607c1c" # v7.9.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=ab67b7b099d5eea73256290c34c40f7adc6de475" # v7.9.1
 
   providers = {
     # Default and replication regions

--- a/terraform/environments/bootstrap/secure-baselines/main.tf
+++ b/terraform/environments/bootstrap/secure-baselines/main.tf
@@ -6,7 +6,7 @@ data "aws_kms_key" "cloudtrail_key" {
 
 #trivy:ignore:AVD-AWS-0136
 module "baselines" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=ab67b7b099d5eea73256290c34c40f7adc6de475" # v7.9.1
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=c27c1e9591b4d9b2587e87575ceb0d5e6458330c" # v7.9.2
 
   providers = {
     # Default and replication regions

--- a/terraform/modernisation-platform-account/baselines.tf
+++ b/terraform/modernisation-platform-account/baselines.tf
@@ -18,7 +18,7 @@ locals {
 # Secure baselines (GuardDuty, Config, SecurityHub, etc)
 #trivy:ignore:AVD-AWS-0136 trivy:ignore:AVD-AWS-0132
 module "baselines-modernisation-platform" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=ab67b7b099d5eea73256290c34c40f7adc6de475" # v7.9.1
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=c27c1e9591b4d9b2587e87575ceb0d5e6458330c" # v7.9.2
   providers = {
     # Default and replication regions
     aws                    = aws.modernisation-platform-eu-west-2

--- a/terraform/modernisation-platform-account/baselines.tf
+++ b/terraform/modernisation-platform-account/baselines.tf
@@ -18,7 +18,7 @@ locals {
 # Secure baselines (GuardDuty, Config, SecurityHub, etc)
 #trivy:ignore:AVD-AWS-0136 trivy:ignore:AVD-AWS-0132
 module "baselines-modernisation-platform" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=55841c7044d20fafd756a06961d0690bf7607c1c" # v7.9.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=ab67b7b099d5eea73256290c34c40f7adc6de475" # v7.9.1
   providers = {
     # Default and replication regions
     aws                    = aws.modernisation-platform-eu-west-2


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/8076

There was an issue rolling out `v7.9.0` as there was a naming clash for the kms key in `core-network-services`.

## How does this PR fix the problem?

`v7.9.2` uses `name_prefix` for the kms alias which adds a unique ID and avoids the naming clash.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Sprinkler!

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [X] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
