### PR TITLE
Update repository module to `allow_update_branch` by default

### DIFF
--- a/terraform/github/modules/repository/main.tf
+++ b/terraform/github/modules/repository/main.tf
@@ -8,22 +8,23 @@ locals {
 resource "github_repository" "default" {
   name                   = var.name
   description            = join(" • ", [var.description, "This repository is defined and managed in Terraform"])
-  homepage_url           = var.homepage_url
-  visibility             = var.visibility
+  allow_merge_commit     = true
+  allow_squash_merge     = true
+  allow_rebase_merge     = true
+  allow_update_branch    = true
+  archived               = false
+  archive_on_destroy     = true
+  auto_init              = false
+  delete_branch_on_merge = true
   has_issues             = true
   has_projects           = true
   has_wiki               = var.type == "core" ? true : false
   has_downloads          = true
+  homepage_url           = var.homepage_url
   is_template            = var.type == "template" ? true : false
-  allow_merge_commit     = true
-  allow_squash_merge     = true
-  allow_rebase_merge     = true
-  delete_branch_on_merge = true
-  auto_init              = false
-  archived               = false
-  archive_on_destroy     = true
-  vulnerability_alerts   = true
   topics                 = concat(local.topics, var.topics)
+  visibility             = var.visibility
+  vulnerability_alerts   = true
 
   security_and_analysis {
     dynamic "advanced_security" {


### PR DESCRIPTION
## A reference to the issue / Description of it

https://mojdt.slack.com/archives/C01A7QK5VM1/p1732213198294939

## How does this PR fix the problem?

Adds allow_update_branch to repository module, so that all repositories allow the updating of branches through the UI. You can see this option described here: https://github.blog/changelog/2022-02-03-more-ways-to-keep-your-pull-request-branch-up-to-date/

## How has this been tested?

Not tested - we could enable this manually in a repository to confirm the behaviour before applying the change through code

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
