### PR TITLE
Remove Conditional logic to switch OIDC role

### DIFF
--- a/.github/workflows/reusable_terraform_plan_apply.yml
+++ b/.github/workflows/reusable_terraform_plan_apply.yml
@@ -72,18 +72,9 @@ jobs:
           echo ACCOUNT_NUMBER=$ACCOUNT_NUMBER >> $GITHUB_ENV
 
       - name: configure aws credentials
-        if: github.event.ref != 'refs/heads/main'
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
         with:
-          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions-plan"
-          role-session-name: githubactionsrolesession
-          aws-region: ${{ inputs.aws_region }}
-
-      - name: configure aws credentials
-        if: github.event.ref == 'refs/heads/main'
-        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
-        with:
-          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions-apply"
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
           role-session-name: githubactionsrolesession
           aws-region: ${{ inputs.aws_region }}
 


### PR DESCRIPTION
This PR will remove the conditional logic for the OIDC role, as it is causing issues during Terratest runs due to the use of github-action-plan, which has only read permissions. By removing this condition, it will revert to using the previous GitHub Actions role, restoring the earlier functionality.