### PR TITLE
Remove `imkatiewatson` github account

### DIFF
--- a/terraform/github/locals.tf
+++ b/terraform/github/locals.tf
@@ -31,8 +31,7 @@ locals {
   general_members = [
     "kcbotsh",
     "seanprivett",
-    "SimonPPledger",
-    "imkatiewatson"
+    "SimonPPledger"
   ]
 
   # GitHub usernames for engineers who need full AWS access


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/actions/runs/11728688602/job/32673722475#step:12:1959

Job is failing I believe as Katie's github account has been removed from the MoJ organisation.

## How does this PR fix the problem?

Removing Katie's account form locals.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
