### PR TITLE
allow LDAPS connections from legacy prod

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/production_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/production_rules.json
@@ -293,6 +293,13 @@
     "destination_port": "389",
     "protocol": "TCP"
   },
+  "delius_prod_to_hmpps_production_ldaps": {
+    "action": "PASS",
+    "source_ip": "${delius-prod}",
+    "destination_ip": "${hmpps-production}",
+    "destination_port": "636",
+    "protocol": "TCP"
+  },
   "cp_to_mp_hmpps_production_ldap": {
     "action": "PASS",
     "source_ip": "${cloud-platform}",


### PR DESCRIPTION
## A reference to the issue / Description of it

We're migrating LDAP in production and need legacy production resources to access the secure LDAP port for our new LDAP instance in MP

## How does this PR fix the problem?

It allows the connectivity

## How has this been tested?

Just the PR checks

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No, it will only add the LDAPS port access

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)
