### PR TITLE
remove secret from reusable-signed-commit.yml

### DIFF
--- a/.github/workflows/reusable-signed-commit.yml
+++ b/.github/workflows/reusable-signed-commit.yml
@@ -10,10 +10,6 @@ on:
         description: "Body for the PR (only required if creating a new PR)"
         required: false
         type: string
-    secrets:
-      GITHUB_TOKEN:
-        description: "GitHub token with permissions for signing commits"
-        required: true
 
 permissions:
   contents: write


### PR DESCRIPTION
Removing GitHub token as GitHub automatically provides secrets.GITHUB_TOKEN, so defining it inside the workflow_call is causing an error.

![image](https://github.com/user-attachments/assets/6b5e006b-5086-4e11-8527-cd22ae83e84b)
