### PR TITLE
Add subnet share file to `analytical-platform-compute-common` environment

### DIFF
--- a/terraform/environments/analytical-platform-common/subnet_share.tf
+++ b/terraform/environments/analytical-platform-common/subnet_share.tf
@@ -1,0 +1,41 @@
+######## DO NOT EDIT - THIS FILE WILL BE OVERWRITTEN BY TERRAFORM #########
+
+data "aws_caller_identity" "current" {}
+
+
+module "ram-principal-association" {
+
+  count = (var.networking[0].set == "") ? 0 : 1
+
+  source = "../../modules/ram-principal-association"
+
+  providers = {
+    aws.share-acm    = aws.core-network-services
+    aws.share-host   = aws.core-vpc
+    aws.share-tenant = aws
+  }
+  principal   = data.aws_caller_identity.current.account_id
+  vpc_name    = var.networking[0].business-unit
+  subnet_set  = var.networking[0].set
+  acm_pca     = "acm-pca-${local.is_live[0]}"
+  environment = local.environment
+
+}
+
+#ram-ec2-retagging module 
+module "ram-ec2-retagging" {
+
+  count = (var.networking[0].set == "") ? 0 : 1
+
+
+  source = "../../modules/ram-ec2-retagging"
+  providers = {
+    aws.share-host   = aws.core-vpc
+    aws.share-tenant = aws
+  }
+
+  vpc_name   = "${var.networking[0].business-unit}-${local.environment}"
+  subnet_set = var.networking[0].set
+
+  depends_on = [module.ram-principal-association[0]]
+}


### PR DESCRIPTION
## A reference to the issue / Description of it

I'm changing this account to a regular member account with regular networking setup. However as we originally set it up as member unrestricted the subnet share was not included in the files.

## How does this PR fix the problem?

This PR adds the subnet share file.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
