### PR TITLE
Moving AP collaborators to different access level

### DIFF
--- a/collaborators.json
+++ b/collaborators.json
@@ -412,7 +412,7 @@
       "accounts": [
         {
           "account-name": "analytical-platform-ingestion-production",
-          "access": "read-only"
+          "access": "security-read-only"
         }
       ]
     },
@@ -422,7 +422,7 @@
       "accounts": [
         {
           "account-name": "analytical-platform-ingestion-production",
-          "access": "read-only"
+          "access": "security-read-only"
         }
       ]
     }


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/analytical-platform-ithc-2024/issues/26

External collaborators need read-only + security-audit access.

## How does this PR fix the problem?

Bumping them to the new `security-read-only` access level

## How has this been tested?

Testing post-deployment

## Deployment Plan / Instructions

This should not impact wider platform.

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)


