### PR TITLE
Add permission for CloudWatch Synthetics to MemberInfrastructureAccess

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -187,6 +187,7 @@ data "aws_iam_policy_document" "member-access" {
       "sso-directory:DescribeUser",
       "sso-directory:DescribeGroup",
       "states:*",
+      "synthetics:*",
       "waf:*",
       "wafv2:*",
       "resource-groups:*",


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform-environments/actions/runs/11878640330

## How does this PR fix the problem?

Nuke jobs all failed due to a lack of permissions for CloudWatch Synthetics

## How has this been tested?

Not tested - but this is a simple PR that adds a permission to a role which we regularly manipulate.

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
