### PR TITLE
Issue/8674-tidyup

### DIFF
--- a/terraform/environments/core-shared-services/instance-scheduler-lambda-function.tf
+++ b/terraform/environments/core-shared-services/instance-scheduler-lambda-function.tf
@@ -14,10 +14,6 @@ module "instance_scheduler" {
   create_role                    = true
   reserved_concurrent_executions = 1
   additional_trust_roles         = [module.github-oidc.github_actions_role]
-  environment_variables = {
-    # Only nomis-preproduction is a member account having the InstanceSchedulerAccess role
-    "INSTANCE_SCHEDULING_SKIP_ACCOUNTS" = "analytical-platform-compute-development,analytical-platform-compute-test,analytical-platform-data-development,analytical-platform-data-engineering-sandboxa,analytical-platform-development,bichard7-sandbox-a,bichard7-sandbox-b,bichard7-sandbox-c,bichard7-sandbox-shared,bichard7-shared,bichard7-test-current,bichard7-test-next,cooker-development,core-sandbox-dev,core-vpc-development,core-vpc-preproduction,core-vpc-sandbox,core-vpc-test,mi-platform-development,moj-network-operations-centre-preproduction,nomis-preproduction,opg-lpa-data-store-development"
-  }
   image_uri    = "${local.environment_management.account_ids[terraform.workspace]}.dkr.ecr.eu-west-2.amazonaws.com/${module.instance_scheduler_ecr_repo.ecr_repository_name}:latest"
   timeout      = 600
   tracing_mode = "Active"


### PR DESCRIPTION
Removes the INSTANCE_SCHEDULING_SKIP_ACCOUNTS variable assignment as this is no longer used. As the variable itself in the module is not required, the version of the module can remain the same.

## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/8674

## How does this PR fix the problem?

As above. Note that the Go source no longer relies on this environment variable so this removes it to avoid confusion. 

There is no functional change to the operation of the instance scheduler - this is because the module has an empty default for the variable "environment_variables" and so it will handle that empty value as shown below:

https://github.com/ministryofjustice/modernisation-platform-terraform-lambda-function/blob/912834c4449af02c7f9191f1040262c17f0fb5f8/main.tf#L84

```
  dynamic "environment" {
    for_each = length(keys(var.environment_variables)) > 0 ? [1] : []
    content {
      variables = var.environment_variables
    }
  }

```

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

See unit tests below.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
