### PR TITLE
Add components to the JSON configuration

### DIFF
--- a/environments/sprinkler.json
+++ b/environments/sprinkler.json
@@ -1,5 +1,14 @@
 {
   "account-type": "member",
+  "components": [
+    {
+      "name": "playground",
+      "sso_group_name": "modernisation-platform"
+    },
+    {
+      "name": "testbed"
+    }
+  ],
   "environments": [
     {
       "name": "development",


### PR DESCRIPTION
## A reference to the issue / Description of it

This PR is for testing MPE components.
Added two new components: `playground` and `testbed` to the JSON configuration. This change will create two subfolders in the environments repo, each containing separate configuration and state files for the components.

## How does this PR fix the problem?

This change ensures that `playground` and `testbed` components can be deployed into the same account, but their code and configurations are managed independently. By isolating their configurations and state files into separate subfolders, we avoid potential conflicts and make it easier to maintain and update each component individually.



## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
