### PR TITLE
Revert to using old TERRAFORM_GITHUB_TOKEN due to commit failures with MODERNISATION_PAT_MULTIREPO

### DIFF
--- a/.github/workflows/new-member-environment-files.yml
+++ b/.github/workflows/new-member-environment-files.yml
@@ -29,17 +29,17 @@ jobs:
           path: modernisation-platform-environments
           persist-credentials: false
         env:  
-          TERRAFORM_GITHUB_TOKEN: ${{ secrets.MODERNISATION_PAT_MULTIREPO }}
+          TERRAFORM_GITHUB_TOKEN: ${{ secrets.TERRAFORM_GITHUB_TOKEN }}
       - name: Provision member environment directories
         run: bash ./core-repo/scripts/provision-member-directories.sh
       - name: Commit changes to GitHub
         run: bash ./core-repo/scripts/git-setup.sh ./modernisation-platform-environments
       - run: bash ./core-repo/scripts/git-commit.sh . ./modernisation-platform-environments
         env:  
-          TERRAFORM_GITHUB_TOKEN: ${{ secrets.MODERNISATION_PAT_MULTIREPO }} # use this token as writing to a different repo
+          TERRAFORM_GITHUB_TOKEN: ${{ secrets.TERRAFORM_GITHUB_TOKEN }} # use this token as writing to a different repo
       - run: bash ./core-repo/scripts/git-pull-request.sh terraform/environments ./modernisation-platform-environments
         env:
-          TERRAFORM_GITHUB_TOKEN: ${{ secrets.MODERNISATION_PAT_MULTIREPO }}
+          TERRAFORM_GITHUB_TOKEN: ${{ secrets.TERRAFORM_GITHUB_TOKEN }}
       - name: Slack failure notification
         uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
         with:


### PR DESCRIPTION
This PR reverts the workflow to using the old `TERRAFORM_GITHUB_TOKEN` after encountering commit failures with the new `MODERNISATION_PAT_MULTIREPO` token. The new token caused issues when pushing changes to the `modernisation-platform-environments` repository, resulting in a `403` permission error.

https://github.com/ministryofjustice/modernisation-platform/actions/runs/12297013276/job/34317223598#step:6:24
