### PR TITLE
Update workflow

### DIFF
--- a/.github/workflows/generate-dependabot-signed-commits.yml
+++ b/.github/workflows/generate-dependabot-signed-commits.yml
@@ -3,7 +3,9 @@ name: Generate dependabot file Signed Commits
 on:
   workflow_dispatch:
 
-permissions: {}
+permissions:
+  contents: write
+  pull-requests: write
 
 defaults:
   run:
@@ -11,19 +13,17 @@ defaults:
 
 jobs:
   create-and-commit-dependabot-file:
-    permissions:
-      contents: write
-      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      
+
       - name: Generate Dependabot file
         run: bash ./scripts/generate-dependabot-file.sh
 
-      - name: Call Signed Commit & PR Workflow
-        uses: ministryofjustice/modernisation-platform/.github/workflows/reusable-signed-commit.yml@main
-        with:
-          pr_title: "Automated Update: Dependabot File"
-          pr_body: "This PR updates the Dependabot configuration file."
+  call-signed-commit-pr-workflow:
+    needs: create-and-commit-dependabot-file
+    uses: ministryofjustice/modernisation-platform/.github/workflows/reusable-signed-commit.yml@main
+    with:
+      pr_title: "Automated Update: Dependabot File"
+      pr_body: "This PR updates the Dependabot configuration file."


### PR DESCRIPTION
move the signed commit step to a job as seeing below error: 
`Error reusable workflows should be referenced at the top-level `jobs.*.uses' key, not within steps`