### PR TITLE
Update Workflow to Retrieve Secrets from AWS Secrets Manager

### DIFF
--- a/.github/workflows/core-logging-deployment.yml
+++ b/.github/workflows/core-logging-deployment.yml
@@ -28,6 +28,7 @@ permissions:
   id-token: write # This is required for requesting the JWT
   contents: read # This is required for actions/checkout
   pull-requests: write
+
 defaults:
   run:
     shell: bash
@@ -37,7 +38,7 @@ jobs:
     uses: ./.github/workflows/reusable_terraform_plan_apply.yml
     with:
       working-directory: "terraform/environments/core-logging"
-      environment: production
+      environment: "production"
     secrets:
-      modernisation_platform_environments: "${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENTS }}"
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      MODERNISATION_PLATFORM_ACCOUNT_NUMBER: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_NUMBER }}
+      PASSPHRASE: ${{ secrets.PASSPHRASE }}

--- a/.github/workflows/core-network-services-deployment.yml
+++ b/.github/workflows/core-network-services-deployment.yml
@@ -29,6 +29,7 @@ permissions:
   id-token: write # This is required for requesting the JWT
   contents: read # This is required for actions/checkout
   pull-requests: write
+
 defaults:
   run:
     shell: bash
@@ -38,7 +39,7 @@ jobs:
     uses: ./.github/workflows/reusable_terraform_plan_apply.yml
     with:
       working-directory: "terraform/environments/core-network-services"
-      environment: production
+      environment: "production"
     secrets:
-      modernisation_platform_environments: "${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENTS }}"
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      MODERNISATION_PLATFORM_ACCOUNT_NUMBER: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_NUMBER }}
+      PASSPHRASE: ${{ secrets.PASSPHRASE }}

--- a/.github/workflows/core-security-deployment.yml
+++ b/.github/workflows/core-security-deployment.yml
@@ -28,6 +28,7 @@ permissions:
   id-token: write # This is required for requesting the JWT
   contents: read # This is required for actions/checkout
   pull-requests: write
+  
 defaults:
   run:
     shell: bash
@@ -37,7 +38,7 @@ jobs:
     uses: ./.github/workflows/reusable_terraform_plan_apply.yml
     with:
       working-directory: "terraform/environments/core-security"
-      environment: production
+      environment: "production"
     secrets:
-      modernisation_platform_environments: "${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENTS }}"
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      MODERNISATION_PLATFORM_ACCOUNT_NUMBER: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_NUMBER }}
+      PASSPHRASE: ${{ secrets.PASSPHRASE }}

--- a/.github/workflows/core-shared-services-deployment.yml
+++ b/.github/workflows/core-shared-services-deployment.yml
@@ -34,6 +34,7 @@ permissions:
   id-token: write # This is required for requesting the JWT
   contents: read # This is required for actions/checkout
   pull-requests: write
+
 defaults:
   run:
     shell: bash
@@ -43,7 +44,7 @@ jobs:
     uses: ./.github/workflows/reusable_terraform_plan_apply.yml
     with:
       working-directory: "terraform/environments/core-shared-services"
-      environment: production
+      environment: "production"
     secrets:
-      modernisation_platform_environments: "${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENTS }}"
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      MODERNISATION_PLATFORM_ACCOUNT_NUMBER: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_NUMBER }}
+      PASSPHRASE: ${{ secrets.PASSPHRASE }}

--- a/.github/workflows/core-vpc-development-deployment.yml
+++ b/.github/workflows/core-vpc-development-deployment.yml
@@ -55,15 +55,16 @@ env:
   AWS_REGION: "eu-west-2"
   ENVIRONMENT_MANAGEMENT: ${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENTS }}
   TF_ENV: "development"
+  
 jobs:
   core-vpc-development-deployment-plan-apply:
     uses: ./.github/workflows/reusable_terraform_plan_apply.yml
     with:
       working-directory: "terraform/environments/core-vpc"
-      environment: development
+      environment: "development"
     secrets:
-      modernisation_platform_environments: "${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENTS }}"
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      MODERNISATION_PLATFORM_ACCOUNT_NUMBER: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_NUMBER }}
+      PASSPHRASE: ${{ secrets.PASSPHRASE }}
 
   member-account-ram-association:
     runs-on: [ ubuntu-latest ]

