### PR TITLE
Add slack notification for github-plan-and-apply

### DIFF
--- a/.github/workflows/terraform-github.yml
+++ b/.github/workflows/terraform-github.yml
@@ -36,17 +36,29 @@ permissions:
 
 jobs:
   github-plan-and-apply:
-    uses: ./.github/workflows/reusable_terraform_plan_apply.yml
-    with:
-      working-directory: "terraform/github"
-    secrets:
-      modernisation_platform_environments: ${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENTS }}
-      gh_workflow_token: ${{ secrets.TERRAFORM_GITHUB_TOKEN }}
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run reusable Terraform workflow
+        uses: ./.github/workflows/reusable_terraform_plan_apply.yml
+        with:
+          working-directory: "terraform/github"
+        env: # Pass secrets through environment
+          MODERNISATION_PLATFORM_ENVIRONMENTS: ${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENTS }}
+          TERRAFORM_GITHUB_TOKEN: ${{ secrets.TERRAFORM_GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      - name: Send Slack notification
+        if: ${{ failure() }}
+        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
+        with:
+           payload: |
+            {"blocks":[{"type": "section","text": {"type": "mrkdwn","text": ":no_entry: Failed GitHub Action:"}},{"type": "section","fields":[{"type": "mrkdwn","text": "*Workflow:*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>"},{"type": "mrkdwn","text": "*Job:*\n${{ github.job }}"},{"type": "mrkdwn","text": "*Repo:*\n${{ github.repository }}"}]}]}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
   create-github-environments:
     runs-on: ubuntu-latest
-    needs: [ github-plan-and-apply ]
+    needs: [github-plan-and-apply]
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:


### PR DESCRIPTION
## A reference to the issue / Description of it

Issue identified by @sukeshreddyg that no slack notification is triggered if the first job fails, only the second job. This PR adds a Slack notification step to the first job. 

## How does this PR fix the problem?

see above

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

No

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
