### PR TITLE
Add workflow_dispatch to enable manual trigger in GitHub workflow

### DIFF
--- a/.github/workflows/collaborator-inactivity-monitoring.yml
+++ b/.github/workflows/collaborator-inactivity-monitoring.yml
@@ -3,6 +3,7 @@ name: Check Inactive Collaborators
 on:
   schedule:
     - cron: '30 9 */100,1-7 * 1'
+  workflow_dispatch:
 
 env:
     AWS_REGION: "eu-west-2"

--- a/.github/workflows/secrets-rotation-reminder.yml
+++ b/.github/workflows/secrets-rotation-reminder.yml
@@ -8,6 +8,7 @@ on:
       - ".github/workflows/secrets-rotation-reminder.yaml"
   schedule: 
       - cron: '30 11 * * *' # run at 11:30 daily 
+  workflow_dispatch:
 
 env:
     AWS_REGION: "eu-west-2"

--- a/.github/workflows/terraform-member-environment.yml
+++ b/.github/workflows/terraform-member-environment.yml
@@ -17,6 +17,7 @@ on:
       - 'terraform/environments/*/*.tf'
       - '!terraform/environments/bootstrap/*/*.tf'
       - '!terraform/environments/core-*/*.tf'
+  workflow_dispatch:
 
 defaults:
   run:


### PR DESCRIPTION
This change adds workflow_dispatch to the GitHub workflow to allow manual execution of pipelines.
The purpose is to test the default GitHub token by providing the necessary permissions. Manually triggering these pipelines will help verify whether the token works correctly after adding the required permissions. #8476 