### PR TITLE
Add OIDC role to allow terraform plan with read-only permissions

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -698,6 +698,58 @@ resource "aws_ssm_parameter" "modernisation_platform_account_id" {
   tags  = local.tags
 }
 
+# OIDC Provider for GitHub Actions Plan
+module "github_oidc_plan_role" {
+  count                  = (local.account_data.account-type == "member" && terraform.workspace != "testing-test") ? 1 : 0
+  source                 = "github.com/ministryofjustice/modernisation-platform-github-oidc-provider?ref=82f546bd5f002674138a2ccdade7d7618c6758b3" # v3.0.0
+  role_name              = "github-actions-plan"
+  additional_permissions = data.aws_iam_policy_document.oidc_assume_plan_role_member[0].json
+  github_repositories    = ["ministryofjustice/modernisation-platform-environments:pull_request"]
+  tags_common            = { "Name" = format("%s-oidc-plan", terraform.workspace) }
+  tags_prefix            = ""
+}
+
+data "aws_iam_policy_document" "oidc_assume_plan_role_member" {
+  count = local.account_data.account-type == "member" && terraform.workspace != "testing-test" ? 1 : 0
+  statement {
+    sid    = "AllowOIDCToAssumeRoles"
+    effect = "Allow"
+    resources = [
+      format("arn:aws:iam::%s:role/member-delegation-%s-%s", local.environment_management.account_ids[format("core-vpc-%s", local.application_environment)], lower(local.business_unit), local.application_environment),
+      format("arn:aws:iam::%s:role/modify-dns-records", local.environment_management.account_ids["core-network-services-production"]),
+      format("arn:aws:iam::%s:role/modernisation-account-limited-read-member-access", local.environment_management.modernisation_platform_account_id),
+      format("arn:aws:iam::%s:role/modernisation-account-terraform-state-member-access", local.environment_management.modernisation_platform_account_id),
+      format("arn:aws:iam::%s:role/ModernisationPlatformSSOReadOnly", local.environment_management.aws_organizations_root_account_id),
+      # the two below are required as sprinkler and cooker have development accounts but are in the sandbox vpc
+      local.application_name == "sprinkler" ? format("arn:aws:iam::%s:role/member-delegation-garden-sandbox", local.environment_management.account_ids["core-vpc-sandbox"]) : format("arn:aws:iam::%s:role/modernisation-account-limited-read-member-access", local.environment_management.modernisation_platform_account_id),
+      local.application_name == "cooker" ? format("arn:aws:iam::%s:role/member-delegation-house-sandbox", local.environment_management.account_ids["core-vpc-sandbox"]) : format("arn:aws:iam::%s:role/modernisation-account-limited-read-member-access", local.environment_management.modernisation_platform_account_id)
+    ]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalOrgID"
+      values   = [data.aws_organizations_organization.root_account.id]
+    }
+    actions = ["sts:AssumeRole"]
+  }
+
+  # checkov:skip=CKV_AWS_111: "Cannot restrict by KMS alias so leaving open"
+  # checkov:skip=CKV_AWS_356: "Cannot restrict by KMS alias so leaving open"
+  statement {
+    sid       = "AllowOIDCToDecryptKMS"
+    effect    = "Allow"
+    resources = ["*"]
+    actions   = ["kms:Decrypt"]
+  }
+
+  statement {
+    sid       = "AllowOIDCReadState"
+    effect    = "Allow"
+    resources = ["arn:aws:s3:::modernisation-platform-terraform-state/*", "arn:aws:s3:::modernisation-platform-terraform-state/"]
+    actions = ["s3:Get*",
+    "s3:List*"]
+  }
+}
+
 # Github OIDC provider
 module "github-oidc" {
   count                  = (local.account_data.account-type == "member" && terraform.workspace != "testing-test") ? 1 : 0

--- a/terraform/modernisation-platform-account/iam.tf
+++ b/terraform/modernisation-platform-account/iam.tf
@@ -256,7 +256,7 @@ resource "aws_iam_role_policy_attachment" "modernisation_account_terraform_state
 module "github_oidc_plan_role" {
   source                 = "github.com/ministryofjustice/modernisation-platform-github-oidc-provider?ref=82f546bd5f002674138a2ccdade7d7618c6758b3" # v3.0.0
   role_name              = "github-actions-plan"
-  additional_permissions = data.aws_iam_policy_document.oidc_assume_plan_role_member[0].json
+  additional_permissions = data.aws_iam_policy_document.oidc_assume_plan_role_member.json
   github_repositories    = ["ministryofjustice/modernisation-platform:pull_request", "ministryofjustice/modernisation-platform-ami-builds:pull_request", "ministryofjustice/modernisation-platform-security:pull_request"]
   tags_common            = { "Name" = format("%s-oidc-plan", terraform.workspace) }
   tags_prefix            = ""


### PR DESCRIPTION
## A reference to the issue / Description of it

Non-main branches currently have full permissions for running terraform apply, which introduces risks of unintentional infrastructure modifications during development or testing

## How does this PR fix the problem?

A new OIDC role is introduced that limits non-main branches to only running terraform plan with read-only permissions. This setup allows to preview changes (terraform plan) without the ability to modify infrastructure, which is restricted to the main branch.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
