### PR TITLE
Introduce Component-Based Subfolder Structure in Modernisation Platform Environments

### DIFF
--- a/.github/workflows/new-environment.yml
+++ b/.github/workflows/new-environment.yml
@@ -149,6 +149,8 @@ jobs:
         run: bash scripts/provision-terraform-workspaces.sh bootstrap
       - name: Provision workspaces in terraform/environments/*
         run: bash scripts/provision-terraform-workspaces.sh all-environments
+      - name: Provision Member Component Workspaces
+        run: bash scripts/provision-member-component-workspaces.sh
       - name: Slack failure notification
         uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
         with:

--- a/scripts/provision-member-component-workspaces.sh
+++ b/scripts/provision-member-component-workspaces.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+# Enable error handling
+set -e
+set -o pipefail
+
+# Set S3 bucket and AWS region
+S3_BUCKET="modernisation-platform-terraform-state"
+
+git_dir="$(git rev-parse --show-toplevel)"
+TERRAFORM_PATH="${git_dir}/tmp"
+mkdir -p "${TERRAFORM_PATH}"
+
+# Check if Terraform state file exists in S3
+state_file_exists() {
+    local key="$1"
+    aws s3api head-object --bucket ${S3_BUCKET} --key "${key}" > /dev/null 2>&1
+}
+
+# Create temporary Terraform files
+setup_terraform_files() {
+    local application_name="$1" component="$2"
+    echo "Setting up Terraform files for ${application_name}/${component}"
+    rm -rf "${TERRAFORM_PATH}" && mkdir -p "${TERRAFORM_PATH}"
+    sed "s/\$application_name/${application_name}/g; s/\$component_name/${component}/g" "${git_dir}/terraform/templates/modernisation-platform-environments-components/platform_backend.tf" > "${TERRAFORM_PATH}/platform_backend.tf"
+    cp "${git_dir}/terraform/templates/modernisation-platform/providers.tf" "${TERRAFORM_PATH}/providers.tf"
+    cp "${git_dir}/terraform/templates/modernisation-platform/secrets.tf" "${TERRAFORM_PATH}/secrets.tf"
+    cp "${git_dir}/terraform/templates/modernisation-platform/versions.tf" "${TERRAFORM_PATH}/versions.tf"
+}
+
+# Create Terraform workspace
+create_workspace() {
+    local workspace="$1"
+    echo "Creating Terraform workspace: ${workspace}"
+    terraform -chdir="${TERRAFORM_PATH}" init > /dev/null 2>&1
+    terraform -chdir="${TERRAFORM_PATH}" workspace new "${workspace}" > /dev/null 2>&1
+}
+
+# Process JSON files in the directory
+process_json() {
+    for JSON_FILE in ${git_dir}/environments/*.json
+    do
+        application_name=$(basename "${JSON_FILE}" .json)
+        echo "Processing ${JSON_FILE}"
+
+        # Check if "components" exists and has at least one element
+        component_count=$(jq -r '.components | length' "${JSON_FILE}")
+        if [[ "$component_count" -eq 0 ]]; then
+            echo "Skipping ${JSON_FILE}: 'components' attribute is empty"
+            continue
+        fi
+
+        environments=$(jq -r '.environments[].name' "${JSON_FILE}")
+        components=$(jq -r '.components[].name' "${JSON_FILE}")
+
+        for env in ${environments}; do
+            workspace_name="${application_name}-${env}"
+            for component in ${components}; do
+                state_path="environments/members/${application_name}/${component}/${application_name}-${env}/terraform.tfstate"
+                if ! state_file_exists "${state_path}"; then
+                    echo "State file missing: ${state_path}, workspace required."
+                    setup_terraform_files "${application_name}" "${component}"
+                    create_workspace "${workspace_name}"
+                fi
+            done
+        done
+    done
+}
+
+# Run the process
+process_json

--- a/terraform/templates/modernisation-platform-environments-components/platform_backend.tf
+++ b/terraform/templates/modernisation-platform-environments-components/platform_backend.tf
@@ -1,0 +1,14 @@
+# Backend
+terraform {
+  # `backend` blocks do not support variables, so the following are hard-coded here:
+  # - S3 bucket name, which is created in modernisation-platform-account/s3.tf
+  backend "s3" {
+    acl                  = "bucket-owner-full-control"
+    bucket               = "modernisation-platform-terraform-state"
+    encrypt              = true
+    key                  = "terraform.tfstate"
+    region               = "eu-west-2"
+    use_lockfile         = true
+    workspace_key_prefix = "environments/members/$application_name/$component_name" # This will store the object as environments/members/analytical-platform-ingestion/${workspace}/terraform.tfstate
+  }
+}

--- a/terraform/templates/modernisation-platform-environments-components/platform_base_variables.tf
+++ b/terraform/templates/modernisation-platform-environments-components/platform_base_variables.tf
@@ -1,0 +1,9 @@
+variable "networking" {
+  type = list(any)
+}
+
+variable "collaborator_access" {
+  type        = string
+  default     = "developer"
+  description = "Collaborators must specify which access level they are using, eg set an environment variable of export TF_VAR_collaborator_access=migration"
+}

--- a/terraform/templates/modernisation-platform-environments-components/platform_data.tf
+++ b/terraform/templates/modernisation-platform-environments-components/platform_data.tf
@@ -1,0 +1,46 @@
+# Current account data
+data "aws_region" "current" {}
+
+data "aws_caller_identity" "current" {}
+
+# Route53 DNS data
+data "aws_route53_zone" "network-services" {
+  provider = aws.core-network-services
+
+  name         = "modernisation-platform.service.justice.gov.uk."
+  private_zone = false
+}
+
+# State for core-network-services resource information
+data "terraform_remote_state" "core_network_services" {
+  backend = "s3"
+  config = {
+    acl     = "bucket-owner-full-control"
+    bucket  = "modernisation-platform-terraform-state"
+    key     = "environments/accounts/core-network-services/core-network-services-production/terraform.tfstate"
+    region  = "eu-west-2"
+    encrypt = "true"
+  }
+}
+
+data "aws_organizations_organization" "root_account" {}
+
+# Retrieve information about the modernisation platform account
+data "aws_caller_identity" "modernisation_platform" {
+  provider = aws.modernisation-platform
+}
+
+# caller account information to instantiate aws.oidc provider
+data "aws_caller_identity" "original_session" {
+  provider = aws.original-session
+}
+
+data "aws_iam_session_context" "whoami" {
+  provider = aws.original-session
+  arn      = data.aws_caller_identity.original_session.arn
+}
+
+# Get the environments file from the main repository
+data "http" "environments_file" {
+  url = "https://raw.githubusercontent.com/ministryofjustice/modernisation-platform/main/environments/${local.application_name}.json"
+}

--- a/terraform/templates/modernisation-platform-environments-components/platform_locals.tf
+++ b/terraform/templates/modernisation-platform-environments-components/platform_locals.tf
@@ -1,0 +1,39 @@
+locals {
+
+  application_name = "$application_name"
+  component_name   = "$component_name"
+
+  environment_management = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
+
+  # Stores modernisation platform account id for setting up the modernisation-platform provider
+  modernisation_platform_account_id = data.aws_ssm_parameter.modernisation_platform_account_id.value
+
+  # This takes the name of the Terraform workspace (e.g. core-vpc-production), strips out the application name (e.g. core-vpc), and checks if
+  # the string leftover is `-production`, if it isn't (e.g. core-vpc-non-production => -non-production) then it sets the var to false.
+  is-production    = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-production"
+  is-preproduction = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-preproduction"
+  is-test          = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-test"
+  is-development   = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-development"
+
+  # Merge tags from the environment json file with additional ones
+  tags = merge(
+    jsondecode(data.http.environments_file.response_body).tags,
+    { "is-production" = local.is-production },
+    { "environment-name" = terraform.workspace },
+    { "source-code" = "https://github.com/ministryofjustice/modernisation-platform-environments" }
+  )
+
+  environment     = trimprefix(terraform.workspace, "${var.networking[0].application}-")
+  vpc_name        = var.networking[0].business-unit
+  subnet_set      = var.networking[0].set
+  vpc_all         = "${local.vpc_name}-${local.environment}"
+  subnet_set_name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}"
+
+  is_live       = [substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-production" || substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-preproduction" ? "live" : "non-live"]
+  provider_name = "core-vpc-${local.environment}"
+
+  # environment specfic variables
+  # example usage:
+  # example_data = local.application_data.accounts[local.environment].example_var
+  application_data = fileexists("./application_variables.json") ? jsondecode(file("./application_variables.json")) : null
+}

--- a/terraform/templates/modernisation-platform-environments-components/platform_providers.tf
+++ b/terraform/templates/modernisation-platform-environments-components/platform_providers.tf
@@ -1,0 +1,49 @@
+# AWS provider for the original session which you connect with
+provider "aws" {
+  alias  = "original-session"
+  region = "eu-west-2"
+}
+
+# AWS provider for the workspace you're working in (every resource will default to using this, unless otherwise specified)
+provider "aws" {
+  region = "eu-west-2"
+  assume_role {
+    role_arn = !can(regex("githubactionsrolesession|AdministratorAccess|user", data.aws_caller_identity.original_session.arn)) ? null : can(regex("user", data.aws_caller_identity.original_session.arn)) ? "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/${var.collaborator_access}" : "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccess"
+  }
+}
+
+# AWS provider for the Modernisation Platform, to get things from there if required
+provider "aws" {
+  alias  = "modernisation-platform"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${local.modernisation_platform_account_id}:role/modernisation-account-limited-read-member-access"
+  }
+}
+
+# AWS provider for network services to enable dns entries for certificate validation to be created
+provider "aws" {
+  alias  = "core-network-services"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = !can(regex("githubactionsrolesession|AdministratorAccess", data.aws_caller_identity.original_session.arn)) ? "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/read-log-records" : "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/modify-dns-records"
+  }
+}
+
+# Provider for creating resources in us-east-1, eg ACM resources for CloudFront
+provider "aws" {
+  alias  = "us-east-1"
+  region = "us-east-1"
+  assume_role {
+    role_arn = !can(regex("githubactionsrolesession|AdministratorAccess|user", data.aws_caller_identity.original_session.arn)) ? null : can(regex("user", data.aws_caller_identity.original_session.arn)) ? "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/${var.collaborator_access}" : "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
+  }
+}
+
+# Provider for reading resources from root account IdentityStore
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "sso-readonly"
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.aws_organizations_root_account_id}:role/ModernisationPlatformSSOReadOnly"
+  }
+}

--- a/terraform/templates/modernisation-platform-environments-components/platform_secrets.tf
+++ b/terraform/templates/modernisation-platform-environments-components/platform_secrets.tf
@@ -1,0 +1,17 @@
+# Get modernisation account id from ssm parameter
+data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.original-session
+  name     = "modernisation_platform_account_id"
+}
+
+# Get secret by arn for environment management
+data "aws_secretsmanager_secret" "environment_management" {
+  provider = aws.modernisation-platform
+  name     = "environment_management"
+}
+
+# Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
+data "aws_secretsmanager_secret_version" "environment_management" {
+  provider  = aws.modernisation-platform
+  secret_id = data.aws_secretsmanager_secret.environment_management.id
+}

--- a/terraform/templates/modernisation-platform-environments-components/versions.tf
+++ b/terraform/templates/modernisation-platform-environments-components/versions.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_providers {
+    aws = {
+      version = "~> 5.0"
+      source  = "hashicorp/aws"
+    }
+    dns = {
+      version = "~> 3.0"
+      source  = "hashicorp/dns"
+    }
+    external = {
+      version = "~> 2.0"
+      source  = "hashicorp/external"
+    }
+    http = {
+      version = "~> 3.0"
+      source  = "hashicorp/http"
+    }
+  }
+  required_version = "~> 1.10"
+}


### PR DESCRIPTION
## A reference to the issue / Description of it

The current structure of the Modernisation Platform Environments makes it challenging for multiple teams to collaborate within a single account. The common workaround—requesting a new account—is not always practical, especially for larger projects that require multiple teams working concurrently.

https://github.com/ministryofjustice/analytical-platform/issues/6602

## How does this PR fix the problem?

This PR introduces a component-based subfolder structure within the application folder

- Work on different components in their own isolated directories.
- Reduce the need for requesting additional accounts.
- Improve maintainability and scalability of projects.

This change enhances collaboration within the Modernisation Platform Environments, making it easier for larger teams to contribute without conflicts.

## How has this been tested?

Tested all the scripts locally to ensure proper functionality. Everything is working as expected before pushing to the repository.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
