### PR TITLE
Fix permissions for GitHub Actions plan role to allow role assumption and add missing permissions

### DIFF
--- a/terraform/modernisation-platform-account/iam.tf
+++ b/terraform/modernisation-platform-account/iam.tf
@@ -265,10 +265,11 @@ module "github_actions_plan_role" {
 data "aws_iam_policy_document" "oidc_assume_plan_role_member" {
   # checkov:skip=CKV_AWS_111: "Cannot restrict by KMS alias so leaving open"
   # checkov:skip=CKV_AWS_356: "Cannot restrict by KMS alias so leaving open"
+  # checkov:skip=CKV_AWS_108: "Allowing secretsmanager:GetSecretValue with open resource due to specific use case"
   statement {
     effect    = "Allow"
     resources = ["*"]
-    actions   = [
+    actions = [
       "kms:Decrypt",
       "secretsmanager:GetSecretValue"
     ]


### PR DESCRIPTION
## A reference to the issue / Description of it

The` github-actions-plan` policy currently does not allow assuming roles and is missing required permissions for actions in the GitHub workflow. This results in failures when attempting to execute tasks during the `plan` step. #8078 

## How does this PR fix the problem?

The updated permissions explicitly grant the` sts:AssumeRole` action for the required roles and ensure that the policy includes read-only permissions for all resources needed during the `plan` step. This resolves the failures encountered when attempting to assume roles or access specific AWS resources in the current setup.

## How has this been tested?

tested manually editing the role

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)