### PR TITLE
Allow developers to manipulate Terraform state locks

### DIFF
--- a/terraform/modernisation-platform-account/s3.tf
+++ b/terraform/modernisation-platform-account/s3.tf
@@ -251,7 +251,7 @@ data "aws_iam_policy_document" "allow-state-access-from-root-account" {
   statement {
     sid     = "DeleteLockFromModernisationPlatformOU"
     effect  = "Allow"
-    actions = ["s3:GetObject"]
+    actions = ["s3:DeleteObject","s3:GetObject","s3:PutObject"]
     resources = [
       "${module.state-bucket.bucket.arn}/*.tflock",
     ]


### PR DESCRIPTION
## A reference to the issue / Description of it

#8345

## How does this PR fix the problem?

Permissions for Developer wishing to run local plans were not sufficient

## How has this been tested?

Manually amended bucket policy, tested access with developer credentials

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
