### PR TITLE
chore: add ses suppression list actions to oidc role

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -608,6 +608,7 @@ data "aws_iam_policy_document" "policy" {
       "secretsmanager:PutSecretValue",
       "secretsmanager:RotateSecret",
       "secretsmanager:UpdateSecretVersionStage",
+      "ses:*SuppressedDestination",
       "ssm:GetParameter",
       "ssm:PutParameter",
       "ssm:DescribeSessions",


### PR DESCRIPTION
## A reference to the issue / Description of it

We'd like to create a GitHub workflow to manage SES suppression lists in the `delius-jitbit` accounts. The Jitbit devs need to be able to remove emails that have been incorrectly added. Currently, the role used lacks the required permissions.

```
An error occurred (AccessDeniedException) when calling the DeleteSuppressedDestination operation: User: arn:aws:sts::142262177450:assumed-role/modernisation-platform-oidc-cicd/hmpps-cr-ancillary-jitbit-app-2 is not authorized to perform: ses:DeleteSuppressedDestination on resource: * because no identity-based policy allows the ses:DeleteSuppressedDestination action
```

## How does this PR fix the problem?

Adds required SES permissions to the OIDC role.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
