### PR TITLE
Update generate-dependabot-signed-commits.yml

### DIFF
--- a/.github/workflows/generate-dependabot-signed-commits.yml
+++ b/.github/workflows/generate-dependabot-signed-commits.yml
@@ -23,7 +23,7 @@ jobs:
         run: bash ./scripts/generate-dependabot-file.sh
 
       - name: Call Signed Commit & PR Workflow
-        uses: ./.github/workflows/reusable-signed-commit.yml
+        uses:  ministryofjustice/modernisation-platform/.github/workflows/reusable-signed-commit.yml@main
         with:
           pr_title: "Automated Update: Dependabot File"
           pr_body: "This PR updates the Dependabot configuration file."


### PR DESCRIPTION
Updating to use full workflow path as receiving the below error: 
`Error: Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under '/home/runner/work/modernisation-platform/modernisation-platform/.github/workflows/reusable-signed-commit.yml'. Did you forget to run actions/checkout before running your local action?`