### PR TITLE
Add setup terraform step to ram association jobs

### DIFF
--- a/.github/workflows/core-vpc-development-deployment.yml
+++ b/.github/workflows/core-vpc-development-deployment.yml
@@ -86,6 +86,11 @@ jobs:
           role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions-apply"
           role-session-name: githubactionsrolesession
           aws-region: ${{ env.AWS_REGION }}
+      
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+        with:
+          terraform_wrapper: false
 
       - name: Run RAM association if needed
         run: bash scripts/get-applications-and-run-ram.sh ${TF_ENV}

--- a/.github/workflows/core-vpc-preproduction-deployment.yml
+++ b/.github/workflows/core-vpc-preproduction-deployment.yml
@@ -86,6 +86,11 @@ jobs:
           role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions-apply"
           role-session-name: githubactionsrolesession
           aws-region: ${{ env.AWS_REGION }}
+          
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+        with:
+          terraform_wrapper: false
 
       - name: Run RAM association if needed
         run: bash scripts/get-applications-and-run-ram.sh ${TF_ENV}

--- a/.github/workflows/core-vpc-production-deployment.yml
+++ b/.github/workflows/core-vpc-production-deployment.yml
@@ -87,6 +87,11 @@ jobs:
           role-session-name: githubactionsrolesession
           aws-region: ${{ env.AWS_REGION }}
 
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+        with:
+          terraform_wrapper: false
+
       - name: Run RAM association if needed
         run: bash scripts/get-applications-and-run-ram.sh ${TF_ENV}
 

--- a/.github/workflows/core-vpc-test-deployment.yml
+++ b/.github/workflows/core-vpc-test-deployment.yml
@@ -85,6 +85,11 @@ jobs:
           role-session-name: githubactionsrolesession
           aws-region: ${{ env.AWS_REGION }}
 
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+        with:
+          terraform_wrapper: false
+
       - name: Run RAM association if needed
         run: bash scripts/get-applications-and-run-ram.sh ${TF_ENV}
 


### PR DESCRIPTION
## A reference to the issue / Description of it

When running the ram association jobs I encountered an error where terraform is not installed on the GHA runner e.g. https://github.com/ministryofjustice/modernisation-platform/actions/runs/12350065862/job/34462206713#step:5:25

## How does this PR fix the problem?

This PR adds a setup terraform step to the ram association jobs as latest version of ubuntu (24.04) does not have it pre-installed in GHA runners

See [here](https://github.com/actions/runner-images/issues/10636) for more details.

Longer term we could finesse this setup in our backlogged issue to make this a reusable workflow step: https://github.com/ministryofjustice/modernisation-platform/issues/8233

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Difficult to test as the ram association step is skipped unless running on main but I think it should do the trick.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [X] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
