### PR TITLE
Add SageMaker permissions to Deployment role

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -217,7 +217,8 @@ data "aws_iam_policy_document" "member-access" {
       "resource-explorer-2:*",
       "transfer:*",
       "kinesisanalytics:*Application*",
-      "kinesisanalytics:*Resource"
+      "kinesisanalytics:*Resource",
+      "sagemaker:*"
     ]
     resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
   }


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/analytical-platform/issues/6355

Running a POC in SageMaker JumpStart and encountering this while applying: https://github.com/ministryofjustice/modernisation-platform-environments/actions/runs/12392755001/job/34593931257?pr=9132#:~:text=Error%3A%20creating,sagemaker%3AAddTags%20action

## How does this PR fix the problem?

Adds `sagemaker` permissions to the infra role.

## How has this been tested?

Test post-deployment


## Deployment Plan / Instructions

N/A


## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
