### PR TITLE
Update .trivyignore.yaml

### DIFF
--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -36,6 +36,11 @@ vulnerabilities:
 - id: CVE-2024-21626
   expired_at: 2024-08-19
   statement: "Review in 6 months"
+- id: CVE-2024-45337
+  expired_at: 2025-01-12
+  statement: "Review in 1 month, check terratests crypto version in latest release."
+
+  CVE-2024-45337
 
 misconfigurations:
 - id: AVD-GIT-0001


### PR DESCRIPTION
## A reference to the issue / Description of it

This PR doesn't let you run the tests but fixes a security issue.

https://github.com/ministryofjustice/modernisation-platform/pull/8738

The issue is here - https://github.com/gruntwork-io/terratest/blob/v0.48.0/go.mod#L37

Terratest need to release a new version with the updated crypto version so this does not occur here - https://github.com/ministryofjustice/modernisation-platform/actions/runs/12291468567/job/34300293531#step:4:1026


## How does this PR fix the problem?

Ignores it for a month until terratest push a new release.

## How has this been tested?

Nothing to test 

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x ] I have performed a self-review of my own code
- [x ] All checks have passed

## Additional comments (if any)


