### PR TITLE
Add s3:GetObjectACL permission to allow cross-account object download

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -261,6 +261,7 @@ data "aws_iam_policy_document" "developer_additional" {
       "s3:PutObject",
       "s3:DeleteObject",
       "s3:DeleteObjectVersion",
+      "s3:GetObjectAcl",
       "s3:PutObjectAcl",
       "s3:RestoreObject",
       "s3:*StorageLens*",


### PR DESCRIPTION
## A reference to the issue / Description of it

https://mojdt.slack.com/archives/C01A7QK5VM1/p1731918476419409

## How does this PR fix the problem?

This PR addresses the issue where cross-account users are unable to download objects to the artifact bucket due to missing permissions. By adding the s3:GettObjectACL permission, users from other accounts will now have the ability to get the objects, ensuring successful download from the command line.

## How has this been tested?

Tested manually on developer role

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?


## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)
