### PR TITLE
🛂 Update Analytical Platform access model

### DIFF
--- a/environments/analytical-platform-common.json
+++ b/environments/analytical-platform-common.json
@@ -5,8 +5,12 @@
       "name": "production",
       "access": [
         {
-          "sso_group_name": "analytical-platform",
+          "sso_group_name": "analytical-platform-engineers",
           "level": "developer"
+        },
+        {
+          "sso_group_name": "data-platform-audit-and-security",
+          "level": "security-audit"
         }
       ]
     }

--- a/environments/analytical-platform-compute.json
+++ b/environments/analytical-platform-compute.json
@@ -5,13 +5,21 @@
       "name": "development",
       "access": [
         {
-          "sso_group_name": "analytical-platform",
+          "sso_group_name": "analytical-platform-engineers",
           "level": "sandbox",
           "nuke": "exclude"
         },
         {
-          "sso_group_name": "analytical-platform",
+          "sso_group_name": "analytical-platform-engineers",
           "level": "data-engineer"
+        },
+        {
+          "sso_group_name": "analytical-platform-engineers",
+          "level": "quicksight-admin"
+        },
+        {
+          "sso_group_name": "data-platform-audit-and-security",
+          "level": "security-audit"
         }
       ],
       "instance_scheduler_skip": ["true"]
@@ -20,16 +28,20 @@
       "name": "test",
       "access": [
         {
-          "sso_group_name": "analytical-platform",
+          "sso_group_name": "analytical-platform-engineers",
           "level": "developer"
         },
         {
-          "sso_group_name": "analytical-platform",
+          "sso_group_name": "analytical-platform-engineers",
           "level": "data-engineer"
         },
         {
-          "sso_group_name": "analytical-platform",
+          "sso_group_name": "analytical-platform-engineers",
           "level": "quicksight-admin"
+        },
+        {
+          "sso_group_name": "data-platform-audit-and-security",
+          "level": "security-audit"
         }
       ],
       "instance_scheduler_skip": ["true"]
@@ -38,16 +50,20 @@
       "name": "production",
       "access": [
         {
-          "sso_group_name": "analytical-platform",
+          "sso_group_name": "analytical-platform-engineers",
           "level": "developer"
         },
         {
-          "sso_group_name": "analytical-platform",
+          "sso_group_name": "analytical-platform-engineers",
           "level": "data-engineer"
         },
         {
-          "sso_group_name": "analytical-platform",
+          "sso_group_name": "analytical-platform-engineers",
           "level": "quicksight-admin"
+        },
+        {
+          "sso_group_name": "data-platform-audit-and-security",
+          "level": "security-audit"
         }
       ]
     }

--- a/environments/analytical-platform-data-engineering.json
+++ b/environments/analytical-platform-data-engineering.json
@@ -5,7 +5,7 @@
       "name": "production",
       "access": [
         {
-          "sso_group_name": "analytical-platform-data-engineering-production-administrator",
+          "sso_group_name": "analytical-platform-engineers",
           "level": "administrator"
         },
         {
@@ -25,6 +25,10 @@
     {
       "name": "sandboxa",
       "access": [
+        {
+          "sso_group_name": "analytical-platform-engineers",
+          "level": "administrator"
+        },
         {
           "sso_group_name": "analytical-platform-data-engineering-sandboxa-administrator",
           "level": "administrator"

--- a/environments/analytical-platform-data.json
+++ b/environments/analytical-platform-data.json
@@ -5,7 +5,7 @@
       "name": "development",
       "access": [
         {
-          "sso_group_name": "analytical-platform-data-development-administrator",
+          "sso_group_name": "analytical-platform-engineers",
           "level": "administrator"
         },
         {
@@ -22,7 +22,7 @@
       "name": "production",
       "access": [
         {
-          "sso_group_name": "analytical-platform-data-production-administrator",
+          "sso_group_name": "analytical-platform-engineers",
           "level": "administrator"
         },
         {

--- a/environments/analytical-platform-ingestion.json
+++ b/environments/analytical-platform-ingestion.json
@@ -6,9 +6,13 @@
       "name": "development",
       "access": [
         {
-          "sso_group_name": "analytical-platform",
+          "sso_group_name": "analytical-platform-engineers",
           "level": "sandbox",
           "nuke": "exclude"
+        },
+        {
+          "sso_group_name": "data-platform-audit-and-security",
+          "level": "security-audit"
         }
       ],
       "instance_scheduler_skip": ["true"]
@@ -17,8 +21,12 @@
       "name": "production",
       "access": [
         {
-          "sso_group_name": "analytical-platform",
+          "sso_group_name": "analytical-platform-engineers",
           "level": "developer"
+        },
+        {
+          "sso_group_name": "data-platform-audit-and-security",
+          "level": "security-audit"
         }
       ]
     }

--- a/environments/analytical-platform-landing.json
+++ b/environments/analytical-platform-landing.json
@@ -5,7 +5,7 @@
       "name": "production",
       "access": [
         {
-          "sso_group_name": "analytical-platform-landing-production-administrator",
+          "sso_group_name": "analytical-platform-engineers",
           "level": "administrator"
         },
         {

--- a/environments/analytical-platform-management.json
+++ b/environments/analytical-platform-management.json
@@ -5,7 +5,7 @@
       "name": "production",
       "access": [
         {
-          "sso_group_name": "analytical-platform-management-production-administrator",
+          "sso_group_name": "analytical-platform-engineers",
           "level": "administrator"
         },
         {

--- a/environments/analytical-platform.json
+++ b/environments/analytical-platform.json
@@ -5,16 +5,16 @@
       "name": "development",
       "access": [
         {
-          "sso_group_name": "analytical-platform-development-administrator",
+          "sso_group_name": "analytical-platform-engineers",
           "level": "administrator"
-        },
-        {
-          "sso_group_name": "data-platform-audit-and-security",
-          "level": "security-audit"
         },
         {
           "sso_group_name": "analytical-platform-data-development-data-engineer",
           "level": "data-engineer"
+        },
+        {
+          "sso_group_name": "data-platform-audit-and-security",
+          "level": "security-audit"
         }
       ]
     },
@@ -22,7 +22,7 @@
       "name": "production",
       "access": [
         {
-          "sso_group_name": "analytical-platform-production-administrator",
+          "sso_group_name": "analytical-platform-engineers",
           "level": "administrator"
         },
         {


### PR DESCRIPTION
## A reference to the issue / Description of it

We have too many teams, some accounts didn't have the same level of access across environments, and our audit team was missing from most

## How does this PR fix the problem?

Uses new `analytical-platform-engineers` team for access, corrects any drift in access, adds audit team where missing

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

It hasn't

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

Only Analytical Platform

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

Requires https://github.com/ministryofjustice/data-platform-github-access/pull/350
