### PR TITLE
Use multi-region KMS key for environment management

### DIFF
--- a/terraform/environments/core-logging/athena.tf
+++ b/terraform/environments/core-logging/athena.tf
@@ -4,7 +4,7 @@ data "aws_caller_identity" "mod-platform" {
 
 data "aws_kms_alias" "environment_management" {
   provider = aws.modernisation-platform
-  name     = "alias/environment-management"
+  name     = "alias/environment-management-multi-region"
 }
 
 #S3 Bucket for Athena temp SQL queries 


### PR DESCRIPTION
## A reference to the issue / Description of it

#8545 
## How does this PR fix the problem?

The AccessDenied error encountered when the athena_table_update Lambda function attempts to retrieve the environment_management secret from AWS Secrets Manager was caused by the Lambda function using an incorrect single-region KMS key for decryption, instead of the multi-region key associated with the secret.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
