### PR TITLE
TM-720: set default priority on DSO pagerduty alerts

### DIFF
--- a/terraform/pagerduty/member-services-integrations.tf
+++ b/terraform/pagerduty/member-services-integrations.tf
@@ -2056,6 +2056,25 @@ resource "pagerduty_slack_connection" "az_dso_alerts" {
   }
 }
 
+resource "pagerduty_event_orchestration_service" "az_dso_alerts" {
+  for_each = pagerduty_service.az_dso_alerts
+
+  service                                = each.value.id
+  enable_event_orchestration_for_service = true
+  set {
+    id = "start"
+    rule {
+      label = "Set the default priority to P5 so breaches appear in the PagerDuty UI"
+      actions {
+        priority = data.pagerduty_priority.p5.id
+      }
+    }
+  }
+  catch_all {
+    actions {}
+  }
+}
+
 # END - DSO Azure alerts
 
 resource "pagerduty_service" "sprinkler-development" {


### PR DESCRIPTION
## A reference to the issue / Description of it

Some DSO alerts are not showing in "impacting incidents" page in PagerDuty

## How does this PR fix the problem?

This assigns a default priority to AZ DSO alerts which ensures these alerts then show up in the impacting incidents business service page.

## How has this been tested?

This is already working for some of our alerts - we just missed some for our az services

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
