### PR TITLE
Added optional configuration to keep squash merges tidy

### DIFF
--- a/terraform/github/modules/repository/main.tf
+++ b/terraform/github/modules/repository/main.tf
@@ -6,25 +6,27 @@ locals {
 
 # Repository basics
 resource "github_repository" "default" {
-  name                   = var.name
-  description            = join(" • ", [var.description, "This repository is defined and managed in Terraform"])
-  allow_merge_commit     = true
-  allow_squash_merge     = true
-  allow_rebase_merge     = true
-  allow_update_branch    = true
-  archived               = false
-  archive_on_destroy     = true
-  auto_init              = false
-  delete_branch_on_merge = true
-  has_issues             = true
-  has_projects           = true
-  has_wiki               = var.type == "core" ? true : false
-  has_downloads          = true
-  homepage_url           = var.homepage_url
-  is_template            = var.type == "template" ? true : false
-  topics                 = concat(local.topics, var.topics)
-  visibility             = var.visibility
-  vulnerability_alerts   = true
+  name                        = var.name
+  description                 = join(" • ", [var.description, "This repository is defined and managed in Terraform"])
+  allow_merge_commit          = true
+  allow_squash_merge          = true
+  allow_rebase_merge          = true
+  allow_update_branch         = true
+  archived                    = false
+  archive_on_destroy          = true
+  auto_init                   = false
+  delete_branch_on_merge      = true
+  has_issues                  = true
+  has_projects                = true
+  has_wiki                    = var.type == "core" ? true : false
+  has_downloads               = true
+  homepage_url                = var.homepage_url
+  is_template                 = var.type == "template" ? true : false
+  squash_merge_commit_title   = var.squash_merge_commit_message == true ? "PR_TITLE" : null
+  squash_merge_commit_message = var.squash_merge_commit_title == true ? "COMMIT_MESSAGES" : null
+  topics                      = concat(local.topics, var.topics)
+  visibility                  = var.visibility
+  vulnerability_alerts        = true
 
   security_and_analysis {
     dynamic "advanced_security" {

--- a/terraform/github/modules/repository/variables.tf
+++ b/terraform/github/modules/repository/variables.tf
@@ -41,13 +41,13 @@ variable "secrets" {
 variable "squash_merge_commit_message" {
   type        = bool
   description = "Should squash merge commit message be set to MERGE_MESSAGE?"
-  default     = false
+  default     = true
 }
 
 variable "squash_merge_commit_title" {
   type        = bool
   description = "Should squash merge commit title be set to PR_TITLE?"
-  default     = false
+  default     = true
 }
 
 variable "topics" {

--- a/terraform/github/modules/repository/variables.tf
+++ b/terraform/github/modules/repository/variables.tf
@@ -8,16 +8,46 @@ variable "description" {
   description = "Repository description"
 }
 
+variable "dismissal_restrictions" {
+  type        = list(string)
+  description = "The list of actor Names/IDs with dismissal access e.g. 'exampleorganization/exampleteam' or '/exampleuser'"
+  default     = []
+}
+
 variable "homepage_url" {
   type        = string
   description = "Repository homepage URL"
   default     = ""
 }
 
+variable "required_checks" {
+  type        = list(string)
+  description = "List of required checks"
+  default     = []
+}
+
+variable "restrict_dismissals" {
+  type        = bool
+  description = "Restrict pull request review dismissals"
+  default     = false
+}
+
 variable "secrets" {
   type        = map(any)
   description = "key:value map for GitHub actions secrets"
   default     = {}
+}
+
+variable "squash_merge_commit_message" {
+  type        = bool
+  description = "Should squash merge commit message be set to MERGE_MESSAGE?"
+  default     = false
+}
+
+variable "squash_merge_commit_title" {
+  type        = bool
+  description = "Should squash merge commit title be set to PR_TITLE?"
+  default     = false
 }
 
 variable "topics" {
@@ -35,22 +65,4 @@ variable "visibility" {
   type        = string
   description = "Visibility type: `public`, `internal`, `private`"
   default     = "public"
-}
-
-variable "required_checks" {
-  type        = list(string)
-  description = "List of required checks"
-  default     = []
-}
-
-variable "restrict_dismissals" {
-  type        = bool
-  description = "Restrict pull request review dismissals"
-  default     = false
-}
-
-variable "dismissal_restrictions" {
-  type        = list(string)
-  description = "The list of actor Names/IDs with dismissal access e.g. 'exampleorganization/exampleteam' or '/exampleuser'"
-  default     = []
 }

--- a/terraform/github/repositories.tf
+++ b/terraform/github/repositories.tf
@@ -10,8 +10,6 @@ module "core" {
     "aws",
     "documentation"
   ]
-  squash_merge_commit_message = true
-  squash_merge_commit_title   = true
   secrets = {
     # Terraform GitHub token for the CI/CD user
     TERRAFORM_GITHUB_TOKEN = data.aws_secretsmanager_secret_version.github_ci_user_token.secret_string
@@ -52,10 +50,12 @@ module "terraform-module-cross-account-access" {
 }
 
 module "terraform-module-environments" {
-  source      = "./modules/repository"
-  name        = "modernisation-platform-terraform-environments"
-  type        = "module"
-  description = "Module for creating organizational units and accounts within AWS Organizations from JSON files"
+  source                      = "./modules/repository"
+  name                        = "modernisation-platform-terraform-environments"
+  type                        = "module"
+  description                 = "Module for creating organizational units and accounts within AWS Organizations from JSON files"
+  squash_merge_commit_message = false
+  squash_merge_commit_title   = false
   topics = [
     "organizational-units",
     "aws"

--- a/terraform/github/repositories.tf
+++ b/terraform/github/repositories.tf
@@ -10,6 +10,8 @@ module "core" {
     "aws",
     "documentation"
   ]
+  squash_merge_commit_message = true
+  squash_merge_commit_title   = true
   secrets = {
     # Terraform GitHub token for the CI/CD user
     TERRAFORM_GITHUB_TOKEN = data.aws_secretsmanager_secret_version.github_ci_user_token.secret_string


### PR DESCRIPTION
## A reference to the issue / Description of it

No issue - but I've noted that our commit messages aren't always to the highest standard; GitHub can allow us to - by default - set the commit title & message in a squash merge to the PR title and concatenated commit messages by default

## How does this PR fix the problem?

Sets the values for `squash_merge_commit_message` and `squash_merge_commit_title`.

## How has this been tested?

Tested through local plan.

## Deployment Plan / Instructions

Deploy through CI.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
