### PR TITLE
Feature/3058-update-refs-to-github-ci-user-pat-token

### DIFF
--- a/.github/workflows/modernisation-platform-account.yml
+++ b/.github/workflows/modernisation-platform-account.yml
@@ -37,5 +37,4 @@ jobs:
       working-directory: "terraform/modernisation-platform-account"
     secrets:
       modernisation_platform_environments: ${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENTS }}
-      gh_workflow_token: ${{ secrets.TERRAFORM_GITHUB_TOKEN }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/terraform-pagerduty.yml
+++ b/.github/workflows/terraform-pagerduty.yml
@@ -35,7 +35,6 @@ jobs:
       working-directory: "terraform/pagerduty"
     secrets:
       modernisation_platform_environments: ${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENTS }}
-      gh_workflow_token: ${{ secrets.TERRAFORM_GITHUB_TOKEN }}
       pagerduty_token: ${{ secrets.PAGERDUTY_TOKEN }}
       pagerduty_userapi_token: ${{ secrets.PAGERDUTY_USERAPI_TOKEN}}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/terraform-single-sign-on.yml
+++ b/.github/workflows/terraform-single-sign-on.yml
@@ -35,5 +35,4 @@ jobs:
       working-directory: "terraform/single-sign-on"
     secrets:
       modernisation_platform_environments: ${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENTS }}
