### PR TITLE
🙅 Exclude Analytical Platform Compute accounts from instance scheduler

### DIFF
--- a/terraform/environments/core-shared-services/instance-scheduler-lambda-function.tf
+++ b/terraform/environments/core-shared-services/instance-scheduler-lambda-function.tf
@@ -16,7 +16,7 @@ module "instance_scheduler" {
   additional_trust_roles         = [module.github-oidc.github_actions_role]
   environment_variables = {
     # Only nomis-preproduction is a member account having the InstanceSchedulerAccess role
-    "INSTANCE_SCHEDULING_SKIP_ACCOUNTS" = "nomis-preproduction,mi-platform-development,analytical-platform-data-development,bichard7-test-next,bichard7-sandbox-shared,core-vpc-development,bichard7-sandbox-a,bichard7-shared,bichard7-test-current,bichard7-sandbox-c,core-vpc-sandbox,core-vpc-test,bichard7-sandbox-b,core-vpc-preproduction,core-sandbox-dev,"
+    "INSTANCE_SCHEDULING_SKIP_ACCOUNTS" = "nomis-preproduction,mi-platform-development,analytical-platform-data-development,bichard7-test-next,bichard7-sandbox-shared,core-vpc-development,bichard7-sandbox-a,bichard7-shared,bichard7-test-current,bichard7-sandbox-c,core-vpc-sandbox,core-vpc-test,bichard7-sandbox-b,core-vpc-preproduction,core-sandbox-dev,analytical-platform-compute-development,analytical-platform-compute-test"
   }
   image_uri    = "${local.environment_management.account_ids[terraform.workspace]}.dkr.ecr.eu-west-2.amazonaws.com/${module.instance_scheduler_ecr_repo.ecr_repository_name}:latest"
   timeout      = 600


### PR DESCRIPTION
## A reference to the issue / Description of it

We have long running overnight jobs in our test EKS cluster that are being shutdown

https://github.com/ministryofjustice/data-platform-support/issues/946

## How does this PR fix the problem?

Excludes APC non-prod accounts

## How has this been tested?

It hasn't

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

I don't think so

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk> 