--- a/.github/workflows/core-vpc-preproduction-deployment.yml
+++ b/.github/workflows/core-vpc-preproduction-deployment.yml
@@ -46,10 +46,12 @@ env:
   AWS_REGION: "eu-west-2"
   ENVIRONMENT_MANAGEMENT: ${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENTS }}
   TF_ENV: "preproduction"
+  
 permissions:
   id-token: write # This is required for requesting the JWT
   contents: read # This is required for actions/checkout
   pull-requests: write
+
 defaults:
   run:
     shell: bash
@@ -59,10 +61,10 @@ jobs:
     uses: ./.github/workflows/reusable_terraform_plan_apply.yml
     with:
       working-directory: "terraform/environments/core-vpc"
-      environment: preproduction
+      environment: "preproduction"
     secrets:
-      modernisation_platform_environments: "${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENTS }}"
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      MODERNISATION_PLATFORM_ACCOUNT_NUMBER: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_NUMBER }}
+      PASSPHRASE: ${{ secrets.PASSPHRASE }}
 
   member-account-ram-association:
     runs-on: [ ubuntu-latest ]

--- a/.github/workflows/core-vpc-production-deployment.yml
+++ b/.github/workflows/core-vpc-production-deployment.yml
@@ -46,6 +46,7 @@ permissions:
   id-token: write # This is required for requesting the JWT
   contents: read # This is required for actions/checkout
   pull-requests: write
+  
 defaults:
   run:
     shell: bash
@@ -54,15 +55,16 @@ env:
   AWS_REGION: "eu-west-2"
   ENVIRONMENT_MANAGEMENT: ${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENTS }}
   TF_ENV: "production"
+
 jobs:
   core-vpc-production-deployment-plan-apply:
     uses: ./.github/workflows/reusable_terraform_plan_apply.yml
     with:
       working-directory: "terraform/environments/core-vpc"
-      environment: production
+      environment: "production"
     secrets:
-      modernisation_platform_environments: "${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENTS }}"
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      MODERNISATION_PLATFORM_ACCOUNT_NUMBER: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_NUMBER }}
+      PASSPHRASE: ${{ secrets.PASSPHRASE }}
 
   member-account-ram-association:
     runs-on: [ ubuntu-latest ]

--- a/.github/workflows/core-vpc-test-deployment.yml
+++ b/.github/workflows/core-vpc-test-deployment.yml
@@ -44,6 +44,7 @@ permissions:
   id-token: write # This is required for requesting the JWT
   contents: read # This is required for actions/checkout
   pull-requests: write
+
 defaults:
   run:
     shell: bash
@@ -52,15 +53,16 @@ env:
   AWS_REGION: "eu-west-2"
   ENVIRONMENT_MANAGEMENT: ${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENTS }}
   TF_ENV: "test"
+
 jobs:
   core-vpc-test-deployment-plan-apply:
     uses: ./.github/workflows/reusable_terraform_plan_apply.yml
     with:
       working-directory: "terraform/environments/core-vpc"
-      environment: test
+      environment: "test"
     secrets:
-      modernisation_platform_environments: "${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENTS }}"
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      MODERNISATION_PLATFORM_ACCOUNT_NUMBER: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_NUMBER }}
+      PASSPHRASE: ${{ secrets.PASSPHRASE }}
 
   member-account-ram-association:
     runs-on: [ ubuntu-latest ]

--- a/.github/workflows/modernisation-platform-account.yml
+++ b/.github/workflows/modernisation-platform-account.yml
@@ -30,6 +30,7 @@ permissions:
   id-token: write # This is required for requesting the JWT
   contents: read # This is required for actions/checkout
   pull-requests: write
+
 jobs:
   modernisation-platform-account-plan-and-apply:
     uses: ./.github/workflows/reusable_terraform_plan_apply.yml
@@ -37,5 +38,5 @@ jobs:
       working-directory: "terraform/modernisation-platform-account"
       workflow_id: "modernisation-platform-account"
     secrets:
-      modernisation_platform_environments: ${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENTS }}
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      MODERNISATION_PLATFORM_ACCOUNT_NUMBER: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_NUMBER }}
+      PASSPHRASE: ${{ secrets.PASSPHRASE }}

