### PR TITLE
TM-781: disable pagerduty alarm auto resolve for DSO services

### DIFF
--- a/terraform/pagerduty/member-services-integrations.tf
+++ b/terraform/pagerduty/member-services-integrations.tf
@@ -1946,7 +1946,7 @@ resource "pagerduty_service" "services" {
 
   name                    = each.key
   description             = "${each.key}-alarms"
-  auto_resolve_timeout    = 345600
+  auto_resolve_timeout    = "null"
   acknowledgement_timeout = "null"
   escalation_policy       = pagerduty_escalation_policy.member_policy.id
   alert_creation          = "create_alerts_and_incidents"
@@ -2010,7 +2010,7 @@ resource "pagerduty_service" "az_dso_alerts" {
   for_each = local.dso_az_alerts.channel_ids
 
   name                    = each.key
-  auto_resolve_timeout    = 345600
+  auto_resolve_timeout    = "null"
   acknowledgement_timeout = "null"
   escalation_policy       = pagerduty_escalation_policy.member_policy.id
   alert_creation          = "create_alerts_and_incidents"


### PR DESCRIPTION
## A reference to the issue / Description of it

Some pagerduty alarms are being missed, especially over long weekend, due to auto resolve

## How does this PR fix the problem?

Disables auto resolve. Each alarm needs to be resolved in AWS/Azure, slack or pagerduty

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Other services already have same setting so assume this works.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
