### PR TITLE
Add PagerDuty service and Slack connection for electronic monitoring data alarms

### DIFF
--- a/terraform/pagerduty/member-services-integrations.tf
+++ b/terraform/pagerduty/member-services-integrations.tf
@@ -2229,3 +2229,47 @@ resource "pagerduty_slack_connection" "delius_oracle_nonprod_connection" {
     priorities = ["*"]
   }
 }
+
+resource "pagerduty_service" "electronic_monitoring_data" {
+  name                    = "Electronic Monitoring Data Alarms"
+  description             = "Electronic Monitoring Data Alarms"
+  auto_resolve_timeout    = 345600
+  acknowledgement_timeout = "null"
+  escalation_policy       = pagerduty_escalation_policy.member_policy.id
+  alert_creation          = "create_alerts_and_incidents"
+}
+
+resource "pagerduty_service_integration" "electronic_monitoring_data_cloudwatch" {
+  name    = data.pagerduty_vendor.cloudwatch.name
+  service = pagerduty_service.electronic_monitoring_data.id
+  vendor  = data.pagerduty_vendor.cloudwatch.id
+}
+
+resource "pagerduty_slack_connection" "electronic_monitoring_data_connection" {
+  source_id         = pagerduty_service.electronic_monitoring_data.id
+  source_type       = "service_reference"
+  workspace_id      = local.slack_workspace_id
+  channel_id        = "C07TXBPBLKG"
+  notification_type = "responder"
+  config {
+    events = [
+      "incident.triggered",
+      "incident.acknowledged",
+      "incident.escalated",
+      "incident.resolved",
+      "incident.reassigned",
+      "incident.annotated",
+      "incident.unacknowledged",
+      "incident.delegated",
+      "incident.priority_updated",
+      "incident.responder.added",
+      "incident.responder.replied",
+      "incident.action_invocation.created",
+      "incident.action_invocation.terminated",
+      "incident.action_invocation.updated",
+      "incident.status_update_published",
+      "incident.reopened"
+    ]
+    priorities = ["*"]
+  }
+}


### PR DESCRIPTION
## A reference to the issue / Description of it

Adding a pager duty service for alerting for EMD

## How does this PR fix the problem?

Adds the service

## How has this been tested?

n/a

## Deployment Plan / Instructions

n/a

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

