### PR TITLE
Remove breaking line from trivy ignore file

### DIFF
--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -40,8 +40,6 @@ vulnerabilities:
   expired_at: 2025-01-12
   statement: "Review in 1 month, check terratests crypto version in latest release."
 
-  CVE-2024-45337
-
 misconfigurations:
 - id: AVD-GIT-0001
 # Added AVD-GIT-0004 as Modernisation Platform Environments does not currently use signed commits. 

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -4,9 +4,6 @@ vulnerabilities:
 - id: CVE-2019-11253
 - id: CVE-2020-8558
 - id: CVE-2020-10675
-- id: CVE-2020-15114
-  expired_at: 2024-08-20
-  statement: "Review in 6 months"
 - id: CVE-2020-26160
 - id: CVE-2020-35381
 - id: CVE-2021-25741
@@ -27,15 +24,6 @@ vulnerabilities:
 - id: CVE-2023-5528
 - id: CVE-2023-37788
 - id: CVE-2023-39325
-- id: CVE-2024-3154
-  expired_at: 2024-10-29
-  statement: "Review in 6 months; this one appeared to be Terratest related"
-- id: CVE-2024-15114
-  expired_at: 2024-08-19
-  statement: "Review in 6 months"
-- id: CVE-2024-21626
-  expired_at: 2024-08-19
-  statement: "Review in 6 months"
 - id: CVE-2024-45337
   expired_at: 2025-01-12
   statement: "Review in 1 month, check terratests crypto version in latest release."


### PR DESCRIPTION
As described; there's an entry in the trivyignore that breaks the YAML and means that Trivy can't parse it.