### PR TITLE
Update Access Monitoring to use generic template

### DIFF
--- a/.github/workflows/access-keys-monitoring.yml
+++ b/.github/workflows/access-keys-monitoring.yml
@@ -9,7 +9,7 @@ env:
     AWS_REGION: "eu-west-2"
     ENVIRONMENT_MANAGEMENT: ${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENTS }}
     API_KEY: ${{ secrets.GOV_UK_NOTIFY_API_KEY }}
-    TEMPLATE_ID: "59394802-1a11-4e79-9943-3e9ecb5b3913"
+    TEMPLATE_ID: "1f0f5ccc-0f67-4ee2-942f-6e48804828ea"
 
 permissions:
     id-token: write # This is required for requesting the JWT


### PR DESCRIPTION
As per ticket https://github.com/ministryofjustice/modernisation-platform/issues/8359 this PR updates the `access-keys-monitoring` script to use a generic gov notify template containing only ((subject)) and ((message)) personalisation's (see below screenshot).

The email body and subject are now defined in code and passed to Gov Notify.

![image](https://github.com/user-attachments/assets/88c37acf-9bff-41cd-9465-7de98736ebff)

Tested locally and emailed received successfully:

![image](https://github.com/user-attachments/assets/a0b83bcc-4eff-4f8e-8313-b9390c21d40a)
