### PR TITLE
Adding ram:AssociateResourceShare to the MemberInfrastructureAccess role

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -165,6 +165,7 @@ data "aws_iam_policy_document" "member-access" {
       "organizations:List*",
       "oam:*",
       "quicksight:*",
+      "ram:AssociateResourceShare",
       "ram:CreateResourceShare",
       "ram:DeleteResourceShare",
       "ram:Get*",


### PR DESCRIPTION
## A reference to the issue / Description of it

User request: https://mojdt.slack.com/archives/C01A7QK5VM1/p1739446680635549?thread_ts=1739380874.018489&cid=C01A7QK5VM1

## How does this PR fix the problem?

This should fix the error experiences by the customer: https://github.com/ministryofjustice/modernisation-platform-environments/actions/runs/13306577923/job/37159407352#step:9:21

## How has this been tested?

Deployment to Sprinkler prior to rolling out to all member accounts

## Deployment Plan / Instructions

see above


## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

