### PR TITLE
Edit SSM Inventory Sync bucket policy for matching source org ID

### DIFF
--- a/terraform/modernisation-platform-account/s3.tf
+++ b/terraform/modernisation-platform-account/s3.tf
@@ -420,9 +420,9 @@ data "aws_iam_policy_document" "ssm_inventory_sync_bucket_policy" {
       values   = ["bucket-owner-full-control"]
     }
     condition {
-      test     = "ForAnyValue:StringLike"
-      variable = "aws:PrincipalOrgPaths"
-      values   = ["${data.aws_organizations_organization.root_account.id}/*/${local.environment_management.modernisation_platform_organisation_unit_id}/*"]
+      test     = "StringEquals"
+      variable = "aws:SourceOrgID"
+      values   = ["${data.aws_organizations_organization.root_account.id}"]
     }
   }
 

--- a/terraform/modernisation-platform-account/s3.tf
+++ b/terraform/modernisation-platform-account/s3.tf
@@ -422,7 +422,7 @@ data "aws_iam_policy_document" "ssm_inventory_sync_bucket_policy" {
     condition {
       test     = "StringEquals"
       variable = "aws:SourceOrgID"
-      values   = ["${data.aws_organizations_organization.root_account.id}"]
+      values   = [data.aws_organizations_organization.root_account.id]
     }
   }
 


### PR DESCRIPTION
## A reference to the issue / Description of it

Having created a central bucket to store inventory data in the Modernisation Platform account I subsequently tried to create a resource data sync from Sprinkler but encountered an access denied error: https://github.com/ministryofjustice/modernisation-platform/actions/runs/11895397311/job/33146521856?pr=8517#step:7:236

## How does this PR fix the problem?

After troubleshooting with AWS support it seemed that my policy where I had deviated slightly from AWS's [suggested one](https://docs.aws.amazon.com/systems-manager/latest/userguide/inventory-create-resource-data-sync.html#systems-manager-inventory-resource-data-sync-AWS-Organizations) was causing the issue.

I can only restrict this down to the source org ID of the MoJ organization rather than a `ForAnyValue:StringLike` in `aws:PrincipalOrgPaths`.

Though this means MoJ accounts outside of MP could sync their inventory data into the bucket I would say the risk of malicious activity is acceptably low. I won't be creating a resource data sync for those accounts anyhow as they are out of scope.

## How has this been tested?

Manually tested in CLI/console.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [X] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
