### PR TITLE
Fix missing comma in `expected.rego`

### DIFF
--- a/policies/networking/expected.rego
+++ b/policies/networking/expected.rego
@@ -366,7 +366,7 @@ expected :=
           "mlra-preproduction",
           "mojfin-preproduction",
           "oas-preproduction",
-          "portal-preproduction",
+          "portal-preproduction"
         ]
       }
     },

--- a/policies/networking/expected.rego
+++ b/policies/networking/expected.rego
@@ -361,7 +361,7 @@ expected :=
           "corporate-information-system-preproduction",
           "edw-preproduction",
           "laa-mail-relay-preproduction",
-          "laa-oem-preproduction"
+          "laa-oem-preproduction",
           "maat-preproduction",
           "mlra-preproduction",
           "mojfin-preproduction",


### PR DESCRIPTION
## A reference to the issue / Description of it

A missing comma in [this PR](https://github.com/ministryofjustice/modernisation-platform/pull/8713/files) is causing the linter to fail

## How does this PR fix the problem?

Adds the missing comma

## How has this been tested?

Tested locally with `regal lint`

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
