### PR TITLE
Update Bucket Ownership Control to Allow Cross-Account Uploads

### DIFF
--- a/terraform/environments/core-shared-services/s3.tf
+++ b/terraform/environments/core-shared-services/s3.tf
@@ -9,7 +9,7 @@ module "s3-bucket" {
   replication_enabled = false
   versioning_enabled  = true
   force_destroy       = false
-  ownership_controls  = "BucketOwnerEnforced" # Disable all S3 bucket ACL to ensure that objects owner it the bucket with bucket policy IAM governing permissions
+  ownership_controls  = "BucketOwnerPreferred"
   lifecycle_rule = [
     {
       id      = "main"


### PR DESCRIPTION
## A reference to the issue / Description of it

This PR changes the bucket ownership control setting from `BucketOwnerEnforced` to `BucketOwnerPreferred` to allow cross-account uploads. This update is necessary to enable collaborators from other accounts to upload files to the bucket.

## How does this PR fix the problem?

he current ownership control setting, `BucketOwnerEnforced`, restricts certain permissions that are required for cross-account uploads. By switching to `BucketOwnerPreferred`, we ensure that external accounts can upload files without ownership conflicts.

## How has this been tested?

Tested this with test-artifact-buck

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
