### PR TITLE
TM-844: update nart role to enable patching

### DIFF
--- a/environments/nomis-combined-reporting.json
+++ b/environments/nomis-combined-reporting.json
@@ -55,7 +55,7 @@
       "access": [
         {
           "sso_group_name": "national-applications-reporting-team",
-          "level": "instance-access"
+          "level": "instance-management"
         },
         {
           "sso_group_name": "hosting-migrations",
@@ -78,7 +78,7 @@
       "access": [
         {
           "sso_group_name": "national-applications-reporting-team",
-          "level": "instance-access"
+          "level": "instance-management"
         },
         {
           "sso_group_name": "hosting-migrations",

--- a/environments/nomis-combined-reporting.json
+++ b/environments/nomis-combined-reporting.json
@@ -32,7 +32,7 @@
       "access": [
         {
           "sso_group_name": "national-applications-reporting-team",
-          "level": "instance-management"
+          "level": "developer"
         },
         {
           "sso_group_name": "hosting-migrations",
@@ -55,7 +55,7 @@
       "access": [
         {
           "sso_group_name": "national-applications-reporting-team",
-          "level": "instance-management"
+          "level": "developer"
         },
         {
           "sso_group_name": "hosting-migrations",
@@ -78,7 +78,7 @@
       "access": [
         {
           "sso_group_name": "national-applications-reporting-team",
-          "level": "instance-management"
+          "level": "developer"
         },
         {
           "sso_group_name": "hosting-migrations",


### PR DESCRIPTION
## A reference to the issue / Description of it

NART team are unable to run ansible to patch SAP software.

## How does this PR fix the problem?

Ansible requires ssm and s3:DeleteObject permissions.  Neither instance-access nor instance-management allow s3:DeleteObject. Since NART will be patching EC2 instances anyway with sudo, it seems reasonable to grant them developer access, in the same way we do DBAs.

## How has this been tested?

Tested ansible patching using lesser roles and it doesn't work. Developer role is known to work.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
