### PR TITLE
Confirm Owner Environments - Bug fix

### DIFF
--- a/scripts/confirm-environment-owner/get-environment-owners.sh
+++ b/scripts/confirm-environment-owner/get-environment-owners.sh
@@ -32,7 +32,7 @@ for file in "$DIR"/*.json; do
     FILE_NAME=$(basename "$file" .json)
 
     # Ensures we ignore the Modernisaiton Platform environments.
-    if [[ ! " ${MP_ENVS[@]} " =~ " $file " ]]; then
+    if [[ ! " ${MP_ENVS[@]} " =~ " $FILE_NAME " ]]; then
 
       file_path="$REMOTE_DIR/$FILE_NAME.json"
   


### PR DESCRIPTION
Spotted bug whereby the wrong variable was used as the test to exclude MP's own environments.

## A reference to the issue / Description of it

Spotted an issue that would have prevented MP's own environments from being excluded from the notifications. This amends the bash script to use the right variable.

## How does this PR fix the problem?

See above.

## How has this been tested?

Yes - see https://github.com/ministryofjustice/modernisation-platform/actions/runs/11609777100/job/32327722227 (which has the subsequent steps disabled.

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
