### PR TITLE
Transit gateway circular dependency

### DIFF
--- a/terraform/environments/core-network-services/versions.tf
+++ b/terraform/environments/core-network-services/versions.tf
@@ -4,6 +4,10 @@ terraform {
       version = "~> 5.0"
       source  = "hashicorp/aws"
     }
+    time = {
+      source = "hashicorp/time"
+      version = "~> 0.12.1"
+    }
   }
   required_version = "~> 1.0"
 }

--- a/terraform/environments/core-vpc/8854-migrations.tf
+++ b/terraform/environments/core-vpc/8854-migrations.tf
@@ -1,0 +1,315 @@
+# This short-lived file should exist only until the moved blocks have been integrated into state, and then deleted.
+
+# core-vpc-sandbox
+moved {
+  from = module.vpc_attachment["garden-sandbox"].aws_ec2_transit_gateway_vpc_attachment.default
+  to   = module.vpc["garden-sandbox"].aws_ec2_transit_gateway_vpc_attachment.main
+}
+moved {
+  from = module.vpc_attachment["house-sandbox"].aws_ec2_transit_gateway_vpc_attachment.default
+  to   = module.vpc["house-sandbox"].aws_ec2_transit_gateway_vpc_attachment.main
+}
+moved {
+  from = module.vpc_attachment["garden-sandbox"].aws_ec2_transit_gateway_route_table_association.default
+  to   = module.vpc["garden-sandbox"].aws_ec2_transit_gateway_route_table_association.type
+}
+moved {
+  from = module.vpc_attachment["house-sandbox"].aws_ec2_transit_gateway_route_table_association.default
+  to   = module.vpc["house-sandbox"].aws_ec2_transit_gateway_route_table_association.type
+}
+
+# core-vpc-development
+moved {
+  from = module.vpc_attachment["cica-development"].aws_ec2_transit_gateway_vpc_attachment.default
+  to   = module.vpc["cica-development"].aws_ec2_transit_gateway_vpc_attachment.main
+}
+moved {
+  from = module.vpc_attachment["cjse-development"].aws_ec2_transit_gateway_vpc_attachment.default
+  to   = module.vpc["cjse-development"].aws_ec2_transit_gateway_vpc_attachment.main
+}
+moved {
+  from = module.vpc_attachment["hmcts-development"].aws_ec2_transit_gateway_vpc_attachment.default
+  to   = module.vpc["hmcts-development"].aws_ec2_transit_gateway_vpc_attachment.main
+}
+moved {
+  from = module.vpc_attachment["hmpps-development"].aws_ec2_transit_gateway_vpc_attachment.default
+  to   = module.vpc["hmpps-development"].aws_ec2_transit_gateway_vpc_attachment.main
+}
+moved {
+  from = module.vpc_attachment["hq-development"].aws_ec2_transit_gateway_vpc_attachment.default
+  to   = module.vpc["hq-development"].aws_ec2_transit_gateway_vpc_attachment.main
+}
+moved {
+  from = module.vpc_attachment["laa-development"].aws_ec2_transit_gateway_vpc_attachment.default
+  to   = module.vpc["laa-development"].aws_ec2_transit_gateway_vpc_attachment.main
+}
+moved {
+  from = module.vpc_attachment["opg-development"].aws_ec2_transit_gateway_vpc_attachment.default
+  to   = module.vpc["opg-development"].aws_ec2_transit_gateway_vpc_attachment.main
+}
+moved {
+  from = module.vpc_attachment["platforms-development"].aws_ec2_transit_gateway_vpc_attachment.default
+  to   = module.vpc["platforms-development"].aws_ec2_transit_gateway_vpc_attachment.main
+}
+moved {
+  from = module.vpc_attachment["yjb-development"].aws_ec2_transit_gateway_vpc_attachment.default
+  to   = module.vpc["yjb-development"].aws_ec2_transit_gateway_vpc_attachment.main
+}
+moved {
+  from = module.vpc_attachment["cica-development"].aws_ec2_transit_gateway_route_table_association.default
+  to   = module.vpc["cica-development"].aws_ec2_transit_gateway_route_table_association.type
+}
+moved {
+  from = module.vpc_attachment["cjse-development"].aws_ec2_transit_gateway_route_table_association.default
+  to   = module.vpc["cjse-development"].aws_ec2_transit_gateway_route_table_association.type
+}
+moved {
+  from = module.vpc_attachment["hmcts-development"].aws_ec2_transit_gateway_route_table_association.default
+  to   = module.vpc["hmcts-development"].aws_ec2_transit_gateway_route_table_association.type
+}
+moved {
+  from = module.vpc_attachment["hmpps-development"].aws_ec2_transit_gateway_route_table_association.default
+  to   = module.vpc["hmpps-development"].aws_ec2_transit_gateway_route_table_association.type
+}
+moved {
+  from = module.vpc_attachment["hq-development"].aws_ec2_transit_gateway_route_table_association.default
+  to   = module.vpc["hq-development"].aws_ec2_transit_gateway_route_table_association.type
+}
+moved {
+  from = module.vpc_attachment["laa-development"].aws_ec2_transit_gateway_route_table_association.default
+  to   = module.vpc["laa-development"].aws_ec2_transit_gateway_route_table_association.type
+}
+moved {
+  from = module.vpc_attachment["opg-development"].aws_ec2_transit_gateway_route_table_association.default
+  to   = module.vpc["opg-development"].aws_ec2_transit_gateway_route_table_association.type
+}
+moved {
+  from = module.vpc_attachment["platforms-development"].aws_ec2_transit_gateway_route_table_association.default
+  to   = module.vpc["platforms-development"].aws_ec2_transit_gateway_route_table_association.type
+}
+moved {
+  from = module.vpc_attachment["yjb-development"].aws_ec2_transit_gateway_route_table_association.default
+  to   = module.vpc["yjb-development"].aws_ec2_transit_gateway_route_table_association.type
+}
+
+# core-vpc-test
+moved {
+  from = module.vpc_attachment["cica-test"].aws_ec2_transit_gateway_vpc_attachment.default
+  to   = module.vpc["cica-test"].aws_ec2_transit_gateway_vpc_attachment.main
+}
+moved {
+  from = module.vpc_attachment["cjse-test"].aws_ec2_transit_gateway_vpc_attachment.default
+  to   = module.vpc["cjse-test"].aws_ec2_transit_gateway_vpc_attachment.main
+}
+moved {
+  from = module.vpc_attachment["hmcts-test"].aws_ec2_transit_gateway_vpc_attachment.default
+  to   = module.vpc["hmcts-test"].aws_ec2_transit_gateway_vpc_attachment.main
+}
+moved {
+  from = module.vpc_attachment["hmpps-test"].aws_ec2_transit_gateway_vpc_attachment.default
+  to   = module.vpc["hmpps-test"].aws_ec2_transit_gateway_vpc_attachment.main
+}
+moved {
+  from = module.vpc_attachment["hq-test"].aws_ec2_transit_gateway_vpc_attachment.default
+  to   = module.vpc["hq-test"].aws_ec2_transit_gateway_vpc_attachment.main
+}
+moved {
+  from = module.vpc_attachment["laa-test"].aws_ec2_transit_gateway_vpc_attachment.default
+  to   = module.vpc["laa-test"].aws_ec2_transit_gateway_vpc_attachment.main
+}
+moved {
+  from = module.vpc_attachment["opg-test"].aws_ec2_transit_gateway_vpc_attachment.default
+  to   = module.vpc["opg-test"].aws_ec2_transit_gateway_vpc_attachment.main
+}
+moved {
+  from = module.vpc_attachment["platforms-test"].aws_ec2_transit_gateway_vpc_attachment.default
+  to   = module.vpc["platforms-test"].aws_ec2_transit_gateway_vpc_attachment.main
+}
+moved {
+  from = module.vpc_attachment["yjb-test"].aws_ec2_transit_gateway_vpc_attachment.default
+  to   = module.vpc["yjb-test"].aws_ec2_transit_gateway_vpc_attachment.main
+}
+moved {
+  from = module.vpc_attachment["cica-test"].aws_ec2_transit_gateway_route_table_association.default
+  to   = module.vpc["cica-test"].aws_ec2_transit_gateway_route_table_association.type
+}
+moved {
+  from = module.vpc_attachment["cjse-test"].aws_ec2_transit_gateway_route_table_association.default
+  to   = module.vpc["cjse-test"].aws_ec2_transit_gateway_route_table_association.type
+}
+moved {
+  from = module.vpc_attachment["hmcts-test"].aws_ec2_transit_gateway_route_table_association.default
+  to   = module.vpc["hmcts-test"].aws_ec2_transit_gateway_route_table_association.type
+}
+moved {
+  from = module.vpc_attachment["hmpps-test"].aws_ec2_transit_gateway_route_table_association.default
+  to   = module.vpc["hmpps-test"].aws_ec2_transit_gateway_route_table_association.type
+}
+moved {
+  from = module.vpc_attachment["hq-test"].aws_ec2_transit_gateway_route_table_association.default
+  to   = module.vpc["hq-test"].aws_ec2_transit_gateway_route_table_association.type
+}
+moved {
+  from = module.vpc_attachment["laa-test"].aws_ec2_transit_gateway_route_table_association.default
+  to   = module.vpc["laa-test"].aws_ec2_transit_gateway_route_table_association.type
+}
+moved {
+  from = module.vpc_attachment["opg-test"].aws_ec2_transit_gateway_route_table_association.default
+  to   = module.vpc["opg-test"].aws_ec2_transit_gateway_route_table_association.type
+}
+moved {
+  from = module.vpc_attachment["platforms-test"].aws_ec2_transit_gateway_route_table_association.default
+  to   = module.vpc["platforms-test"].aws_ec2_transit_gateway_route_table_association.type
+}
+moved {
+  from = module.vpc_attachment["yjb-test"].aws_ec2_transit_gateway_route_table_association.default
+  to   = module.vpc["yjb-test"].aws_ec2_transit_gateway_route_table_association.type
+}
+
+# core-vpc-preproduction
+moved {
+  from = module.vpc_attachment["cica-preproduction"].aws_ec2_transit_gateway_vpc_attachment.default
+  to   = module.vpc["cica-preproduction"].aws_ec2_transit_gateway_vpc_attachment.main
+}
+moved {
+  from = module.vpc_attachment["cjse-preproduction"].aws_ec2_transit_gateway_vpc_attachment.default
+  to   = module.vpc["cjse-preproduction"].aws_ec2_transit_gateway_vpc_attachment.main
+}
+moved {
+  from = module.vpc_attachment["hmcts-preproduction"].aws_ec2_transit_gateway_vpc_attachment.default
+  to   = module.vpc["hmcts-preproduction"].aws_ec2_transit_gateway_vpc_attachment.main
+}
+moved {
+  from = module.vpc_attachment["hmpps-preproduction"].aws_ec2_transit_gateway_vpc_attachment.default
+  to   = module.vpc["hmpps-preproduction"].aws_ec2_transit_gateway_vpc_attachment.main
+}
+moved {
+  from = module.vpc_attachment["hq-preproduction"].aws_ec2_transit_gateway_vpc_attachment.default
+  to   = module.vpc["hq-preproduction"].aws_ec2_transit_gateway_vpc_attachment.main
+}
+moved {
+  from = module.vpc_attachment["laa-preproduction"].aws_ec2_transit_gateway_vpc_attachment.default
+  to   = module.vpc["laa-preproduction"].aws_ec2_transit_gateway_vpc_attachment.main
+}
+moved {
+  from = module.vpc_attachment["opg-preproduction"].aws_ec2_transit_gateway_vpc_attachment.default
+  to   = module.vpc["opg-preproduction"].aws_ec2_transit_gateway_vpc_attachment.main
+}
+moved {
+  from = module.vpc_attachment["platforms-preproduction"].aws_ec2_transit_gateway_vpc_attachment.default
+  to   = module.vpc["platforms-preproduction"].aws_ec2_transit_gateway_vpc_attachment.main
+}
+moved {
+  from = module.vpc_attachment["yjb-preproduction"].aws_ec2_transit_gateway_vpc_attachment.default
+  to   = module.vpc["yjb-preproduction"].aws_ec2_transit_gateway_vpc_attachment.main
+}
+moved {
+  from = module.vpc_attachment["cica-preproduction"].aws_ec2_transit_gateway_route_table_association.default
+  to   = module.vpc["cica-preproduction"].aws_ec2_transit_gateway_route_table_association.type
+}
+moved {
+  from = module.vpc_attachment["cjse-preproduction"].aws_ec2_transit_gateway_route_table_association.default
+  to   = module.vpc["cjse-preproduction"].aws_ec2_transit_gateway_route_table_association.type
+}
+moved {
+  from = module.vpc_attachment["hmcts-preproduction"].aws_ec2_transit_gateway_route_table_association.default
+  to   = module.vpc["hmcts-preproduction"].aws_ec2_transit_gateway_route_table_association.type
+}
+moved {
+  from = module.vpc_attachment["hmpps-preproduction"].aws_ec2_transit_gateway_route_table_association.default
+  to   = module.vpc["hmpps-preproduction"].aws_ec2_transit_gateway_route_table_association.type
+}
+moved {
+  from = module.vpc_attachment["hq-preproduction"].aws_ec2_transit_gateway_route_table_association.default
+  to   = module.vpc["hq-preproduction"].aws_ec2_transit_gateway_route_table_association.type
+}
+moved {
+  from = module.vpc_attachment["laa-preproduction"].aws_ec2_transit_gateway_route_table_association.default
+  to   = module.vpc["laa-preproduction"].aws_ec2_transit_gateway_route_table_association.type
+}
+moved {
+  from = module.vpc_attachment["opg-preproduction"].aws_ec2_transit_gateway_route_table_association.default
+  to   = module.vpc["opg-preproduction"].aws_ec2_transit_gateway_route_table_association.type
+}
+moved {
+  from = module.vpc_attachment["platforms-preproduction"].aws_ec2_transit_gateway_route_table_association.default
+  to   = module.vpc["platforms-preproduction"].aws_ec2_transit_gateway_route_table_association.type
+}
+moved {
+  from = module.vpc_attachment["yjb-preproduction"].aws_ec2_transit_gateway_route_table_association.default
+  to   = module.vpc["yjb-preproduction"].aws_ec2_transit_gateway_route_table_association.type
+}
+
+# core-vpc-production
+moved {
+  from = module.vpc_attachment["cica-production"].aws_ec2_transit_gateway_vpc_attachment.default
+  to   = module.vpc["cica-production"].aws_ec2_transit_gateway_vpc_attachment.main
+}
+moved {
+  from = module.vpc_attachment["cjse-production"].aws_ec2_transit_gateway_vpc_attachment.default
+  to   = module.vpc["cjse-production"].aws_ec2_transit_gateway_vpc_attachment.main
+}
+moved {
+  from = module.vpc_attachment["hmcts-production"].aws_ec2_transit_gateway_vpc_attachment.default
+  to   = module.vpc["hmcts-production"].aws_ec2_transit_gateway_vpc_attachment.main
+}
+moved {
+  from = module.vpc_attachment["hmpps-production"].aws_ec2_transit_gateway_vpc_attachment.default
+  to   = module.vpc["hmpps-production"].aws_ec2_transit_gateway_vpc_attachment.main
+}
+moved {
+  from = module.vpc_attachment["hq-production"].aws_ec2_transit_gateway_vpc_attachment.default
+  to   = module.vpc["hq-production"].aws_ec2_transit_gateway_vpc_attachment.main
+}
+moved {
+  from = module.vpc_attachment["laa-production"].aws_ec2_transit_gateway_vpc_attachment.default
+  to   = module.vpc["laa-production"].aws_ec2_transit_gateway_vpc_attachment.main
+}
+moved {
+  from = module.vpc_attachment["opg-production"].aws_ec2_transit_gateway_vpc_attachment.default
+  to   = module.vpc["opg-production"].aws_ec2_transit_gateway_vpc_attachment.main
+}
+moved {
+  from = module.vpc_attachment["platforms-production"].aws_ec2_transit_gateway_vpc_attachment.default
+  to   = module.vpc["platforms-production"].aws_ec2_transit_gateway_vpc_attachment.main
+}
+moved {
+  from = module.vpc_attachment["yjb-production"].aws_ec2_transit_gateway_vpc_attachment.default
+  to   = module.vpc["yjb-production"].aws_ec2_transit_gateway_vpc_attachment.main
+}
+moved {
+  from = module.vpc_attachment["cica-production"].aws_ec2_transit_gateway_route_table_association.default
+  to   = module.vpc["cica-production"].aws_ec2_transit_gateway_route_table_association.type
+}
+moved {
+  from = module.vpc_attachment["cjse-production"].aws_ec2_transit_gateway_route_table_association.default
+  to   = module.vpc["cjse-production"].aws_ec2_transit_gateway_route_table_association.type
+}
+moved {
+  from = module.vpc_attachment["hmcts-production"].aws_ec2_transit_gateway_route_table_association.default
+  to   = module.vpc["hmcts-production"].aws_ec2_transit_gateway_route_table_association.type
+}
+moved {
+  from = module.vpc_attachment["hmpps-production"].aws_ec2_transit_gateway_route_table_association.default
+  to   = module.vpc["hmpps-production"].aws_ec2_transit_gateway_route_table_association.type
+}
+moved {
+  from = module.vpc_attachment["hq-production"].aws_ec2_transit_gateway_route_table_association.default
+  to   = module.vpc["hq-production"].aws_ec2_transit_gateway_route_table_association.type
+}
+moved {
+  from = module.vpc_attachment["laa-production"].aws_ec2_transit_gateway_route_table_association.default
+  to   = module.vpc["laa-production"].aws_ec2_transit_gateway_route_table_association.type
+}
+moved {
+  from = module.vpc_attachment["opg-production"].aws_ec2_transit_gateway_route_table_association.default
+  to   = module.vpc["opg-production"].aws_ec2_transit_gateway_route_table_association.type
+}
+moved {
+  from = module.vpc_attachment["platforms-production"].aws_ec2_transit_gateway_route_table_association.default
+  to   = module.vpc["platforms-production"].aws_ec2_transit_gateway_route_table_association.type
+}
+moved {
+  from = module.vpc_attachment["yjb-production"].aws_ec2_transit_gateway_route_table_association.default
+  to   = module.vpc["yjb-production"].aws_ec2_transit_gateway_route_table_association.type
+}

