### PR TITLE
add guardduty permissions and update trust policy for MemberInfrastructureAccess role

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -4,27 +4,27 @@ locals {
 }
 
 module "member-access" {
-  count                  = (local.account_data.account-type == "member" && terraform.workspace != "testing-test" && terraform.workspace != "sprinkler-development") ? 1 : 0
-  source                 = "github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access?ref=6819b090bce6d3068d55c7c7b9b3fd18c9dca648" #v3.0.0
-  account_id             = local.modernisation_platform_account.id
-  additional_trust_roles = [module.github-oidc[0].github_actions_role, one(data.aws_iam_roles.member-sso-admin-access.arns)] 
-  policy_arn             = aws_iam_policy.member-access[0].id
-  role_name              = "MemberInfrastructureAccess"
+  count                       = (local.account_data.account-type == "member" && terraform.workspace != "testing-test" && terraform.workspace != "sprinkler-development") ? 1 : 0
+  source                      = "github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access?ref=6819b090bce6d3068d55c7c7b9b3fd18c9dca648" #v3.0.0
+  account_id                  = local.modernisation_platform_account.id
+  additional_trust_roles      = [module.github-oidc[0].github_actions_role, one(data.aws_iam_roles.member-sso-admin-access.arns)]
+  policy_arn                  = aws_iam_policy.member-access[0].id
+  role_name                   = "MemberInfrastructureAccess"
   additional_trust_statements = [data.aws_iam_policy_document.additional_trust_policy.json]
 }
 
 module "member-access-sprinkler" {
-  count                  = (terraform.workspace == "sprinkler-development") ? 1 : 0
-  source                 = "github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access?ref=6819b090bce6d3068d55c7c7b9b3fd18c9dca648" #v3.0.0
-  account_id             = local.modernisation_platform_account.id
-  additional_trust_roles = [data.aws_iam_role.sprinkler_oidc[0].arn, one(data.aws_iam_roles.member-sso-admin-access.arns)]
-  policy_arn             = aws_iam_policy.member-access[0].id
-  role_name              = "MemberInfrastructureAccess"
+  count                       = (terraform.workspace == "sprinkler-development") ? 1 : 0
+  source                      = "github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access?ref=6819b090bce6d3068d55c7c7b9b3fd18c9dca648" #v3.0.0
+  account_id                  = local.modernisation_platform_account.id
+  additional_trust_roles      = [data.aws_iam_role.sprinkler_oidc[0].arn, one(data.aws_iam_roles.member-sso-admin-access.arns)]
+  policy_arn                  = aws_iam_policy.member-access[0].id
+  role_name                   = "MemberInfrastructureAccess"
   additional_trust_statements = [data.aws_iam_policy_document.additional_trust_policy.json]
 }
 data "aws_iam_policy_document" "additional_trust_policy" {
   statement {
-    effect = "Allow"
+    effect  = "Allow"
     actions = ["sts:AssumeRole"]
     principals {
       type        = "Service"
@@ -245,10 +245,10 @@ data "aws_iam_policy_document" "member-access" {
       ]
     }
   }
-    statement {
-    sid       = "GuardDutyMalwareProtectionActions"
-    effect    = "Allow"
-    actions   = [
+  statement {
+    sid    = "GuardDutyMalwareProtectionActions"
+    effect = "Allow"
+    actions = [
       "guardduty:CreateMalwareProtectionPlan",
       "guardduty:UpdateMalwareProtectionPlan",
       "guardduty:DeleteMalwareProtectionPlan",

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -345,7 +345,6 @@ data "aws_iam_policy_document" "assume_role_policy" {
   }
 }
 
-
 # IAM role to be assumed
 resource "aws_iam_role" "testing_member_infrastructure_access_role" {
   count              = terraform.workspace == "testing-test" ? 1 : 0

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -10,22 +10,8 @@ module "member-access" {
   additional_trust_roles = [module.github-oidc[0].github_actions_role, one(data.aws_iam_roles.member-sso-admin-access.arns)] 
   policy_arn             = aws_iam_policy.member-access[0].id
   role_name              = "MemberInfrastructureAccess"
-  additional_trust_statements = [
-    jsonencode({
-      Version = "2012-10-17",
-      Statement = [
-        {
-          Effect = "Allow",
-          Action = "sts:AssumeRole",
-          Principal = {
-            Service = "malware-protection-plan.guardduty.amazonaws.com"
-          }
-        }
-      ]
-    })
-  ]
+  additional_trust_statements = [data.aws_iam_policy_document.additional_trust_policy.json]
 }
-
 
 module "member-access-sprinkler" {
   count                  = (terraform.workspace == "sprinkler-development") ? 1 : 0
@@ -34,20 +20,17 @@ module "member-access-sprinkler" {
   additional_trust_roles = [data.aws_iam_role.sprinkler_oidc[0].arn, one(data.aws_iam_roles.member-sso-admin-access.arns)]
   policy_arn             = aws_iam_policy.member-access[0].id
   role_name              = "MemberInfrastructureAccess"
-  additional_trust_statements = [
-    jsonencode({
-      Version = "2012-10-17",
-      Statement = [
-        {
-          Effect = "Allow",
-          Action = "sts:AssumeRole",
-          Principal = {
-            Service = "malware-protection-plan.guardduty.amazonaws.com"
-          }
-        }
-      ]
-    })
-  ]
+  additional_trust_statements = [data.aws_iam_policy_document.additional_trust_policy.json]
+}
+data "aws_iam_policy_document" "additional_trust_policy" {
+  statement {
+    effect = "Allow"
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["malware-protection-plan.guardduty.amazonaws.com"]
+    }
+  }
 }
 # lots of SCA ignores and skips on this one as it is the main role allowing members to build most things in the platform
 #tfsec:ignore:aws-iam-no-policy-wildcards


### PR DESCRIPTION
## A reference to the issue / Description of it

#8050 
## How does this PR fix the problem?

This PR updates the MemberInfrastructureAccess IAM role to include:

- Trust policy for `malware-protection-plan.guardduty.amazonaws.com.
- Permissions to create and manage GuardDuty malware protection plans for S3.

The role already has permissions for:
EventBridge Management: Managing rules and targets specific to GuardDuty operations.
S3 Access: Accessing objects, managing bucket notifications, and handling validation objects for scanning. But also tagging so post-scan it will show if threat was found/not found.
KMS: for decryption

More detailed information can be found here: https://docs.aws.amazon.com/guardduty/latest/ug/malware-protection-s3-iam-policy-prerequisite.html

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
