### PR TITLE
🛂 Allow CICA devices access to Tariff.

### DIFF
--- a/terraform/environments/core-network-services/cidr-ranges.tf
+++ b/terraform/environments/core-network-services/cidr-ranges.tf
@@ -84,18 +84,19 @@ locals {
     hmpps-production-general-private-subnets    = "10.27.10.0/22"
 
     # cica cidr ranges
-    cica-aws-ss-a       = "10.10.10.0/24"
-    cica-aws-ss-b       = "10.10.110.0/24"
-    cica-aws-dev-a      = "10.11.10.0/24"
-    cica-aws-dev-b      = "10.11.110.0/24"
-    cica-aws-dev-data-a = "10.11.20.0/24"
-    cica-aws-dev-data-b = "10.11.120.0/24"
-    cica-aws-uat-a      = "10.12.10.0/24"
-    cica-aws-uat-b      = "10.12.110.0/24"
-    cica-aws-uat-data-a = "10.12.20.0/24"
-    cica-aws-uat-data-b = "10.12.120.0/24"
-    cica-onprem-uat     = "192.168.4.0/24"
-    cica-onprem-prod    = "10.2.30.0/24"
+    cica-aws-ss-a         = "10.10.10.0/24"
+    cica-aws-ss-b         = "10.10.110.0/24"
+    cica-aws-dev-a        = "10.11.10.0/24"
+    cica-aws-dev-b        = "10.11.110.0/24"
+    cica-aws-dev-data-a   = "10.11.20.0/24"
+    cica-aws-dev-data-b   = "10.11.120.0/24"
+    cica-aws-uat-a        = "10.12.10.0/24"
+    cica-aws-uat-b        = "10.12.110.0/24"
+    cica-aws-uat-data-a   = "10.12.20.0/24"
+    cica-aws-uat-data-b   = "10.12.120.0/24"
+    cica-onprem-uat       = "192.168.4.0/24"
+    cica-onprem-prod      = "10.2.30.0/24"
+    cica-end-user-devices = "10.9.14.0/23"
 
 
 

--- a/terraform/environments/core-network-services/firewall-rules/development_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/development_rules.json
@@ -573,6 +573,48 @@
     "destination_port": "ANY",
     "protocol": "TCP"
   },
+  "cica_devices_to_cica_tariff_dev_oracle": {
+    "action": "PASS",
+    "source_ip": "${cica-end-user-devices}",
+    "destination_ip": "${cica-development}",
+    "destination_port": "1521",
+    "protocol": "TCP"
+  },
+  "cica_devices_to_cica_tariff_dev_forms": {
+    "action": "PASS",
+    "source_ip": "${cica-end-user-devices}",
+    "destination_ip": "${cica-development}",
+    "destination_port": "8001",
+    "protocol": "TCP"
+  },
+  "cica_devices_to_cica_tariff_dev_reports": {
+    "action": "PASS",
+    "source_ip": "${cica-end-user-devices}",
+    "destination_ip": "${cica-development}",
+    "destination_port": "8002",
+    "protocol": "TCP"
+  },
+  "cica_devices_to_cica_tariff_dev_weblogic": {
+    "action": "PASS",
+    "source_ip": "${cica-end-user-devices}",
+    "destination_ip": "${cica-development}",
+    "destination_port": "7001",
+    "protocol": "TCP"
+  },
+  "cica_devices_to_cica_tariff_dev_weblogic2": {
+    "action": "PASS",
+    "source_ip": "${cica-end-user-devices}",
+    "destination_ip": "${cica-development}",
+    "destination_port": "7002",
+    "protocol": "TCP"
+  },
+  "cica_tariff_dev_to_cica_devices": {
+    "action": "PASS",
+    "source_ip": "$${cica-development}",
+    "destination_ip": "${cica-end-user-devices}",
+    "destination_port": "ANY",
+    "protocol": "TCP"
+  },
   "mojo_alz_to_laa_development": {
     "action": "PASS",
     "source_ip": "${mojo-azure-landing-zone}",


### PR DESCRIPTION
Allow CICA end user devices access to Tariff Development.

## A reference to the issue / Description of it

CICA devices require access to Dev Tariff for testing.

## How does this PR fix the problem?

Allows inbound to Tariff on specific ports and all outbound.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
