### PR TITLE
Add OIDC role for sprinkler

### DIFF
--- a/terraform/environments/sprinkler/iam.tf
+++ b/terraform/environments/sprinkler/iam.tf
@@ -1,0 +1,23 @@
+# OIDC resources
+
+module "github-oidc" {
+  source                      = "github.com/ministryofjustice/modernisation-platform-github-oidc-provider?ref=84a83751b5289f363a728eb181470b59fc5e2899" # v3.0.1
+  additional_permissions      = data.aws_iam_policy_document.oidc_deny_specific_actions.json
+  additional_managed_policies = ["arn:aws:iam::aws:policy/AdministratorAccess"]
+  github_repositories         = ["ministryofjustice/modernisation-platform:*"]
+  tags_common                 = { "Name" = format("%s-oidc", terraform.workspace) }
+  tags_prefix                 = ""
+}
+
+data "aws_iam_policy_document" "oidc_deny_specific_actions" {
+  statement {
+    effect = "Deny"
+    actions = [
+      "iam:ChangePassword",
+      "iam:CreateLoginProfile",
+      "iam:DeleteUser",
+      "iam:DeleteVirtualMFADevice"
+    ]
+    resources = ["*"]
+  }
+}


### PR DESCRIPTION
This PR introduces an OIDC role for Sprinkler to replace the previously removed `github-actions` role.