### PR TITLE
Addinb S3, Athena, SSM, Secrets Manager, Glue and CloudWatch to platform-engineer-admin policy

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -559,7 +559,7 @@ data "aws_iam_policy_document" "platform_engineer_additional_additional" {
   #checkov:skip=CKV_AWS_110
   #checkov:skip=CKV_AWS_356: Needs to access multiple resources
   statement {
-    sid    = "QuickSightConsoleAdmin"
+    sid    = "PlatformEngineerAdmin"
     effect = "Allow"
 
     actions = [
@@ -578,6 +578,12 @@ data "aws_iam_policy_document" "platform_engineer_additional_additional" {
       "sns:*",
       "lakeformation:*",
       "lambda:*",
+      "s3:*",
+      "athena:*",
+      "glue:*",
+      "cloudwatch:*",
+      "secretsmanager:*",
+      "ssm:*",
       "iam:AttachRolePolicy",
       "iam:DetachRolePolicy",
       "iam:ListAttachedRolePolicies",
@@ -593,7 +599,6 @@ data "aws_iam_policy_document" "platform_engineer_additional_additional" {
       "iam:CreatePolicy",
       "iam:ListEntitiesForPolicy",
       "iam:ListPolicies",
-      "s3:ListAllMyBuckets",
       "athena:ListDataCatalogs",
       "athena:GetDataCatalog",
       "sso:DescribeApplication",


### PR DESCRIPTION
## A reference to the issue / Description of it

This isn't being tracked by an issue. Adding some services to the plat-eng-admin policy

## How does this PR fix the problem?

The policy as-is lacks some permissions that are quite needed for a platform engineer, chiefly S3, CloudWatch, SSM and Secrets Manager. Because AP is going to utilise these permissions extensively, and because MP engineers also work with some of the analytical services, also adding Glue and Athena.

## How has this been tested?

Will be tested post-deployment

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

Nothing specific

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [X] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
