### PR TITLE
Update links to domain naming standard

### DIFF
--- a/source/concepts/networking/dns.html.md.erb
+++ b/source/concepts/networking/dns.html.md.erb
@@ -62,6 +62,6 @@ DNS entries for applications will be created in the relevant zone following the 
 
 Public facing services must have a `service.justice.gov.uk` domain name, excluding exceptional cases.
 
-See the MoJ Technical guidance on [Naming domains](https://technical-guidance.service.justice.gov.uk/documentation/standards/naming-domains.html#naming-domains) for more information.
+See the MoJ Technical guidance on [Naming domains](https://user-guide.operations-engineering.service.justice.gov.uk/documentation/services/domain-naming-standard.html) for more information.
 
 For more information on implementing DNS on the Modernisation Platform please see [How to configure DNS](../../user-guide/how-to-configure-dns.html)

--- a/source/concepts/networking/dns.html.md.erb
+++ b/source/concepts/networking/dns.html.md.erb
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#modernisation-platform"
 title: DNS
-last_reviewed_on: 2024-06-28
+last_reviewed_on: 2024-12-06
 review_in: 6 months
 ---
 

--- a/source/user-guide/how-to-configure-dns.html.md.erb
+++ b/source/user-guide/how-to-configure-dns.html.md.erb
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#modernisation-platform"
 title: How to configure DNS for public services
-last_reviewed_on: 2024-08-20
+last_reviewed_on: 2024-12-06
 review_in: 6 months
 ---
 
@@ -44,7 +44,7 @@ The following resources need to be created in different AWS accounts (see diagra
 
 ### Production environments
 
-Production environments should use a `service.justice.gov.uk` domain as per MoJ [naming domains](https://technical-guidance.service.justice.gov.uk/documentation/standards/naming-domains.html#naming-domains) guidance.
+Production environments should use a `service.justice.gov.uk` domain as per MoJ [naming domains](https://user-guide.operations-engineering.service.justice.gov.uk/documentation/services/domain-naming-standard.html) guidance.
 
 The Modernisation Platform will need to request the delegation of the application domain (eg `my-application.service.justice.gov.uk`) from the [Operations Engineering](https://user-guide.operations-engineering.service.justice.gov.uk/documentation/services/domainmgt.html) team via an email to the [domains mailbox](mailto:domains@digital.justice.gov.uk) with the details of the records to be added to the `service.justice.gov.uk` domain and to discuss if the subdomain name meets the MoJ naming domains standard.  Please contact the Modernisation Platform team in the [#ask-modernisation-platform](https://mojdt.slack.com/archives/C01A7QK5VM1) Slack channel to do this.
 


### PR DESCRIPTION
## A reference to the issue / Description of it

This PR updates the link to the new location for the MoJ Domain Naming Standard. All DNS related guidance is being co-located in the Operations Engineering User Guide.

## How does this PR fix the problem?

Updated link to Domain Naming standard

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

N/A

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No. Just update to documentation

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

I like your template 😀
