### PR TITLE
add hosting-migrations team to their environments

### DIFF
--- a/environments/delius-core.json
+++ b/environments/delius-core.json
@@ -12,6 +12,12 @@
           "github_action_reviewer": "true"
         },
         {
+          "sso_group_name": "hosting-migrations",
+          "level": "sandbox",
+          "nuke": "exclude",
+          "github_action_reviewer": "true"
+        },
+        {
           "sso_group_name": "hmpps-dba",
           "level": "developer",
           "nuke": "exclude",
@@ -40,6 +46,11 @@
           "github_action_reviewer": "true"
         },
         {
+          "sso_group_name": "hosting-migrations",
+          "level": "developer",
+          "github_action_reviewer": "true"
+        },
+        {
           "sso_group_name": "hmpps-dba",
           "level": "developer"
         },
@@ -62,6 +73,11 @@
           "github_action_reviewer": "true"
         },
         {
+          "sso_group_name": "hosting-migrations",
+          "level": "developer",
+          "github_action_reviewer": "true"
+        },
+        {
           "sso_group_name": "hmpps-dba",
           "level": "developer"
         },
@@ -76,6 +92,11 @@
       "access": [
         {
           "sso_group_name": "hmpps-migration",
+          "level": "developer",
+          "github_action_reviewer": "true"
+        },
+        {
+          "sso_group_name": "hosting-migrations",
           "level": "developer",
           "github_action_reviewer": "true"
         },

--- a/environments/delius-iaps.json
+++ b/environments/delius-iaps.json
@@ -11,6 +11,11 @@
           "nuke": "include"
         },
         {
+          "sso_group_name": "hosting-migrations",
+          "level": "sandbox",
+          "nuke": "include"
+        },
+        {
           "sso_group_name": "hmpps-dba",
           "level": "instance-management"
         }
@@ -24,6 +29,10 @@
           "level": "developer"
         },
         {
+          "sso_group_name": "hosting-migrations",
+          "level": "developer"
+        },
+        {
           "sso_group_name": "hmpps-dba",
           "level": "instance-management"
         }
@@ -34,6 +43,10 @@
       "access": [
         {
           "sso_group_name": "hmpps-migration",
+          "level": "developer"
+        },
+        {
+          "sso_group_name": "hosting-migrations",
           "level": "developer"
         },
         {

--- a/environments/delius-jitbit.json
+++ b/environments/delius-jitbit.json
@@ -10,6 +10,10 @@
           "level": "developer"
         },
         {
+          "sso_group_name": "hosting-migrations",
+          "level": "developer"
+        },
+        {
           "sso_group_name": "hmpps-delius-jitbit-devs",
           "level": "instance-management"
         }
@@ -20,6 +24,10 @@
       "access": [
         {
           "sso_group_name": "hmpps-migration",
+          "level": "developer"
+        },
+        {
+          "sso_group_name": "hosting-migrations",
           "level": "developer"
         },
         {
@@ -36,6 +44,10 @@
           "level": "developer"
         },
         {
+          "sso_group_name": "hosting-migrations",
+          "level": "developer"
+        },
+        {
           "sso_group_name": "hmpps-delius-jitbit-devs",
           "level": "instance-management"
         }
@@ -46,6 +58,10 @@
       "access": [
         {
           "sso_group_name": "hmpps-migration",
+          "level": "developer"
+        },
+        {
+          "sso_group_name": "hosting-migrations",
           "level": "developer"
         },
         {

--- a/environments/delius-mis.json
+++ b/environments/delius-mis.json
@@ -11,6 +11,11 @@
           "nuke": "exclude"
         },
         {
+          "sso_group_name": "hosting-migrations",
+          "level": "sandbox",
+          "nuke": "exclude"
+        },
+        {
           "sso_group_name": "hmpps-dba",
           "level": "sandbox"
         },
@@ -28,6 +33,10 @@
           "level": "developer"
         },
         {
+          "sso_group_name": "hosting-migrations",
+          "level": "developer"
+        },
+        {
           "sso_group_name": "hmpps-dba",
           "level": "developer"
         },
@@ -42,6 +51,10 @@
       "access": [
         {
           "sso_group_name": "hmpps-migration",
+          "level": "developer"
+        },
+        {
+          "sso_group_name": "hosting-migrations",
           "level": "developer"
         },
         {

--- a/environments/delius-nextcloud.json
+++ b/environments/delius-nextcloud.json
@@ -10,6 +10,12 @@
           "level": "sandbox",
           "nuke": "exclude",
           "github_action_reviewer": "true"
+        },
+        {
+          "sso_group_name": "hosting-migrations",
+          "level": "sandbox",
+          "nuke": "exclude",
+          "github_action_reviewer": "true"
         }
       ]
     },
@@ -18,6 +24,11 @@
       "access": [
         {
           "sso_group_name": "hmpps-migration",
+          "level": "developer",
+          "github_action_reviewer": "true"
+        },
+        {
+          "sso_group_name": "hosting-migrations",
           "level": "developer",
           "github_action_reviewer": "true"
         }
@@ -30,6 +41,11 @@
           "sso_group_name": "hmpps-migration",
           "level": "developer",
           "github_action_reviewer": "true"
+        },
+        {
+          "sso_group_name": "hosting-migrations",
+          "level": "developer",
+          "github_action_reviewer": "true"
         }
       ]
     },
@@ -38,6 +54,11 @@
       "access": [
         {
           "sso_group_name": "hmpps-migration",
+          "level": "developer",
+          "github_action_reviewer": "true"
+        },
+        {
+          "sso_group_name": "hosting-migrations",
           "level": "developer",
           "github_action_reviewer": "true"
         }


### PR DESCRIPTION
## A reference to the issue / Description of it
We used to use the hmmps-migration team but have had a team restructure and want to use the hosting-migrations team now

## How does this PR fix the problem?

It adds the hosting-migrations team to the envs we need access to

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

The built in github checks are the only ones being used here

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No as it is only adding access to a new team

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

