### PR TITLE
Additional data engineer permissions

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/main.tf
+++ b/terraform/environments/bootstrap/single-sign-on/main.tf
@@ -5,7 +5,6 @@ locals {
 }
 
 # Get MP-specific AWS SSO permission sets
-
 data "terraform_remote_state" "mp-sso-permissions-sets" {
   backend = "s3"
   config = {
@@ -16,7 +15,6 @@ data "terraform_remote_state" "mp-sso-permissions-sets" {
     encrypt = "true"
   }
 }
-
 
 # Get Identity Store groups
 data "aws_identitystore_group" "platform_admin" {
@@ -31,7 +29,6 @@ data "aws_identitystore_group" "platform_admin" {
     }
   }
 }
-
 
 # Get Identity Store groups
 data "aws_identitystore_group" "member" {
@@ -50,6 +47,7 @@ data "aws_identitystore_group" "member" {
   }
 }
 
+# Create account assignments
 resource "aws_ssoadmin_account_assignment" "platform_admin" {
 
   provider = aws.sso-management

--- a/terraform/environments/bootstrap/single-sign-on/main.tf
+++ b/terraform/environments/bootstrap/single-sign-on/main.tf
@@ -307,6 +307,14 @@ resource "aws_ssoadmin_account_assignment" "data_engineer" {
   target_type = "AWS_ACCOUNT"
 }
 
+resource "aws_ssoadmin_managed_policy_attachment" "data_engineer_lakeformation_crossaccountmanager" {
+  depends_on = [aws_ssoadmin_account_assignment.data_engineer]
+
+  instance_arn       = local.sso_instance_arn
+  managed_policy_arn = "arn:aws:iam::aws:policy/AWSLakeFormationCrossAccountManager"
+  permission_set_arn = data.terraform_remote_state.mp-sso-permissions-sets.outputs.data_engineer
+}
+
 resource "aws_ssoadmin_account_assignment" "reporting-operations" {
 
   for_each = {

--- a/terraform/environments/bootstrap/single-sign-on/main.tf
+++ b/terraform/environments/bootstrap/single-sign-on/main.tf
@@ -308,6 +308,7 @@ resource "aws_ssoadmin_account_assignment" "data_engineer" {
 }
 
 resource "aws_ssoadmin_managed_policy_attachment" "data_engineer_lakeformation_crossaccountmanager" {
+  provider   = aws.sso-management
   depends_on = [aws_ssoadmin_account_assignment.data_engineer]
 
   instance_arn       = local.sso_instance_arn


### PR DESCRIPTION
## A reference to the issue / Description of it

#8285

## How does this PR fix the problem?

This PR attaches an AWS managed policy to the Data Engineering role so that data engineers can responsibly investigate what they require to place into code for Lake Formation cross-account sharing.

Cross-account sharing will still require the receiving account to accept the resource share.

You can see the AWSLakeFormationCrossAccountManager policy [here](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AWSLakeFormationCrossAccountManager.html).

You will note that it does not have [ram:AcceptResourceShareInvitation](https://docs.aws.amazon.com/ram/latest/APIReference/API_AcceptResourceShareInvitation.html).

## How has this been tested?

Will be tested by deployment to sprinkler

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
