### PR TITLE
Update docs now that state files are stored natively in S3

### DIFF
--- a/source/runbooks/terraform.html.md.erb
+++ b/source/runbooks/terraform.html.md.erb
@@ -54,24 +54,22 @@ $ terraform workspace select core-logging-production
 $ terraform plan
 ```
 
-You will likely get an error if you haven't changed your workspace from `default`.
+You will get errors if you haven't changed your workspace from `default`.
 
 ### Permissions required for `terraform/environments/` directory in [`modernisation-platform-environments`](https://github.com/ministryofjustice/modernisation-platform-environments) repo
 
 You can run `terraform plan` and `terraform apply` in customer directories using credentials for AdministratorAccess SSO role for the terraform workspace you're running against. For example, if you're want to run code in the `terraform/environments/nomis` directory in the `nomis-development` workspace, you will need to retrieve the [AWS SSO credentials](../user-guide/getting-aws-credentials.html) for the `nomis-development` account and paste them into your environment prior to running terraform commands.
 
-After pasting the credentials, use the following steps to run terraform in the `nomis` directory against `nomis-development` account:
+After pasting the credentials, use the following steps to run terraform in the `example` directory against `example-development` account:
 
 ```bash
 $ cd terraform/environments/nomis
-$ terraform init -backend-config=assume_role={role_arn=\"arn:aws:iam::<modernisation-platform account number>:role/modernisation-account-terraform-state-member-access\"}
+$ terraform init
 $ terraform workspace list
-$ terraform workspace select nomis-development
+$ terraform workspace select example-development
 $ terraform plan
 $ terraform apply
 ```
-
-NOTE, you are required to replace `<modernisation-platform account number>` with the actual account number of the `modernisation-platform` account in order to run the `terraform init` command.
 
 >If you encounter `Access Denied` error, try running `rm -rf .terraform` and rerun `terraform init`
 

--- a/source/user-guide/running-terraform-plan-locally.html.md.erb
+++ b/source/user-guide/running-terraform-plan-locally.html.md.erb
@@ -29,24 +29,10 @@ Get your AWS SSO credentials as detailed [here](./getting-aws-credentials.html),
 
 Follow the instructions [here](https://learn.hashicorp.com/tutorials/terraform/install-cli) to install the latest version of Terraform according to your platform.
 
-## Retrieve the Modernisation Platform account ID
-
-You will need the Modernisation Platform account ID to assume the correct role when running `terraform init`.
-You can retrieve the Modernisation Platform account ID from the SSM Parameter store via the web console, or via CLI.
-This will allow you to assume the correct `role_arn`.
-
-```
-aws ssm get-parameters --region eu-west-2 \
---names "modernisation_platform_account_id" --with-decryption --query "Parameters[*].{Value:Value}" --output text
-```
-
 ## Run Terraform plan
 
 1. Navigate to your application infrastructure code - `cd modernisation-platform-environments/terraform/environments/my-application`
-2. Run a Terraform init that assumes the backend role in the **Modernisation Platform** account - `terraform init -backend-config=assume_role={role_arn=\"arn:aws:iam::000000000000:role/modernisation-account-terraform-state-member-access\"}`
-
-> Remember to replace the `000000000000` placeholder with the Modernisation Platform account ID.
-
+2. Run `terraform init`
 3. View the workspaces (you have different workspaces for your different environment accounts) - `terraform workspace list`
 4. Select the required workspace - `terraform workspace select my-application-development`
 5. Run a Terraform plan - `terraform plan`


### PR DESCRIPTION
## A reference to the issue / Description of it

#8345 

## How does this PR fix the problem?

Updates documentation to reflect that there's no need to assume a backend role for state locking through DynamoDB

## How has this been tested?

Tested through peer review of PR

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
