### PR TITLE
Add condition to `modernisation-platform-oidc-cicd` `iam:PassRole` permission

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -568,6 +568,11 @@ data "aws_iam_policy_document" "policy" {
     actions   = ["iam:PassRole"]
     effect    = "Allow"
     resources = ["*"]
+    condition {
+      test     = "StringEquals"
+      values   = ["ssm.amazonaws.com"]
+      variable = "iam:PassedToService"
+    }
   }
 
   statement {


### PR DESCRIPTION
## A reference to the issue / Description of it

#7907 

## How does this PR fix the problem?

This PR prevents the `modernisation-platform-oidc-cicd` role from being passed to any AWS service or resource unless it is `ssm.amazonaws.com`.

This will prevent the accidental - or malicious - passing of this role to an unexpected resource such as an EC2 instance or lambda function.

## How has this been tested?

Tested via ClickOps with `nomis-test` and @keirwilliams who confirmed the condition does not negatively affect their automation tasks.

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
