### PR TITLE
Update version of tech docs publisher

### DIFF
--- a/.github/workflows/publish-gh-pages.yml
+++ b/.github/workflows/publish-gh-pages.yml
@@ -24,13 +24,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: ministryofjustice/tech-docs-github-pages-publisher:v3.0.1
+      image: ministryofjustice/tech-docs-github-pages-publisher:v4.0.0
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Compile Markdown to HTML and create artifact
         run: |
-          /scripts/deploy.sh
+          /usr/local/bin/package
       - name: Upload artifact to be published
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v3.1.0
         with:


### PR DESCRIPTION
## A reference to the issue / Description of it

#6333

## How does this PR fix the problem?

Updates reference to tech docs publish and amends action in line with guidance [here](https://github.com/ministryofjustice/tech-docs-github-pages-publisher?tab=readme-ov-file#v4)

## How has this been tested?

Will test through CI pipeline checks

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
