### PR TITLE
Subscribe member account alarms into pagerduty/slack

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/collaborators.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/collaborators.tf
@@ -13,7 +13,7 @@ module "collaborator_readonly_role" {
 
   # Allow created users to assume these roles
   trusted_role_arns = [
-    local.modernisation_platform_account.id
+    data.aws_ssm_parameter.modernisation_platform_account_id.value
   ]
 }
 
@@ -40,7 +40,7 @@ module "collaborator_security_audit_role" {
 
   # Allow created users to assume these roles
   trusted_role_arns = [
-    local.modernisation_platform_account.id
+    data.aws_ssm_parameter.modernisation_platform_account_id.value
   ]
 }
 
@@ -52,7 +52,7 @@ module "collaborator_developer_role" {
   source = "github.com/terraform-aws-modules/terraform-aws-iam//modules/iam-assumable-role?ref=de95e21a3bc51cd3a44b3b95a4c2f61000649ebb" # v5.39.1
 
   trusted_role_arns = [
-    local.modernisation_platform_account.id
+    data.aws_ssm_parameter.modernisation_platform_account_id.value
   ]
 
   create_role       = true
@@ -79,7 +79,7 @@ module "collaborator_sandbox_role" {
   source = "github.com/terraform-aws-modules/terraform-aws-iam//modules/iam-assumable-role?ref=de95e21a3bc51cd3a44b3b95a4c2f61000649ebb" # v5.39.1
 
   trusted_role_arns = [
-    local.modernisation_platform_account.id
+    data.aws_ssm_parameter.modernisation_platform_account_id.value
   ]
 
   create_role       = true
@@ -110,7 +110,7 @@ module "collaborator_migration_role" {
   source = "github.com/terraform-aws-modules/terraform-aws-iam//modules/iam-assumable-role?ref=de95e21a3bc51cd3a44b3b95a4c2f61000649ebb" # v5.39.1
 
   trusted_role_arns = [
-    local.modernisation_platform_account.id
+    data.aws_ssm_parameter.modernisation_platform_account_id.value
   ]
 
   create_role       = true
@@ -143,7 +143,7 @@ module "collaborator_instance_access_role" {
   source = "github.com/terraform-aws-modules/terraform-aws-iam//modules/iam-assumable-role?ref=de95e21a3bc51cd3a44b3b95a4c2f61000649ebb" # v5.39.1
 
   trusted_role_arns = [
-    local.modernisation_platform_account.id
+    data.aws_ssm_parameter.modernisation_platform_account_id.value
   ]
 
   create_role       = true
@@ -170,7 +170,7 @@ module "collaborator_database_mgmt_role" {
   source = "github.com/terraform-aws-modules/terraform-aws-iam//modules/iam-assumable-role?ref=de95e21a3bc51cd3a44b3b95a4c2f61000649ebb" # v5.39.1
 
   trusted_role_arns = [
-    local.modernisation_platform_account.id
+    data.aws_ssm_parameter.modernisation_platform_account_id.value
   ]
 
   create_role       = true
@@ -197,7 +197,7 @@ module "collaborator_fleet_manager_role" {
   source = "github.com/terraform-aws-modules/terraform-aws-iam//modules/iam-assumable-role?ref=de95e21a3bc51cd3a44b3b95a4c2f61000649ebb" # v5.39.1
 
   trusted_role_arns = [
-    local.modernisation_platform_account.id
+    data.aws_ssm_parameter.modernisation_platform_account_id.value
   ]
 
   create_role       = true
@@ -224,7 +224,7 @@ module "collaborator_s3_upload_role" {
   source = "github.com/terraform-aws-modules/terraform-aws-iam//modules/iam-assumable-role?ref=de95e21a3bc51cd3a44b3b95a4c2f61000649ebb" # v5.39.1
 
   trusted_role_arns = [
-    local.modernisation_platform_account.id
+    data.aws_ssm_parameter.modernisation_platform_account_id.value
   ]
 
   create_role       = true

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -6,7 +6,7 @@ locals {
 module "member-access" {
   count                       = (local.account_data.account-type == "member" && terraform.workspace != "testing-test" && terraform.workspace != "sprinkler-development") ? 1 : 0
   source                      = "github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access?ref=6819b090bce6d3068d55c7c7b9b3fd18c9dca648" #v3.0.0
-  account_id                  = local.modernisation_platform_account.id
+  account_id                  = data.aws_ssm_parameter.modernisation_platform_account_id.value
   additional_trust_roles      = [module.github-oidc[0].github_actions_role, one(data.aws_iam_roles.member-sso-admin-access.arns)]
   policy_arn                  = aws_iam_policy.member-access[0].id
   role_name                   = "MemberInfrastructureAccess"
@@ -16,7 +16,7 @@ module "member-access" {
 module "member-access-sprinkler" {
   count                       = (terraform.workspace == "sprinkler-development") ? 1 : 0
   source                      = "github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access?ref=6819b090bce6d3068d55c7c7b9b3fd18c9dca648" #v3.0.0
-  account_id                  = local.modernisation_platform_account.id
+  account_id                  = data.aws_ssm_parameter.modernisation_platform_account_id.value
   additional_trust_roles      = [data.aws_iam_role.sprinkler_oidc[0].arn, one(data.aws_iam_roles.member-sso-admin-access.arns)]
   policy_arn                  = aws_iam_policy.member-access[0].id
   role_name                   = "MemberInfrastructureAccess"
@@ -344,7 +344,7 @@ data "aws_iam_policy_document" "assume_role_policy" {
 
     principals {
       type = "AWS"
-      identifiers = ["arn:aws:iam::${local.modernisation_platform_account.id}:root",
+      identifiers = ["arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:root",
         "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:user/testing-ci",
         one(data.aws_iam_roles.member-sso-admin-access.arns)
       ]
@@ -370,7 +370,7 @@ resource "aws_iam_role_policy_attachment" "testing_member_infrastructure_access_
 module "member-access-us-east" {
   count                  = (local.account_data.account-type == "member" && terraform.workspace != "testing-test" && terraform.workspace != "sprinkler-development") ? 1 : 0
   source                 = "github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access?ref=6819b090bce6d3068d55c7c7b9b3fd18c9dca648" #v3.0.0
-  account_id             = local.modernisation_platform_account.id
+  account_id             = data.aws_ssm_parameter.modernisation_platform_account_id.value
   additional_trust_roles = [module.github-oidc[0].github_actions_role, one(data.aws_iam_roles.member-sso-admin-access.arns)]
   policy_arn             = aws_iam_policy.member-access-us-east[0].id
   role_name              = "MemberInfrastructureAccessUSEast"
@@ -379,7 +379,7 @@ module "member-access-us-east" {
 module "member-access-us-east-sprinkler" {
   count                  = (terraform.workspace == "sprinkler-development") ? 1 : 0
   source                 = "github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access?ref=6819b090bce6d3068d55c7c7b9b3fd18c9dca648" #v3.0.0
-  account_id             = local.modernisation_platform_account.id
+  account_id             = data.aws_ssm_parameter.modernisation_platform_account_id.value
   additional_trust_roles = [data.aws_iam_role.sprinkler_oidc[0].arn, one(data.aws_iam_roles.member-sso-admin-access.arns)]
   policy_arn             = aws_iam_policy.member-access-us-east[0].id
   role_name              = "MemberInfrastructureAccessUSEast"
@@ -653,7 +653,7 @@ data "aws_iam_policy_document" "policy" {
 module "member-access-eu-central" {
   count                  = (local.account_data.account-type == "member" && terraform.workspace != "testing-test" && terraform.workspace != "sprinkler-development") ? 1 : 0
   source                 = "github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access?ref=6819b090bce6d3068d55c7c7b9b3fd18c9dca648" #v3.0.0
-  account_id             = local.modernisation_platform_account.id
+  account_id             = data.aws_ssm_parameter.modernisation_platform_account_id.value
   additional_trust_roles = [module.github-oidc[0].github_actions_role, one(data.aws_iam_roles.member-sso-admin-access.arns)]
   policy_arn             = aws_iam_policy.member-access-eu-central[0].id
   role_name              = "MemberInfrastructureBedrockEuCentral"
@@ -662,7 +662,7 @@ module "member-access-eu-central" {
 module "member-access-eu-central-sprinkler" {
   count                  = (terraform.workspace == "sprinkler-development") ? 1 : 0
   source                 = "github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access?ref=6819b090bce6d3068d55c7c7b9b3fd18c9dca648" #v3.0.0
-  account_id             = local.modernisation_platform_account.id
+  account_id             = data.aws_ssm_parameter.modernisation_platform_account_id.value
   additional_trust_roles = [data.aws_iam_role.sprinkler_oidc[0].arn, one(data.aws_iam_roles.member-sso-admin-access.arns)]
   policy_arn             = aws_iam_policy.member-access-eu-central[0].id
   role_name              = "MemberInfrastructureBedrockEuCentral"

--- a/terraform/environments/bootstrap/member-bootstrap/notifications.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/notifications.tf
@@ -103,3 +103,9 @@ data "aws_secretsmanager_secret" "pagerduty_integration_keys" {
 locals {
   pagerduty_integration_keys = jsondecode(data.aws_secretsmanager_secret_version.pagerduty_integration_keys.secret_string)
 }
+
+# Subscribe SNS topics in member accounts to pagerduty for core monitoring
+module "core_monitoring" {
+  source                     = "../../../modules/core-monitoring"
+  pagerduty_integration_keys = local.pagerduty_integration_keys
+}

--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -85,8 +85,8 @@ data "aws_iam_policy_document" "common_statements" {
       "arn:aws:iam::*:role/member-delegation-read-only",
       "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/member-shared-services",
       "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/ad-fixngo-ec2-access",
-      "arn:aws:iam::${local.modernisation_platform_account.id}:role/modernisation-account-limited-read-member-access",
-      "arn:aws:iam::${local.modernisation_platform_account.id}:role/modernisation-account-terraform-state-member-access"
+      "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access",
+      "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-terraform-state-member-access"
     ]
   }
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

As part of https://github.com/ministryofjustice/modernisation-platform/issues/7825 I've been looking at the ability to monitor/alert for root account activity.

As part of this I've noticed that the baselines code has already deployed a set of alarms for certain scenarios to all MP accounts, including root usage activity: https://github.com/ministryofjustice/modernisation-platform-terraform-baselines/blob/main/modules/securityhub-alarms/main.tf#L133

These are labelled "security-hub alarms" and have been deployed as they are direct recommendations from the security hub controls e.g. AWS/CIS best practices.

Currently we only receive alerts for these issues where we have subscribed our "core" accounts (i.e. `core-shared-services`, `core-logging`, `core-network-services`, `core-security`, `core-vpc` and `modernisation-platform`) which then feed into our [core-alerts](https://moj-digital-tools.pagerduty.com/service-directory/PYDTWVM) pagerduty service which in turn feed the [low-priority](https://moj.enterprise.slack.com/archives/C02PFCG8M1R) or [high-priority](https://app.slack.com/client/E01066BNN9G/C03CY6451QT) Slack channels.

An example of me triggering the root account usage alarm for the MP account can be seen [here](https://mojdt.slack.com/archives/C02PFCG8M1R/p1733144952405839).

## NOTE:

This also fixes an issue described in [this thread](https://mojdt.slack.com/archives/C013RM6MFFW/p1733159697853769)

In the words of Sukesh:

_"The issue occurred because the `aws_caller_identity` data resource was unable to retrieve the `account_id` for the Modernisation Platform (MP). This happened because the provider was using the Sprinkler GitHub OIDC role now. Recently, Sprinkler introduced a separate GitHub OIDC role, and the workflow was updated to use that role from the Sprinkler account. Previously, the workflow was associated with the MP provider and assumed the role from the MP account. These changes caused the errors you were seeing.
I have now updated the reference to the MP account reference in single-sign-on and member-bootstrap in your PR, which should resolve the issue."_  

## How does this PR fix the problem?

This PR subscribes the existing cloudwatch alarms/SNS topics deployed through the baseline to pagerduty in the same way as our core accounts so that we will start to receive alerts in our channels for member accounts also.

This will mean we can monitor any root account usage across the platform as well as for any of the other alarms defined in [ministryofjustice/modernisation-platform-terraform-baselines/modules/securityhub-alarms/](https://github.com/ministryofjustice/modernisation-platform-terraform-baselines/blob/main/modules/securityhub-alarms/)

This would include such alarms as `admin-role-usage`, where we have been tracking the MP teams usage of the `AdministratorAccess` role,  and a whole lot more.

I did consider creating a separate channel or service to split these although it seems like too much duplication initially - plus although these alarms are deployed to  member accounts they are for our (MP teams) benefit. and so should have equal importance to those already subscribed in the core account set.

Potential downsides to this could be that we see certain alarms triggering too frequently such as `unauthorised-api-calls` which we have recently been trying to filter out by addressing any shortcomings with our own code-base. If receiving these for member accounts it might not necessarily be within our gift to remedy these although we could notify them and enquire as to why it's occurring.

If the alerting seems to noisy we could pivot and create a new dedicated sns topic for some of the least frequently occuring events i.e. root account usage, admin role usage etc.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Tested in Sprinkler 
See example alerts:
https://moj-digital-tools.pagerduty.com/incidents/Q1OY2KAUS4MELK?utm_campaign=channel&utm_source=slack
https://moj-digital-tools.pagerduty.com/incidents/Q2NZBEYMP5NPB8?utm_campaign=channel&utm_source=slack


## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [X] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
