### PR TITLE
Resolve resource deprecation warning for read-only role

### DIFF
--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -316,8 +316,7 @@ resource "aws_iam_role_policy" "member-delegation" {
 
 # Read only role for developer sso plans and for viewing via the console
 resource "aws_iam_role" "member_delegation_read_only" {
-  name                = "member-delegation-read-only"
-  managed_policy_arns = ["arn:aws:iam::aws:policy/ReadOnlyAccess"]
+  name = "member-delegation-read-only"
   assume_role_policy = jsonencode( # checkov:skip=CKV_AWS_60: "the policy is secured with the condition"
     {
       "Version" : "2012-10-17",
@@ -343,4 +342,9 @@ resource "aws_iam_role" "member_delegation_read_only" {
       Name = "member-delegation-read-only"
     },
   )
+}
+
+resource "aws_iam_role_policy_attachments_exclusive" "member_delegation_read_only" {
+  policy_arns = ["arn:aws:iam::aws:policy/ReadOnlyAccess"]
+  role_name   = aws_iam_role.member_delegation_read_only.name
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

When running Terraform for one of the `core-vpc` workspaces the following warning is output:
```
│ Warning: Argument is deprecated
│ 
│   with aws_iam_role.member_delegation_read_only,
│   on vpc.tf line 320, in resource "aws_iam_role" "member_delegation_read_only":
│  320:   managed_policy_arns = ["arn:aws:iam::aws:policy/ReadOnlyAccess"]
│ 
│ The managed_policy_arns argument is deprecated. Use the aws_iam_role_policy_attachments_exclusive resource instead.
│ 
│ (and one more similar warning elsewhere)
```

## How does this PR fix the problem?

This PR implements the `aws_iam_role_policy_attachments_exclusive` resource. Strictly speaking I don't think this exact resource is required, but it will enforce that only the read-only policy will be attached to this role, and any other policies will be detached should they be picked up on a terraform run.

## How has this been tested?

Tested in `core-vpc-sandbox` successfully

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
