### PR TITLE
added permission for service linked roles to developer permissions

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -242,6 +242,7 @@ data "aws_iam_policy_document" "developer_additional" {
       "elasticloadbalancing:AddListenerCertificates",
       "events:DisableRule",
       "events:EnableRule",
+      "iam:CreateServiceLinkedRole",
       "identitystore:DescribeUser",
       "kms:Decrypt*",
       "kms:Encrypt",


### PR DESCRIPTION
## A reference to the issue / Description of it

https://mojdt.slack.com/archives/C01A7QK5VM1/p1737114582221569

## How does this PR fix the problem?

Developers have the ability to request service quota increases. In some instances, those quota changes require the ability to create service-linked roles to an account. So that developers can continue to self-serve their quota requests, this PR grants them the necessary permission.

https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create-service-linked-role.html

## How has this been tested?

N/A

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
