### PR TITLE
Fix Missing Assume Roles in GitHub Actions OIDC Plan Role

### DIFF
--- a/terraform/modernisation-platform-account/iam.tf
+++ b/terraform/modernisation-platform-account/iam.tf
@@ -293,7 +293,16 @@ data "aws_iam_policy_document" "oidc_assume_plan_role_member" {
     actions = [
       "sts:AssumeRole"
     ]
-    resources = ["arn:aws:iam::${local.environment_management.account_ids["core-logging-production"]}:role/ModernisationPlatformAccess"]
+    resources = [
+      "arn:aws:iam::${local.environment_management.account_ids["core-logging-production"]}:role/ModernisationPlatformAccess",
+      "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess",
+      "arn:aws:iam::${local.environment_management.account_ids["core-vpc-development"]}:role/ModernisationPlatformAccess",
+      "arn:aws:iam::${local.environment_management.account_ids["core-vpc-preproduction"]}:role/ModernisationPlatformAccess",
+      "arn:aws:iam::${local.environment_management.account_ids["core-vpc-production"]}:role/ModernisationPlatformAccess",
+      "arn:aws:iam::${local.environment_management.account_ids["core-security-production"]}:role/ModernisationPlatformAccess",
+      "arn:aws:iam::${local.environment_management.account_ids["testing-test"]}:role/ModernisationPlatformAccess",
+      "arn:aws:iam::${local.environment_management.aws_organizations_root_account_id}:role/ModernisationPlatformSSOAdministrator"
+    ]
   }
 
   statement {


### PR DESCRIPTION
This PR updates the GitHub Actions OIDC role to include the missing assume roles that were causing failures in the pipeline. Certain workflows were failing due to insufficient permissions for assuming the necessary roles, leading to execution errors. By adding the required assume roles to the OIDC role configuration, these failures will be resolved. #8078 