### PR TITLE
POC Datasync

### DIFF
--- a/terraform/environments/cooker/bastion_linux.json
+++ b/terraform/environments/cooker/bastion_linux.json
@@ -1,0 +1,11 @@
+{
+    "keys": {
+      "sandbox": {
+        "davidelliott": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDoPyLxEkdq8VJctmdJYLt73X7C5XWQNK5BHtHjGFbx99IdWukjd+YniF5WSV+T+PGVWPUjnPS0UHMwQXz7rmevWuKQfFGf3OgPdYWG6BmjaQVlRj2gULHBk7wXoTMVi/e93gA4qq/GwCVOW2GsiidDUXCzDDJwJVhHKGVoLAY5uItW5qkLrlhGmNiX2g3PajzakPhMQUNy+4/8iRnzj2Xm9W17o23IowY/7FgFvaoT9D5+JWsIr+DuFZZ/Nnbioxejyk0IwrL4sf7MOW8uowq3Q2D3z+84uH5MBwbZRiw7a0elC/UaBAcs6pMd9H3H7cg7lOZDF8sWZ/+gcFUrjUyg/uh0QkJTh+ymosbcuUaO7elEJ9j9UTYtIr/Z0E5VV4pAyVbZs7Q6P1oupPijBDmUPu2D03cdQMw/cqf1LFjRAf2ZGuq3nuUlx/V3CCZxS4fY3R0ZNpUgTmF9lpxFIrqXFYa8pqRLLcI3D9O4jUOGRgqwZ2XeqAnuh+zbMpPezOE= davidelliot@L0421",
+        "ewastempel": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDn8g/Fo0Vr5uCcUp4+P1UdXtYdY73taERpeI7MrhZKQ0PVu4OSOAOQ8xv32xRSDgZsgZP3pkUkWprbgE9S8DGZjORyWndbPYhnC6nerfakEIiK4N30jNHDMmRWSwSCtwGC/ww+HQE+AR0UjoTTL56oNxN7zmgCelCuX/jgdXfTuuYKGwhqXE5hiz8YVwNUvPPgx0AI1OtbX6JPn+U8blnBfoI5mXhRw8GCvqW50OQetH6e9o0njtZPy+16XLM1sMzG1QpDfTlHVfklxqwLvFm1NDrZeYgsT76dV/YvgK74/SFBTWBjDTXtIO4rXoyjFhInzUQsMCEWuPPpov82fkqp ewastempel@L0693"
+      },
+      "test": {},
+      "preproduction": {},
+      "production": {}
+    }
+  }

--- a/terraform/environments/cooker/bastion_linux.tf
+++ b/terraform/environments/cooker/bastion_linux.tf
@@ -1,0 +1,36 @@
+
+locals {
+  public_key_data = jsondecode(file("./bastion_linux.json"))
+}
+
+# tfsec:ignore:aws-s3-enable-bucket-encryption tfsec:ignore:aws-s3-encryption-customer-key tfsec:ignore:aws-s3-enable-bucket-logging tfsec:ignore:aws-s3-enable-versioning
+module "bastion_linux" {
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-bastion-linux?ref=95ed3c3f454e2014a62990aacd5d68c64d026f11" # v4.2.1
+
+  providers = {
+    aws.share-host   = aws.core-vpc # core-vpc-(environment) holds the networking for all accounts
+    aws.share-tenant = aws          # The default provider (unaliased, `aws`) is the tenant
+  }
+
+  # s3 - used for logs and user ssh public keys
+  bucket_name = "bastion"
+  # public keys
+  public_key_data = local.public_key_data.keys[local.environment]
+  # logs
+  log_auto_clean       = "Enabled"
+  log_standard_ia_days = 30  # days before moving to IA storage
+  log_glacier_days     = 60  # days before moving to Glacier
+  log_expiry_days      = 180 # days before log expiration
+  # bastion
+  allow_ssh_commands = false
+
+  app_name      = var.networking[0].application
+  business_unit = local.vpc_name
+  subnet_set    = local.subnet_set
+  environment   = "sandbox"
+  region        = "eu-west-2"
+
+  # Tags
+  tags_common = local.tags
+  tags_prefix = terraform.workspace
+}

