### PR TITLE
Fix incorrect variable reference in source_ip

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/development_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/development_rules.json
@@ -610,7 +610,7 @@
   },
   "cica_tariff_dev_to_cica_devices": {
     "action": "PASS",
-    "source_ip": "$${cica-development}",
+    "source_ip": "${cica-development}",
     "destination_ip": "${cica-end-user-devices}",
     "destination_port": "ANY",
     "protocol": "TCP"


### PR DESCRIPTION
This PR corrects the source_ip field in the cica_tariff_dev_to_cica_devices rule by replacing "$${cica-development}" with "${cica-development}". The extra $ was causing incorrect variable resolution.