### PR TITLE
Update policy documents with permissions to remove lock files

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -807,16 +807,29 @@ data "aws_iam_policy_document" "oidc_assume_role_member" {
     sid       = "AllowOIDCReadState"
     effect    = "Allow"
     resources = ["arn:aws:s3:::modernisation-platform-terraform-state/*", "arn:aws:s3:::modernisation-platform-terraform-state/"]
-    actions = ["s3:Get*",
-    "s3:List*"]
+    actions = [
+      "s3:GetObject",
+      "s3:ListObject"
+    ]
   }
 
   statement {
     sid       = "AllowOIDCWriteState"
     effect    = "Allow"
     resources = ["arn:aws:s3:::modernisation-platform-terraform-state/environments/members/*"]
-    actions = ["s3:PutObject",
-    "s3:PutObjectAcl"]
+    actions = [
+      "s3:PutObject",
+      "s3:PutObjectAcl"
+    ]
+  }
+
+  statement {
+    sid    = "AllowOIDCRemoveLock"
+    effect = "Allow"
+    resources = [
+      "arn:aws:s3:::modernisation-platform-terraform-state/environments/members/*.tflock"
+    ]
+    actions = ["s3:DeleteObject"]
   }
 }
 

--- a/terraform/environments/sprinkler/iam.tf
+++ b/terraform/environments/sprinkler/iam.tf
@@ -23,8 +23,10 @@ data "aws_iam_policy_document" "oidc_deny_specific_actions" {
     sid       = "AllowOIDCReadState"
     effect    = "Allow"
     resources = ["arn:aws:s3:::modernisation-platform-terraform-state/*", "arn:aws:s3:::modernisation-platform-terraform-state/"]
-    actions = [
-    "s3:List*"]
+    actions   = [
+      "s3:GetObject",
+      "s3:ListBucket"
+    ]
   }
 
   statement {
@@ -34,8 +36,19 @@ data "aws_iam_policy_document" "oidc_deny_specific_actions" {
       "arn:aws:s3:::modernisation-platform-terraform-state/single-sign-on/terraform.tfstate",
       "arn:aws:s3:::modernisation-platform-terraform-state/environments/bootstrap/*/sprinkler-development/terraform.tfstate"
     ]
-    actions = ["s3:PutObject",
-      "s3:PutObjectAcl",
-    "s3:GetObject"]
+    actions = [
+      "s3:PutObject",
+      "s3:PutObjectAcl"
+    ]
+  }
+
+  statement {
+    sid    = "AllowOIDCRemoveLock"
+    effect = "Allow"
+    resources = [
+      "arn:aws:s3:::modernisation-platform-terraform-state/single-sign-on/*.tflock",
+      "arn:aws:s3:::modernisation-platform-terraform-state/environments/bootstrap/*/sprinkler-development/*.tflock"
+    ]
+    actions = ["s3:DeleteObject"]
   }
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

#8345

## How does this PR fix the problem?

Adds missing permissions required for the `github-actions` role to remove `.tflock` files.

## How has this been tested?

Tested through CI pipeline against `sprinkler-development`

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
