### PR TITLE
Restrict GitHub OIDC role permissions to main branch

### DIFF
--- a/.github/workflows/remove-default-vpc.yml
+++ b/.github/workflows/remove-default-vpc.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
         with:
-          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions-apply"
           role-session-name: githubactionsrolesession
           aws-region: ${{ env.AWS_REGION }}
 


### PR DESCRIPTION
## A reference to the issue / Description of it

This PR updates the GitHub Actions OIDC role to enhance security by restricting admin-level permissions to the `main` branch only #8078 

## How does this PR fix the problem?

Admin permissions are only available on the main branch, preventing potentially harmful terraform apply commands from running in pull requests or non-reviewed branches.
Engineers must go through the review and merge process, enforcing compliance with the code review policies and enhancing overall security.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
