### PR TITLE
Change `analytical-platform-compute-common` to `member` account type

### DIFF
--- a/environments/analytical-platform-common.json
+++ b/environments/analytical-platform-common.json
@@ -1,5 +1,5 @@
 {
-  "account-type": "member-unrestricted",
+  "account-type": "member",
   "environments": [
     {
       "name": "production",


### PR DESCRIPTION
## A reference to the issue / Description of it

After speaking to @jacobwoffenden we're changing this account type to `member` as it should create the necessary files to create infra/pipelines in the `modrnisation-platform-environments` repository. 

Also there wasn't a real need for the account to be unrestricted.

## How does this PR fix the problem?

Changes account type.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
