### PR TITLE
iam:PassRole permission 

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -327,17 +327,21 @@ data "aws_iam_policy_document" "developer_additional" {
     resources = ["arn:aws:iam::*:user/cicd-member-user"]
   }
 
-  statement {
-    sid       = "iamForECSAllow"
-    effect    = "Allow"
-    actions   = ["iam:PassRole"]
-    resources = ["*"]
-    condition {
-      test     = "StringEquals"
-      variable = "iam:PassedToService"
-      values   = ["ecs.amazonaws.com"]
-    }
+statement {
+  sid       = "iamForECSAndGuardDutyAllow"
+  effect    = "Allow"
+  actions   = ["iam:PassRole"]
+  resources = ["*"]
+  condition {
+    test     = "StringEquals"
+    variable = "iam:PassedToService"
+    values   = [
+      "ecs.amazonaws.com",
+      "malware-protection-plan.guardduty.amazonaws.com"
+    ]
   }
+}
+
 
   statement {
     sid    = "cloudWatchCrossAccountAllow"


### PR DESCRIPTION
## A reference to the issue / Description of it

User: arn:aws:sts::348456244381:assumed-role/AWSReservedSSO_modernisation-platform-developeris not authorized to perform: iam:PassRole on resource: arn:aws:iam::acctNR:role/S3MalwareProtectionRole


## How does this PR fix the problem?

This PR adds the required iam:PassRole permission to allow the GuardDuty service (malware-protection-plan.guardduty.amazonaws.com) to assume the S3MalwareProtectionRole.
## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
