### PR TITLE
TM-988: Enable VSS backups for DSO managed DC's

### DIFF
--- a/terraform/environments/core-shared-services/ad-fixngo.tf
+++ b/terraform/environments/core-shared-services/ad-fixngo.tf
@@ -134,7 +134,7 @@ locals {
     ec2_iam_roles = {
       # NOTE: roles will be granted access to relevant domain secrets in hmpps-domain-services accounts
       ad-fixngo-ec2-nonlive-role = {
-        description = "AD FixNGo EC2 instance role for SSM and accessing non-live Secrets"
+        description = "AD FixNGo EC2 instance role for SSM, VSS snapshots and accessing non-live Secrets"
         assume_role_policy = jsonencode({
           "Version" : "2012-10-17",
           "Statement" : [{
@@ -148,12 +148,13 @@ locals {
         })
         managed_policy_arns = [
           "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
+          "arn:aws:iam::aws:policy/AWSEC2VssSnapshotPolicy",
           "ad-fixngo-ec2-policy",
           "ad-fixngo-nonlive-secrets-policy",
         ]
       }
       ad-fixngo-ec2-live-role = {
-        description = "AD FixNGo EC2 instance role for SSM and accessing live Secrets"
+        description = "AD FixNGo EC2 instance role for SSM, VSS snapshots and accessing live Secrets"
         assume_role_policy = jsonencode({
           "Version" : "2012-10-17",
           "Statement" : [{
@@ -167,6 +168,7 @@ locals {
         })
         managed_policy_arns = [
           "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
+          "arn:aws:iam::aws:policy/AWSEC2VssSnapshotPolicy",
           "ad-fixngo-ec2-policy",
           "ad-fixngo-live-secrets-policy",
         ]


### PR DESCRIPTION
Enable VSS backup capability on AWS Domain Controllers for azure.noms.root domain, currently completing with VSS warnings.

## How does this PR fix the problem?

This PR assigns the missing IAM policy to fix the warning.

## How has this been tested?

As tested in other accounts managed by DSO.

## Deployment Plan / Instructions

Scope is limited to DSO instances.

- [X] I have performed a self-review of my own code
- [X] All checks have passed
- [X] I have made corresponding changes to the documentation
- [X] Plan and discussed how it should be deployed to PROD (If needed)

