### PR TITLE
Add GuardDuty S3 malware protection role and policy

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -795,7 +795,7 @@ trusted_role_arns = [
   ]
   create_role = true
   role_name   = "GuardDutyMalwareProtectionRole"
-  role_requires_mfa = true
+  role_requires_mfa = false
 
   custom_role_policy_arns = [
     data.aws_iam_policy.guardduty_malware.arn

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -780,3 +780,29 @@ resource "aws_iam_account_alias" "alias" {
   count         = (local.account_data.account-type != "member-unrestricted") && !(contains(local.skip_alias, terraform.workspace)) ? 1 : 0
   account_alias = terraform.workspace
 }
+# GuardDuty Malware Protection Role
+module "guardduty_malware_protection_role" {
+  # checkov:skip=CKV_TF_1:
+
+  count  = local.account_data.account-type == "member" ? 1 : 0
+  source = "github.com/terraform-aws-modules/terraform-aws-iam//modules/iam-assumable-role?ref=e20e0b9a42084bbc885fd5abb18b8744810bd567" # v5.48.0
+
+  trusted_role_services = [
+    "malware-protection-plan.guardduty.amazonaws.com"
+  ]
+trusted_role_arns = [
+    local.modernisation_platform_account.id
+  ]
+  create_role = true
+  role_name   = "GuardDutyMalwareProtectionRole"
+  role_requires_mfa = true
+
+  custom_role_policy_arns = [
+    data.aws_iam_policy.guardduty_malware.arn
+  ]
+  number_of_custom_role_policy_arns = 1
+}
+
+data "aws_iam_policy" "guardduty_malware" {
+  name = "GuardDutyMalwareProtectionPolicy"
+}

--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -1444,7 +1444,7 @@ data "aws_iam_policy_document" "guardduty_policy_document" {
       "kms:GenerateDataKey",
       "kms:Decrypt"
     ]
-    resources = ["${aws_kms_key.malware_protection_key.arn}"]
+    resources = ["*"]
     condition {
       test     = "StringLike"
       variable = "kms:ViaService"

--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -1390,3 +1390,74 @@ data "aws_iam_policy_document" "s3_upload_policy_document" {
     ]
   }
 }
+# IAM Policy for GuardDuty Malware Protection
+resource "aws_iam_policy" "guardduty_policy" {
+  name        = "GuardDutyMalwareProtectionPolicy"
+  description = "Policy for GuardDuty Malware Protection Plan"
+  policy      = aws_iam_policy_document.guardduty_policy_document.json
+}
+
+# IAM Policy Document for GuardDuty Malware Protection
+resource "aws_iam_policy_document" "guardduty_policy_document" {
+  statement {
+    sid     = "EventBridgeActionsForGuardDuty"
+    effect  = "Allow"
+    actions = [
+      "events:PutRule",
+      "events:DeleteRule",
+      "events:PutTargets",
+      "events:RemoveTargets",
+      "events:DescribeRule",
+      "events:ListTargetsByRule"
+    ]
+    resources = [
+      "arn:aws:events:eu-west-2:${local.environment_management.modernisation_platform_account_id}:rule/DO-NOT-DELETE-AmazonGuardDutyMalwareProtectionS3*"
+    ]
+    condition {
+      test     = "StringLike"
+      variable = "events:ManagedBy"
+      values   = ["malware-protection-plan.guardduty.amazonaws.com"]
+    }
+  }
+
+  statement {
+    sid     = "S3ActionsForGuardDuty"
+    effect  = "Allow"
+    actions = [
+      "s3:PutObjectTagging",
+      "s3:GetObjectTagging",
+      "s3:PutObjectVersionTagging",
+      "s3:GetObjectVersionTagging",
+      "s3:PutBucketNotification",
+      "s3:GetBucketNotification",
+      "s3:PutObject",
+      "s3:GetObject",
+      "s3:GetObjectVersion",
+      "s3:GetBucketAcl",
+      "s3:ListBucket",
+      "s3:PutObjectAcl"
+    ]
+    resources = [
+      "arn:aws:s3:::*/malware-protection-resource-validation-object",
+      "arn:aws:s3:::*"
+    ]
+    condition {
+      test     = "StringEqualsIfExists"
+      variable = "aws:CalledVia"
+      values   = ["malware-protection-plan.guardduty.amazonaws.com"]
+    }
+  }
+
+  statement {
+    sid     = "AllowPassGuardDutyRole"
+    effect  = "Allow"
+    actions = ["iam:PassRole"]
+    resources = ["arn:aws:iam::*:role/GuardDutyMalwareProtectionRole"]
+    condition {
+      test     = "StringEqualsIfExists"
+      variable = "iam:PassedToService"
+      values   = ["malware-protection-plan.guardduty.amazonaws.com"]
+    }
+  }
+}
+

