### PR TITLE
Added bucket statement to allow GitHub Actions to delete tflock files

### DIFF
--- a/terraform/modernisation-platform-account/s3.tf
+++ b/terraform/modernisation-platform-account/s3.tf
@@ -228,6 +228,7 @@ data "aws_iam_policy_document" "allow-state-access-from-root-account" {
       type        = "AWS"
       identifiers = ["*"]
     }
+
     condition {
       test     = "ForAnyValue:StringLike"
       variable = "aws:PrincipalOrgPaths"
@@ -255,6 +256,32 @@ data "aws_iam_policy_document" "allow-state-access-from-root-account" {
     actions = ["s3:PutObject"]
     resources = [
       "${module.state-bucket.bucket.arn}/environments/members/*",
+    ]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    condition {
+      test     = "ForAnyValue:StringLike"
+      variable = "aws:PrincipalOrgPaths"
+      values   = ["${data.aws_organizations_organization.root_account.id}/*/${local.environment_management.modernisation_platform_organisation_unit_id}/*"]
+    }
+
+    condition {
+      test     = "ForAnyValue:StringLike"
+      variable = "aws:PrincipalArn"
+      values   = ["arn:aws:iam::*:role/github-actions"]
+    }
+  }
+
+  statement {
+    sid     = "AllowGithubActionsRoleDeleteTFLock"
+    effect  = "Allow"
+    actions = ["s3:DeleteObject"]
+    resources = [
+      "${module.state-bucket.bucket.arn}/*/terraform.tfstate.tflock",
     ]
 
     principals {


### PR DESCRIPTION
## A reference to the issue / Description of it

#8345 

## How does this PR fix the problem?

Amends S3 bucket policy to allow the deletion of `terraform.tfstate.tflock` files. This is necessary in order to cleanly remove locks after Terraform runs complete

## How has this been tested?

Checked against Terraform documentation and AWS guidance

## Deployment Plan / Instructions

Deploy through CI. This PR _adds_ permissions so there ought to be no negative impact to existing workflows.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

https://developer.hashicorp.com/terraform/language/backend/s3#s3-bucket-permissions

https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_resource.html
