### PR TITLE
Associate non-prod VPCs with cloudwatch rqlc-only and r53 dns firewall monitoring

### DIFF
--- a/terraform/environments/core-logging/logging.tf
+++ b/terraform/environments/core-logging/logging.tf
@@ -1,6 +1,6 @@
 locals {
   resolver_query_log_config_names = toset(["core-logging-rlq-cloudwatch", "core-logging-rlq-s3"])
-  vpc_ids                         = { for key, value in module.vpc : key => value["vpc_id"] if key == "live_data" }
+  vpc_ids                         = { for key, value in module.vpc : key => value["vpc_id"] if key == "live_data" || key == "non_live_data" }
   rlq_ids                         = { for name, config in data.aws_route53_resolver_query_log_config.core_logging : name => config.id }
   vpc_rlq_associations = merge([
     for vpc_key, vpc_id in local.vpc_ids : {

--- a/terraform/environments/core-logging/logging.tf
+++ b/terraform/environments/core-logging/logging.tf
@@ -1,24 +1,14 @@
 locals {
   resolver_query_log_config_names = toset(["core-logging-rlq-cloudwatch", "core-logging-rlq-s3"])
-  vpc_ids_live_data               = { for key, value in module.vpc : key => value["vpc_id"] if key == "live_data" }
-  vpc_ids_non_live_data           = { for key, value in module.vpc : key => value["vpc_id"] if key == "non_live_data" }
+  vpc_ids                         = { for key, value in module.vpc : key => value["vpc_id"] if key == "live_data" }
   rlq_ids                         = { for name, config in data.aws_route53_resolver_query_log_config.core_logging : name => config.id }
-  vpc_rlq_associations_live_data = merge([
-    for vpc_key, vpc_id in local.vpc_ids_live_data : {
+  vpc_rlq_associations = merge([
+    for vpc_key, vpc_id in local.vpc_ids : {
       for rlq_name, rlq_id in local.rlq_ids :
       "${vpc_key}_${rlq_name}" => {
         vpc_id = vpc_id
         rlq_id = rlq_id
       }
-    }
-  ]...)
-  vpc_rlq_associations_non_live_data = merge([
-    for vpc_key, vpc_id in local.vpc_ids_non_live_data : {
-      for rlq_name, rlq_id in local.rlq_ids :
-      "${vpc_key}_${rlq_name}" => {
-        vpc_id = vpc_id
-        rlq_id = rlq_id
-      } if rlq_name == "core-logging-rlq-cloudwatch"
     }
   ]...)
 }
@@ -32,13 +22,7 @@ data "aws_route53_resolver_query_log_config" "core_logging" {
 }
 
 resource "aws_route53_resolver_query_log_config_association" "core_logging" {
-  for_each                     = local.is-production ? local.vpc_rlq_associations_live_data : {}
-  resolver_query_log_config_id = each.value.rlq_id
-  resource_id                  = each.value.vpc_id
-}
-
-resource "aws_route53_resolver_query_log_config_association" "core_logging_non_live_data" {
-  for_each                     = local.is-production ? local.vpc_rlq_associations_non_live_data : {}
+  for_each                     = local.is-production ? local.vpc_rlq_associations : {}
   resolver_query_log_config_id = each.value.rlq_id
   resource_id                  = each.value.vpc_id
 }

--- a/terraform/environments/core-logging/r53_logs.tf
+++ b/terraform/environments/core-logging/r53_logs.tf
@@ -90,3 +90,91 @@ data "aws_iam_policy_document" "r53_resolver_logs_kms" {
     }
   }
 }
+
+resource "aws_cloudwatch_log_metric_filter" "r53_dns_firewall_metric_filter" {
+  name           = "r53-dns-firewall-matches"
+  log_group_name = aws_cloudwatch_log_group.r53_resolver_logs.name
+
+  pattern = "{ ($.firewall_rule_action = \"BLOCK\" || $.firewall_rule_action = \"ALERT\") }"
+  metric_transformation {
+    name      = "r53-dns-firewall-matches"
+    namespace = "R53DNSFirewall"
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "r53_dns_firewall_alarm" {
+  alarm_name          = "r53-dns-firewall-matches"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = aws_cloudwatch_log_metric_filter.r53_dns_firewall_metric_filter.metric_transformation[0].name
+  namespace           = aws_cloudwatch_log_metric_filter.r53_dns_firewall_metric_filter.metric_transformation[0].namespace
+  period              = "60"
+  statistic           = "Sum"
+  threshold           = "1"
+  alarm_actions       = [aws_sns_topic.r53_dns_firewall.arn]
+  tags                = local.tags
+}
+
+resource "aws_sns_topic" "r53_dns_firewall" {
+  name              = "r53-dns-firewall-sns-topic"
+  kms_master_key_id = aws_kms_key.r53_dns_firewall.key_id
+  tags              = local.tags
+}
+
+resource "aws_kms_key" "r53_dns_firewall" {
+  description         = "KMS key for DNS Firewall SNS Topic Encryption"
+  enable_key_rotation = true
+  policy              = data.aws_iam_policy_document.r53_dns_firewall_kms_policy.json
+  tags                = local.tags
+}
+
+resource "aws_kms_alias" "r53_dns_firewall" {
+  name_prefix   = "alias/r53-dns-firewall-sns-encryption"
+  target_key_id = aws_kms_key.r53_dns_firewall.key_id
+}
+
+data "aws_iam_policy_document" "r53_dns_firewall_kms_policy" {
+  # checkov:skip=CKV_AWS_111: "policy is directly related to the resource"
+  # checkov:skip=CKV_AWS_109: "policy is directly related to the resource"
+  # checkov:skip=CKV_AWS_356: "policy is directly related to the resource"
+  statement {
+    sid    = "Allow SNS/Cloudwatch services to use the KMS key"
+    effect = "Allow"
+    actions = [
+      "kms:Encrypt",
+      "kms:Decrypt",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:DescribeKey"
+    ]
+    resources = [
+      "*"
+    ]
+    principals {
+      type        = "Service"
+      identifiers = ["sns.amazonaws.com", "cloudwatch.amazonaws.com", "logs.amazonaws.com"]
+    }
+  }
+
+  statement {
+    sid    = "Allow account to manage key"
+    effect = "Allow"
+    actions = [
+      "kms:*"
+    ]
+    resources = [
+      "*"
+    ]
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+  }
+}
+module "pagerduty_r53_dns_firewall" {
+  depends_on                = [aws_sns_topic.r53_dns_firewall]
+  source                    = "github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration?ref=0179859e6fafc567843cd55c0b05d325d5012dc4" # v2.0.0
+  sns_topics                = [aws_sns_topic.r53_dns_firewall.name]
+  pagerduty_integration_key = local.pagerduty_integration_keys["core_alerts_cloudwatch"]
+}

--- a/terraform/environments/core-vpc/logging.tf
+++ b/terraform/environments/core-vpc/logging.tf
@@ -11,15 +11,6 @@ locals {
       }
     }
   ]...)
-  vpc_rlq_associations_cloudwatch_only = merge([
-    for vpc_key, vpc_id in local.vpc_ids : {
-      for rlq_name, rlq_id in local.rlq_ids :
-      "${vpc_key}_${rlq_name}" => {
-        vpc_id = vpc_id
-        rlq_id = rlq_id
-      } if rlq_name == "core-logging-rlq-cloudwatch"
-    }
-  ]...)
 }
 
 data "aws_route53_resolver_query_log_config" "core_logging" {
@@ -31,7 +22,10 @@ data "aws_route53_resolver_query_log_config" "core_logging" {
 }
 
 resource "aws_route53_resolver_query_log_config_association" "core_logging" {
-  for_each                     = local.is-production ? local.vpc_rlq_associations : local.vpc_rlq_associations_cloudwatch_only
+  for_each = {
+    for key, value in local.vpc_rlq_associations :
+    key => value if local.is-production || can(regex("core-logging-rlq-cloudwatch", key))
+  }
   resolver_query_log_config_id = each.value.rlq_id
   resource_id                  = each.value.vpc_id
 }

--- a/terraform/environments/core-vpc/logging.tf
+++ b/terraform/environments/core-vpc/logging.tf
@@ -11,6 +11,15 @@ locals {
       }
     }
   ]...)
+  vpc_rlq_associations_cloudwatch_only = merge([
+    for vpc_key, vpc_id in local.vpc_ids : {
+      for rlq_name, rlq_id in local.rlq_ids :
+      "${vpc_key}_${rlq_name}" => {
+        vpc_id = vpc_id
+        rlq_id = rlq_id
+      } if rlq_name == "core-logging-rlq-cloudwatch"
+    }
+  ]...)
 }
 
 data "aws_route53_resolver_query_log_config" "core_logging" {
@@ -22,7 +31,7 @@ data "aws_route53_resolver_query_log_config" "core_logging" {
 }
 
 resource "aws_route53_resolver_query_log_config_association" "core_logging" {
-  for_each                     = local.is-production ? local.vpc_rlq_associations : {}
+  for_each                     = local.is-production ? local.vpc_rlq_associations : local.vpc_rlq_associations_cloudwatch_only
   resolver_query_log_config_id = each.value.rlq_id
   resource_id                  = each.value.vpc_id
 }

--- a/terraform/environments/core-vpc/logging.tf
+++ b/terraform/environments/core-vpc/logging.tf
@@ -11,6 +11,9 @@ locals {
       }
     }
   ]...)
