### PR TITLE
Conditionally load OIDC role for `sprinkler-development` workspace only

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -16,7 +16,7 @@ module "member-access-sprinkler" {
   count                  = (terraform.workspace == "sprinkler-development") ? 1 : 0
   source                 = "github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access?ref=6819b090bce6d3068d55c7c7b9b3fd18c9dca648" #v3.0.0
   account_id             = local.modernisation_platform_account.id
-  additional_trust_roles = [data.aws_iam_role.sprinkler_oidc.arn, one(data.aws_iam_roles.member-sso-admin-access.arns)]
+  additional_trust_roles = [data.aws_iam_role.sprinkler_oidc[0].arn, one(data.aws_iam_roles.member-sso-admin-access.arns)]
   policy_arn             = aws_iam_policy.member-access[0].id
   role_name              = "MemberInfrastructureAccess"
 }
@@ -344,7 +344,7 @@ module "member-access-us-east-sprinkler" {
   count                  = (terraform.workspace == "sprinkler-development") ? 1 : 0
   source                 = "github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access?ref=6819b090bce6d3068d55c7c7b9b3fd18c9dca648" #v3.0.0
   account_id             = local.modernisation_platform_account.id
-  additional_trust_roles = [data.aws_iam_role.sprinkler_oidc.arn, one(data.aws_iam_roles.member-sso-admin-access.arns)]
+  additional_trust_roles = [data.aws_iam_role.sprinkler_oidc[0].arn, one(data.aws_iam_roles.member-sso-admin-access.arns)]
   policy_arn             = aws_iam_policy.member-access-us-east[0].id
   role_name              = "MemberInfrastructureAccessUSEast"
 }
@@ -627,7 +627,7 @@ module "member-access-eu-central-sprinkler" {
   count                  = (terraform.workspace == "sprinkler-development") ? 1 : 0
   source                 = "github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access?ref=6819b090bce6d3068d55c7c7b9b3fd18c9dca648" #v3.0.0
   account_id             = local.modernisation_platform_account.id
-  additional_trust_roles = [data.aws_iam_role.sprinkler_oidc.arn, one(data.aws_iam_roles.member-sso-admin-access.arns)]
+  additional_trust_roles = [data.aws_iam_role.sprinkler_oidc[0].arn, one(data.aws_iam_roles.member-sso-admin-access.arns)]
   policy_arn             = aws_iam_policy.member-access-eu-central[0].id
   role_name              = "MemberInfrastructureBedrockEuCentral"
 }

--- a/terraform/environments/bootstrap/member-bootstrap/locals.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/locals.tf
@@ -16,6 +16,7 @@ data "aws_iam_roles" "member-sso-admin-access" {
 }
 
 data "aws_iam_role" "sprinkler_oidc" {
+  count = (terraform.workspace == "sprinkler-development") ? 1 : 0
   name  = "github-actions"
 }
 


### PR DESCRIPTION
This PR introduces conditional logic to the `sprinkler_oidc` IAM role data block. The role is only loaded for the `sprinkler-development` workspace, ensuring that it is not retrieved or used in other environments.