### PR TITLE
Remove isolated value from APC json

### DIFF
--- a/environments/analytical-platform-compute.json
+++ b/environments/analytical-platform-compute.json
@@ -1,6 +1,5 @@
 {
   "account-type": "member",
-  "isolated-network": "true",
   "environments": [
     {
       "name": "development",


### PR DESCRIPTION
## A reference to the issue / Description of it

https://mojdt.slack.com/archives/C01A7QK5VM1/p1730285409189469

## How does this PR fix the problem?

Removing this value should allow our scripts to populate the `networking.auto.tfvars.json` for analytical-platform-compute.

## How has this been tested?

It has not been tested.

## Deployment Plan / Instructions

Deploy through CI. Fallback to manual terraform runs if required.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
