### PR TITLE
Remove data call from `core-logging`

### DIFF
--- a/terraform/environments/core-logging/cortex.tf
+++ b/terraform/environments/core-logging/cortex.tf
@@ -219,11 +219,6 @@ resource "aws_sqs_queue_policy" "logging" {
   queue_url = aws_sqs_queue.logging[each.key].url
 }
 
-data "aws_kms_alias" "secrets" {
-  provider = aws.modernisation-platform
-  name     = "alias/secrets_key"
-}
-
 resource "aws_iam_policy" "cortex_xsiam_policy" {
   name        = "cortex-user-policy"
   description = "Allows the access to the created SQS queue"


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/actions/runs/11517694104

## How does this PR fix the problem?

Removes a data call that does not appear to be references in code anywhere

## How has this been tested?

Tested with CI pipeline

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
