### PR TITLE
Add `analytical-platform-common` to networking resources

### DIFF
--- a/environments-networks/platforms-production.json
+++ b/environments-networks/platforms-production.json
@@ -4,11 +4,12 @@
       "general": {
         "cidr": "10.27.96.0/21",
         "accounts": [
+          "analytical-platform-common-production",
           "analytical-platform-compute-production",
           "analytical-platform-ingestion-production",
-          "long-term-storage-production",
           "data-platform-apps-and-tools-production",
           "data-platform-production",
+          "long-term-storage-production",
           "observability-platform-production"
         ]
       }

--- a/policies/networking/expected.rego
+++ b/policies/networking/expected.rego
@@ -390,10 +390,11 @@ expected :=
       "general": {
         "cidr": "10.27.96.0/21",
         "accounts": [
+          "analytical-platform-common-production",
           "analytical-platform-ingestion-production",
           "data-platform-production",
-          "long-term-storage-production",
           "data-platform-apps-and-tools-production",
+          "long-term-storage-production",
           "observability-platform-production"
         ]
       }


### PR DESCRIPTION
## A reference to the issue / Description of it

#8621

## How does this PR fix the problem?

Completes [part two ](https://user-guide.modernisation-platform.service.justice.gov.uk/runbooks/creating-accounts-for-end-users.html#networking-stage)of our new account setup. Does a little extra alphabetising.

## How has this been tested?

Tested through CI pipeline

## Deployment Plan / Instructions

Deploy through CI. Confirm RAM shares are in place following deployment

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
