### PR TITLE
give nart team access to hmpps-domain-services environments

### DIFF
--- a/environments/hmpps-domain-services.json
+++ b/environments/hmpps-domain-services.json
@@ -1,6 +1,9 @@
 {
   "account-type": "member",
-  "codeowners": ["hosting-migrations", "studio-webops"],
+  "codeowners": [
+    "hosting-migrations",
+    "studio-webops"
+  ],
   "environments": [
     {
       "name": "development",
@@ -17,6 +20,10 @@
         },
         {
           "sso_group_name": "csr-application-support",
+          "level": "instance-management"
+        },
+        {
+          "sso_group_name": "national-applications-reporting-team",
           "level": "instance-management"
         }
       ]
@@ -37,6 +44,10 @@
         {
           "sso_group_name": "csr-application-support",
           "level": "instance-management"
+        },
+        {
+          "sso_group_name": "national-applications-reporting-team",
+          "level": "instance-management"
         }
       ]
     },
@@ -56,6 +67,10 @@
         {
           "sso_group_name": "csr-application-support",
           "level": "instance-management"
+        },
+        {
+          "sso_group_name": "national-applications-reporting-team",
+          "level": "instance-management"
         }
       ]
     },
@@ -74,6 +89,10 @@
         },
         {
           "sso_group_name": "csr-application-support",
+          "level": "instance-management"
+        },
+        {
+          "sso_group_name": "national-applications-reporting-team",
           "level": "instance-management"
         }
       ]


### PR DESCRIPTION
## A reference to the issue / Description of it

Give Nart team access to hmpps-domain-services as their BIP Client machines will be hosted here

## How does this PR fix the problem?

Gives them instance-management access

## How has this been tested?

They'll be able to access things, it's fine

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

Nope

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

Will write this up for the nart team when everything else is in place
