### PR TITLE
:wrench: Update engineer access in `analytical-platform-ingestion` accounts

### DIFF
--- a/environments/analytical-platform-ingestion.json
+++ b/environments/analytical-platform-ingestion.json
@@ -8,7 +8,7 @@
       "access": [
         {
           "sso_group_name": "analytical-platform-engineers",
-          "level": "sandbox",
+          "level": "platform-engineer-admin",
           "nuke": "exclude"
         },
         {
@@ -23,7 +23,7 @@
       "access": [
         {
           "sso_group_name": "analytical-platform-engineers",
-          "level": "developer"
+          "level": "platform-engineer-admin"
         },
         {
           "sso_group_name": "data-platform-audit-and-security",


### PR DESCRIPTION
## A reference to the issue / Description of it

This has been created off of the back of [this](https://github.com/ministryofjustice/analytical-platform/issues/5175) issue.

That being said, that issue is large and the reason for this PR is to allow AP engineers to act as Administrators in the Analytical Platform Ingestion accounts.

## How does this PR fix the problem?

Provides `platform-engineer-admin` access.

## How has this been tested?

Adopted elsewhere.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)
NA