### PR TITLE
Update comments referring to action version

### DIFF
--- a/.github/workflows/monitor-ecs-eks-amis.yml
+++ b/.github/workflows/monitor-ecs-eks-amis.yml
@@ -42,7 +42,7 @@ jobs:
             run: bash ./scripts/check-ecs-eks-amis.sh
 
           - name: Upload AMI CSV file
-            uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+            uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 #v4.4.3
             with:
               name: ecs-eks-ami-results
               path: ./outdated-amis.csv

--- a/.github/workflows/publish-gh-pages.yml
+++ b/.github/workflows/publish-gh-pages.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           /usr/local/bin/package
       - name: Upload artifact to be published
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v3.1.0
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 #v4.4.3
         with:
           name: github-pages
           path: artifact.tar

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -59,7 +59,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v3.1.0
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 #v4.4.3
         with:
           name: SARIF file
           path: results.sarif


### PR DESCRIPTION
Saw a few cases where our hash value refers to the latest version of the `artifact` action, but that isn't reflected by the comment.

EG: https://github.com/actions/upload-artifact/releases/tag/v4.4.3 has the SHA value `b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882`.