### PR TITLE
Expand native locking permissions

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -806,17 +806,33 @@ data "aws_iam_policy_document" "oidc_assume_role_member" {
   statement {
     sid       = "AllowOIDCReadState"
     effect    = "Allow"
-    resources = ["arn:aws:s3:::modernisation-platform-terraform-state/*", "arn:aws:s3:::modernisation-platform-terraform-state/"]
-    actions = ["s3:Get*",
-    "s3:List*"]
+    resources = [
+      "arn:aws:s3:::modernisation-platform-terraform-state/*",
+      "arn:aws:s3:::modernisation-platform-terraform-state/"
+    ]
+    actions = [
+      "s3:Get*",
+      "s3:List*"
+    ]
   }
 
   statement {
     sid       = "AllowOIDCWriteState"
     effect    = "Allow"
     resources = ["arn:aws:s3:::modernisation-platform-terraform-state/environments/members/*"]
-    actions = ["s3:PutObject",
-    "s3:PutObjectAcl"]
+    actions   = [
+      "s3:PutObject",
+      "s3:PutObjectAcl"
+    ]
+  }
+
+  statement {
+    sid       = "AllowOIDCDeleteLock"
+    effect    = "Allow"
+    resources = ["arn:aws:s3:::modernisation-platform-terraform-state/environments/members/*.tflock"]
+    actions   = [
+      "s3:DeleteObject"
+    ]
   }
 }
 

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -804,8 +804,8 @@ data "aws_iam_policy_document" "oidc_assume_role_member" {
   }
 
   statement {
-    sid       = "AllowOIDCReadState"
-    effect    = "Allow"
+    sid    = "AllowOIDCReadState"
+    effect = "Allow"
     resources = [
       "arn:aws:s3:::modernisation-platform-terraform-state/*",
       "arn:aws:s3:::modernisation-platform-terraform-state/"
@@ -820,7 +820,7 @@ data "aws_iam_policy_document" "oidc_assume_role_member" {
     sid       = "AllowOIDCWriteState"
     effect    = "Allow"
     resources = ["arn:aws:s3:::modernisation-platform-terraform-state/environments/members/*"]
-    actions   = [
+    actions = [
       "s3:PutObject",
       "s3:PutObjectAcl"
     ]
@@ -830,7 +830,7 @@ data "aws_iam_policy_document" "oidc_assume_role_member" {
     sid       = "AllowOIDCDeleteLock"
     effect    = "Allow"
     resources = ["arn:aws:s3:::modernisation-platform-terraform-state/environments/members/*.tflock"]
-    actions   = [
+    actions = [
       "s3:DeleteObject"
     ]
   }

--- a/terraform/environments/sprinkler/iam.tf
+++ b/terraform/environments/sprinkler/iam.tf
@@ -41,7 +41,7 @@ data "aws_iam_policy_document" "oidc_deny_specific_actions" {
   }
 
   statement {
-    sid    = "AllowOIDCRemoveLock"
+    sid    = "AllowOIDCDeleteLock"
     effect = "Allow"
     resources = [
       "arn:aws:s3:::modernisation-platform-terraform-state/single-sign-on/*.tflock",

--- a/terraform/environments/sprinkler/iam.tf
+++ b/terraform/environments/sprinkler/iam.tf
@@ -23,7 +23,7 @@ data "aws_iam_policy_document" "oidc_deny_specific_actions" {
     sid       = "AllowOIDCReadState"
     effect    = "Allow"
     resources = ["arn:aws:s3:::modernisation-platform-terraform-state/*", "arn:aws:s3:::modernisation-platform-terraform-state/"]
-    actions  = ["s3:List*"]
+    actions   = ["s3:List*"]
   }
 
   statement {

--- a/terraform/github/testing-ci.tf
+++ b/terraform/github/testing-ci.tf
@@ -37,7 +37,7 @@ data "aws_iam_policy_document" "testing_ci_policy" {
   }
 
   statement {
-    effect = "Allow"
+    effect  = "Allow"
     actions = ["s3:DeleteObject"]
     resources = [
       "arn:aws:s3:::modernisation-platform-terraform-state/*.tflock",

--- a/terraform/github/testing-ci.tf
+++ b/terraform/github/testing-ci.tf
@@ -30,8 +30,18 @@ data "aws_iam_policy_document" "testing_ci_policy" {
       "s3:PutObjectAcl",
     ]
     resources = [
+      "arn:aws:s3:::modernisation-platform-terraform-state/*.tflock",
       "arn:aws:s3:::modernisation-platform-terraform-state/terraform.tfstate",
       "arn:aws:s3:::modernisation-platform-terraform-state/environments/members/testing/testing-test/terraform.tfstate"
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = ["s3:DeleteObject"]
+    resources = [
+      "arn:aws:s3:::modernisation-platform-terraform-state/*.tflock",
+      "arn:aws:s3:::modernisation-platform-terraform-state/environments/members/testing/testing-test/*.tflock"
     ]
   }
 

--- a/terraform/modernisation-platform-account/iam.tf
+++ b/terraform/modernisation-platform-account/iam.tf
@@ -82,7 +82,7 @@ data "aws_iam_policy_document" "collaborator_local_plan" {
   }
 
   statement {
-    sid = "TerraformStateAccessDeleteLock"
+    sid     = "TerraformStateAccessDeleteLock"
     actions = ["s3:DeleteObject"]
 
     resources = ["arn:aws:s3:::modernisation-platform-terraform-state/*.tflock"]
@@ -209,9 +209,9 @@ data "aws_iam_policy_document" "modernisation_account_terraform_state_role" {
     resources = ["arn:aws:dynamodb:eu-west-2:${data.aws_caller_identity.current.account_id}:table/modernisation-platform-terraform-state-lock"]
   }
   statement {
-    sid    = "AllowS3AccessList"
-    effect = "Allow"
-    actions = ["s3:ListBucket"]
+    sid       = "AllowS3AccessList"
+    effect    = "Allow"
+    actions   = ["s3:ListBucket"]
     resources = ["arn:aws:s3:::modernisation-platform-terraform-state"]
   }
   statement {

--- a/terraform/modernisation-platform-account/iam.tf
+++ b/terraform/modernisation-platform-account/iam.tf
@@ -67,11 +67,26 @@ data "aws_iam_policy_document" "collaborator_local_plan" {
     ]
 
     resources = [
+      "arn:aws:s3:::modernisation-platform-terraform-state/*.tflock",
       "arn:aws:s3:::modernisation-platform-terraform-state/terraform.tfstate",
       "arn:aws:s3:::modernisation-platform-terraform-state/environments/members/*",
       "arn:aws:s3:::modernisation-platform-terraform-state/environments/accounts/core-network-services/*",
       "arn:aws:s3:::modernisation-platform-terraform-state"
     ]
+
+    condition {
+      test     = "BoolIfExists"
+      variable = "aws:MultiFactorAuthPresent"
+      values   = ["true"]
+    }
+  }
+
+  statement {
+    sid = "TerraformStateAccessDeleteLock"
+    actions = ["s3:DeleteObject"]
+
+    resources = ["arn:aws:s3:::modernisation-platform-terraform-state/*.tflock"]
+
     condition {
       test     = "BoolIfExists"
       variable = "aws:MultiFactorAuthPresent"
@@ -196,9 +211,7 @@ data "aws_iam_policy_document" "modernisation_account_terraform_state_role" {
   statement {
     sid    = "AllowS3AccessList"
     effect = "Allow"
-    actions = [
-      "s3:ListBucket",
-    ]
+    actions = ["s3:ListBucket"]
     resources = ["arn:aws:s3:::modernisation-platform-terraform-state"]
   }
   statement {
@@ -315,8 +328,17 @@ data "aws_iam_policy_document" "oidc_assume_plan_role_member" {
     sid       = "AllowOIDCReadState"
     effect    = "Allow"
     resources = ["arn:aws:s3:::modernisation-platform-terraform-state/*", "arn:aws:s3:::modernisation-platform-terraform-state/"]
-    actions = ["s3:Get*",
-    "s3:List*"]
+    actions = [
+      "s3:Get*",
+      "s3:List*"
+    ]
+  }
+
+  statement {
+    sid       = "AllowOIDCDeleteLock"
+    effect    = "Allow"
+    resources = ["arn:aws:s3:::modernisation-platform-terraform-state/*.tflock"]
+    actions   = ["s3:DeleteObject"]
   }
 }
 

--- a/terraform/modernisation-platform-account/s3.tf
+++ b/terraform/modernisation-platform-account/s3.tf
@@ -426,7 +426,7 @@ data "aws_iam_policy_document" "allow-state-access-from-root-account" {
   }
 
   statement {
-    sid    = "AllowSprinklerGithubActionRoleRemoveLock"
+    sid    = "AllowSprinklerGithubActionRoleDeleteLock"
     effect = "Allow"
     actions = [
       "s3:DeleteObject"

--- a/terraform/single-sign-on/backend.tf
+++ b/terraform/single-sign-on/backend.tf
@@ -2,11 +2,11 @@ terraform {
   # `backend` blocks do not support variables, so the following are hard-coded here:
   # - S3 bucket name, which is created in terraform/modernisation-platform-account/s3.tf
   backend "s3" {
-    acl            = "bucket-owner-full-control"
-    bucket         = "modernisation-platform-terraform-state"
-    encrypt        = true
-    key            = "single-sign-on/terraform.tfstate"
-    region         = "eu-west-2"
-    use_lockfile   = true
+    acl          = "bucket-owner-full-control"
+    bucket       = "modernisation-platform-terraform-state"
+    encrypt      = true
+    key          = "single-sign-on/terraform.tfstate"
+    region       = "eu-west-2"
+    use_lockfile = true
   }
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

#8345

## How does this PR fix the problem?

Where roles permit access to the `modernisation-platform-terraform-state` S3 bucket, this PR expands them to allow them to `put` and `delete` .tflock files.

This PR also implements small linting fixes where appropriate.

## How has this been tested?

Tested through CI pipeline

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
