### PR TITLE
🛂 Update Analytical Platform's member account environments

### DIFF
--- a/environments/analytical-platform-common.json
+++ b/environments/analytical-platform-common.json
@@ -1,6 +1,7 @@
 {
   "account-type": "member",
   "codeowners": ["analytical-platform-engineers"],
+  "github_action_reviewers": ["analytical-platform-engineers"],
   "environments": [
     {
       "name": "production",
@@ -8,6 +9,10 @@
         {
           "sso_group_name": "analytical-platform-engineers",
           "level": "developer"
+        },
+        {
+          "sso_group_name": "analytical-platform-engineers",
+          "level": "platform-engineer-admin"
         },
         {
           "sso_group_name": "analytical-platform-airflow",

--- a/environments/analytical-platform-compute.json
+++ b/environments/analytical-platform-compute.json
@@ -1,10 +1,15 @@
 {
   "account-type": "member",
   "codeowners": ["analytical-platform-engineers"],
+  "github_action_reviewers": ["analytical-platform-engineers"],
   "environments": [
     {
       "name": "development",
       "access": [
+        {
+          "sso_group_name": "analytical-platform-engineers",
+          "level": "platform-engineer-admin"
+        },
         {
           "sso_group_name": "analytical-platform-engineers",
           "level": "sandbox",
@@ -34,6 +39,10 @@
       "access": [
         {
           "sso_group_name": "analytical-platform-engineers",
+          "level": "platform-engineer-admin"
+        },
+        {
+          "sso_group_name": "analytical-platform-engineers",
           "level": "developer"
         },
         {
@@ -58,6 +67,10 @@
     {
       "name": "production",
       "access": [
+        {
+          "sso_group_name": "analytical-platform-engineers",
+          "level": "platform-engineer-admin"
+        },
         {
           "sso_group_name": "analytical-platform-engineers",
           "level": "developer"

--- a/environments/analytical-platform-ingestion.json
+++ b/environments/analytical-platform-ingestion.json
@@ -1,6 +1,7 @@
 {
   "account-type": "member",
   "codeowners": ["analytical-platform-engineers"],
+  "github_action_reviewers": ["analytical-platform-engineers"],
   "isolated-network": "true",
   "environments": [
     {


### PR DESCRIPTION
## A reference to the issue / Description of it

1. All our customers that are included in access config are getting spammed with notifications for environment approval
2. We want Platform Engineer Admin access to our member accounts

## How does this PR fix the problem?

1. Sets `github_action_reviewers`
2. Adds `platform-engineer-admin` to all our member accounts

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.
No

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

If anything, just AP

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
