### PR TITLE
Denying `iam:PassRole` of infrastructure access roles

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -275,6 +275,12 @@ data "aws_iam_policy_document" "member-access" {
     ]
     resources = ["arn:aws:iam::*:user/cicd-member-user"]
   }
+
+  statement {
+    actions   = ["iam:PassRole"]
+    effect    = "Deny"
+    resources = ["arn:aws:iam:*:role/MemberInfrastructureAccess"]
+  }
 }
 
 resource "aws_iam_policy" "member-access" {
@@ -389,6 +395,12 @@ data "aws_iam_policy_document" "member-access-us-east" {
       "iam:UpdateUser"
     ]
     resources = ["*"]
+  }
+
+  statement {
+    actions   = ["iam:PassRole"]
+    effect    = "Deny"
+    resources = ["arn:aws:iam:*:role/MemberInfrastructureAccessUSEast"]
   }
 }
 

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -279,7 +279,7 @@ data "aws_iam_policy_document" "member-access" {
   statement {
     actions   = ["iam:PassRole"]
     effect    = "Deny"
-    resources = ["arn:aws:iam:*:role/MemberInfrastructureAccess"]
+    resources = ["arn:aws:iam::*:role/MemberInfrastructureAccess"]
   }
 }
 
@@ -400,7 +400,7 @@ data "aws_iam_policy_document" "member-access-us-east" {
   statement {
     actions   = ["iam:PassRole"]
     effect    = "Deny"
-    resources = ["arn:aws:iam:*:role/MemberInfrastructureAccessUSEast"]
+    resources = ["arn:aws:iam::*:role/MemberInfrastructureAccessUSEast"]
   }
 }
 


### PR DESCRIPTION
## A reference to the issue / Description of it

#6170

## How does this PR fix the problem?

This IAM statement restricts the ability of the `MemberInfrastructureAccessRole` to be passed to other entities.

## How has this been tested?

Checked for any references to this role being passed to services in either this repository of `Modernisation-Platform-Environments`

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

https://aws.amazon.com/blogs/security/how-to-use-the-passrole-permission-with-iam-roles/

https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_passrole.html
