### PR TITLE
Remove non-multi-region KMS keys

### DIFF
--- a/terraform/modernisation-platform-account/dynamodb.tf
+++ b/terraform/modernisation-platform-account/dynamodb.tf
@@ -1,20 +1,3 @@
-resource "aws_kms_key" "dynamo_encryption" {
-  enable_key_rotation = true
-  policy              = data.aws_iam_policy_document.dynamo_encryption.json
-
-  tags = merge(
-    local.tags,
-    {
-      Name = "dynamo_encryption"
-    }
-  )
-}
-
-resource "aws_kms_alias" "dynamo_encryption" {
-  name          = "alias/dynamodb-state-lock"
-  target_key_id = aws_kms_key.dynamo_encryption.id
-}
-
 resource "aws_kms_key" "dynamo_encryption_multi_region" {
   enable_key_rotation = true
   policy              = data.aws_iam_policy_document.dynamo_encryption.json

--- a/terraform/modernisation-platform-account/s3.tf
+++ b/terraform/modernisation-platform-account/s3.tf
@@ -1,16 +1,3 @@
-# State bucket KMS Source
-resource "aws_kms_key" "s3_state_bucket" {
-  description             = "s3-state-bucket"
-  policy                  = data.aws_iam_policy_document.kms_state_bucket.json
-  enable_key_rotation     = true
-  deletion_window_in_days = 30
-}
-
-resource "aws_kms_alias" "s3_state_bucket" {
-  name          = "alias/s3-state-bucket"
-  target_key_id = aws_kms_key.s3_state_bucket.id
-}
-
 # State bucket KMS multi-Region
 resource "aws_kms_key" "s3_state_bucket_multi_region" {
   description             = "s3-state-bucket-multi-region"

--- a/terraform/modernisation-platform-account/secrets.tf
+++ b/terraform/modernisation-platform-account/secrets.tf
@@ -1,18 +1,6 @@
 # Slack channel modernisation-platform-notifications webhook url for sending notifications to slack
 # Not adding a secret version as this url is provided by slack and cannot be added programatically
 # Secret should be manually set in the console.
-resource "aws_kms_key" "secrets_key" {
-  description             = "AWS Secretsmanager CMK"
-  policy                  = data.aws_iam_policy_document.kms_secrets_key.json
-  enable_key_rotation     = true
-  deletion_window_in_days = 30
-}
-
-resource "aws_kms_alias" "secrets_key" {
-  name          = "alias/secrets_key"
-  target_key_id = aws_kms_key.secrets_key.id
-}
-
 resource "aws_kms_key" "secrets_key_multi_region" {
   description             = "AWS Secretsmanager CMK"
   policy                  = data.aws_iam_policy_document.kms_secrets_key.json


### PR DESCRIPTION
## A reference to the issue / Description of it

#7943

## How does this PR fix the problem?

Now that the multi-region KMS keys are in active use this PR removes the old keys and schedules them for deletion

## How has this been tested?

Tested through CI pipeline checks

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
