### PR TITLE
Stops "No failed workflows" notification being sent to the team slack.

### DIFF
--- a/scripts/failed-workflows-report/create-slack-report.sh
+++ b/scripts/failed-workflows-report/create-slack-report.sh
@@ -4,7 +4,7 @@
 
 echo $formatted_date
 
-# Check if recent_failures.json exists, is not empty (so more than just []) and contains valid JSON. Else send the no failures found message.
+# Check if recent_failures.json exists, is not empty (so more than just []) and contains valid JSON).
 if [ -f recent_failures.json ] && [ "$(jq '. | length' recent_failures.json)" -gt 0 ]; then
     # This generates the slack report of failed workflows as json.
     slack_message=$(jq -n --arg formatted_date "$formatted_date" --arg repository "$GITHUB_REPO" --slurpfile failures recent_failures.json '
@@ -47,27 +47,6 @@ if [ -f recent_failures.json ] && [ "$(jq '. | length' recent_failures.json)" -g
             }
         ))
         )
-    }'
-    )
-else
-    slack_message=$(jq -n --arg formatted_date "$formatted_date" --arg repository "$GITHUB_REPO" '
-    {
-    "blocks": [
-        {
-        "type": "section",
-        "text": {
-            "type": "mrkdwn",
-            "text": ":no_entry: *Failed GitHub Actions Report in \($repository)*"
-        }
-        },
-        {
-        "type": "section",
-        "text": {
-            "type": "mrkdwn",
-            "text": "No failed workflows were found since \($formatted_date)."
-        }
-        }
-    ]
     }'
     )
 fi

--- a/scripts/failed-workflows-report/get-failed-workflows.sh
+++ b/scripts/failed-workflows-report/get-failed-workflows.sh
@@ -45,7 +45,8 @@ sendreport="true"
 
 # This checks the contents of $recent_failures and if not empty it saves the variable to a file for use in the next step.
 if [[ "$recent_failures" == "[]" ]]; then
-  echo "No workflow failures without subsequent successful completion that finished since $formatted_date ." 
+  echo "No workflow failures without subsequent successful completion that finished since $formatted_date ."
+  sendreport="false"
 elif [[ -n "$recent_failures" ]]; then
   echo "Most recent failed GitHub Actions without subsequent success that finished since $formatted_date :"
   echo "$recent_failures" > recent_failures.json


### PR DESCRIPTION
This change prevents any no-failed-workflows alerts being sent to the MP team slack channel. This cuts down on the overall noise of the channel.

## A reference to the issue / Description of it

This was mentioned in today's team retro.

## How does this PR fix the problem?

If no failed workflows are found then the steps to create & send the report are skipped. The shell script that compiles the report has the "no faults found" option removed.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
