### PR TITLE
DPR2-1553: Grant dms:ModifyReplicationInstance to DPR circle_ci

### DIFF
--- a/terraform/environments/digital-prison-reporting/iam.tf
+++ b/terraform/environments/digital-prison-reporting/iam.tf
@@ -172,6 +172,7 @@ data "aws_iam_policy_document" "circleci_iam_policy" {
       "iam:DeletePolicyVersion",
       "dms:DescribeReplicationSubnetGroups",
       "dms:DescribeReplicationInstances",
+      "dms:ModifyReplicationInstance",
       "dms:DescribeReplicationTasks",
       "dms:ModifyReplicationTask",
       "dms:DeleteReplicationTask",


### PR DESCRIPTION
## A reference to the issue / Description of it

The digital prisons reporting `circle_ci` role needs to be able to modify DMS instances e.g. when performing an upgrade.

## How does this PR fix the problem?

This PR grants `dms:ModifyReplicationInstance` to the `circle_ci` role

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

N/A

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

None
