### PR TITLE
chore: add zaizi-devs to delius-core-dev

### DIFF
--- a/environments/delius-core.json
+++ b/environments/delius-core.json
@@ -34,6 +34,12 @@
           "level": "developer",
           "nuke": "exclude",
           "github_action_reviewer": "true"
+        },
+        {
+          "sso_group_name": "zaizi-devs",
+          "level": "instance-access",
+          "nuke": "exclude",
+          "github_action_reviewer": "false"
         }
       ]
     },


### PR DESCRIPTION
## A reference to the issue / Description of it

Give zaizi-devs group access to delius-core-dev account with instance-access role.

## How does this PR fix the problem?

{Please write here}

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
