### PR TITLE
Added firewall rules to allow platforms VPCs to Cloud Platform RDS

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/development_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/development_rules.json
@@ -125,6 +125,13 @@
     "destination_port": "5432",
     "protocol": "TCP"
   },
+  "platforms_development_to_cloud_platform_pgres": {
+    "action": "PASS",
+    "source_ip": "${platforms-development}",
+    "destination_ip": "${cloud-platform}",
+    "destination_port": "5432",
+    "protocol": "TCP"
+  },
   "noms_test_dr_vnet_to_mp_hmpps_development": {
     "action": "PASS",
     "source_ip": "${noms-test-dr-vnet}",

--- a/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
@@ -202,6 +202,13 @@
     "destination_port": "5432",
     "protocol": "TCP"
   },
+  "platforms_preproduction_to_cloud_platform_pgres": {
+    "action": "PASS",
+    "source_ip": "${platforms-preproduction}",
+    "destination_ip": "${cloud-platform}",
+    "destination_port": "5432",
+    "protocol": "TCP"
+  },
   "mp_hmpps_preproduction_to_saas_agent_tcp": {
     "action": "PASS",
     "source_ip": "${hmpps-preproduction}",

--- a/terraform/environments/core-network-services/firewall-rules/production_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/production_rules.json
@@ -307,6 +307,13 @@
     "destination_port": "5432",
     "protocol": "TCP"
   },
+  "platforms_production_to_cloud_platform_pgres": {
+    "action": "PASS",
+    "source_ip": "${platforms-production}",
+    "destination_ip": "${cloud-platform}",
+    "destination_port": "5432",
+    "protocol": "TCP"
+  },
   "rfc_10-0-0-0-8_to_ppud_production_https": {
     "action": "PASS",
     "source_ip": "10.0.0.0/8",

--- a/terraform/environments/core-network-services/firewall-rules/test_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/test_rules.json
@@ -188,6 +188,13 @@
     "destination_port": "5432",
     "protocol": "TCP"
   },
+  "platforms_test_to_cloud_platform_pgres": {
+    "action": "PASS",
+    "source_ip": "${platforms-test}",
+    "destination_ip": "${cloud-platform}",
+    "destination_port": "5432",
+    "protocol": "TCP"
+  },
   "cp_to_hmpps_test_https": {
     "action": "PASS",
     "source_ip": "${cloud-platform}",


### PR DESCRIPTION
## A reference to the issue / Description of it

Analytical Platform Quicksight needs to query Cloud Platform RDS instances

## How does this PR fix the problem?

Adds required firewall rules

## How has this been tested?

Not tested / simple firewall rule

## Deployment Plan / Instructions

Deploy through CI pipeline

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
