### PR TITLE
Bump baselines to `v7.12.2`

### DIFF
--- a/terraform/environments/bootstrap/secure-baselines/main.tf
+++ b/terraform/environments/bootstrap/secure-baselines/main.tf
@@ -6,7 +6,7 @@ data "aws_kms_key" "cloudtrail_key" {
 
 #trivy:ignore:AVD-AWS-0136
 module "baselines" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=c7e60f3255077d67cb75da5dce3f32c9d5d360ec" # v7.12.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=1d3ffbb31d280bea94cdc711312a2952bd0ffffb" # v7.12.2
 
   providers = {
     # Default and replication regions

--- a/terraform/modernisation-platform-account/baselines.tf
+++ b/terraform/modernisation-platform-account/baselines.tf
@@ -18,7 +18,7 @@ locals {
 # Secure baselines (GuardDuty, Config, SecurityHub, etc)
 #trivy:ignore:AVD-AWS-0136 trivy:ignore:AVD-AWS-0132
 module "baselines-modernisation-platform" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=c7e60f3255077d67cb75da5dce3f32c9d5d360ec" # v7.12.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=1d3ffbb31d280bea94cdc711312a2952bd0ffffb" # v7.12.2
   providers = {
     # Default and replication regions
     aws                    = aws.modernisation-platform-eu-west-2


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/9207

`v7.12.0` rollout failed https://github.com/ministryofjustice/modernisation-platform/actions/runs/13367813632

If there is no account alias set you get the error...

```
Error: reading IAM Account Alias: empty result

  with module.baselines.data.aws_iam_account_alias.current
```

## How does this PR fix the problem?

Bumps baselines to `v7.12.2` which uses a workspace call to get the account name with a tweak in there for the MP account which uses `default` workspace.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
