### PR TITLE
Add s3:PutObjectAcl permission to allow object uploads from cross-account

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -261,6 +261,7 @@ data "aws_iam_policy_document" "developer_additional" {
       "s3:PutObject",
       "s3:DeleteObject",
       "s3:DeleteObjectVersion",
+      "s3:PutObjectAcl",
       "s3:RestoreObject",
       "s3:*StorageLens*",
       "secretsmanager:Get*",


### PR DESCRIPTION
## A reference to the issue / Description of it

After modifying the artifact bucket's object ownership settings, cross-account users began experiencing permission issues while trying to upload objects using the CLI. Without `s3:PutObjectACL` permission, these users cannot set the ACL for their uploaded objects, resulting in a permissions error.

## How does this PR fix the problem?

This PR addresses the issue where cross-account users are unable to upload objects to the artifact bucket due to missing permissions. By adding the s3:PutObjectACL permission, users from other accounts will now have the ability to set the ACL on the uploaded objects, ensuring successful uploads from the command line.

## How has this been tested?

tested on nomis-test account developer role

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
