### PR TITLE
Remove `MoJRedTeam` and grant`tvm-purple-team` access to cooker

### DIFF
--- a/environments/cooker.json
+++ b/environments/cooker.json
@@ -20,7 +20,7 @@
           "nuke": "rebuild"
         },
         {
-          "sso_group_name": "MoJRedTeam",
+          "sso_group_name": "tvm-purple-team",
           "level": "sandbox",
           "nuke": "rebuild"
         }


### PR DESCRIPTION
## A reference to the issue / Description of it

As requested in the ask channel here: https://mojdt.slack.com/archives/C01A7QK5VM1/p1736171196013009

And after the requirement was refined in a private group chat here: https://moj.enterprise.slack.com/archives/C087EKMGXLK

## How does this PR fix the problem?

1. Removes `MoJRedTeam` acceess from cooker as they no longer require it.

2. Grants`tvm-purple-team` access to cooker as agreed

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
