### PR TITLE
Update and alphabetise more secrets keys

### DIFF
--- a/terraform/modernisation-platform-account/secrets.tf
+++ b/terraform/modernisation-platform-account/secrets.tf
@@ -76,7 +76,7 @@ resource "aws_secretsmanager_secret" "slack_webhook_url" {
   # checkov:skip=CKV2_AWS_57:Auto rotation not possible
   name        = "slack_webhook_url"
   description = "Slack channel modernisation-platform-notifications webhook url for sending notifications to slack"
-  kms_key_id  = aws_kms_key.secrets_key.id
+  kms_key_id  = aws_kms_key.secrets_key_multi_region.id
   tags        = local.tags
   replica {
     region = local.replica_region
@@ -87,7 +87,7 @@ resource "aws_secretsmanager_secret" "slack_webhook_url_modernisation_platform_u
   # checkov:skip=CKV2_AWS_57:Auto rotation not possible
   name        = "slack_webhook_url_modernisation_platform_update"
   description = "Slack channel modernisation-platform-update webhook url for sending notifications to slack"
-  kms_key_id  = aws_kms_key.secrets_key.id
+  kms_key_id  = aws_kms_key.secrets_key_multi_region.id
   tags        = local.tags
   replica {
     region = local.replica_region
@@ -101,7 +101,7 @@ resource "aws_secretsmanager_secret" "github_ci_user_pat" {
   # checkov:skip=CKV2_AWS_57:Auto rotation not possible
   name        = "github_ci_user_pat"
   description = "GitHub CI user PAT used for generated resources in GitHub via Terraform"
-  kms_key_id  = aws_kms_key.secrets_key.id
+  kms_key_id  = aws_kms_key.secrets_key_multi_region.id
   tags        = local.tags
   replica {
     region = local.replica_region
@@ -115,7 +115,7 @@ resource "aws_secretsmanager_secret" "github_ci_user_environments_repo_pat" {
   # checkov:skip=CKV2_AWS_57:Auto rotation not possible
   name        = "github_ci_user_environments_repo_pat"
   description = "This PAT token is used in reusable pipelines of the modernisation-platform-environments repository. This is so that the CI user can post comments in PRs, e.g. tf plan/apply output. Expires on Tue, Apr 9 2024."
-  kms_key_id  = aws_kms_key.secrets_key.id
+  kms_key_id  = aws_kms_key.secrets_key_multi_region.id
   tags        = local.tags
   replica {
     region = local.replica_region
@@ -129,7 +129,7 @@ resource "aws_secretsmanager_secret" "github_ci_user_password" {
   # checkov:skip=CKV2_AWS_57:Auto rotation not possible
   name        = "github_ci_user_password"
   description = "GitHub CI user password"
-  kms_key_id  = aws_kms_key.secrets_key.id
+  kms_key_id  = aws_kms_key.secrets_key_multi_region.id
   tags        = local.tags
   replica {
     region = local.replica_region
@@ -141,7 +141,7 @@ resource "aws_secretsmanager_secret" "nuke_account_blocklist" {
   # checkov:skip=CKV2_AWS_57:Auto rotation not possible
   name        = "nuke_account_blocklist"
   description = "Account IDs to be excluded from auto-nuke. AWS-Nuke (https://github.com/rebuy-de/aws-nuke) requires at least one Account ID to be present in this blocklist, while it is recommended to add every production account to this blocklist."
-  kms_key_id  = aws_kms_key.secrets_key.id
+  kms_key_id  = aws_kms_key.secrets_key_multi_region.id
   tags        = local.tags
   replica {
     region = local.replica_region
@@ -153,7 +153,7 @@ resource "aws_secretsmanager_secret" "nuke_account_ids" {
   # checkov:skip=CKV2_AWS_57:Auto rotation not possible
   name        = "nuke_account_ids"
   description = "Account IDs to be auto-nuked on weekly basis. CAUTION: Any account ID you add here will be automatically nuked! This secret is used by GitHub actions job nuke.yml inside the environments repo, to find the Account IDs to be nuked."
-  kms_key_id  = aws_kms_key.secrets_key.id
+  kms_key_id  = aws_kms_key.secrets_key_multi_region.id
   tags        = local.tags
   replica {
     region = local.replica_region
@@ -174,7 +174,7 @@ resource "aws_secretsmanager_secret" "circleci" {
   # checkov:skip=CKV2_AWS_57:Auto rotation not possible
   name        = "mod-platform-circleci"
   description = "CircleCI organisation ID for ministryofjustice, used for OIDC IAM policies"
-  kms_key_id  = aws_kms_key.secrets_key.id
+  kms_key_id  = aws_kms_key.secrets_key_multi_region.id
 
   replica {
     region = local.replica_region
@@ -201,7 +201,7 @@ resource "aws_secretsmanager_secret" "gov_uk_notify_api_key" {
   # checkov:skip=CKV2_AWS_57:Auto rotation not possible
   name        = "gov_uk_notify_api_key"
   description = "API key for accessing the GOV.UK Notify service for sending email notifications"
-  kms_key_id  = aws_kms_key.secrets_key.id
+  kms_key_id  = aws_kms_key.secrets_key_multi_region.id
   tags        = local.tags
   replica {
     region = local.replica_region
@@ -212,7 +212,7 @@ resource "aws_secretsmanager_secret" "slack_webhooks" {
   # checkov:skip=CKV2_AWS_57:Auto rotation not possible
   name        = "slack_webhooks"
   description = "Used for sending notifications to specified Slack channels when environment JSON files are modified"
-  kms_key_id  = aws_kms_key.secrets_key.id
+  kms_key_id  = aws_kms_key.secrets_key_multi_region.id
   tags        = local.tags
   replica {
     region = local.replica_region


### PR DESCRIPTION
## A reference to the issue / Description of it

#7943 

## How does this PR fix the problem?

Observed a number of secrets not listed in this backlog issue were using the single-region key.

This PR updates them, and also alphabetises the secret resources

## How has this been tested?

Previous changes to KMS key for secrets have been seamless.

Tested through CI pipeline checks

## Deployment Plan / Instructions

Deploy through GitHub actions

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
