### PR TITLE
Removed `if` clause for `platform_versions.tf` from script

### DIFF
--- a/scripts/replace-platform-files-with-templates.sh
+++ b/scripts/replace-platform-files-with-templates.sh
@@ -17,12 +17,8 @@ do
           if [ -f "$file" ]; then
             filename=$(basename "$file")
             echo "    $filename"
-            if [ "$filename" == "platform_versions.tf" ]; then
-              echo "Skipping $filename"
-            else
-              cp "$file" "$subfolder/$filename"
-              sed -i '' "s/$token/$application_name/g" "$subfolder/$filename"
-            fi
+            cp "$file" "$subfolder/$filename"
+            sed -i '' "s/$token/$application_name/g" "$subfolder/$filename"
           fi
       done
     fi
@@ -30,4 +26,4 @@ do
 done
 
 echo
-echo "NOTE: This script skips sprinkler and cooker, and all platform_versions.tf files"
+echo "NOTE: This script skips sprinkler and cooker directories."


### PR DESCRIPTION
## A reference to the issue / Description of it

#8272 

## How does this PR fix the problem?

Because we no longer reference `platform_versions.tf` in our templates we no longer need to skip copying it.

## How has this been tested?

Ran script locally to confirm function

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
