### PR TITLE
Use `aws_vpc_endpoint_route_table_association` resource

### DIFF
--- a/terraform/environments/core-shared-services/vpc.tf
+++ b/terraform/environments/core-shared-services/vpc.tf
@@ -53,7 +53,8 @@ locals {
     for value in setproduct(keys(local.networking), local.vpc_interface_endpoint_service_names) :
     "${value[0]}-${value[1]}" => {
       vpc_name      = value[0],
-      endpoint_name = value[1]
+      endpoint_name = value[1],
+      rtb_ids       = local.private_route_tables[value[0]]
     }
   }
 
@@ -61,9 +62,18 @@ locals {
     for value in setproduct(keys(local.networking), local.vpc_gateway_endpoint_service_names) :
     "${value[0]}-${value[1]}" => {
       vpc_name      = value[0],
-      endpoint_name = value[1]
+      endpoint_name = value[1],
+      rtb_ids       = local.private_route_tables[value[0]]
     }
   }
+
+  route_table_to_gateway_endpoint = merge([
+    for key, value in local.private_route_tables : {
+      for rt_id in value :
+      rt_id => aws_vpc_endpoint.vpc_gateway_endpoints["${key}-${local.vpc_gateway_endpoint_service_names[0]}"].id
+    }
+  ]...)
+
 }
 
 resource "aws_vpc_endpoint" "vpc_interface_endpoints" {
@@ -87,13 +97,18 @@ resource "aws_vpc_endpoint" "vpc_gateway_endpoints" {
   vpc_endpoint_type = "Gateway"
   vpc_id            = module.vpc[each.value.vpc_name].vpc_id
   service_name      = each.value.endpoint_name
-  route_table_ids   = local.private_route_tables[each.value.vpc_name]
   tags = merge(
     local.tags,
     {
       Name = "${local.application_name}-${each.value.endpoint_name}"
     }
   )
+}
+
+resource "aws_vpc_endpoint_route_table_association" "vpc_gateway_endpoints" {
+  for_each = local.route_table_to_gateway_endpoint
+  route_table_id  = each.key
+  vpc_endpoint_id = each.value
 }
 
 # Create security group for vpc endpoints


### PR DESCRIPTION
## A reference to the issue / Description of it

Attempting to manage the association of the `s3` gateway endpoint with the route table associated with the private subnets in the `core-shared-services` additional cidr results in some resource thrashing.

## How does this PR fix the problem?

VPC endpoint route table associations can be handled by the resource that creates the endpoint, or by the association resource, but not by both simultaneously.

This PR disaggregates the association of the gateway endpoint with the route tables from the resource creation.

## How has this been tested?

Tested with local plan and CI pipeline

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
