### PR TITLE
feature#8739-excluding example account from nuke & adding green-ops sso

### DIFF
--- a/environments/example.json
+++ b/environments/example.json
@@ -6,7 +6,13 @@
       "access": [
         {
           "sso_group_name": "modernisation-platform",
-          "level": "developer"
+          "level": "developer",
+          "nuke": "exclude"
+        },
+        {
+          "sso_group_name": "green-ops",
+          "level": "data-engineer",
+          "nuke": "exclude"
         }
       ]
     }


### PR DESCRIPTION
## A reference to the issue / Description of it

[#8739](https://github.com/ministryofjustice/modernisation-platform/issues/8739) - Example account will be used for GreenOps PoC, as a result 

- it needs to be temporarily removed from nuke
- Julien Nioche will need access to the account so a new GitHub group has been created (green-ops) to allow him to access the account as opposed to his whole team.

## How does this PR fix the problem?

See above

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

See unit tests below.

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
