### PR TITLE
Testing new permissions for on-demand backups in Sprinkler only - DO NOT MERGE

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/data.tf
+++ b/terraform/environments/bootstrap/single-sign-on/data.tf
@@ -7,3 +7,10 @@ data "aws_s3_bucket" "mod_platform_artefact" {
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
   name = "modernisation_platform_account_id"
 }
+
+# Allows access to the current account ID
+data "aws_caller_identity" "current" {}
+
+output "account_id" {
+  value = data.aws_caller_identity.current.account_id
+}

--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -192,6 +192,7 @@ data "aws_iam_policy_document" "developer_additional" {
       "athena:List*",
       "athena:St*",
       "aws-marketplace:ViewSubscriptions",
+      "backup:StartBackupJob",
       "cloudwatch:DisableAlarmActions",
       "cloudwatch:EnableAlarmActions",
       "cloudwatch:PutDashboard",

--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -364,6 +364,20 @@ data "aws_iam_policy_document" "developer_additional" {
       values   = ["true"]
     }
   }
+
+  # Additional statement that allows for the creation of on-demand AWS Backups.
+  statement {
+    sid    = "AllowPassRoleForBackup"
+    effect = "Allow"
+    actions = ["iam:PassRole"]
+    resources = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/AWSBackup"]
+    condition {
+      test     = "StringEquals"
+      variable = "iam:PassedToService"
+      values   = ["backup.amazonaws.com"]
+    }
+  }
+
 }
 
 # data engineering policy (developer + glue + some athena)


### PR DESCRIPTION
This adds permissions to allow the developer policy to create on-demand AWS Backups.

## A reference to the issue / Description of it

{Please write here}

## How does this PR fix the problem?

{Please write here}

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
