### PR TITLE
Add inventory resource data sync to member bootstrap

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/ssm.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/ssm.tf
@@ -127,3 +127,14 @@ resource "aws_ssm_resource_data_sync" "security_account" {
     kms_key_arn = local.environment_management.ssm_resource_sync_kms_arn
   }
 }
+
+# Mod Platform SSM Inventory Resource Data Sync
+# This will gather inventory data from all MP accounts and deliver to a central S3 bucket hosted in the organisation-security account
+resource "aws_ssm_resource_data_sync" "mod_platform_inventory_sync" {
+  name = "mod-platform-inventory-resource-data-sync"
+  s3_destination {
+    bucket_name = local.environment_management.mp_ssm_inventory_resource_data_sync_bucket_name
+    region      = data.aws_region.current.name
+    sync_format = "JsonSerDe"
+  }
+}


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/8360

## How does this PR fix the problem?

This PR creates a resource data sync in the bootstrap which will send all the gathered inventory data into a central bucket in the `organisation-security` account.

To note:
An SSM [global inventory association](https://docs.aws.amazon.com/systems-manager/latest/userguide/inventory-collection.html#inventory-management-inventory-all) has already been applied to every account because AWS Inspector has been configured at the organisation level. This means that by default any accounts with instances using the SSM agent are already reporting their inventory information every 30 minutes. This is why I haven't configured a separate resource to enable this as the information is already being collected. This PR will now ensure that the data being collected is synced into a central s3 bucket which we can query with Athena.

## How has this been tested?

Tested successfully in Sprinkler (see status checks).

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
