### PR TITLE
Issue/8617 - Reusing existing local to obtain current account id.

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/data.tf
+++ b/terraform/environments/bootstrap/single-sign-on/data.tf
@@ -8,8 +8,3 @@ data "aws_ssm_parameter" "modernisation_platform_account_id" {
   name = "modernisation_platform_account_id"
 }
 
-# Allows access to the current account ID
-data "aws_caller_identity" "current" {}
-output "account_id" {
-  value = data.aws_caller_identity.current.account_id
-}

--- a/terraform/environments/bootstrap/single-sign-on/locals.tf
+++ b/terraform/environments/bootstrap/single-sign-on/locals.tf
@@ -10,7 +10,7 @@ locals {
 
   modernisation_platform_account = data.aws_caller_identity.modernisation-platform
   environment_management         = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
-  mp_accounts                    = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
+  # mp_accounts                    = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
 
 
   defname = jsondecode(file("../../../../environments/${local.app_name}.json"))

--- a/terraform/environments/bootstrap/single-sign-on/locals.tf
+++ b/terraform/environments/bootstrap/single-sign-on/locals.tf
@@ -10,6 +10,8 @@ locals {
 
   modernisation_platform_account = data.aws_caller_identity.modernisation-platform
   environment_management         = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
+  mp_accounts                    = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
+
 
   defname = jsondecode(file("../../../../environments/${local.app_name}.json"))
 

--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -372,7 +372,7 @@ data "aws_iam_policy_document" "developer_additional" {
     sid       = "AllowPassRoleForBackup"
     effect    = "Allow"
     actions   = ["iam:PassRole"]
-    resources = ["arn:aws:iam::${local.environment_management[terraform.workspace]}:role/AWSBackup"]
+    resources = ["arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/AWSBackup"]
     condition {
       test     = "StringEquals"
       variable = "iam:PassedToService"

--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -368,17 +368,17 @@ data "aws_iam_policy_document" "developer_additional" {
   }
 
   # Additional statement that allows for the creation of on-demand AWS Backups.
-  # statement {
-  #   sid       = "AllowPassRoleForBackup"
-  #   effect    = "Allow"
-  #   actions   = ["iam:PassRole"]
-  #   resources = ["arn:aws:iam::${local.mp_accounts.account_ids[terraform.workspace]}:role/AWSBackup"]
-  #   condition {
-  #     test     = "StringEquals"
-  #     variable = "iam:PassedToService"
-  #     values   = ["backup.amazonaws.com"]
-  #   }
-  # }
+  statement {
+    sid       = "AllowPassRoleForBackup"
+    effect    = "Allow"
+    actions   = ["iam:PassRole"]
+    resources = ["arn:aws:iam::${local.mp_accounts.account_ids[terraform.workspace]}:role/AWSBackup"]
+    condition {
+      test     = "StringEquals"
+      variable = "iam:PassedToService"
+      values   = ["backup.amazonaws.com"]
+    }
+  }
 
 }
 

--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -372,7 +372,7 @@ data "aws_iam_policy_document" "developer_additional" {
     sid       = "AllowPassRoleForBackup"
     effect    = "Allow"
     actions   = ["iam:PassRole"]
-    resources = ["arn:aws:iam::${local.environment_managementterraform.workspace]}:role/AWSBackup"]
+    resources = ["arn:aws:iam::${local.environment_management[terraform.workspace]}:role/AWSBackup"]
     condition {
       test     = "StringEquals"
       variable = "iam:PassedToService"

--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -372,7 +372,7 @@ data "aws_iam_policy_document" "developer_additional" {
     sid       = "AllowPassRoleForBackup"
     effect    = "Allow"
     actions   = ["iam:PassRole"]
-    resources = ["arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/AWSBackup"]
+    resources = ["arn:aws:iam::${local.mp_accounts.account_ids[terraform.workspace]}:role/AWSBackup"]
     condition {
       test     = "StringEquals"
       variable = "iam:PassedToService"

--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -372,7 +372,7 @@ data "aws_iam_policy_document" "developer_additional" {
     sid       = "AllowPassRoleForBackup"
     effect    = "Allow"
     actions   = ["iam:PassRole"]
-    resources = ["arn:aws:iam::${local.mp_accounts.account_ids[terraform.workspace]}:role/AWSBackup"]
+    resources = ["arn:aws:iam::${local.environment_managementterraform.workspace]}:role/AWSBackup"]
     condition {
       test     = "StringEquals"
       variable = "iam:PassedToService"

--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -371,7 +371,7 @@ data "aws_iam_policy_document" "developer_additional" {
     sid       = "AllowPassRoleForBackup"
     effect    = "Allow"
     actions   = ["iam:PassRole"]
-    resources = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/AWSBackup"]
+    resources = ["arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/AWSBackup"]
     condition {
       test     = "StringEquals"
       variable = "iam:PassedToService"

--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -368,17 +368,17 @@ data "aws_iam_policy_document" "developer_additional" {
   }
 
   # Additional statement that allows for the creation of on-demand AWS Backups.
-  statement {
-    sid       = "AllowPassRoleForBackup"
-    effect    = "Allow"
-    actions   = ["iam:PassRole"]
-    resources = ["arn:aws:iam::${local.mp_accounts.account_ids[terraform.workspace]}:role/AWSBackup"]
-    condition {
-      test     = "StringEquals"
-      variable = "iam:PassedToService"
-      values   = ["backup.amazonaws.com"]
-    }
-  }
+  # statement {
+  #   sid       = "AllowPassRoleForBackup"
+  #   effect    = "Allow"
+  #   actions   = ["iam:PassRole"]
+  #   resources = ["arn:aws:iam::${local.mp_accounts.account_ids[terraform.workspace]}:role/AWSBackup"]
+  #   condition {
+  #     test     = "StringEquals"
+  #     variable = "iam:PassedToService"
+  #     values   = ["backup.amazonaws.com"]
+  #   }
+  # }
 
 }
 


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/8617

## How does this PR fix the problem?

Uses the environment_management local to obtain the current account id.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

This has been tested against sprinkler bootstrap.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

Note - this is a fix to a new policy statement

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
