### PR TITLE
Added alias to multi_region kms key used for terraform state bucket

### DIFF
--- a/terraform/modernisation-platform-account/s3.tf
+++ b/terraform/modernisation-platform-account/s3.tf
@@ -12,6 +12,11 @@ resource "aws_kms_alias" "s3_state_bucket_multi_region" {
   target_key_id = aws_kms_key.s3_state_bucket_multi_region.id
 }
 
+resource "aws_kms_alias" "s3_state_bucket" {
+  name          = "alias/s3-state-bucket"
+  target_key_id = aws_kms_key.s3_state_bucket_multi_region.id
+}
+
 resource "aws_kms_replica_key" "s3_state_bucket_multi_region_replica" {
   description             = "AWS S3 bucket replica key"
   deletion_window_in_days = 30


### PR DESCRIPTION
## A reference to the issue / Description of it

#7943 

## How does this PR fix the problem?

Because the IAM policy applied to the `ModernisationPlatformGithubActionsRole` role in the MOJ Master account has a condition applied like so:
```
 "Condition": {
                "ForAnyValue:StringLike": {
                    "kms:ResourceAliases": [
                        "alias/s3-state-bucket"
                    ]
                }
            }
```
This PR applies the old alias to the new multi-region key in order to preserve this functionality.

Broadly speaking the role needs this alias to point at the key used to encrypt the default state file in the root of the state file bucket, which Terraform uses to confirm that access to the backend is available prior to switching to the configured workspace.

## How has this been tested?

Tested manually.

## Deployment Plan / Instructions

1. Remove alias from Modernisation Platform account manually
2. Amend KMS key used to encrypt `terraform.tfstate` in the root of the bucket to the new key
3. Run Terraform to apply alias
4. In the event of a failure apply the alias manually and import it into the Modernisation Platform Account state file.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
