### PR TITLE
chore: add dms to kms service principal list

### DIFF
--- a/terraform/modules/kms/main.tf
+++ b/terraform/modules/kms/main.tf
@@ -126,7 +126,8 @@ data "aws_iam_policy_document" "kms-general" {
       identifiers = [
         "cloudwatch.amazonaws.com",
         "ses.amazonaws.com",
-        "s3.amazonaws.com"
+        "s3.amazonaws.com",
+        "dms.amazonaws.com"
       ]
     }
   }


### PR DESCRIPTION
## A reference to the issue / Description of it

Trying to create a DMS Event Subscription targetting SNS encrypted with the general shared key fails with the following error:
```
│ Error: creating DMS Event Subscription (dms-task-event-alerts): operation error Database Migration Service: CreateEventSubscription, https response error StatusCode: 400, RequestID: 172d846f-d7ae-46e9-881e-fca921829ab9, KMSAccessDeniedFault: The request to create event subscription for SNS topic 'arn:aws:sns:eu-west-2:***:delius-dms-alerting' has failed because the ciphertext references a key that doesn't exist or DMS account doesn't have an access to
│ 
│   with module.environment_dev[0].module.dms[0].aws_dms_event_subscription.dms_task_event_subscription,
│   on modules/components/dms/cloudwatch-alarms.tf line 109, in resource "aws_dms_event_subscription" "dms_task_event_subscription":
│  109: resource "aws_dms_event_subscription" "dms_task_event_subscription" {
```

## How does this PR fix the problem?

Adds DMS to the KMS service principals.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
