### PR TITLE
Update S3 bucket policy to support Sprinkler workflow using GitHub Actions role

### DIFF
--- a/terraform/modernisation-platform-account/s3.tf
+++ b/terraform/modernisation-platform-account/s3.tf
@@ -310,6 +310,24 @@ data "aws_iam_policy_document" "allow-state-access-from-root-account" {
       identifiers = tolist(data.aws_iam_roles.sso-admin-access.arns)
     }
   }
+
+  statement {
+    sid    = "AllowSprinklerGithubActionRole"
+    effect = "Allow"
+    actions = [
+      "s3:PutObject",
+      "s3:PutObjectAcl",
+      "s3:GetObject"
+    ]
+    resources = [
+      "arn:aws:s3:::modernisation-platform-terraform-state/single-sign-on/terraform.tfstate",
+      "arn:aws:s3:::modernisation-platform-terraform-state/environments/bootstrap/*/sprinkler-development/terraform.tfstate"
+    ]
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${local.environment_management.account_ids["sprinkler-development"]}:role/github-actions"]
+    }
+  }
 }
 
 module "cost-management-bucket" {


### PR DESCRIPTION
## A reference to the issue / Description of it

Recent changes to the Sprinkler workflow require the use of the `github-actions` role created in the Sprinkler account. To ensure compatibility, the S3 bucket policy must grant appropriate permissions to the `github-actions` role for specific operations on defined folders within the state bucket. #8078 

## How does this PR fix the problem?

The updated policy ensures that the `github-actions` role has the necessary permissions to execute the Sprinkler workflow without permission errors. This change aligns the policy with the new workflow requirements.

## How has this been tested?

Tested manually

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