--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -1437,6 +1437,20 @@ data "aws_iam_policy_document" "guardduty_policy_document" {
       values   = ["malware-protection-plan.guardduty.amazonaws.com"]
     }
   }
+  statement {
+    sid     = "AllowDecryptForMalwareScan"
+    effect  = "Allow"
+    actions = [
+      "kms:GenerateDataKey",
+      "kms:Decrypt"
+    ]
+    resources = ["${aws_kms_key.malware_protection_key.arn}"]
+    condition {
+      test     = "StringLike"
+      variable = "kms:ViaService"
+      values   = ["s3.eu-west-2.amazonaws.com"]
+    }
+  }
 
   statement {
     sid     = "AllowPassGuardDutyRole"

--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -1394,21 +1394,17 @@ data "aws_iam_policy_document" "s3_upload_policy_document" {
 resource "aws_iam_policy" "guardduty_policy" {
   name        = "GuardDutyMalwareProtectionPolicy"
   description = "Policy for GuardDuty Malware Protection Plan"
-  policy      = aws_iam_policy_document.guardduty_policy_document.json
+  policy      = data.aws_iam_policy_document.guardduty_policy_document.json
 }
 
 # IAM Policy Document for GuardDuty Malware Protection
-resource "aws_iam_policy_document" "guardduty_policy_document" {
+data "aws_iam_policy_document" "guardduty_policy_document" {
   statement {
     sid     = "EventBridgeActionsForGuardDuty"
     effect  = "Allow"
     actions = [
-      "events:PutRule",
-      "events:DeleteRule",
-      "events:PutTargets",
-      "events:RemoveTargets",
-      "events:DescribeRule",
-      "events:ListTargetsByRule"
+    "events:*Rule",
+    "events:*Targets"
     ]
     resources = [
       "arn:aws:events:eu-west-2:${local.environment_management.modernisation_platform_account_id}:rule/DO-NOT-DELETE-AmazonGuardDutyMalwareProtectionS3*"
@@ -1424,18 +1420,12 @@ resource "aws_iam_policy_document" "guardduty_policy_document" {
     sid     = "S3ActionsForGuardDuty"
     effect  = "Allow"
     actions = [
-      "s3:PutObjectTagging",
-      "s3:GetObjectTagging",
-      "s3:PutObjectVersionTagging",
-      "s3:GetObjectVersionTagging",
-      "s3:PutBucketNotification",
-      "s3:GetBucketNotification",
-      "s3:PutObject",
-      "s3:GetObject",
-      "s3:GetObjectVersion",
-      "s3:GetBucketAcl",
-      "s3:ListBucket",
-      "s3:PutObjectAcl"
+    "s3:PutObject*",
+    "s3:GetObject*",
+    "s3:GetBucket*",
+    "s3:ListBucket",
+    "s3:PutBucketNotification",
+    "s3:GetBucketNotification"
     ]
     resources = [
       "arn:aws:s3:::*/malware-protection-resource-validation-object",


### PR DESCRIPTION
## A reference to the issue / Description of it

#8050 
## How does this PR fix the problem?

This PR adds a new role and policy configuration for GuardDuty S3 malware protection. This will help detect and mitigate malware in files uploaded to S3 buckets across our accounts. 
The policy gives permissions for:
EventBridge Management: Managing rules and targets specific to GuardDuty operations.
S3 Access: Accessing objects, managing bucket notifications, and handling validation objects for scanning. But also tagging so post-scan it will show if threat was found/not found.
KMS: for decryption

More detailed information can be found here: https://docs.aws.amazon.com/guardduty/latest/ug/malware-protection-s3-iam-policy-prerequisite.html

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
