### PR TITLE
Remove github-actions role from Sprinkler

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -4,7 +4,7 @@ locals {
 }
 
 module "member-access" {
-  count                  = local.account_data.account-type == "member" && terraform.workspace != "testing-test" ? 1 : 0
+  count                  = (local.account_data.account-type == "member" && terraform.workspace != "testing-test" && terraform.workspace != "sprinkler-development") ? 1 : 0
   source                 = "github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access?ref=6819b090bce6d3068d55c7c7b9b3fd18c9dca648" #v3.0.0
   account_id             = local.modernisation_platform_account.id
   additional_trust_roles = [module.github-oidc[0].github_actions_role, one(data.aws_iam_roles.member-sso-admin-access.arns)]
@@ -323,7 +323,7 @@ resource "aws_iam_role_policy_attachment" "testing_member_infrastructure_access_
 
 # MemberInfrastructureAccessUSEast
 module "member-access-us-east" {
-  count                  = local.account_data.account-type == "member" && terraform.workspace != "testing-test" ? 1 : 0
+  count                  = (local.account_data.account-type == "member" && terraform.workspace != "testing-test" && terraform.workspace != "sprinkler-development") ? 1 : 0
   source                 = "github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access?ref=6819b090bce6d3068d55c7c7b9b3fd18c9dca648" #v3.0.0
   account_id             = local.modernisation_platform_account.id
   additional_trust_roles = [module.github-oidc[0].github_actions_role, one(data.aws_iam_roles.member-sso-admin-access.arns)]
@@ -597,7 +597,7 @@ data "aws_iam_policy_document" "policy" {
 
 # MemberInfrastructureBedrockEuCentral
 module "member-access-eu-central" {
-  count                  = local.account_data.account-type == "member" && terraform.workspace != "testing-test" ? 1 : 0
+  count                  = (local.account_data.account-type == "member" && terraform.workspace != "testing-test" && terraform.workspace != "sprinkler-development") ? 1 : 0
   source                 = "github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access?ref=6819b090bce6d3068d55c7c7b9b3fd18c9dca648" #v3.0.0
   account_id             = local.modernisation_platform_account.id
   additional_trust_roles = [module.github-oidc[0].github_actions_role, one(data.aws_iam_roles.member-sso-admin-access.arns)]

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -701,7 +701,7 @@ resource "aws_ssm_parameter" "modernisation_platform_account_id" {
 
 # Github OIDC provider
 module "github-oidc" {
-  count                  = (local.account_data.account-type == "member" && terraform.workspace != "testing-test") ? 1 : 0
+  count                  = (local.account_data.account-type == "member" && terraform.workspace != "testing-test" && terraform.workspace != "sprinkler-development") ? 1 : 0
   source                 = "github.com/ministryofjustice/modernisation-platform-github-oidc-provider?ref=82f546bd5f002674138a2ccdade7d7618c6758b3" # v3.0.0
   additional_permissions = data.aws_iam_policy_document.oidc_assume_role_member[0].json
   github_repositories    = ["ministryofjustice/modernisation-platform-environments:*"]
@@ -710,7 +710,7 @@ module "github-oidc" {
 }
 
 data "aws_iam_policy_document" "oidc_assume_role_member" {
-  count = local.account_data.account-type == "member" && terraform.workspace != "testing-test" ? 1 : 0
+  count = (local.account_data.account-type == "member" && terraform.workspace != "testing-test" && terraform.workspace != "sprinkler-development") ? 1 : 0
   statement {
     sid    = "AllowOIDCToAssumeRoles"
     effect = "Allow"
@@ -720,8 +720,7 @@ data "aws_iam_policy_document" "oidc_assume_role_member" {
       format("arn:aws:iam::%s:role/modernisation-account-limited-read-member-access", local.environment_management.modernisation_platform_account_id),
       format("arn:aws:iam::%s:role/modernisation-account-terraform-state-member-access", local.environment_management.modernisation_platform_account_id),
       format("arn:aws:iam::%s:role/ModernisationPlatformSSOReadOnly", local.environment_management.aws_organizations_root_account_id),
-      # the two below are required as sprinkler and cooker have development accounts but are in the sandbox vpc
-      local.application_name == "sprinkler" ? format("arn:aws:iam::%s:role/member-delegation-garden-sandbox", local.environment_management.account_ids["core-vpc-sandbox"]) : format("arn:aws:iam::%s:role/modernisation-account-limited-read-member-access", local.environment_management.modernisation_platform_account_id),
+      # the following are required as cooker have development accounts but are in the sandbox vpc
       local.application_name == "cooker" ? format("arn:aws:iam::%s:role/member-delegation-house-sandbox", local.environment_management.account_ids["core-vpc-sandbox"]) : format("arn:aws:iam::%s:role/modernisation-account-limited-read-member-access", local.environment_management.modernisation_platform_account_id)
     ]
     condition {


### PR DESCRIPTION
This PR removes the `github-actions` and `MemberInfrastructureAccess` roles from `Sprinkler` and will be replaced with a new role in a subsequent PR.