### PR TITLE
Update ecr_repos.tf

### DIFF
--- a/terraform/environments/core-shared-services/ecr_repos.tf
+++ b/terraform/environments/core-shared-services/ecr_repos.tf
@@ -1108,6 +1108,29 @@ module "delius_core_new_tech_web_repo" {
   tags_common = local.tags
 }
 
+
+module "delius_core_oracle_observer_ecr_repo" {
+  source = "../../modules/app-ecr-repo"
+
+  app_name = "delius-core-oracle-observer"
+
+  push_principals = [
+    "arn:aws:iam::${local.environment_management.account_ids["delius-core-development"]}:role/modernisation-platform-oidc-cicd",
+    "arn:aws:iam::${local.environment_management.account_ids["delius-core-test"]}:role/modernisation-platform-oidc-cicd"
+  ]
+
+  pull_principals = [
+    local.environment_management.account_ids["delius-core-development"],
+    local.environment_management.account_ids["delius-core-test"],
+    "arn:aws:iam::${local.environment_management.account_ids["delius-core-development"]}:role/modernisation-platform-oidc-cicd",
+    "arn:aws:iam::${local.environment_management.account_ids["delius-core-test"]}:role/modernisation-platform-oidc-cicd"
+  ]
+
+  # Tags
+  tags_common = local.tags
+}
+
+
 module "analytical_platform_ingestion_notify_ecr_repo" {
   source = "../../modules/app-ecr-repo"
 


### PR DESCRIPTION
Add ECR for Oracle Data Guard FSFO Observer image for Delius

## A reference to the issue / Description of it

ECR for storing docker container image to run Oracle Data Guard Observer:  https://docs.oracle.com/en/database/oracle/oracle-database/19/dgbkr/using-data-guard-broker-to-manage-switchovers-failovers.html#GUID-5E2A8696-38B4-4782-B8EF-95C0975CD7C6

This is required for automated fast-start failover of the Delius Oracle database.

## How does this PR fix the problem?

Allows storage of the docker container image.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Following this documentation:   https://user-guide.modernisation-platform.service.justice.gov.uk/user-guide/add-an-ecr-for-docker-images.html#introduction

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No impact on service as merely storing an image at this stage.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [tbd] I have made corresponding changes to the documentation
- [na] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
