### PR TITLE
:wrench: Add push/pull principals

### DIFF
--- a/terraform/environments/core-shared-services/ecr_repos.tf
+++ b/terraform/environments/core-shared-services/ecr_repos.tf
@@ -765,6 +765,7 @@ module "data_platform_jml_ecr_repo" {
 
   enable_retrieval_policy_for_lambdas = [
     "arn:aws:lambda:eu-west-2:${local.environment_management.account_ids["data-platform-apps-and-tools-production"]}:function:data_platform_jml_extract*",
+    "arn:aws:iam::${local.environment_management.account_ids["analytical-platform-data-production"]}:function:data_platform_jml_extract*"
   ]
 
   # Tags

--- a/terraform/environments/core-shared-services/ecr_repos.tf
+++ b/terraform/environments/core-shared-services/ecr_repos.tf
@@ -752,12 +752,14 @@ module "data_platform_jml_ecr_repo" {
   push_principals = [
     "arn:aws:iam::${local.environment_management.account_ids["data-platform-development"]}:role/modernisation-platform-oidc-cicd",
     "arn:aws:iam::${local.environment_management.account_ids["data-platform-apps-and-tools-development"]}:role/modernisation-platform-oidc-cicd",
+    "arn:aws:iam::${local.environment_management.account_ids["analytical-platform-data-production"]}:role/modernisation-platform-oidc-cicd",
     local.environment_management.account_ids["data-platform-apps-and-tools-production"],
   ]
 
   pull_principals = [
     "arn:aws:iam::${local.environment_management.account_ids["data-platform-development"]}:role/modernisation-platform-oidc-cicd",
     "arn:aws:iam::${local.environment_management.account_ids["data-platform-apps-and-tools-development"]}:role/modernisation-platform-oidc-cicd",
+    "arn:aws:iam::${local.environment_management.account_ids["analytical-platform-data-production"]}:role/modernisation-platform-oidc-cicd",
     local.environment_management.account_ids["data-platform-apps-and-tools-production"],
   ]
 


### PR DESCRIPTION
## A reference to the issue / Description of it

Add push/pull principals to facilitate the move of a lambda function from one AWS account to another.
Relates to [this](https://github.com/ministryofjustice/analytical-platform/issues/6517) issue. 

## How does this PR fix the problem?

Adds the correct push/pull principals for the new AWS account. I'll remove the old ones once this is working. 

## How has this been tested?

NA

## Deployment Plan / Instructions

Allows pulls from another AWS account.


## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

