### PR TITLE
Update assume role in OIDC plan role

### DIFF
--- a/terraform/modernisation-platform-account/iam.tf
+++ b/terraform/modernisation-platform-account/iam.tf
@@ -299,6 +299,8 @@ data "aws_iam_policy_document" "oidc_assume_plan_role_member" {
       "arn:aws:iam::${local.environment_management.account_ids["core-vpc-development"]}:role/ModernisationPlatformAccess",
       "arn:aws:iam::${local.environment_management.account_ids["core-vpc-preproduction"]}:role/ModernisationPlatformAccess",
       "arn:aws:iam::${local.environment_management.account_ids["core-vpc-production"]}:role/ModernisationPlatformAccess",
+      "arn:aws:iam::${local.environment_management.account_ids["core-vpc-sandbox"]}:role/ModernisationPlatformAccess",
+      "arn:aws:iam::${local.environment_management.account_ids["core-vpc-test"]}:role/ModernisationPlatformAccess",
       "arn:aws:iam::${local.environment_management.account_ids["core-security-production"]}:role/ModernisationPlatformAccess",
       "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/ModernisationPlatformAccess",
       "arn:aws:iam::${local.environment_management.account_ids["testing-test"]}:role/ModernisationPlatformAccess",


### PR DESCRIPTION
This PR updates the GitHub Actions OIDC role to include the missing assume role that were causing failures in the pipeline.

https://github.com/ministryofjustice/modernisation-platform/actions/runs/11934108449/job/33262827504#step:12:48