### PR TITLE
Remove lakeformation managed policy 

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/main.tf
+++ b/terraform/environments/bootstrap/single-sign-on/main.tf
@@ -307,15 +307,6 @@ resource "aws_ssoadmin_account_assignment" "data_engineer" {
   target_type = "AWS_ACCOUNT"
 }
 
-resource "aws_ssoadmin_managed_policy_attachment" "data_engineer_lakeformation_crossaccountmanager" {
-  provider   = aws.sso-management
-  depends_on = [aws_ssoadmin_account_assignment.data_engineer]
-
-  instance_arn       = local.sso_instance_arn
-  managed_policy_arn = "arn:aws:iam::aws:policy/AWSLakeFormationCrossAccountManager"
-  permission_set_arn = data.terraform_remote_state.mp-sso-permissions-sets.outputs.data_engineer
-}
-
 resource "aws_ssoadmin_account_assignment" "reporting-operations" {
 
   for_each = {


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/actions/runs/12236290660/job/34131158803#step:7:3385

## How does this PR fix the problem?

Removes the resource that attaches lakeformation permissions. For what it's worth I can't actually see how this duplication occurs, but as the policy was only attached as a convenience we're removing it.

## How has this been tested?

Tested via local plan

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
