### PR TITLE
Update template workflow to support components in environments

### DIFF
--- a/.github/workflows/templates/workflow-template.yml
+++ b/.github/workflows/templates/workflow-template.yml
@@ -32,7 +32,7 @@ permissions:
 
 jobs:
   strategy:
-    uses: ./.github/workflows/reusable_terraform_strategy.yml
+    uses: ./.github/workflows/reusable_terraform_components_strategy.yml
     if: inputs.action != 'destroy'
     with:
       application: "${{ github.workflow }}"
@@ -43,23 +43,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.strategy.outputs.matrix) }}
-    uses: ./.github/workflows/reusable_terraform_plan_apply.yml
+    uses: ./.github/workflows/reusable_terraform_components_plan_apply.yml
     with:
       application: "${{ github.workflow }}"
       environment: "${{ matrix.target }}"
       action: "${{ matrix.action }}"
+      component: "${{ matrix.component }}"     # If your strategy workflow also outputs "matrix.component"
     secrets:
       modernisation_platform_environments: "${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENTS }}"
       pipeline_github_token: "${{ secrets.MODERNISATION_PLATFORM_CI_USER_ENVIRONMENTS_REPO_PAT }}"
 
   destroy-development:
     if: inputs.action == 'destroy'
-    uses: ./.github/workflows/reusable_terraform_plan_apply.yml
+    uses: ./.github/workflows/reusable_terraform_components_plan_apply.yml
     with:
       application: "${{ github.workflow }}"
       environment: "development"
       action: "plan_apply"
       plan_apply_tfargs: "-destroy"
+      # If you need component logic on destroy, pass it here as well, e.g. component: ...
     secrets:
       modernisation_platform_environments: "${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENTS }}"
       pipeline_github_token: "${{ secrets.MODERNISATION_PLATFORM_CI_USER_ENVIRONMENTS_REPO_PAT }}"


### PR DESCRIPTION
Updated the template workflow to incorporate reusable workflows that support both component-based and non-component environments. This change eliminates the need for maintaining two separate workflow versions, simplifying workflow management and ensuring consistency across environments. With this update, the workflow dynamically adapts based on whether components exist, reducing duplication and making future maintenance easier. The template is used in the environments repo when creating accounts, ensuring that all newly created accounts follow a unified and scalable workflow structure.