--- a/terraform/environments/cooker/datasync.tf
+++ b/terraform/environments/cooker/datasync.tf
@@ -1,0 +1,119 @@
+
+
+# S3 bucket to store the inventory data in Account A
+resource "aws_s3_bucket" "ssm_inventory_bucket" {
+  bucket = "ssm-inventory-sync-bucket-236861075084-euw2"
+}
+
+# Enable versioning on the S3 bucket
+resource "aws_s3_bucket_versioning" "ssm_inventory_bucket" {
+  bucket = aws_s3_bucket.ssm_inventory_bucket.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+# IAM Role in Account A for Systems Manager to assume and sync inventory data
+resource "aws_iam_role" "ssm_sync_role" {
+  name = "SSMSyncRole"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ssm.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+# IAM Policy for Systems Manager to access S3 bucket in Account A
+resource "aws_iam_policy" "ssm_sync_policy" {
+  name = "SSMSyncPolicy"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject",
+        "s3:PutObjectAcl",
+        "s3:ListBucket"
+      ],
+      "Resource": [
+        "arn:aws:s3:::ssm-inventory-sync-bucket-236861075084-euw2",
+        "arn:aws:s3:::ssm-inventory-sync-bucket-236861075084-euw2/*"
+      ]
+    }
+  ]
+}
+EOF
+}
+
+# Attach policy to the role
+resource "aws_iam_role_policy_attachment" "ssm_sync_policy_attach" {
+  role       = aws_iam_role.ssm_sync_role.name
+  policy_arn = aws_iam_policy.ssm_sync_policy.arn
+}
+
+# S3 bucket policy to allow cross-account access for Account B and Account A
+resource "aws_s3_bucket_policy" "ssm_inventory_bucket_policy" {
+  bucket = aws_s3_bucket.ssm_inventory_bucket.id
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": [
+          "arn:aws:iam::236861075084:root",
+          "arn:aws:iam::348456244381:root"
+        ]
+      },
+      "Action": "s3:PutObject",
+      "Resource": "arn:aws:s3:::ssm-inventory-sync-bucket-236861075084-euw2/*"
+    },
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ssm.amazonaws.com"
+      },
+      "Action": "s3:PutObject",
+      "Resource": "arn:aws:s3:::ssm-inventory-sync-bucket-236861075084-euw2/*"
+    }
+  ]
+}
+EOF
+}
+
+# Create Resource Data Sync in Account A to sync data to the S3 bucket
+resource "aws_ssm_resource_data_sync" "account_a_data_sync" {
+  name = "ResourceDataSyncAccountA"
+  s3_destination {
+    bucket_name = "ssm-inventory-sync-bucket-236861075084-euw2"
+    region      = "eu-west-2"
+    sync_format = "JsonSerDe"
+    prefix      = "ssm-data-sync/"   # Added prefix to store data under this folder
+  }
+}
+
+resource "aws_ssm_association" "ssm_inventory" {
+  name = "AWS-GatherSoftwareInventory"
+  
+  schedule_expression = "rate(30 minutes)"
+  targets {
+    key    = "InstanceIds"
+    values = ["i-0474ba7a45b548e96"]
+  }
+}