--- a/.github/workflows/reusable_terraform_plan_apply.yml
+++ b/.github/workflows/reusable_terraform_plan_apply.yml
@@ -25,30 +25,40 @@ on:
         required: false
         type: string
     secrets:
-      modernisation_platform_environments:
+      MODERNISATION_PLATFORM_ACCOUNT_NUMBER:
         required: true
-      SLACK_WEBHOOK_URL:
+      PASSPHRASE:
         required: true
-      pagerduty_token:
-        required: false
-      pagerduty_userapi_token:
-        required: false
-      gh_workflow_token: 
-        required: false
 
 env:
-  ENVIRONMENT_MANAGEMENT: "${{ secrets.modernisation_platform_environments }}"
-  TF_VAR_github_token: "${{ secrets.gh_workflow_token }}"
   TF_IN_AUTOMATION: true
-  TF_VAR_pagerduty_token: ${{ secrets.pagerduty_token }}
-  TF_VAR_pagerduty_user_token: ${{ secrets.pagerduty_userapi_token }}
-
 jobs:
+  fetch-secrets:
+    uses: ministryofjustice/modernisation-platform-github-actions/.github/workflows/aws-secrets-management.yml@d9e930d93532b84efdcf7d7b82621506e96a15b0 # v1.0.0
+    secrets:
+      MODERNISATION_PLATFORM_ACCOUNT_NUMBER: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_NUMBER }}
+      PASSPHRASE: ${{ secrets.PASSPHRASE }}
   plan-and-apply:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Decrypt Secrets
+        uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@d9e930d93532b84efdcf7d7b82621506e96a15b0 # v1.0.0
+        with:
+          environment_management: ${{ needs.retrieve-secrets.outputs.environment_management }}
+          slack_webhook_url: ${{ needs.retrieve-secrets.outputs.slack_webhook_url }}
+          pagerduty_token: ${{ needs.retrieve-secrets.outputs.pagerduty_token }}
+          pagerduty_userapi_token: ${{ needs.retrieve-secrets.outputs.pagerduty_userapi_token }}
+          terraform_github_token: ${{ needs.retrieve-secrets.outputs.terraform_github_token }}
+          PASSPHRASE: ${{ secrets.PASSPHRASE }}
+
+      - name: set env variables
+        run: |
+          echo "TF_VAR_github_token=$TERRAFORM_GITHUB_TOKEN" >> $GITHUB_ENV
+          echo "TF_VAR_pagerduty_token=$PAGERDUTY_TOKEN" >> $GITHUB_ENV
+          echo "TF_VAR_pagerduty_user_token=$PAGERDUTY_USERAPI_TOKEN" >> $GITHUB_ENV
 
       - name: Set up variables
         id: vars
