### PR TITLE
Set `single-sign-on` to use native lockfile

### DIFF
--- a/terraform/single-sign-on/backend.tf
+++ b/terraform/single-sign-on/backend.tf
@@ -5,9 +5,9 @@ terraform {
   backend "s3" {
     acl            = "bucket-owner-full-control"
     bucket         = "modernisation-platform-terraform-state"
-    dynamodb_table = "modernisation-platform-terraform-state-lock"
     encrypt        = true
     key            = "single-sign-on/terraform.tfstate"
     region         = "eu-west-2"
+    use_lockfile   = true
   }
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

#8345

## How does this PR fix the problem?

Removes the `dynamodb_table` and inserts one to use native state locking

## How has this been tested?

Tested with CI pipeline

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
