### PR TITLE
Revert "Add inventory resource data sync to member bootstrap"

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/ssm.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/ssm.tf
@@ -127,14 +127,3 @@ resource "aws_ssm_resource_data_sync" "security_account" {
     kms_key_arn = local.environment_management.ssm_resource_sync_kms_arn
   }
 }
-
-# Mod Platform SSM Inventory Resource Data Sync
-# This will gather inventory data from all MP accounts and deliver to a central S3 bucket hosted in the organisation-security account
-resource "aws_ssm_resource_data_sync" "mod_platform_inventory_sync" {
-  name = "mod-platform-inventory-resource-data-sync"
-  s3_destination {
-    bucket_name = local.environment_management.mp_ssm_inventory_resource_data_sync_bucket_name
-    region      = data.aws_region.current.name
-    sync_format = "JsonSerDe"
-  }
-}


### PR DESCRIPTION
Relates to Issue https://github.com/ministryofjustice/modernisation-platform/issues/8360

Reverts PR ministryofjustice/modernisation-platform#8517

I'm reverting this PR for now as we have a clash in around 131 Mod Platform accounts where we have already hit the hard limit of 5 SSM resource data syncs. 

See [error log](https://github.com/ministryofjustice/modernisation-platform/actions/runs/12046298138) for reference.

We will need to review and rationalise our use of these resources before this work can continue.