@@ -148,4 +158,4 @@ jobs:
           payload: |
             {"blocks":[{"type": "section","text": {"type": "mrkdwn","text": ":no_entry: Failed GitHub Action:"}},{"type": "section","fields":[{"type": "mrkdwn","text": "*Workflow:*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>"},{"type": "mrkdwn","text": "*Job:*\n${{ github.job }}"},{"type": "mrkdwn","text": "*Repo:*\n${{ github.repository }}"}]}]}
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_URL: ${{ env.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/reusable_terraform_plan_apply.yml
+++ b/.github/workflows/reusable_terraform_plan_apply.yml
@@ -40,6 +40,7 @@ jobs:
       PASSPHRASE: ${{ secrets.PASSPHRASE }}
   plan-and-apply:
     runs-on: ubuntu-latest
+    needs: fetch-secrets
     steps:
       - name: Checkout Repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -47,11 +48,11 @@ jobs:
       - name: Decrypt Secrets
         uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@d9e930d93532b84efdcf7d7b82621506e96a15b0 # v1.0.0
         with:
-          environment_management: ${{ needs.retrieve-secrets.outputs.environment_management }}
-          slack_webhook_url: ${{ needs.retrieve-secrets.outputs.slack_webhook_url }}
-          pagerduty_token: ${{ needs.retrieve-secrets.outputs.pagerduty_token }}
-          pagerduty_userapi_token: ${{ needs.retrieve-secrets.outputs.pagerduty_userapi_token }}
-          terraform_github_token: ${{ needs.retrieve-secrets.outputs.terraform_github_token }}
+          environment_management: ${{ needs.fetch-secrets.outputs.environment_management }}
+          slack_webhook_url: ${{ needs.fetch-secrets.outputs.slack_webhook_url }}
+          pagerduty_token: ${{ needs.fetch-secrets.outputs.pagerduty_token }}
+          pagerduty_userapi_token: ${{ needs.fetch-secrets.outputs.pagerduty_userapi_token }}
+          terraform_github_token: ${{ needs.fetch-secrets.outputs.terraform_github_token }}
           PASSPHRASE: ${{ secrets.PASSPHRASE }}
 
       - name: set env variables

--- a/.github/workflows/terraform-github.yml
+++ b/.github/workflows/terraform-github.yml
@@ -34,6 +34,7 @@ permissions:
   id-token: write # This is required for requesting the JWT
   contents: read # This is required for actions/checkout
   pull-requests: write
+  
 jobs:
   github-plan-and-apply:
     uses: ./.github/workflows/reusable_terraform_plan_apply.yml
@@ -41,9 +42,8 @@ jobs:
       working-directory: "terraform/github"
       workflow_id: "github"
     secrets:
-      modernisation_platform_environments: ${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENTS }}
-      gh_workflow_token: ${{ secrets.TERRAFORM_GITHUB_TOKEN }}
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      MODERNISATION_PLATFORM_ACCOUNT_NUMBER: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_NUMBER }}
+      PASSPHRASE: ${{ secrets.PASSPHRASE }}
 
   create-github-environments:
     runs-on: ubuntu-latest

--- a/.github/workflows/terraform-pagerduty.yml
+++ b/.github/workflows/terraform-pagerduty.yml
@@ -24,6 +24,7 @@ permissions:
   id-token: write # This is required for requesting the JWT
   contents: read # This is required for actions/checkout
   pull-requests: write
+  
 defaults:
   run:
     shell: bash
@@ -35,7 +36,5 @@ jobs:
       working-directory: "terraform/pagerduty"
       workflow_id: "pagerduty"
     secrets:
-      modernisation_platform_environments: ${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENTS }}
-      pagerduty_token: ${{ secrets.PAGERDUTY_TOKEN }}
-      pagerduty_userapi_token: ${{ secrets.PAGERDUTY_USERAPI_TOKEN}}
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      MODERNISATION_PLATFORM_ACCOUNT_NUMBER: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_NUMBER }}
+      PASSPHRASE: ${{ secrets.PASSPHRASE }}

--- a/.github/workflows/terraform-single-sign-on.yml
+++ b/.github/workflows/terraform-single-sign-on.yml
@@ -28,6 +28,7 @@ permissions:
   id-token: write # This is required for requesting the JWT
   contents: read # This is required for actions/checkout
   pull-requests: write
+  
 jobs:
   single-sign-on-plan-and-apply:
     uses: ./.github/workflows/reusable_terraform_plan_apply.yml
@@ -35,5 +36,5 @@ jobs:
       working-directory: "terraform/single-sign-on"
       workflow_id: "single-sign-on"
     secrets:
-      modernisation_platform_environments: ${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENTS }}
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      MODERNISATION_PLATFORM_ACCOUNT_NUMBER: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_NUMBER }}
+      PASSPHRASE: ${{ secrets.PASSPHRASE }}


### PR DESCRIPTION
## A reference to the issue / Description of it

This PR updates the workflow to utilize AWS Secrets Manager for retrieving secrets instead of relying on GitHub secrets. It introduces a new decrypt secrets action within the workflow to handle decryption of the secrets fetched from AWS Secrets Manager. Each job within the workflow has been modified accordingly to incorporate this change. #7109 


## How does this PR fix the problem?

Previously, the workflow relied on GitHub secrets for accessing sensitive information. Now, it will retrieve the secrets from AWS Secrets Manager, enhancing security and providing more robust management of our sensitive data.

## How has this been tested?

I tested this functionality by configuring the updated workflow in my private repository and ensuring that it successfully retrieves secrets from AWS Secrets Manager during workflow execution. I verified that the secrets were decrypted correctly and utilized within the workflow tasks as expected.


## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
