### PR TITLE
Separate OIDC roles for Terraform plan and apply with branch-based restrictions

### DIFF
--- a/terraform/modernisation-platform-account/iam.tf
+++ b/terraform/modernisation-platform-account/iam.tf
@@ -252,6 +252,44 @@ resource "aws_iam_role_policy_attachment" "modernisation_account_terraform_state
   policy_arn = aws_iam_policy.modernisation_account_terraform_state.arn
 }
 
+# OIDC Provider for GitHub Actions Plan
+module "github_oidc_plan_role" {
+  source                 = "github.com/ministryofjustice/modernisation-platform-github-oidc-provider?ref=82f546bd5f002674138a2ccdade7d7618c6758b3" # v3.0.0
+  role_name              = "github-actions-plan"
+  additional_permissions = data.aws_iam_policy_document.oidc_assume_plan_role_member.json
+  github_repositories    = ["ministryofjustice/modernisation-platform:pull_request", "ministryofjustice/modernisation-platform-ami-builds:pull_request", "ministryofjustice/modernisation-platform-security:pull_request"]
+  tags_common            = { "Name" = format("%s-oidc-plan", terraform.workspace) }
+  tags_prefix            = ""
+}
+data "aws_iam_policy_document" "oidc_assume_plan_role_member" {
+  # checkov:skip=CKV_AWS_111: "Cannot restrict by KMS alias so leaving open"
+  # checkov:skip=CKV_AWS_356: "Cannot restrict by KMS alias so leaving open"
+  statement {
+    sid       = "AllowOIDCToDecryptKMS"
+    effect    = "Allow"
+    resources = ["*"]
+    actions   = ["kms:Decrypt"]
+  }
+
+  statement {
+    sid       = "AllowOIDCReadState"
+    effect    = "Allow"
+    resources = ["arn:aws:s3:::modernisation-platform-terraform-state/*", "arn:aws:s3:::modernisation-platform-terraform-state/"]
+    actions = ["s3:Get*",
+    "s3:List*"]
+  }
+}
+
+# OIDC Provider for GitHub Actions Apply
+module "github-oidc" {
+  source                      = "github.com/ministryofjustice/modernisation-platform-github-oidc-provider?ref=82f546bd5f002674138a2ccdade7d7618c6758b3" # v3.0.0
+  role_name                   = "github-actions-apply"
+  additional_permissions      = data.aws_iam_policy_document.oidc-deny-specific-actions.json
+  additional_managed_policies = ["arn:aws:iam::aws:policy/AdministratorAccess"]
+  github_repositories         = ["ministryofjustice/modernisation-platform:ref:refs/heads/main", "ministryofjustice/modernisation-platform-ami-builds:ref:refs/heads/main", "ministryofjustice/modernisation-platform-security:ref:refs/heads/main"]
+  tags_common                 = { "Name" = format("%s-oidc-apply", terraform.workspace) }
+  tags_prefix                 = ""
+}
 
 # OIDC resources
 

--- a/terraform/modernisation-platform-account/iam.tf
+++ b/terraform/modernisation-platform-account/iam.tf
@@ -281,7 +281,7 @@ data "aws_iam_policy_document" "oidc_assume_plan_role_member" {
 }
 
 # OIDC Provider for GitHub Actions Apply
-module "github-oidc" {
+module "github_oidc_apply_role" {
   source                      = "github.com/ministryofjustice/modernisation-platform-github-oidc-provider?ref=82f546bd5f002674138a2ccdade7d7618c6758b3" # v3.0.0
   role_name                   = "github-actions-apply"
   additional_permissions      = data.aws_iam_policy_document.oidc-deny-specific-actions.json


### PR DESCRIPTION
## A reference to the issue / Description of it

This PR updates the OIDC role configuration to enhance security and ensure least-privilege access for GitHub Actions workflows. #8078 

## How does this PR fix the problem?

Previously, the OIDC role allowed all workflows to potentially perform `terraform apply` actions without restrictions to specific branches, which posed a risk of destructive actions occurring without sufficient review. By splitting roles and restricting `apply` to the main branch, this PR mitigates the risk of unauthorized or unreviewed changes.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
