### PR TITLE
Add new component request template and update destroy process to target specific components or root by default

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-component.yml
+++ b/.github/ISSUE_TEMPLATE/new-component.yml
@@ -1,0 +1,56 @@
+name: New Component for Member Application
+description: Request a new component for a member application
+labels: ["onboarding", "member request"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please complete the following details and submit the new issue for requesting one or more components for your existing member application.
+
+        ### Component Example:
+        - **Component Name**: testbed
+        - **SSO Group Name**: (leave blank if not needed)
+  - type: input
+    id: app-name
+    attributes: 
+      label: Application Name
+      description: Name of the existing application for the components being created inside the application directory.
+      value:
+    validations:
+      required: true
+  - type: textarea
+    id: components
+    attributes:
+      label: Components and SSO Group Names
+      description: |
+        Please list the components you want to create, along with their optional SSO group names. If no SSO group is required for a component, leave it blank or simply omit it.
+
+        Example:
+        - Component Name: testbed
+        - Component Name: playground - SSO Group Name: modernisation-platform
+      value:
+    validations:
+      required: true
+  - type: textarea
+    id: other-info
+    attributes:
+      label: Other information
+      description: Any other information you feel is relevant, please remember this is a public repository
+      value:
+    validations:
+      required: false
+  - type: textarea
+    id: dod
+    attributes:
+      description: Please clearly and concisely detail the Definition of Done.
+      label: Definition of Done
+      value:
+        
+        Definition of Done
+        
+        - [ ] components created
+
+        - [ ] customer informed
+
+    validations:
+      required: true

--- a/.github/workflows/templates/workflow-template.yml
+++ b/.github/workflows/templates/workflow-template.yml
@@ -25,6 +25,11 @@ on:
         options:
           - deploy
           - destroy
+      component:
+        description: "Optional: Target a specific component for destroy. Defaults to 'root' to destroy the root or <application> folder."
+        required: false
+        default: "root"
+        type: string
 
 permissions:
   id-token: write  # This is required for requesting the JWT
@@ -61,7 +66,7 @@ jobs:
       environment: "development"
       action: "plan_apply"
       plan_apply_tfargs: "-destroy"
-      # If you need component logic on destroy, pass it here as well, e.g. component: ...
+      component: "${{ inputs.component }}"  # Targets a specific component for the destroy operation; defaults to 'root' if not specified.
     secrets:
       modernisation_platform_environments: "${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENTS }}"
       pipeline_github_token: "${{ secrets.MODERNISATION_PLATFORM_CI_USER_ENVIRONMENTS_REPO_PAT }}"

--- a/terraform/templates/modernisation-platform-environments-components/platform_backend.tf
+++ b/terraform/templates/modernisation-platform-environments-components/platform_backend.tf
@@ -9,6 +9,6 @@ terraform {
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
     use_lockfile         = true
-    workspace_key_prefix = "environments/members/$application_name/$component_name" # This will store the object as environments/members/analytical-platform-ingestion/${workspace}/terraform.tfstate
+    workspace_key_prefix = "environments/members/$application_name/$component_name" # This will store the object as environments/members/<application>/<component>/${workspace}/terraform.tfstate
   }
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

The current destroy process in the workflow template removes all resources within the application, including both the root folder and individual components. This broad behavior increases the risk of unintentionally destroying critical infrastructure.

## How does this PR fix the problem?

By adding the `component` input with a default value of `root`, this template update ensures that the destroy process is controlled and predictable:
- **Default behavior:** Only the root folder will be destroyed if no component is specified.
- **Custom behavior:** Specific components can be targeted for destruction when explicitly provided.

And Adds a new template for requesting the creation of components in member applications

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
