### PR TITLE
Add S3 service principal to KMS keys

### DIFF
--- a/terraform/modules/kms/main.tf
+++ b/terraform/modules/kms/main.tf
@@ -124,7 +124,8 @@ data "aws_iam_policy_document" "kms-general" {
       type = "Service"
       identifiers = [
         "cloudwatch.amazonaws.com",
-        "ses.amazonaws.com"
+        "ses.amazonaws.com",
+        "s3.amazonaws.com"
       ]
     }
   }


### PR DESCRIPTION
## A reference to the issue / Description of it

These keys are currently not able to be used for s3 inventory generation

## How does this PR fix the problem?

adds the `s3.amazonaws.com` service principal to allow the key to be used by the s3 service

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
