### PR TITLE
Allow Sprinkler to place native lockfiles

### DIFF
--- a/terraform/modernisation-platform-account/s3.tf
+++ b/terraform/modernisation-platform-account/s3.tf
@@ -274,6 +274,7 @@ data "aws_iam_policy_document" "allow-state-access-from-root-account" {
     actions = ["s3:PutObject"]
     resources = [
       "${module.state-bucket.bucket.arn}/environments/members/testing/testing-test/terraform.tfstate",
+      "${module.state-bucket.bucket.arn}/environments/members/testing/testing-test/*.tflock",
     ]
 
     principals {
@@ -415,8 +416,8 @@ data "aws_iam_policy_document" "allow-state-access-from-root-account" {
       "s3:GetObject"
     ]
     resources = [
-      "arn:aws:s3:::modernisation-platform-terraform-state/single-sign-on/terraform.tfstate",
-      "arn:aws:s3:::modernisation-platform-terraform-state/environments/bootstrap/*/sprinkler-development/terraform.tfstate"
+      "arn:aws:s3:::modernisation-platform-terraform-state/single-sign-on/*",
+      "arn:aws:s3:::modernisation-platform-terraform-state/environments/bootstrap/*/sprinkler-development/*"
     ]
     principals {
       type        = "AWS"


### PR DESCRIPTION
## A reference to the issue / Description of it

#8345 

## How does this PR fix the problem?

Amends the S3 bucket policy so that Sprinkler can place native terraform locks into S3.

The bucket policy allows Sprinkler slightly broader wildcard permissions, but this is in line with other roles.

## How has this been tested?

Tested through CI pipeline

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
