### PR TITLE
Enable `codedeploy:*` for the sandbox role

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -368,9 +368,9 @@ data "aws_iam_policy_document" "developer_additional" {
 
   # Additional statement that allows for the creation of on-demand AWS Backups.
   statement {
-    sid    = "AllowPassRoleForBackup"
-    effect = "Allow"
-    actions = ["iam:PassRole"]
+    sid       = "AllowPassRoleForBackup"
+    effect    = "Allow"
+    actions   = ["iam:PassRole"]
     resources = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/AWSBackup"]
     condition {
       test     = "StringEquals"
@@ -577,6 +577,7 @@ data "aws_iam_policy_document" "sandbox_additional" {
       "cloudwatch:*",
       "codebuild:ImportSourceCredentials",
       "codebuild:PersistOAuthToken",
+      "codedeploy:*",
       "cognito-identity:*",
       "cognito-idp:*",
       "cur:DescribeReportDefinitions",


### PR DESCRIPTION
## A reference to the issue / Description of it

YJAF are struggling to delete resources with sandbox role, example error:

```
 Error: deleting CodeDeploy Application (841c729b-4e5d-442d-802c-0f5456acaef3:ui): operation error CodeDeploy: DeleteApplication, https response error StatusCode: 400, RequestID: 00f872cb-b2ba-4ae9-969d-115e1dae0323, api error AccessDeniedException: User: arn:aws:sts::711387140977:assumed-role/sandbox/sandbox-moj is not authorized to perform: codedeploy:DeleteApplication on resource: arn:aws:codedeploy:eu-west-2:711387140977:application:ui because no identity-based policy allows the codedeploy:DeleteApplication action
```

## How does this PR fix the problem?

Adds `codedeploy:*` to teh sandbox role.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [X] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
