### PR TITLE
Fixes permissions issue in the confirm-owners workflow.

### DIFF
--- a/.github/workflows/confirm-contacts-for-environments.yml
+++ b/.github/workflows/confirm-contacts-for-environments.yml
@@ -1,10 +1,11 @@
 name: Confirm Contacts for Environments
 
 on:
-
   # Runs on the first day of each month at 9am
   schedule:
     - cron: '0 9 1 * *'
+  # Allows for manual exec
+  workflow_dispatch:
 
 env:
     GITHUB_REPO: ${{ github.repository }}
@@ -56,6 +57,7 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE
           pwd
+          chmod +x scripts/confirm-environment-owner/create-confirm-owner-issue.sh
           ./scripts/confirm-environment-owner/create-confirm-owner-issue.sh
 
 


### PR DESCRIPTION
Fixes permission error and allows for manual running in the event that the cron exec failed.

## A reference to the issue / Description of it

Job failure today at 9am. https://github.com/ministryofjustice/modernisation-platform/actions/runs/11626944778/job/32379460698

## How does this PR fix the problem?

See above.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