--- a/terraform/environments/sprinkler/datasync.tf
+++ b/terraform/environments/sprinkler/datasync.tf
@@ -1,0 +1,77 @@
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "secondary"  # Provider for Account B
+}
+
+# IAM Role in Account B to allow cross-account access to S3 in Account A
+resource "aws_iam_role" "ssm_inventory_sync_role" {
+  name = "SSMInventorySyncRole"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ssm.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+# IAM Policy for the role to allow writing to the S3 bucket in Account A
+resource "aws_iam_policy" "ssm_inventory_sync_policy" {
+  name = "SSMInventorySyncPolicy"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject",
+        "s3:GetBucketLocation",
+        "s3:ListBucket",
+        "s3:PutObjectAcl"
+      ],
+      "Resource": [
+        "arn:aws:s3:::ssm-inventory-sync-bucket-236861075084-euw2",
+        "arn:aws:s3:::ssm-inventory-sync-bucket-236861075084-euw2/*"
+      ]
+    }
+  ]
+}
+EOF
+}
+
+# Attach the policy to the role in Account B
+resource "aws_iam_role_policy_attachment" "ssm_inventory_sync_policy_attach" {
+  role       = aws_iam_role.ssm_inventory_sync_role.name
+  policy_arn = aws_iam_policy.ssm_inventory_sync_policy.arn
+}
+
+
+resource "aws_ssm_association" "ssm_inventory" {
+  name = "AWS-GatherSoftwareInventory"
+  schedule_expression = "rate(30 minutes)"
+  targets {
+    key    = "InstanceIds"
+    values = ["i-087c0f253c9b5b1c6", "i-0936cca4e6be2988c", "i-05311a4161a5fbc29"]
+  }
+}
+
+# Create Resource Data Sync in Account A to sync data to the S3 bucket
+resource "aws_ssm_resource_data_sync" "account_a_data_sync" {
+  name = "ResourceDataSyncAccountA"
+  s3_destination {
+    bucket_name = "ssm-inventory-sync-bucket-236861075084-euw2"
+    region      = "eu-west-2"
+    sync_format = "JsonSerDe"
+    prefix      = "ssm-data-sync/"   # Added prefix to store data under this folder
+  }
+}

--- a/terraform/environments/sprinkler/datasync.tf
+++ b/terraform/environments/sprinkler/datasync.tf
@@ -1,7 +1,3 @@
-provider "aws" {
-  region = "eu-west-2"
-  alias  = "secondary"  # Provider for Account B
-}
 
 # IAM Role in Account B to allow cross-account access to S3 in Account A
 resource "aws_iam_role" "ssm_inventory_sync_role" {
@@ -40,8 +36,8 @@ resource "aws_iam_policy" "ssm_inventory_sync_policy" {
         "s3:PutObjectAcl"
       ],
       "Resource": [
-        "arn:aws:s3:::ssm-inventory-sync-bucket-236861075084-euw2",
-        "arn:aws:s3:::ssm-inventory-sync-bucket-236861075084-euw2/*"
+        "arn:aws:s3:::ssm-inventory-sync-bucket-euw2",
+        "arn:aws:s3:::ssm-inventory-sync-bucket-euw2/*"
       ]
     }
   ]
@@ -58,10 +54,10 @@ resource "aws_iam_role_policy_attachment" "ssm_inventory_sync_policy_attach" {
 
 resource "aws_ssm_association" "ssm_inventory" {
   name = "AWS-GatherSoftwareInventory"
-  schedule_expression = "rate(30 minutes)"
+  schedule_expression = ""
   targets {
     key    = "InstanceIds"
-    values = ["i-087c0f253c9b5b1c6", "i-0936cca4e6be2988c", "i-05311a4161a5fbc29"]
+    values = [""]
   }
 }
 
@@ -69,7 +65,7 @@ resource "aws_ssm_association" "ssm_inventory" {
 resource "aws_ssm_resource_data_sync" "account_a_data_sync" {
   name = "ResourceDataSyncAccountA"
   s3_destination {
-    bucket_name = "ssm-inventory-sync-bucket-236861075084-euw2"
+    bucket_name = "ssm-inventory-sync-bucket-euw2"
     region      = "eu-west-2"
     sync_format = "JsonSerDe"
     prefix      = "ssm-data-sync/"   # Added prefix to store data under this folder


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/7725

## How does this PR fix the problem?

Makes Cooker the main account, with sprinkler data syncing to it. 

1. This PR create an S3 bucket to store the inventory data.
2. Create IAM roles and policies to allow cross-account access.
3. Configure Resource Data Sync to aggregate inventory data into the S3 bucket.
4. Use Athena to query the inventory data stored in S3.

## How has this been tested?

Yes, and shown to Simon.

## Deployment Plan / Instructions

Not to be deployed, but as a POC ready for the rolling out of this.


