### PR TITLE
Remove auto-resolve-timeout for Oracle notifications

### DIFF
--- a/terraform/pagerduty/member-services-integrations.tf
+++ b/terraform/pagerduty/member-services-integrations.tf
@@ -2133,6 +2133,7 @@ resource "pagerduty_slack_connection" "sprinkler_connection" {
 resource "pagerduty_service" "delius_oracle_nonprod" {
   name                    = "Delius Oracle Non Prod"
   description             = "Delius Oracle Non Prod Alarms"
+  auto_resolve_timeout    = "null"
   acknowledgement_timeout = "null"
   escalation_policy       = pagerduty_escalation_policy.member_policy.id
   alert_creation          = "create_alerts_and_incidents"

--- a/terraform/pagerduty/member-services-integrations.tf
+++ b/terraform/pagerduty/member-services-integrations.tf
@@ -2133,7 +2133,6 @@ resource "pagerduty_slack_connection" "sprinkler_connection" {
 resource "pagerduty_service" "delius_oracle_nonprod" {
   name                    = "Delius Oracle Non Prod"
   description             = "Delius Oracle Non Prod Alarms"
-  auto_resolve_timeout    = 345600
   acknowledgement_timeout = "null"
   escalation_policy       = pagerduty_escalation_policy.member_policy.id
   alert_creation          = "create_alerts_and_incidents"


### PR DESCRIPTION
Must clear the underlying issue

## A reference to the issue / Description of it

Notifications raised by CloudWatch alarms for Oracle should not clear automatically if still in alarm state.

## How does this PR fix the problem?

Remove auto-resolve.

## How has this been tested?

Change required for testing.

## Deployment Plan / Instructions

This is for development notifications only - no live service impact.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

PROD not applicable at present.