### PR TITLE
🛂 Amendments to Analytical Platform accounts

### DIFF
--- a/environments/analytical-platform-common.json
+++ b/environments/analytical-platform-common.json
@@ -1,5 +1,6 @@
 {
   "account-type": "member",
+  "codeowners": ["analytical-platform-engineers"],
   "environments": [
     {
       "name": "production",
@@ -7,6 +8,10 @@
         {
           "sso_group_name": "analytical-platform-engineers",
           "level": "developer"
+        },
+        {
+          "sso_group_name": "analytical-platform-airflow",
+          "level": "mwaa-user"
         },
         {
           "sso_group_name": "data-platform-audit-and-security",

--- a/environments/analytical-platform-compute.json
+++ b/environments/analytical-platform-compute.json
@@ -1,5 +1,6 @@
 {
   "account-type": "member",
+  "codeowners": ["analytical-platform-engineers"],
   "environments": [
     {
       "name": "development",

--- a/environments/analytical-platform-ingestion.json
+++ b/environments/analytical-platform-ingestion.json
@@ -1,5 +1,6 @@
 {
   "account-type": "member",
+  "codeowners": ["analytical-platform-engineers"],
   "isolated-network": "true",
   "environments": [
     {


### PR DESCRIPTION
Add mwaa-user to common

## A reference to the issue / Description of it

Sets `codeowners` for members accounts

Adds analytical-platform-airflow as mwaa-user to common accounts

## How does this PR fix the problem?

N/A

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

No

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
