### PR TITLE
New firewall rule for Mojo-Azure-Landing-Zone to LAA Development

### DIFF
--- a/terraform/environments/core-network-services/cidr-ranges.tf
+++ b/terraform/environments/core-network-services/cidr-ranges.tf
@@ -29,6 +29,7 @@ locals {
     i2n                              = "10.110.0.0/16"
     moj-core-azure-1                 = "10.50.25.0/27"
     moj-core-azure-2                 = "10.50.26.0/24"
+    mojo-azure-landing-zone          = "10.192.0.0/16"
     parole-board                     = "10.50.0.0/16"
     psn                              = "51.0.0.0/8"
     psn-ppud                         = "51.247.2.115/32"

--- a/terraform/environments/core-network-services/firewall-rules/development_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/development_rules.json
@@ -572,5 +572,12 @@
     "destination_ip": "${cica-development}",
     "destination_port": "ANY",
     "protocol": "TCP"
+  },
+   "mojo_alz_to_laa_development": {
+    "action": "PASS",
+    "source_ip": "${mojo-azure-landing-zone}",
+    "destination_ip": "${laa-development}",
+    "destination_port": "1521",
+    "protocol": "TCP"
   }
 }


### PR DESCRIPTION
as per slack request https://mojdt.slack.com/archives/C01A7QK5VM1/p1738939223827109?thread_ts=1738939094.061929&cid=C01A7QK5VM1 this PR creates a new firewall allow traffic between Mojo-Azure-Lanading-Zone and LAA Development on port 1521.
