### PR TITLE
🛂 Update mwaa-user permissions

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,24 @@
+{
+  "features": {
+    "ghcr.io/ministryofjustice/devcontainer-feature/aws:1": {
+      "version": "1.0.1",
+      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/aws@sha256:53233b394572638b1853a96a5e9d2adc3bae459eb2038a77584330282c82bf40",
+      "integrity": "sha256:53233b394572638b1853a96a5e9d2adc3bae459eb2038a77584330282c82bf40"
+    },
+    "ghcr.io/ministryofjustice/devcontainer-feature/kubernetes:1": {
+      "version": "1.0.2",
+      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/kubernetes@sha256:d24f235b7578a71a60fce981d250fa300e9f353911561648c31a7022fd8ded6a",
+      "integrity": "sha256:d24f235b7578a71a60fce981d250fa300e9f353911561648c31a7022fd8ded6a"
+    },
+    "ghcr.io/ministryofjustice/devcontainer-feature/static-analysis:1": {
+      "version": "1.0.0",
+      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/static-analysis@sha256:e81d52725655c8ffb861605feac7ad155b447d51af65f6c3a03cab32d59f1e16",
+      "integrity": "sha256:e81d52725655c8ffb861605feac7ad155b447d51af65f6c3a03cab32d59f1e16"
+    },
+    "ghcr.io/ministryofjustice/devcontainer-feature/terraform:1": {
+      "version": "1.2.0",
+      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/terraform@sha256:6343878231decb72427ea2d59d98d0c4bb6f15931d86800330f7c84df8320f6c",
+      "integrity": "sha256:6343878231decb72427ea2d59d98d0c4bb6f15931d86800330f7c84df8320f6c"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,10 @@
+{
+  "name": "modernisation-platform-environments",
+  "image": "ghcr.io/ministryofjustice/devcontainer-base:latest",
+  "features": {
+    "ghcr.io/ministryofjustice/devcontainer-feature/aws:1": {},
+    "ghcr.io/ministryofjustice/devcontainer-feature/kubernetes:1": {},
+    "ghcr.io/ministryofjustice/devcontainer-feature/static-analysis:1": {},
+    "ghcr.io/ministryofjustice/devcontainer-feature/terraform:1": {}
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "name": "modernisation-platform-environments",
+  "name": "modernisation-platform",
   "image": "ghcr.io/ministryofjustice/devcontainer-base:latest",
   "features": {
     "ghcr.io/ministryofjustice/devcontainer-feature/aws:1": {},

--- a/terraform/single-sign-on/sso-permission-sets.tf
+++ b/terraform/single-sign-on/sso-permission-sets.tf
@@ -111,10 +111,40 @@ resource "aws_ssoadmin_permission_set_inline_policy" "modernisation_platform_dat
 
 data "aws_iam_policy_document" "modernisation_platform_data_mwaa_user" {
   statement {
-    actions = [
-      "airflow:CreateWebLoginToken"
+    sid     = "MWAAUIUserAccess"
+    effect  = "Allow"
+    actions = ["airflow:CreateWebLoginToken"]
+    resources = [
+      "arn:aws:airflow:eu-west-2:${local.environment_management.account_ids["analytical-platform-compute-development"]}:role/development/User",
+      "arn:aws:airflow:eu-west-2:${local.environment_management.account_ids["analytical-platform-compute-test"]}:role/test/User",
+      "arn:aws:airflow:eu-west-2:${local.environment_management.account_ids["analytical-platform-compute-production"]}:role/production/User",
     ]
-    resources = ["arn:aws:airflow:*:*:role/*/User"]
+  }
+  statement {
+    sid    = "SecretsManagerKMSAccess"
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+      "kms:Encrypt",
+      "kms:GenerateDataKey"
+    ]
+    resources = formatlist("arn:aws:kms:%s:${local.environment_management.account_ids["analytical-platform-data-production"]}:key/mrk-15afdf54bde745d3b583a6818ee6c154", ["eu-west-1", "eu-west-2"])
+  }
+  statement {
+    sid       = "SecretsManagerAccess"
+    effect    = "Allow"
+    actions   = ["secretsmanager:ListSecrets"]
+    resources = ["*"]
+  }
+  statement {
+    sid    = "SecretsManagerSecretsAccess"
+    effect = "Allow"
+    actions = [
+      "secretsmanager:GetSecretValue",
+      "secretsmanager:PutSecretValue",
+      "secretsmanager:DescribeSecret"
+    ]
+    resources = formatlist("arn:aws:secretsmanager:%s:${local.environment_management.account_ids["analytical-platform-data-production"]}:secret:/airflow/*", ["eu-west-1", "eu-west-2"])
   }
 }
 


### PR DESCRIPTION
## A reference to the issue / Description of it

Updates the permissions for the mwaa-user role to cover KMS and Secrets Manager access

- Scopes MWAA access to Analytical Platform Compute
- Gives access to KMS CMK MRK and Secrets Managed in Analytical Platform Data Production

## How does this PR fix the problem?

mwaa-user was an experimental role for something that never took off in Analytical Platform, this pull request reuses it for our new Airflow service

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

It hasn't been tested, but the changes are additions

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No, only Analytical Platform use this role

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

Adds a dev container to mirror modernisation-platform-environments
