### PR TITLE
Add ecs to allowed services for oidc-cicd role

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -569,7 +569,7 @@ data "aws_iam_policy_document" "policy" {
     resources = ["*"]
     condition {
       test     = "StringEquals"
-      values   = ["ssm.amazonaws.com", "ecs.amazonaws.com"]
+      values   = ["ssm.amazonaws.com", "ecs.amazonaws.com", "ecs-tasks.amazonaws.com"]
       variable = "iam:PassedToService"
     }
   }

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -569,7 +569,7 @@ data "aws_iam_policy_document" "policy" {
     resources = ["*"]
     condition {
       test     = "StringEquals"
-      values   = ["ssm.amazonaws.com"]
+      values   = ["ssm.amazonaws.com", "ecs.amazonaws.com"]
       variable = "iam:PassedToService"
     }
   }


### PR DESCRIPTION
## A reference to the issue / Description of it

Had the following through via Slack from @roncitrus :
```
Error: Failed to register task definition in ECS: User: arn:aws:sts::111111111111:assumed-role/modernisation-platform-oidc-cicd/GitHubActions is not authorized to perform: iam:PassRole on resource: arn:aws:iam::111111111111:role/task-cdpt-chaps because no identity-based policy allows the iam:PassRole action
Error: User: arn:aws:sts::111111111111:assumed-role/modernisation-platform-oidc-cicd/GitHubActions is not authorized to perform: iam:PassRole on resource: arn:aws:iam::111111111111:role/task-cdpt-chaps because no identity-based policy allows the iam:PassRole action
```

## How does this PR fix the problem?

Adds `ecs` to allowed services for passrole permission.

## How has this been tested?

Tested through CI pipeline tests

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
