### PR TITLE
DPR2-1450: Add MoveReplicationTask to circleci role

### DIFF
--- a/terraform/environments/digital-prison-reporting/iam.tf
+++ b/terraform/environments/digital-prison-reporting/iam.tf
@@ -176,6 +176,7 @@ data "aws_iam_policy_document" "circleci_iam_policy" {
       "dms:DescribeReplicationTasks",
       "dms:ModifyReplicationTask",
       "dms:DeleteReplicationTask",
+      "dms:MoveReplicationTask",
       "dms:ModifyReplicationSubnetGroup",
       "logs:ListTagsLogGroup",
       "events:DescribeRule",


### PR DESCRIPTION
## A reference to the issue / Description of it

Error below was encountered when applying terraform changes in dev.
```
Error: moving DMS Replication Task (dpr-dms-dps-postgres-s3-dps-inc-reporting-task-development): operation error Database Migration Service: MoveReplicationTask, https response error StatusCode: 400, RequestID: f7f5ca3c-0bef-40d1-bbd5-cf0fa0f05ffb, api error AccessDeniedException: User: arn:aws:sts::771283872747:assumed-role/circleci_iam_role/circleci-oidc-session is not authorized to perform: dms:MoveReplicationTask on resource: arn:aws:dms:eu-west-2:771283872747:rep:34VQXCP7DNFIPI7ZFSC43FAYOQ because no identity-based policy allows the dms:MoveReplicationTask action
```
https://app.circleci.com/pipelines/github/ministryofjustice/digital-prison-reporting-domains/1935/workflows/c64347ab-af99-4bf8-b670-3126e9da626e/jobs/6140

## How does this PR fix the problem?

This PR adds the dms:MoveReplicationTask to the circleci_iam_role

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

The linked pipeline will be re-applied once merged

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

There will be no impact

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed) - N/A

## Additional comments (if any)

None
