### PR TITLE
Issue/8617 - Using local environment_management to obtain the local account id.

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -367,6 +367,19 @@ data "aws_iam_policy_document" "developer_additional" {
     }
   }
 
+  # Additional statement that allows for the creation of on-demand AWS Backups.
+  statement {
+    sid       = "AllowPassRoleForBackup"
+    effect    = "Allow"
+    actions   = ["iam:PassRole"]
+    resources = ["arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/AWSBackup"]
+    condition {
+      test     = "StringEquals"
+      variable = "iam:PassedToService"
+      values   = ["backup.amazonaws.com"]
+    }
+  }
+
 }
 
 # data engineering policy (developer + glue + some athena)


### PR DESCRIPTION

## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/8617

## How does this PR fix the problem?

Adds back the AllowPassRoleForBackup statement using the local environment_management to obtain the current account id. This was chosen as updating the existing statement to use the local was resulting in an low-level error with the plan. See above ticket for further details.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Sprinkler bootstrap.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

None - this adds back the statement to developer_policy.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
