### PR TITLE
Set modernisation platform account to use native locking

### DIFF
--- a/terraform/modernisation-platform-account/backend.tf
+++ b/terraform/modernisation-platform-account/backend.tf
@@ -3,11 +3,11 @@ terraform {
   # - S3 bucket name, which is created in s3.tf
   # - DynamoDB table name, which is created in dynamodb.tf
   backend "s3" {
-    acl            = "bucket-owner-full-control"
-    bucket         = "modernisation-platform-terraform-state"
-    dynamodb_table = "modernisation-platform-terraform-state-lock"
-    encrypt        = true
-    key            = "modernisation-platform-account/terraform.tfstate"
-    region         = "eu-west-2"
+    acl          = "bucket-owner-full-control"
+    bucket       = "modernisation-platform-terraform-state"
+    encrypt      = true
+    key          = "modernisation-platform-account/terraform.tfstate"
+    region       = "eu-west-2"
+    use_lockfile = true
   }
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

#8345

## How does this PR fix the problem?

Removes the use of DynamoDB and sets the backend to use native state locking

## How has this been tested?

Tested with CI pipeline

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
