### PR TITLE
Force full principal for data-platform-jml-extract-lambda ECR policy

### DIFF
--- a/terraform/environments/core-shared-services/ecr_repos.tf
+++ b/terraform/environments/core-shared-services/ecr_repos.tf
@@ -753,14 +753,14 @@ module "data_platform_jml_ecr_repo" {
     "arn:aws:iam::${local.environment_management.account_ids["data-platform-development"]}:role/modernisation-platform-oidc-cicd",
     "arn:aws:iam::${local.environment_management.account_ids["data-platform-apps-and-tools-development"]}:role/modernisation-platform-oidc-cicd",
     "arn:aws:iam::${local.environment_management.account_ids["analytical-platform-data-production"]}:role/modernisation-platform-oidc-cicd",
-    local.environment_management.account_ids["data-platform-apps-and-tools-production"],
+    "arn:aws:iam::${local.environment_management.account_ids["data-platform-apps-and-tools-production"]}:root",
   ]
 
   pull_principals = [
     "arn:aws:iam::${local.environment_management.account_ids["data-platform-development"]}:role/modernisation-platform-oidc-cicd",
     "arn:aws:iam::${local.environment_management.account_ids["data-platform-apps-and-tools-development"]}:role/modernisation-platform-oidc-cicd",
     "arn:aws:iam::${local.environment_management.account_ids["analytical-platform-data-production"]}:role/modernisation-platform-oidc-cicd",
-    local.environment_management.account_ids["data-platform-apps-and-tools-production"],
+    "arn:aws:iam::${local.environment_management.account_ids["data-platform-apps-and-tools-production"]}:root",
   ]
 
   enable_retrieval_policy_for_lambdas = [


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/actions/runs/12706190508/job/35418649556

## How does this PR fix the problem?

Forces the full principal as, for reasons I'm not currently sure of, the ECR policy for this repository is not expanding out an AWS account ID into a full principal

## How has this been tested?

Tested with local Terraform plan only

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