--- a/terraform/environments/core-vpc/transit-gateway-attachment.tf
+++ b/terraform/environments/core-vpc/transit-gateway-attachment.tf
@@ -26,28 +26,3 @@ resource "aws_ram_principal_association" "transit_gateway_association" {
   principal          = data.aws_caller_identity.transit-gateway-tenant.account_id
   resource_share_arn = data.aws_ram_resource_share.transit-gateway.arn
 }
-
-# Attach the VPC to the central Transit Gateway
-module "vpc_attachment" {
-  depends_on = [
-    aws_ram_principal_association.transit_gateway_association
-  ]
-  for_each = toset(keys(local.vpcs[terraform.workspace]))
-  source   = "../../modules/ec2-tgw-attachment"
-  providers = {
-    aws.transit-gateway-tenant = aws
-    aws.transit-gateway-host   = aws.core-network-services
-  }
-
-  transit_gateway_id = data.aws_ec2_transit_gateway.transit-gateway.id
-  type               = local.is-live_data ? "live_data" : "non_live_data"
-
-  subnet_ids = module.vpc[each.key].tgw_subnet_ids
-  vpc_id     = module.vpc[each.key].vpc_id
-  vpc_name   = each.key
-
-  tags = merge(
-    local.tags,
-    { "Name" = format("%s-attachment", each.key) }
-  )
-}

