### PR TITLE
Amend `provision-member-directories.sh`

### DIFF
--- a/scripts/provision-member-directories.sh
+++ b/scripts/provision-member-directories.sh
@@ -167,7 +167,6 @@ EOL
   done
 
   cat >> $codeowners_file << EOL
-**/providers.tf @ministryofjustice/modernisation-platform
 **/backend.tf @ministryofjustice/modernisation-platform
 **/subnet_share.tf @ministryofjustice/modernisation-platform
 **/networking.auto.tfvars.json @ministryofjustice/modernisation-platform


### PR DESCRIPTION
## A reference to the issue / Description of it

#8272 

## How does this PR fix the problem?

Removes `providers.tf` from the autogenerated `CODEOWNERS` file we populate [modernisation-platform-environments](https://github.com/ministryofjustice/modernisation-platform-environments) with.

This is a precursory step to renaming the `platform_providers.tf` file in our templates directory.

## How has this been tested?

Tested script locally and confirmed behaviour

## Deployment Plan / Instructions

Deploy through CI, review PR in modernisation-platform-environments

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
