### PR TITLE
Add SSM quicksetup to sandbox policy

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -658,6 +658,7 @@ data "aws_iam_policy_document" "sandbox_additional" {
       "sqs:*",
       "ssm:*",
       "ssm-guiconnect:*",
+      "ssm-quicksetup:*",
       "sso:ListDirectoryAssociations",
       "states:*",
       "support:*",


### PR DESCRIPTION
This enables sandbox users to quickly set up SSM on instances if they are clickopsing.

Note the role is already in sprinkler hence no changes sprinkler plan and apply

