### PR TITLE
Add support for extending private DNS zone to relevant VPC

### DIFF
--- a/environments-networks/yjb-development.json
+++ b/environments-networks/yjb-development.json
@@ -11,7 +11,7 @@
     "bastion_linux": true,
     "additional_cidrs": [],
     "additional_endpoints": [],
-    "additional_private_zones": [],
+    "additional_private_zones": ["development.yjaf"],
     "additional_vpcs": [],
     "dns_zone_extend": []
   }


### PR DESCRIPTION
## A reference to the issue / Description of it

Adds the necessary steps and configuration for extending a newly created private DNS zone to the required VPCs.
[extending-the-newly-created-private-dns-zone](https://user-guide.modernisation-platform.service.justice.gov.uk/runbooks/creating-new-private-dns-zones.html#extending-the-newly-created-private-dns-zone)

## How does this PR fix the problem?

The newly created private DNS zone was not associated with the required VPCs, causing DNS resolution issues within the VPCs. This PR ensures the zone is correctly created and associated.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