-      gh_workflow_token: ${{ secrets.TERRAFORM_GITHUB_TOKEN }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/source/runbooks/rotating-secrets.html.md.erb
+++ b/source/runbooks/rotating-secrets.html.md.erb
@@ -29,8 +29,8 @@ This guide advises where secrets are stored and how to rotate them.
 | PagerDuty Integration Keys                                               | pagerduty_integration_keys           | Map of integration keys generated and updated by Terraform PagerDuty integration resources when users create services, used to push alerts to those services                                                                            | AWS Secrets Manager     | Destroy and recreate the PagerDuty integration resource in Terraform                                                                                          | 180 |
 | PagerDuty Modernisation Platform Team user                               | N/A                                  | Used for dead-end notifications as all schedules need a user                                                                                                                                                                            | Not stored              | Use password reset process if needed                                                                                                                          | N/A |
 | Slack Webhook URL                                                        | slack_webhook_url                    | Used to post alarms to Slack                                                                                                                                                                                                            | AWS Secrets Manager     | Use this [runbook](https://user-guide.modernisation-platform.service.justice.gov.uk/runbooks/rotating-secrets.html#slack-webhook-url) to rotate the secret    | 180 |
-| GitHub MP CI User PAT                                                    | github_ci_user_pat                   | Used to create PRs etc in GitHub actions and deploy GitHub resources via Terraform                                                                                                                                                      | AWS Secrets Manager     | Use this [runbook](https://user-guide.modernisation-platform.service.justice.gov.uk/runbooks/rotating-secrets.html#github-mp-ci-user-pat) to rotate the secret | 180 |
-| GitHub MP CI User Environments Repo PAT                                  | github_ci_user_environments_repo_pat | Used in reusable pipelines of the modernisation-platform-environments repository. This is so that the CI user can post comments in PRs, e.g. tf plan/apply output.                                                                      | AWS Secrets Manager     | Log in as the Modernisation Platform CI User and generate a new PAT, revoke the old one and update the secret.                                                | 180 |
+| GitHub MP CI User PAT                                                    | github_ci_user_pat                   | Used to create PRs etc in GitHub actions and deploy GitHub resources via Terraform                                                                                                                                                      | AWS Secrets Manager     | Use this [runbook](https://user-guide.modernisation-platform.service.justice.gov.uk/runbooks/rotating-secrets.html#github-mp-ci-user-pat-or-github-mp-ci-user-environments-repo-pat) to rotate the secret | 180 |
+| GitHub MP CI User Environments Repo PAT                                  | github_ci_user_environments_repo_pat | Used in reusable pipelines of the modernisation-platform-environments repository. This is so that the CI user can post comments in PRs, e.g. tf plan/apply output.                                                                      | AWS Secrets Manager     | Use this [runbook](https://user-guide.modernisation-platform.service.justice.gov.uk/runbooks/rotating-secrets.html#github-mp-ci-user-pat-or-github-mp-ci-user-environments-repo-pat) to rotate the secret                                                | 180 |
 | GitHub MP CI User Password                                               | github_ci_user_password              | Used to log in and set the PAT                                                                                                                                                                                                          | AWS Secrets Manager     | Log in to GitHub as the user and reset the password, update the secret                                                                                        | 180 |
 | Environment Management                                                   | environment_management               | A Map of account names to IDs, and data for environment management, such as organizational unit IDs                                                                                                                                     | AWS Secrets Manager     | Does not need rotating, not really a secret and regenerated on each account creation                                                                          | N/A |
 | Nuke ID List                                                             | nuke_account_ids                     | Account IDs to be auto-nuked on weekly basis. This secret is used by GitHub actions job nuke.yml inside the environments repo, to find the Account IDs to be nuked.                                                                     | AWS Secrets Manager     | Not really a secret, should not be rotated                                                                                                                    | N/A |
@@ -43,39 +43,16 @@ This guide advises where secrets are stored and how to rotate them.
 
 ## Runbooks
 
-### GitHub MP CI User PAT
+### GitHub MP CI User PAT or GitHub MP CI User Environments Repo PAT
 
-This runbook describes the process for rotating the **github_ci_user_pat** secret.
-
-1. Retrieve the MP GitHub credentials by logging in to the AWS [Modernisation Platform account](https://moj.awsapps.com/start#/) with **AdministratorAccess**
-2. Navigate to the Secrets Manager [github_ci_user_password](https://eu-west-2.console.aws.amazon.com/secretsmanager/secret?name=github_ci_user_password&region=eu-west-2) secret and click `Retrieve secret value`
-3. Use the credentials provided to log in to [GitHub](https://github.com)
-4. Once logged in click on the profile icon and then **Settings > Developer settings > Personal access tokens > Tokens (classic) > Generate new token (classic)**
-5. Fill out the details: 
-    * In the **Note** field give the token a descriptive name e.g. `"Modernisation Platform GitHub Terraform"`
-    * Set **Expiration** value to `"No Expiration"`
-    * Set Scopes by ticking the following boxes:
-        * workflow
-        * admin:org (write:org | read:org | manage_runners:org)
-        * user:email
-        * project (read:project)
-6. Click `Generate token` and then copy the token to your clipboard
-7. Navigate to the Secrets Manager [github_ci_user_pat](https://eu-west-2.console.aws.amazon.com/secretsmanager/secret?name=github_ci_user_pat&region=eu-west-2) secret and click `Retrieve secret value`
-8. Click `Edit` and replace the token with the new one and click `Save`
-9. Run the [Github resources Workflow](https://github.com/ministryofjustice/modernisation-platform/actions/workflows/terraform-github.yml) manually on the main branch. This will populate the GH secret with the value that you have just updated in AWS Secrets Manager.
-10. Wait for another workflow to run which uses the secret to confirm that the new token has taken effect successfully. (The secrets status will show as *"Last used within the last week"*)
-11. When you are confident the new secret is working successfully you can delete the old PAT token in GitHub
-
-### GitHub MP CI User Environments Repo PAT
-
-This runbook describes the process for rotating the **github_ci_user_environments_repo_pat** secret.
+This runbook describes the process for rotating the **github_ci_user_pat** or **github_ci_user_environments_repo_pat** secrets.
 
 1. Retrieve the MP GitHub credentials by logging in to the AWS [Modernisation Platform account](https://moj.awsapps.com/start#/) with **AdministratorAccess**
 2. Navigate to the Secrets Manager [github_ci_user_password](https://eu-west-2.console.aws.amazon.com/secretsmanager/secret?name=github_ci_user_password&region=eu-west-2) secret and click `Retrieve secret value`
 3. Use the credentials provided to log in to [GitHub](https://github.com)
-4. Once logged in click on the profile icon and then **Settings > Developer settings > Personal access tokens > Tokens (Fine-grained tokens) > GITHUB_CI_USER_ENVIRONMENTS_REPO_PAT**
+4. Once logged in click on the profile icon and then **Settings > Developer settings > Personal access tokens > Tokens (Fine-grained tokens)** and select the relevant token
 5. Click `Regenerate token` and then copy the token to your clipboard
-6. Navigate to the Secrets Manager [github_ci_user_environments_repo_pat](https://eu-west-2.console.aws.amazon.com/secretsmanager/secret?name=github_ci_user_environments_repo_pat&region=eu-west-2) secret and click `Retrieve secret value`
+6. Navigate to the Secrets Manager [github_ci_user_pat](https://eu-west-2.console.aws.amazon.com/secretsmanager/secret?name=github_ci_user_pat&region=eu-west-2) or [github_ci_user_environments_repo_pat](https://eu-west-2.console.aws.amazon.com/secretsmanager/secret?name=github_ci_user_environments_repo_pat&region=eu-west-2) secret and click `Retrieve secret value`
 7. Click `Edit` and replace the token with the new one and click `Save`
 8. Run the [Github resources Workflow](https://github.com/ministryofjustice/modernisation-platform/actions/workflows/terraform-github.yml) manually on the main branch. This will populate the GH secret with the value that you have just updated in AWS Secrets Manager. 
 9. Wait for another workflow to run which uses the secret to confirm that the new token has taken effect successfully. (The secrets status will show as *"Last used within the last week"*)


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/3058

## How does this PR fix the problem?

This PR makes two changes:

1. It removes references to `TERRAFORM_GITHUB_TOKEN` in workflows that do not require the secret. These have been tested without use of the secret and are still working.

1. It consolidates the runbook for updating the fine-grained github PAT tokens

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Tested by successfully running workflows on another branch without referencing the secret.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [X] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
