### PR TITLE
Adding Sukesh to the on-call rota

### DIFF
--- a/terraform/pagerduty/policy-schedules.tf
+++ b/terraform/pagerduty/policy-schedules.tf
@@ -70,7 +70,8 @@ resource "pagerduty_schedule" "primary" {
       local.edward_proctor,
       local.ewa_stempel,
       local.mark_roberts,
-      local.aaron_robinson
+      local.aaron_robinson,
+      local.sukesh_reddygade
     ]
   }
 
@@ -99,8 +100,9 @@ resource "pagerduty_schedule" "secondary" {
       local.david_sibley,
       local.ewa_stempel,
       local.edward_proctor,
-      local.aaron_robinson,
-      local.mark_roberts
+      local.sukesh_reddygade,
+      local.mark_roberts,
+      local.aaron_robinson
     ]
   }
 


### PR DESCRIPTION
## Description of it

This is to add Sukesh to our on-call rota (primary and secondary)

## How has this been tested?

Terraform plan was run locally and the terraform output was reflecting the code changes.

## Deployment Plan / Instructions

The schedule will be autogenerated once this PR is merged. One full cycle of the current schedule will be preserved by manually overriding first seven weeks of the newly generated schedule.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional information
See [this slack thread](https://mojdt.slack.com/archives/C013RM6MFFW/p1732112592620299) for more details.