### PR TITLE
Update electronic-monitoring-data.json

### DIFF
--- a/environments/electronic-monitoring-data.json
+++ b/environments/electronic-monitoring-data.json
@@ -7,12 +7,7 @@
         {
           "sso_group_name": "hmpps-electronic-monitoring-data-store",
           "level": "sandbox",
-          "nuke": "rebuild"
-        },
-        {
-          "sso_group_name": "hmpps-electronic-monitoring-data-store",
-          "level": "migration",
-          "nuke": "rebuild"
+          "nuke": "exclude"
         }
       ]
     },


### PR DESCRIPTION
## A reference to the issue / Description of it

Until we sort out lake formation, taking them out of the nuke. Currently the nuke jobs fails as we have not assigned the correct permissions in lake formation / glue to that user. Ticket raised to discuss this.
