### PR TITLE
Ensure `git-commit.sh` triggers Slack notifications when failing.

### DIFF
--- a/scripts/git-commit.sh
+++ b/scripts/git-commit.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 if [ ! -z "$2" ]; then
   GIT_DIR=$2
   cd $GIT_DIR


### PR DESCRIPTION
## A reference to the issue / Description of it

Failures such as the following are not triggering a failed GitHub Actions step, and as such not being surfaced through Slack notifications:

https://github.com/ministryofjustice/modernisation-platform/actions/runs/12297013276/job/34319794955#step:6:24

## How does this PR fix the problem?

Ensure script exits out on failure

## How has this been tested?

It hasn't.

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
