### PR TITLE
⏪ Revert removal of developer and sandbox access for Analytical Platform Ingestion

### DIFF
--- a/environments/analytical-platform-ingestion.json
+++ b/environments/analytical-platform-ingestion.json
@@ -12,6 +12,10 @@
           "nuke": "exclude"
         },
         {
+          "sso_group_name": "analytical-platform-engineers",
+          "level": "sandbox"
+        },
+        {
           "sso_group_name": "data-platform-audit-and-security",
           "level": "security-audit"
         }
@@ -24,6 +28,10 @@
         {
           "sso_group_name": "analytical-platform-engineers",
           "level": "platform-engineer-admin"
+        },
+        {
+          "sso_group_name": "analytical-platform-engineers",
+          "level": "developer"
         },
         {
           "sso_group_name": "data-platform-audit-and-security",


### PR DESCRIPTION
## A reference to the issue / Description of it

Platform Engineer Admin does not contain

## How does this PR fix the problem?

Adds developer and sandbox access back for Analytical Platform Engineering

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

No

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No, its additive

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
