### PR TITLE
Adds additional accounts to skip instance-scheduler.

### DIFF
--- a/environments/analytical-platform-compute.json
+++ b/environments/analytical-platform-compute.json
@@ -13,7 +13,8 @@
           "sso_group_name": "analytical-platform",
           "level": "data-engineer"
         }
-      ]
+      ],
+      "instance_scheduler_skip": ["true"]
     },
     {
       "name": "test",
@@ -30,7 +31,8 @@
           "sso_group_name": "analytical-platform",
           "level": "quicksight-admin"
         }
-      ]
+      ],
+      "instance_scheduler_skip": ["true"]
     },
     {
       "name": "production",

--- a/environments/analytical-platform-ingestion.json
+++ b/environments/analytical-platform-ingestion.json
@@ -10,7 +10,8 @@
           "level": "sandbox",
           "nuke": "exclude"
         }
-      ]
+      ],
+      "instance_scheduler_skip": ["true"]
     },
     {
       "name": "production",

--- a/environments/cooker.json
+++ b/environments/cooker.json
@@ -25,7 +25,8 @@
           "nuke": "rebuild"
         }
       ],
-      "additional_reviewers": ["astrobinson"]
+      "additional_reviewers": ["astrobinson"],
+      "instance_scheduler_skip": ["true"]
     }
   ],
   "tags": {


### PR DESCRIPTION
This removes a number of accounts from the instance-scheduler that had been erroneously included following the move away from the fixed skip lists.

## A reference to the issue / Description of it

{Please write here}

## How does this PR fix the problem?

{Please write here}

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
