### PR TITLE
Remove cooker from `autonuke` secret

### DIFF
--- a/terraform/environments/secrets.tf
+++ b/terraform/environments/secrets.tf
@@ -174,5 +174,5 @@ resource "github_actions_secret" "autonuke" {
   secret_name = "MODERNISATION_PLATFORM_AUTONUKE"
   repository  = "modernisation-platform-environments"
   # testing-test, cooker-development, and example-development are internal test account which are not sandpits but require nuking.
-  plaintext_value = jsonencode(concat(module.environments.environment_nuke_accounts, ["testing-test", "cooker-development", "example-development"]))
+  plaintext_value = jsonencode(concat(module.environments.environment_nuke_accounts, ["testing-test", "example-development"]))
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

Cooker is cureently being used by MoJ Red team for a special project and we don't want it to be nuked at the weekend.

## How does this PR fix the problem?

This removes cooker from being hard-coded into the nuke secret. Ideally we should follow-up and make all the testing accounts follow the same convention as any other sandbox 

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
