### PR TITLE
extra permissions need to be able to run a crawler job

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -418,6 +418,7 @@ data "aws_iam_policy_document" "data_engineering_additional" {
       "glue:BatchDeleteTable",
       "glue:CreateDatabase",
       "glue:CreatePartition",
+      "glue:StartCrawler",
       "glue:CreateSession",
       "glue:CreateTable",
       "glue:DeleteDatabase",
@@ -570,13 +571,13 @@ data "aws_iam_policy_document" "platform_engineer_additional_additional" {
       "dbqms:*",
       "dlm:*",
       "dms:*",
-      "drs:*",  
+      "drs:*",
       "kms:*",
       "sagemaker:*",
       "sqs:*",
-      "sns:*",      
+      "sns:*",
       "lakeformation:*",
-      "lambda:*",          
+      "lambda:*",
       "iam:AttachRolePolicy",
       "iam:DetachRolePolicy",
       "iam:ListAttachedRolePolicies",
@@ -652,7 +653,7 @@ data "aws_iam_policy_document" "platform_engineer_additional_additional" {
       "bedrock:DeleteFoundationModelAgreement",
       "bedrock:ListFoundationModelAgreementOffers",
       "bedrock:GetUseCaseForModelAccess",
-      "bedrock:PutUseCaseForModelAccess"      
+      "bedrock:PutUseCaseForModelAccess"
     ]
 
     resources = ["*"]


### PR DESCRIPTION
## A reference to the issue / Description of it

as part of an ask channel request here
Matt Heery
  12:21
hellooo - can someone start [this glue crawler](https://396913731313-hio47vvi.eu-west-2.console.aws.amazon.com/glue/home?region=eu-west-2#/v2/data-catalog/crawlers/view/historic_api_mart_crawler) (in electronic monitoring data test, called historic_api_mart_crawler) for me? its a one off job so sorry but need it done :sweat_smile:

i have found that not even us as administrators can start a crwaler job 

## How does this PR fix the problem?

this PR adds in the missing permission to run a crawaler job from the console

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