--- a/terraform/environments/core-vpc/versions.tf
+++ b/terraform/environments/core-vpc/versions.tf
@@ -4,6 +4,10 @@ terraform {
       version = "~> 5.0"
       source  = "hashicorp/aws"
     }
+    time = {
+      source = "hashicorp/time"
+      version = "~> 0.12.1"
+    }
   }
   required_version = "~> 1.0"
 }

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -83,11 +83,15 @@ locals {
 }
 
 module "vpc" {
-  for_each             = local.vpcs[terraform.workspace]
-  source               = "github.com/ministryofjustice/modernisation-platform-terraform-member-vpc?ref=1366ebe0812d4c129c0b31cfc5bf2a4b0540672c" # v3.1.0
+  providers = {
+    aws.transit-gateway-host = aws.core-network-services
+  }
+  for_each = local.vpcs[terraform.workspace]
+  source               = "github.com/ministryofjustice/modernisation-platform-terraform-member-vpc?ref=b547e82de8f520b0bf0b44f8793ca39eefb93948" # v4.0.0
   additional_endpoints = each.value.options.additional_endpoints
   subnet_sets          = { for key, subnet in each.value.cidr.subnet_sets : key => subnet.cidr }
   transit_gateway_id   = data.aws_ec2_transit_gateway.transit-gateway.id
+  type                 = local.is-live_data ? "live_data" : "non_live_data"
 
   # VPC Flow Logs
   vpc_flow_log_iam_role       = aws_iam_role.vpc_flow_log.arn

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -87,7 +87,7 @@ module "vpc" {
     aws.transit-gateway-host = aws.core-network-services
   }
   for_each = local.vpcs[terraform.workspace]
-  source               = "github.com/ministryofjustice/modernisation-platform-terraform-member-vpc?ref=b547e82de8f520b0bf0b44f8793ca39eefb93948" # v4.0.0
+  source               = "github.com/ministryofjustice/modernisation-platform-terraform-member-vpc?ref=3295b6fdd9ddf7f015eea5eda479aa1d5d19c5a2" # v4.0.0
   additional_endpoints = each.value.options.additional_endpoints
   subnet_sets          = { for key, subnet in each.value.cidr.subnet_sets : key => subnet.cidr }
   transit_gateway_id   = data.aws_ec2_transit_gateway.transit-gateway.id


### PR DESCRIPTION
## A reference to the issue / Description of it

#8874 

## How does this PR fix the problem?

Bumps module version, implements a `migrations.tf` to move the transit gateway attachments and route table associations across to the new code preventing their destruction/recreation.

`aws_ec2_tag` resources have not been included in the scope of this PR. They _could_ be, but would require ~750 additional lines in `migrations.tf`.

## How has this been tested?

Tested with local plans against `sandbox` and `development`.
On approval of this PR, will run with local `apply` against `sandbox` prior to completing the PR.

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
