### PR TITLE
 Add SSM Inventory Sync bucket/policy to Mod Platform account

### DIFF
--- a/terraform/modernisation-platform-account/s3.tf
+++ b/terraform/modernisation-platform-account/s3.tf
@@ -347,3 +347,93 @@ data "aws_iam_policy_document" "cost_management_bucket_policy" {
     }
   }
 }
+
+# SSM Inventory Sync Bucket
+module "ssm-inventory-sync-bucket" {
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=cadab519b10a7d28dfa3b77d407725db6b37614a" # v8.0.0
+  providers = {
+    aws.bucket-replication = aws.modernisation-platform-eu-west-1
+  }
+  bucket_policy       = [data.aws_iam_policy_document.ssm_inventory_sync_bucket_policy.json]
+  bucket_name         = "ssm-inventory-sync-bucket-euw2"
+  custom_kms_key      = aws_kms_key.s3_state_bucket_multi_region.arn
+  replication_enabled = false
+  lifecycle_rule = [
+    {
+      id      = "main"
+      enabled = "Enabled"
+      tags    = {}
+      transition = [
+        {
+          days          = 90
+          storage_class = "STANDARD_IA"
+          }, {
+          days          = 700
+          storage_class = "GLACIER"
+        }
+      ]
+      expiration = {
+        days = 730
+      }
+      noncurrent_version_transition = [
+        {
+          days          = 90
+          storage_class = "STANDARD_IA"
+          }, {
+          days          = 700
+          storage_class = "GLACIER"
+        }
+      ]
+      noncurrent_version_expiration = {
+        days = 730
+      }
+    }
+  ]
+  tags = local.tags
+}
+
+# SSM Inventory Sync Bucket Policy
+data "aws_iam_policy_document" "ssm_inventory_sync_bucket_policy" {
+  statement {
+    sid    = "SSMBucketPermissionsCheck"
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["ssm.amazonaws.com"]
+    }
+    actions   = ["s3:GetBucketAcl"]
+    resources = ["arn:aws:s3:::ssm-inventory-sync-bucket-euw2"]
+  }
+
+  statement {
+    sid    = "SSMBucketDelivery"
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["ssm.amazonaws.com"]
+    }
+    actions   = ["s3:PutObject"]
+    resources = ["arn:aws:s3:::ssm-inventory-sync-bucket-euw2/*/accountid=*/*"]
+    condition {
+      test     = "StringEquals"
+      variable = "s3:x-amz-acl"
+      values   = ["bucket-owner-full-control"]
+    }
+    condition {
+      test     = "ForAnyValue:StringLike"
+      variable = "aws:PrincipalOrgPaths"
+      values   = ["${data.aws_organizations_organization.root_account.id}/*/${local.environment_management.modernisation_platform_organisation_unit_id}/*"]
+    }
+  }
+
+  statement {
+    sid    = "SSMBucketDeliveryTagging"
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["ssm.amazonaws.com"]
+    }
+    actions   = ["s3:PutObjectTagging"]
+    resources = ["arn:aws:s3:::ssm-inventory-sync-bucket-euw2/*/accountid=*/*"]
+  }
+}

--- a/terraform/modernisation-platform-account/s3.tf
+++ b/terraform/modernisation-platform-account/s3.tf
@@ -350,7 +350,7 @@ data "aws_iam_policy_document" "cost_management_bucket_policy" {
 
 # SSM Inventory Sync Bucket
 module "ssm-inventory-sync-bucket" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=cadab519b10a7d28dfa3b77d407725db6b37614a" # v8.0.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=52a40b0dd18aaef0d7c5565d93cc8997aad79636" # v8.2.0
   providers = {
     aws.bucket-replication = aws.modernisation-platform-eu-west-1
   }


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/8360

## How does this PR fix the problem?

Adds a SSM inventory sync bucket and associated policy which grants the SSM service permission to add objects as long as they are in they originate from MP OU.

Next step will be to add a resource data sync to the bootstrap so that all other environments can send their inventory data to this central bucket.

## How has this been tested?

Terraform plan in status checks.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [X] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
