### PR TITLE
Update assume role in OIDC plan role

### DIFF
--- a/terraform/modernisation-platform-account/iam.tf
+++ b/terraform/modernisation-platform-account/iam.tf
@@ -300,6 +300,7 @@ data "aws_iam_policy_document" "oidc_assume_plan_role_member" {
       "arn:aws:iam::${local.environment_management.account_ids["core-vpc-preproduction"]}:role/ModernisationPlatformAccess",
       "arn:aws:iam::${local.environment_management.account_ids["core-vpc-production"]}:role/ModernisationPlatformAccess",
       "arn:aws:iam::${local.environment_management.account_ids["core-security-production"]}:role/ModernisationPlatformAccess",
+      "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/ModernisationPlatformAccess",
       "arn:aws:iam::${local.environment_management.account_ids["testing-test"]}:role/ModernisationPlatformAccess",
       "arn:aws:iam::${local.environment_management.aws_organizations_root_account_id}:role/ModernisationPlatformSSOAdministrator"
     ]


### PR DESCRIPTION
This PR updates the GitHub Actions OIDC role to include the missing assume role that were causing failures in the pipeline.

https://github.com/ministryofjustice/modernisation-platform/actions/runs/11912296203/job/33197467818#step:12:26