### PR TITLE
Enable R53 DNS Firewall in ALERT mode

### DIFF
--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -80,26 +80,6 @@ locals {
 
   modernisation-platform-domain          = "modernisation-platform.service.justice.gov.uk"
   modernisation-platform-internal-domain = "modernisation-platform.internal"
-
-  # These locals can be used to define custom allow or block list of domains on a per-VPC basis
-  dns_firewall_allowed_domains = {
-    core-vpc-production    = {}
-    core-vpc-preproduction = {}
-    core-vpc-test          = {}
-    core-vpc-development   = {}
-    core-vpc-sandbox = {
-      garden-sandbox = []
-    }
-  }
-  dns_firewall_blocked_domains = {
-    core-vpc-production    = {}
-    core-vpc-preproduction = {}
-    core-vpc-test          = {}
-    core-vpc-development   = {}
-    core-vpc-sandbox = {
-      garden-sandbox = []
-    }
-  }
 }
 
 module "vpc" {
@@ -370,11 +350,6 @@ resource "aws_iam_role_policy_attachments_exclusive" "member_delegation_read_onl
 }
 
 # R53 Resolver DNS Firewall
-# By default the AWS managed domain lists are set to ALERT - see https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resolver-dns-firewall-managed-domain-lists.html
-# We will look to switch these to BLOCK in a future PR
-# A custom list of blocked or allowed domains can be defined in locals
-# R53 Query logging is enabled and sends logs to a CloudWatch log group where a metric filters for the firewall alerting on or blocking traffic
-# When the Cloudwatch alarm is triggered, it will send an alert to PagerDuty/Slack
 module "r53_dns_firewall" {
   for_each = local.vpcs[terraform.workspace]
   source   = "../../modules/r53-dns-firewall"

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -354,11 +354,7 @@ module "r53_dns_firewall" {
   for_each = local.vpcs[terraform.workspace]
   source   = "../../modules/r53-dns-firewall"
 
-  vpc_id = module.vpc[each.key].vpc_id
-
-  allowed_domains = lookup(local.dns_firewall_allowed_domains[terraform.workspace], each.key, [])
-  blocked_domains = lookup(local.dns_firewall_blocked_domains[terraform.workspace], each.key, [])
-
+  vpc_id                    = module.vpc[each.key].vpc_id
   pagerduty_integration_key = local.pagerduty_integration_keys["core_alerts_cloudwatch"]
 
   tags_prefix = each.key

--- a/terraform/modules/r53-dns-firewall/README.md
+++ b/terraform/modules/r53-dns-firewall/README.md
@@ -1,0 +1,122 @@
+# R53 DNS Firewall
+
+Terraform module used to create R53 DNS Firewall resources for Modernisation Platform VPCs. For more info see https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resolver-dns-firewall-overview.html
+
+This module creates the following resources per VPC:
+
+- a R53 Resolver Firewall Rule Group associated with the VPC
+- a custom list of allowed and blocked domains which can be defined via the `allowed_domains` and `blocked_domains` inputs
+- R53 Resolver Firewall Rules in the following priority:
+  **1** - An allow rule for the `allowed_domains` list
+  **2-5** - a set of rules that ALERT on any domains that match the [AWS-managed threat lists](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resolver-dns-firewall-managed-domain-lists.html)
+  **6** - A Block rule for the `blocked_domains` list
+- R53 Resolver query logging config to be associated with a cloudwatch log group
+- Cloudwatch alarm so any matching domains that the firewall acts on trigger a dedicated SNS topic which is hooked into PagerDuty (this is currently subscribed to the PagerDuty Core Alerts service - associated with the `#modernisation-platform-low-priority-alarms` Slack channel)
+
+# Example usage
+
+```
+locals {
+  dns_firewall_allowed_domains = {
+    core-vpc-production    = {}
+    core-vpc-preproduction = {}
+    core-vpc-test          = {}
+    core-vpc-development   = {}
+    core-vpc-sandbox = {
+      garden-sandbox = ["good-domain.com"]
+    }
+  }
+  dns_firewall_blocked_domains = {
+    core-vpc-production    = {}
+    core-vpc-preproduction = {}
+    core-vpc-test          = {}
+    core-vpc-development   = {}
+    core-vpc-sandbox = {
+      garden-sandbox = ["bad-domain.com"]
+    }
+  }
+}
+
+module "r53_dns_firewall" {
+  for_each = local.vpcs[terraform.workspace]
+  source   = "../../modules/r53-dns-firewall"
+
+  vpc_id = module.vpc[each.key].vpc_id
+
+  allowed_domains = lookup(local.dns_firewall_allowed_domains[terraform.workspace], each.key, [])
+  blocked_domains = lookup(local.dns_firewall_blocked_domains[terraform.workspace], each.key, [])
+
+  pagerduty_integration_key = local.pagerduty_integration_keys["core_alerts_cloudwatch"]
+
+  tags_prefix = each.key
+  tags_common = local.tags
+}
+```
+
+## Looking for issues?
+If you're looking to raise an issue with this module, please create a new issue in the [Modernisation Platform repository](https://github.com/ministryofjustice/modernisation-platform/issues).
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
+| <a name="requirement_external"></a> [external](#requirement\_external) | ~> 2.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.0 |
+| <a name="provider_external"></a> [external](#provider\_external) | ~> 2.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_pagerduty_r53_dns_firewall"></a> [pagerduty\_r53\_dns\_firewall](#module\_pagerduty\_r53\_dns\_firewall) | github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration | 0179859e6fafc567843cd55c0b05d325d5012dc4 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_cloudwatch_log_group.dns_firewall_log_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_cloudwatch_log_metric_filter.dns_firewall_metric_filter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_metric_filter) | resource |
+| [aws_cloudwatch_metric_alarm.dns_firewall_alarm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_kms_alias.dns_firewall_kms_alias](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
+| [aws_kms_key.dns_firewall_kms_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
+| [aws_route53_resolver_firewall_domain_list.allow](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_resolver_firewall_domain_list) | resource |
+| [aws_route53_resolver_firewall_domain_list.block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_resolver_firewall_domain_list) | resource |
+| [aws_route53_resolver_firewall_rule.allow](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_resolver_firewall_rule) | resource |
+| [aws_route53_resolver_firewall_rule.block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_resolver_firewall_rule) | resource |
+| [aws_route53_resolver_firewall_rule.default_alert](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_resolver_firewall_rule) | resource |
+| [aws_route53_resolver_firewall_rule_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_resolver_firewall_rule_group) | resource |
+| [aws_route53_resolver_firewall_rule_group_association.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_resolver_firewall_rule_group_association) | resource |
+| [aws_route53_resolver_query_log_config.dns_firewall_log_config](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_resolver_query_log_config) | resource |
+| [aws_route53_resolver_query_log_config_association.dns_firewall_log_config_association](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_resolver_query_log_config_association) | resource |
+| [aws_sns_topic.dns_firewall_sns_topic](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.dns_firewall_kms_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [external_external.aws_managed_domain_lists](https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/external) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_allowed_domains"></a> [allowed\_domains](#input\_allowed\_domains) | List of allowed domains | `list(string)` | `[]` | no |
+| <a name="input_association_priority"></a> [association\_priority](#input\_association\_priority) | Priority of the firewall rule group association | `number` | `101` | no |
+| <a name="input_block_response"></a> [block\_response](#input\_block\_response) | The way that you want DNS Firewall to block the request. Supported Valid values are NODATA, NXDOMAIN, or OVERRIDE | `string` | `"NXDOMAIN"` | no |
+| <a name="input_blocked_domains"></a> [blocked\_domains](#input\_blocked\_domains) | List of blocked domains | `list(string)` | `[]` | no |
+| <a name="input_pagerduty_integration_key"></a> [pagerduty\_integration\_key](#input\_pagerduty\_integration\_key) | The PagerDuty integration key | `string` | n/a | yes |
+| <a name="input_tags_common"></a> [tags\_common](#input\_tags\_common) | Ministry of Justice required tags | `map(any)` | n/a | yes |
+| <a name="input_tags_prefix"></a> [tags\_prefix](#input\_tags\_prefix) | Prefix for name tags, e.g. the name of the VPC for unique identification of resources | `string` | n/a | yes |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The ID of the VPC to associate with the DNS Firewall rule group | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_firewall_rule_group_id"></a> [firewall\_rule\_group\_id](#output\_firewall\_rule\_group\_id) | The ID of the DNS Firewall rule group |
+<!-- END_TF_DOCS -->

--- a/terraform/modules/r53-dns-firewall/fetch-aws-managed-domain-lists.sh
+++ b/terraform/modules/r53-dns-firewall/fetch-aws-managed-domain-lists.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+aws route53resolver list-firewall-domain-lists | jq -r '
+{
+  "AWSManagedDomainsAggregateThreatList": (.FirewallDomainLists[] | select(.Name == "AWSManagedDomainsAggregateThreatList") | .Id),
+  "AWSManagedDomainsMalwareDomainList": (.FirewallDomainLists[] | select(.Name == "AWSManagedDomainsMalwareDomainList") | .Id),
+  "AWSManagedDomainsBotnetCommandandControl": (.FirewallDomainLists[] | select(.Name == "AWSManagedDomainsBotnetCommandandControl") | .Id),
+  "AWSManagedDomainsAmazonGuardDutyThreatList": (.FirewallDomainLists[] | select(.Name == "AWSManagedDomainsAmazonGuardDutyThreatList") | .Id)
+}'

--- a/terraform/modules/r53-dns-firewall/main.tf
+++ b/terraform/modules/r53-dns-firewall/main.tf
@@ -1,0 +1,186 @@
+# R53 Resolver DNS Firewall Resources - created on a per-VPC basis
+
+# Rule group
+resource "aws_route53_resolver_firewall_rule_group" "this" {
+  name = "${var.tags_prefix}-r53-dns-firewall-rule-group"
+  tags = var.tags_common
+}
+
+# Allowed domain list
+resource "aws_route53_resolver_firewall_domain_list" "allow" {
+  name    = "${var.tags_prefix}-allow-domain-list"
+  domains = [for domain in var.allowed_domains : "${domain}."]
+  tags    = var.tags_common
+}
+
+# Blocked domain list
+resource "aws_route53_resolver_firewall_domain_list" "block" {
+  name    = "${var.tags_prefix}-block-domain-list"
+  domains = [for domain in var.blocked_domains : "${domain}."]
+  tags    = var.tags_common
+}
+
+# Default rule to ALERT on AWS-managed bad domain lists - see https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resolver-dns-firewall-managed-domain-lists.html
+# These rules will be set to ALERT initially and enabled in production - after a period of monitoring we will switch to BLOCK
+data "external" "aws_managed_domain_lists" {
+  program = ["bash", "${path.module}/fetch-aws-managed-domain-lists.sh"]
+}
+resource "aws_route53_resolver_firewall_rule" "default_alert" {
+  for_each = data.external.aws_managed_domain_lists.result
+
+
+  action                  = "ALERT"
+  firewall_domain_list_id = each.value
+  priority                = each.key == "AWSManagedDomainsAggregateThreatList" ? 2 : each.key == "AWSManagedDomainsMalwareDomainList" ? 3 : each.key == "AWSManagedDomainsBotnetCommandandControl" ? 4 : 5
+  firewall_rule_group_id  = aws_route53_resolver_firewall_rule_group.this.id
+  name                    = "Alert_${each.key}"
+  # block_response          = var.block_response # Leaving this commented out until we turn on blocking in a future PR
+}
+
+# Rule to allow domains in the allow list (takes top priority)
+resource "aws_route53_resolver_firewall_rule" "allow" {
+  action                  = "ALLOW"
+  firewall_domain_list_id = aws_route53_resolver_firewall_domain_list.allow.id
+  priority                = 1
+  firewall_rule_group_id  = aws_route53_resolver_firewall_rule_group.this.id
+  name                    = "Allow_${var.tags_prefix}_domain_list"
+}
+
+# Rule to block domains in the block list (takes lowest priority)
+resource "aws_route53_resolver_firewall_rule" "block" {
+  action                  = "BLOCK"
+  firewall_domain_list_id = aws_route53_resolver_firewall_domain_list.block.id
+  priority                = 6
+  firewall_rule_group_id  = aws_route53_resolver_firewall_rule_group.this.id
+  name                    = "Block_${var.tags_prefix}_domain_list"
+  block_response          = var.block_response # defaults to NXDOMAIN
+}
+
+# Association of the rule group with the VPC
+resource "aws_route53_resolver_firewall_rule_group_association" "this" {
+  firewall_rule_group_id = aws_route53_resolver_firewall_rule_group.this.id
+  vpc_id                 = var.vpc_id
+  priority               = var.association_priority
+  name                   = "${var.tags_prefix}-association"
+  tags                   = var.tags_common
+}
+
+# Configures DNS Firewall logging to CloudWatch 
+resource "aws_route53_resolver_query_log_config" "dns_firewall_log_config" {
+  name            = "${var.tags_prefix}-rqlc-cloudwatch"
+  destination_arn = aws_cloudwatch_log_group.dns_firewall_log_group.arn
+  tags            = var.tags_common
+}
+
+# Associate the DNS Firewall log config with the VPC
+resource "aws_route53_resolver_query_log_config_association" "dns_firewall_log_config_association" {
+  resolver_query_log_config_id = aws_route53_resolver_query_log_config.dns_firewall_log_config.id
+  resource_id                  = var.vpc_id
+}
+
+# Creates a CloudWatch log group for DNS Firewall logs (logs retained for 365 days)
+resource "aws_cloudwatch_log_group" "dns_firewall_log_group" {
+  name              = "/aws/route53resolver/dns_firewall/${var.tags_prefix}"
+  retention_in_days = 365
+  kms_key_id        = aws_kms_key.dns_firewall_kms_key.arn
+  tags              = var.tags_common
+}
+
+# Creates a metric filter for DNS Firewall logs to count the number of domain matches that are blocked or alerted on
+resource "aws_cloudwatch_log_metric_filter" "dns_firewall_metric_filter" {
+  name           = "${var.tags_prefix}-DNSFirewallMatches"
+  log_group_name = aws_cloudwatch_log_group.dns_firewall_log_group.name
+
+  pattern = "{ ($.firewall_rule_action = \"BLOCK\" || $.firewall_rule_action = \"ALERT\") && $.vpc_id = \"${var.vpc_id}\" }"
+  metric_transformation {
+    name      = "${var.tags_prefix}-DNSFirewallMatches"
+    namespace = "DNSFirewall"
+    value     = "1"
+  }
+}
+
+# Creates a CloudWatch alarm to alert on DNS Firewall matches and links to an SNS topic
+resource "aws_cloudwatch_metric_alarm" "dns_firewall_alarm" {
+  alarm_name          = "${var.tags_prefix}-DNSFirewallMatchesAlarm"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = aws_cloudwatch_log_metric_filter.dns_firewall_metric_filter.metric_transformation[0].name
+  namespace           = aws_cloudwatch_log_metric_filter.dns_firewall_metric_filter.metric_transformation[0].namespace
+  period              = "60"
+  statistic           = "Sum"
+  threshold           = "1"
+
+  alarm_actions = [aws_sns_topic.dns_firewall_sns_topic.arn]
+  tags          = var.tags_common
+}
+
+# Creates an SNS topic for DNS Firewall matches
+resource "aws_sns_topic" "dns_firewall_sns_topic" {
+  name              = "${var.tags_prefix}-DNSFirewallMatchesTopic"
+  kms_master_key_id = aws_kms_key.dns_firewall_kms_key.key_id
+  tags              = var.tags_common
+}
+
+# Creates a KMS key for DNS Firewall SNS Topic encryption
+resource "aws_kms_key" "dns_firewall_kms_key" {
+  description         = "KMS key for DNS Firewall SNS Topic Encryption"
+  enable_key_rotation = true
+  policy              = data.aws_iam_policy_document.dns_firewall_kms_policy.json
+  tags                = var.tags_common
+}
+
+resource "aws_kms_alias" "dns_firewall_kms_alias" {
+  name_prefix   = "alias/${var.tags_prefix}-DNSFirewallSNSKey"
+  target_key_id = aws_kms_key.dns_firewall_kms_key.key_id
+}
+
+# Policy for the KMS key to allow SNS/Cloudwatch services to use the key
+data "aws_iam_policy_document" "dns_firewall_kms_policy" {
+  # checkov:skip=CKV_AWS_111: "policy is directly related to the resource"
+  # checkov:skip=CKV_AWS_109: "policy is directly related to the resource"
+  # checkov:skip=CKV_AWS_356: "policy is directly related to the resource"
+  statement {
+    sid    = "Allow SNS/Cloudwatch services to use the KMS key"
+    effect = "Allow"
+    actions = [
+      "kms:Encrypt",
+      "kms:Decrypt",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:DescribeKey"
+    ]
+    resources = [
+      "*"
+    ]
+    principals {
+      type        = "Service"
+      identifiers = ["sns.amazonaws.com", "cloudwatch.amazonaws.com", "logs.amazonaws.com"]
+    }
+  }
+
+  statement {
+    sid    = "Allow account to manage key"
+    effect = "Allow"
+    actions = [
+      "kms:*"
+    ]
+    resources = [
+      "*"
+    ]
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+  }
+}
+
+# Data source to get the current AWS account ID
+data "aws_caller_identity" "current" {}
+
+# Subscribes the SNS topic to PagerDuty
+module "pagerduty_r53_dns_firewall" {
+  depends_on                = [aws_sns_topic.dns_firewall_sns_topic]
+  source                    = "github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration?ref=0179859e6fafc567843cd55c0b05d325d5012dc4" # v2.0.0
+  sns_topics                = [aws_sns_topic.dns_firewall_sns_topic.name]
+  pagerduty_integration_key = var.pagerduty_integration_key
+}

--- a/terraform/modules/r53-dns-firewall/outputs.tf
+++ b/terraform/modules/r53-dns-firewall/outputs.tf
@@ -1,0 +1,4 @@
+output "firewall_rule_group_id" {
+  description = "The ID of the DNS Firewall rule group"
+  value       = aws_route53_resolver_firewall_rule_group.this.id
+}

--- a/terraform/modules/r53-dns-firewall/variables.tf
+++ b/terraform/modules/r53-dns-firewall/variables.tf
@@ -1,0 +1,42 @@
+variable "tags_prefix" {
+  description = "Prefix for name tags, e.g. the name of the VPC for unique identification of resources"
+  type        = string
+}
+
+variable "tags_common" {
+  description = "Ministry of Justice required tags"
+  type        = map(any)
+}
+
+variable "vpc_id" {
+  description = "The ID of the VPC to associate with the DNS Firewall rule group"
+  type        = string
+}
+
+variable "association_priority" {
+  description = "Priority of the firewall rule group association"
+  type        = number
+  default     = 101
+}
+
+variable "block_response" {
+  description = "The way that you want DNS Firewall to block the request. Supported Valid values are NODATA, NXDOMAIN, or OVERRIDE"
+  type        = string
+  default     = "NXDOMAIN"
+}
+variable "allowed_domains" {
+  description = "List of allowed domains"
+  type        = list(string)
+  default     = []
+}
+
+variable "blocked_domains" {
+  description = "List of blocked domains"
+  type        = list(string)
+  default     = []
+}
+
+variable "pagerduty_integration_key" {
+  description = "The PagerDuty integration key"
+  type        = string
+}

--- a/terraform/modules/r53-dns-firewall/versions.tf
+++ b/terraform/modules/r53-dns-firewall/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    aws = {
+      version = "~> 5.0"
+      source  = "hashicorp/aws"
+    }
+    external = {
+      version = "~> 2.0"
+      source  = "hashicorp/external"
+    }
+  }
+  required_version = "~> 1.0"
+}


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/7474

## How does this PR fix the problem?

This PR adds a new module `r53-dns-firewall` which creates the following resources per VPC:

-  a R53 Resolver Firewall Rule Group 
- a custom list of allowed and blocked domains which can be defined via locals
- R53 Resolver Firewall Rules in the following priority:
  **1** - An allow rule for the custom allowed domains list
  **2-5** - a set of rules that alert any domains that match the [AWS-managed threat lists](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resolver-dns-firewall-managed-domain-lists.html)
  **6** - A Block rule for the custom blocked domains list
- Associates the rule group to the VPC
- R53 Resolver query logging config to be associated with a cloudwatch log group
- Cloudwatch alarm so any matching domains that the firewall acts on trigger a dedicated SNS topic which is hooked into PagerDuty (this is currently subscribed to the PagerDuty Core Alerts service - associated with the `#modernisation-patform-low-priority-alarms` Slack channel)

I've then called the module in the `core-vpc` code and have added a rule to ALERT on any matches to the AWS-managed lists (https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resolver-dns-firewall-managed-domain-lists.html), this should mean any matches are alerted on (not yet blocked as I'm imagining a period of a sprint or so where we deploy to prod on alert mode only before updating to BLOCK at a later date after a careful review of the logs).

I've also demonstrated how the custom allow/block domain lists can be populated to block or allow certain domains - with some random dummy values for now. 

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

I've tested this in the garden and house sandbox VPCs by running the code locally and then running `nslookup` queries for the blocked domains on an ec2 instance in the VPCs. This has proved that the rules and logging/alerting are working.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

Not initially as we will leave it set to ALERT only but I plan to write a follow on issue to review the logs in a few weeks and then all being well turn on blocking the domains in the AWS managed lists.

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [X] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
