### PR TITLE
Update Duty Rota responsibilities

### DIFF
--- a/source/runbooks/duty-rota.html.md.erb
+++ b/source/runbooks/duty-rota.html.md.erb
@@ -45,7 +45,6 @@ Other engineers may also complete any of these activities at any time; all team 
 | Monitor [#ask-modernisation-platform](https://mojdt.slack.com/archives/C01A7QK5VM1) chanel        | Respond to queries.  Liaise with team members where needed. Ensure all requests are responded to.         |
 | Handle high priority incidents in the [#modernisation-platform-high-priority-alarms](https://mojdt.slack.com/archives/C03CY6451QT) channel | Use [runbooks](https://user-guide.modernisation-platform.service.justice.gov.uk/#runbooks) for guidance.                                                                         |
 | Review AWS Health issues                                                                          | Monitor team inbox for emails. Create backlog issues as needed.                                           |
-| Address TVMSOC emails                                                                             | Review, respond, and raise issues as appropriate.                                                         | 
 
 ### Optional tasks
 


### PR DESCRIPTION
## A reference to the issue / Description of it

N/A

## How does this PR fix the problem?

TVM SOC no longer distributes information via mailing list as per Mike Cooper's email on the 18th of December 2024

## How has this been tested?

Test through CI pipeline

## Deployment Plan / Instructions

Deploy through CI pipeline

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