+  vpc_cloudwatch_rlq_associations = {
+    for key, value in local.vpc_rlq_associations : key => value if can(regex("cloudwatch", key))
+  }
 }
 
 data "aws_route53_resolver_query_log_config" "core_logging" {
@@ -22,10 +25,7 @@ data "aws_route53_resolver_query_log_config" "core_logging" {
 }
 
 resource "aws_route53_resolver_query_log_config_association" "core_logging" {
-  for_each = {
-    for key, value in local.vpc_rlq_associations :
-    key => value if local.is-production || can(regex("core-logging-rlq-cloudwatch", key))
-  }
+  for_each                     = local.is-production ? local.vpc_rlq_associations : local.vpc_cloudwatch_rlq_associations
   resolver_query_log_config_id = each.value.rlq_id
   resource_id                  = each.value.vpc_id
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/7474

## How does this PR fix the problem?

Having already enabled r53 DNS firewall for all MP VPCs in https://github.com/ministryofjustice/modernisation-platform/pull/8917 , I had to rollback the query logging/monitoring config as in https://github.com/ministryofjustice/modernisation-platform/pull/9041 as it conflicted with the existing logging setup in `core-logging`.

In this PR I have done two things:

1. Associated all dev/test/preprod VPCs with the cloudwatch r53 query logging config (shared from `core-logging`) so that we can capture when the r53 dns firewall captures traffic in the logs.
2. In `core-logging` I've created a Cloudwatch metric filter/alarm so any matching domains that the firewall acts on triggers a dedicated SNS topic which is hooked into PagerDuty (this is currently subscribed to the PagerDuty Core Alerts service - associated with the `#modernisation-platform-low-priority-alarms` Slack channel)

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Local Terraform plan only.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}


