### PR TITLE
Adding standard networking to APC Production

### DIFF
--- a/environments-networks/platforms-production.json
+++ b/environments-networks/platforms-production.json
@@ -4,6 +4,7 @@
       "general": {
         "cidr": "10.27.96.0/21",
         "accounts": [
+          "analytical-platform-compute-production",
           "analytical-platform-ingestion-production",
           "long-term-storage-production",
           "data-platform-apps-and-tools-production",


### PR DESCRIPTION
## A reference to the issue / Description of it

Support request from Analytical Platform user to be able to connect QuickSight to a database which requires networking connectivity.

## How does this PR fix the problem?

This will share the standard subnets into Analytical Platform Compute Production account so we can set up a vpc connection with QuickSight.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Will be tested post-implementation

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

This should not have impact on wider platform.

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)
