### PR TITLE
Remove dynamodb references for testing-ci permissions

### DIFF
--- a/terraform/github/data.tf
+++ b/terraform/github/data.tf
@@ -16,10 +16,6 @@ data "aws_kms_key" "s3_state_bucket_multi_region" {
   key_id = "alias/s3-state-bucket-multi-region"
 }
 
-data "aws_kms_key" "dynamodb_state_lock_multi_region" {
-  key_id = "alias/dynamodb-state-lock-multi-region"
-}
-
 data "aws_kms_key" "environment_management_multi_region" {
   key_id = "alias/environment-management-multi-region"
 }

--- a/terraform/github/testing-ci.tf
+++ b/terraform/github/testing-ci.tf
@@ -45,17 +45,6 @@ data "aws_iam_policy_document" "testing_ci_policy" {
     ]
   }
 
-  # Based on https://www.terraform.io/docs/language/settings/backends/s3.html#dynamodb-table-permissions
-  statement {
-    effect = "Allow"
-    actions = [
-      "dynamodb:GetItem",
-      "dynamodb:PutItem",
-      "dynamodb:DeleteItem"
-    ]
-    resources = ["arn:aws:dynamodb:eu-west-2:${data.aws_caller_identity.modernisation_platform.account_id}:table/modernisation-platform-terraform-state-lock"]
-  }
-
   # Based on https://docs.amazonaws.cn/en_us/AmazonS3/latest/userguide/UsingKMSEncryption.htm
   statement {
     effect = "Allow"
@@ -65,7 +54,6 @@ data "aws_iam_policy_document" "testing_ci_policy" {
     ]
     resources = [
       data.aws_kms_key.s3_state_bucket_multi_region.arn,
-      data.aws_kms_key.dynamodb_state_lock_multi_region.arn,
       data.aws_kms_key.environment_management_multi_region.arn,
       data.aws_kms_key.pagerduty_multi_region.arn
     ]

--- a/terraform/modernisation-platform-account/backend.tf
+++ b/terraform/modernisation-platform-account/backend.tf
@@ -1,7 +1,6 @@
 terraform {
   # `backend` blocks do not support variables, so the following are hard-coded here:
   # - S3 bucket name, which is created in s3.tf
-  # - DynamoDB table name, which is created in dynamodb.tf
   backend "s3" {
     acl          = "bucket-owner-full-control"
     bucket       = "modernisation-platform-terraform-state"

--- a/terraform/modernisation-platform-account/iam.tf
+++ b/terraform/modernisation-platform-account/iam.tf
@@ -217,18 +217,6 @@ data "aws_iam_policy_document" "oidc_assume_plan_role_member" {
   }
 
   statement {
-    sid    = "AllowDynamoDBAccess"
-    effect = "Allow"
-    actions = [
-      "dynamodb:DescribeTable",
-      "dynamodb:GetItem",
-      "dynamodb:PutItem",
-      "dynamodb:DeleteItem"
-    ]
-    resources = ["arn:aws:dynamodb:eu-west-2:${data.aws_caller_identity.current.account_id}:table/modernisation-platform-terraform-state-lock"]
-  }
-
-  statement {
     sid    = "AssumeRole"
     effect = "Allow"
     actions = [


### PR DESCRIPTION
## A reference to the issue / Description of it

#8345 

## How does this PR fix the problem?

Removes statements relating to the now-removed DynamoDB state locking table

## How has this been tested?

Tested through CI pipeline checks

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
