### PR TITLE
Separate out `iam:PassRole` statements

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -522,7 +522,6 @@ data "aws_iam_policy_document" "policy" {
       "iam:listInstanceProfilesForRole",
       "iam:listRolePolicies",
       "iam:ListRoles",
-      "iam:PassRole",
       "kinesis:PutRecord",
       "kms:DescribeKey",
       "kms:Decrypt",
@@ -564,6 +563,13 @@ data "aws_iam_policy_document" "policy" {
     ]
     resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
   }
+
+  statement {
+    actions   = ["iam:PassRole"]
+    effect    = "Allow"
+    resources = ["*"]
+  }
+
   statement {
     effect = "Allow"
     actions = [

--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -1166,7 +1166,6 @@ data "aws_iam_policy_document" "reporting-operations" {
       "dynamodb:Get*",
       "dynamodb:Query",
       "dynamodb:Scan",
-      "iam:PassRole",
       "redshift:*",
       "redshift-data:*",
       "redshift-serverless:*",
@@ -1192,6 +1191,13 @@ data "aws_iam_policy_document" "reporting-operations" {
     ]
     resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
   }
+
+  statement {
+    actions   = ["iam:PassRole"]
+    effect    = "Allow"
+    resources = ["*"]
+  }
+
 }
 
 #tfsec:ignore:aws-iam-no-policy-wildcards

--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -328,9 +328,7 @@ data "aws_iam_policy_document" "developer_additional" {
   statement {
     sid    = "iamForECSAllow"
     effect = "Allow"
-    actions = [
-      "iam:PassRole"
-    ]
+    actions = ["iam:PassRole"]
     resources = ["*"]
     condition {
       test     = "StringEquals"


### PR DESCRIPTION
## A reference to the issue / Description of it

#7907

## How does this PR fix the problem?

Prior to implementing any controls or conditions, this PR separates out the `iam:PassRole` permission into separate statements in line with [AWS documented practice](https://aws.amazon.com/blogs/security/how-to-use-the-passrole-permission-with-iam-roles/).

## How has this been tested?

Tested through CI pipelines; no practical impact from this PR.

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
