### PR TITLE
issue/8695

### DIFF
--- a/.github/workflows/reusable_terraform_plan_apply.yml
+++ b/.github/workflows/reusable_terraform_plan_apply.yml
@@ -32,6 +32,7 @@ on:
 
 env:
   TF_IN_AUTOMATION: true
+  TF_DESTROY_THRESHOLD: 10 # Sets a threshold to alert if the number of resources shown to be destroyed in the plan output is equal or threater than this number.
 jobs:
   fetch-secrets:
     uses: ministryofjustice/modernisation-platform-github-actions/.github/workflows/aws-secrets-management.yml@d9e930d93532b84efdcf7d7b82621506e96a15b0 # v1.0.0
@@ -126,6 +127,43 @@ jobs:
         id: show
         run: |
           bash scripts/terraform-plan.sh ${{ inputs.working-directory }}
+
+      - name: Get Destroy Count
+        if: github.event_name == 'pull_request'
+        id: get_destroy_count
+        env:
+          destroy_threshold: ${{ env.TF_DESTROY_THRESHOLD }}
+          plan_summary: ${{ steps.show.outputs.summary }}
+        run: |
+            bash scripts/get-terraform-destroy-count.sh
+
+      - name: Post Warning & Check for Approval
+        id: post_warning_check_approval
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        env:
+          destroy_count: ${{ steps.get_destroy_count.outputs.destroy_count }}
+          destroy_threshold: ${{ env.TF_DESTROY_THRESHOLD }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const orgName = 'ministryofjustice';
+            const teamSlug = 'modernisation-platform';
+            const destroyCount = parseInt(process.env.destroy_count, 10);
+            const destroyThreshold = parseInt(process.env.destroy_threshold, 10);
+            const summary = `\`${{ steps.show.outputs.summary }}\``;
+            const workflowId = "${{ env.WORKSPACE_NAME }}";
+            const identifier = workflowId ? `_${workflowId}_\n` : `_${{ inputs.workflow_id }}_\n`;
+
+            if (destroyCount >= destroyThreshold) {
+              await github.rest.pulls.createReview({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.payload.pull_request.number,
+                event: 'REQUEST_CHANGES',
+                body: `### :warning: Warning - Large Number of Resources to be Destroyed.\n ${identifier}${summary}\n Please review the plan and confirm the changes are expected.`
+              });
+            }
 
       - name: Post Comment
         if: github.event.ref != 'refs/heads/main'

--- a/scripts/get-terraform-destroy-count.sh
+++ b/scripts/get-terraform-destroy-count.sh
@@ -1,0 +1,45 @@
+
+#!/bin/bash
+
+set -o pipefail
+
+# This script reads the terraform plan summary and gets the count of resources to be destroyed and sets it to the variable destroy_count.
+# It also runs some checks to ensure that the values for the count and the threshold are valid.
+
+# Checks that PLAN_DESTROY_CHECK is set. Without this the script will fail so we force an exit.
+if [ -z "$plan_summary" ]; then
+    echo "Plan Summary is not set"
+    exit 1
+fi
+
+# This looks for the summary output for no changes & exits the script if found.
+if echo "$plan_summary" | grep -q "No changes. Your infrastructure matches the configuration."; then
+    echo "No changes. Your infrastructure matches the configuration."
+    destroy_count=0
+    exit 0
+fi
+
+destroy_count=$(echo "$plan_summary" | grep -oE 'Plan: [0-9]+ to add, [0-9]+ to change, [0-9]+ to destroy.' | awk '{print $8}')
+
+echo "destroy_threshold=$destroy_threshold"
+echo "destroy_count=$destroy_count"
+
+# These tests will force an exit of the script if the values are not valid as we don't want to proceed if invalid.
+if ! [[ "$destroy_threshold" =~ ^[0-9]+$ ]]; then
+    echo "Invalid destroy_threshold value: $destroy_threshold"
+    exit 1
+elif ! [[ "$destroy_count" =~ ^[0-9]+$ ]]; then
+    echo "Invalid destroy_count value: $destroy_count"
+    exit 1
+fi
+
+# These checks will print a warning if the destroy count is above the threshold. Useful for trouble-shooting.
+if [ "$destroy_count" -gt "$destroy_threshold" ]; then
+    echo "Warning: There are $destroy_count resources to be destroyed in this plan."
+elif [ "$destroy_count" -gt 0 ]; then
+    echo "There are $destroy_count resources to be destroyed, which is below the set threshold of $DESTROY_THRESHOLD."
+else
+    echo "No resources to be destroyed"
+fi
+
+echo "destroy_count=$destroy_count" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/8695

## How does this PR fix the problem?

This adds a check on the number of resources identified to be destroyed in the plan output. If greater or equal to the set threshold then a warning will be displayed along with a review request. This is achieved by the following:

1. A new environment variable in the reusable-plan-and-apply workflow - that sets this threshold. Initially set to 10.
2. A new bash script that greps the output of the "show" step in the above workflow, obtains from it the number of resources to be destroyed from the plan and outputs depending on the result.
3. Two new steps for the reusable-plan-and-apply workflow - the exec of the above bash script and a step that generates a review request should the destroy threshold be met or exceeded.

Example of the output:

![image](https://github.com/user-attachments/assets/1b08b15c-760d-47ef-8ee8-0de54ec605ad)

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Tested extensively - for example https://github.com/ministryofjustice/modernisation-platform/pull/9084. 

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

There is the potential to encapsulate this in a standalone reusable workflow.