### PR TITLE
Temporarily resolve SNS topic error for new account bootstrapping

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/notifications.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/notifications.tf
@@ -107,5 +107,6 @@ locals {
 # Subscribe SNS topics in member accounts to pagerduty for core monitoring
 module "core_monitoring" {
   source                     = "../../../modules/core-monitoring"
+  depends_on = [data.aws_sns_topic.existing_topic]
   pagerduty_integration_keys = local.pagerduty_integration_keys
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/actions/runs/12319236885/job/34387352123#step:7:302

## How does this PR fix the problem?

Places a `depends_on` similarly to an [existing example](https://github.com/ministryofjustice/modernisation-platform/blob/main/terraform/environments/bootstrap/member-bootstrap/notifications.tf#L25) in the same code.

I'm not 100% convinced that this is the right approach - if anything this feels like a tactical fix that we should look at again in a strategic manner. Relying on a data call to retrieve an SNS topic created elsewhere doesn't feel right to me, but we might want to raise an issue / discuss with our TA a more strategic approach.

## How has this been tested?

Ran local plan. Tested through CI.

A more thorough test might involve a `terraform apply --destroy` in say, the `sprinkler-development` workspace, then a local `terraform apply`.

## Deployment Plan / Instructions

Deploy through CI. Observe new accounts creating successfully without the need to be retriggered.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
