### PR TITLE
Update repo name in OIDC role

### DIFF
--- a/environments/laa-stabilisation-cdc-poc.json
+++ b/environments/laa-stabilisation-cdc-poc.json
@@ -19,6 +19,6 @@
     "owner": "wendy.calverley@digital.justice.gov.uk",
     "critical-national-infrastructure": false
   },
-  "github-oidc-team-repositories": ["ministryofjustice/cdc-replacement"],
+  "github-oidc-team-repositories": ["ministryofjustice/laa-cdc-replacement"],
   "go-live-date": ""
 }


### PR DESCRIPTION
Simple change to update the OIDC role for deployments to AWS after the repo name was changed. PoC environment for CDC replacement.
