### PR TITLE
Graceful handling of git commit in `git-commit.sh`

### DIFF
--- a/scripts/git-commit.sh
+++ b/scripts/git-commit.sh
@@ -17,13 +17,14 @@ commit_message="Workflow: created files in ${1}"
 
 git checkout -b "$branch"
 git add "$1"
-git commit -m "$commit_message"
 
-commit_success=$?
-if [ $commit_success -ne 0 ]; then
-  echo "Nothing to commit"
+# Check if there are any changes to commit
+if git diff-index --quiet HEAD --; then
+  echo "Nothing to commit, working tree clean"
   exit 0
 fi
+
+git commit -m "$commit_message"
 
 git remote rm origin || true
 git remote add origin "https://${TOKEN}@github.com/${GITHUB_REPOSITORY}.git"


### PR DESCRIPTION
## A reference to the issue / Description of it

We are seeing the git-commit.sh script fail when there are no changes to commit, e.g.

```
Switched to a new branch 'date-1734447481'
On branch date-1734447481
nothing to commit, working tree clean
Error: Process completed with exit code 1.
```

https://github.com/ministryofjustice/modernisation-platform/actions/runs/12374331516/job/34540652979

## How does this PR fix the problem?

The issue seemed to be that when the script runs a `git commit` and there are no changes the script would exit with code 1.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Runs successfully here: https://github.com/ministryofjustice/modernisation-platform/actions/runs/12379611085/job/34554145511

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
