### PR TITLE
:adhesive_bandage: Fix `arn:aws:iam` -> `arn:aws:lambda`

### DIFF
--- a/terraform/environments/core-shared-services/ecr_repos.tf
+++ b/terraform/environments/core-shared-services/ecr_repos.tf
@@ -765,7 +765,7 @@ module "data_platform_jml_ecr_repo" {
 
   enable_retrieval_policy_for_lambdas = [
     "arn:aws:lambda:eu-west-2:${local.environment_management.account_ids["data-platform-apps-and-tools-production"]}:function:data_platform_jml_extract*",
-    "arn:aws:iam::${local.environment_management.account_ids["analytical-platform-data-production"]}:function:data_platform_jml_extract*"
+    "arn:aws:lambda:eu-west-2:${local.environment_management.account_ids["analytical-platform-data-production"]}:function:data_platform_jml_extract*"
   ]
 
   # Tags


### PR DESCRIPTION
This PR resolves errors seen as a result of [this](https://github.com/ministryofjustice/modernisation-platform/commit/1783aae3e2e08b8bef8ae2f440740bd0b23eeefe) previous commit. 

This was raised in [this](https://mojdt.slack.com/archives/C06TFT94JTC/p1736429549168269) Slack thread.