### PR TITLE
Feature #8739- excluding example account from nuke

### DIFF
--- a/terraform/environments/secrets.tf
+++ b/terraform/environments/secrets.tf
@@ -174,5 +174,5 @@ resource "github_actions_secret" "autonuke" {
   secret_name = "MODERNISATION_PLATFORM_AUTONUKE"
   repository  = "modernisation-platform-environments"
   # testing-test, cooker-development, and example-development are internal test account which are not sandpits but require nuking.
-  plaintext_value = jsonencode(concat(module.environments.environment_nuke_accounts, ["testing-test", "example-development"]))
+  plaintext_value = jsonencode(concat(module.environments.environment_nuke_accounts, ["testing-test"]))
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

[#8739](https://github.com/ministryofjustice/modernisation-platform/issues/8739) - Example account will be used for GreenOps PoC, as a result, it needs to be temporarily removed from nuke

## How does this PR fix the problem?

See above

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

See unit tests below.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
