### PR TITLE
🛂 Update Analytical Platform Engineer state access

### DIFF
--- a/terraform/modernisation-platform-account/s3.tf
+++ b/terraform/modernisation-platform-account/s3.tf
@@ -442,9 +442,13 @@ data "aws_iam_policy_document" "allow-state-access-from-root-account" {
   }
 
   statement {
-    sid       = "AllowAnalyticalPlatformEngineersAccess"
-    effect    = "Allow"
-    actions   = ["s3:PutObject"]
+    sid    = "AllowAnalyticalPlatformEngineersAccess"
+    effect = "Allow"
+    actions = [
+      "s3:DeleteObject",
+      "s3:GetObject",
+      "s3:PutObject"
+    ]
     resources = ["${module.state-bucket.bucket.arn}/environments/members/analytical-platform-*/*"]
     principals {
       type        = "AWS"


### PR DESCRIPTION
## A reference to the issue / Description of it

When trying to refresh the state I got

```
│ Error: Error refreshing state: Unable to access object "environments/members/analytical-platform-ingestion/analytical-platform-ingestion-production/terraform.tfstate" in S3 bucket "modernisation-platform-terraform-state": operation error S3: HeadObject, https response error StatusCode: 403, RequestID: TRTAA1RYFJD08N9P, HostID: 71Tg6Idj/mP7QcMnn5pUdDXqEXcpg/0vpW6GA6ltItImyMJpp0rFnoEdlvktuwAHQFs2D3SCNR/n35ybBFDJ7A==, api error Forbidden: Forbidden
```

## How does this PR fix the problem?

Adds `s3:GetObject` which resolves `HeadObject` issues

## How has this been tested?

It hasn't, but is based on https://developer.hashicorp.com/terraform/language/backend/s3#permissions-required

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No, it's adding permissions

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

I have also added a new statement with scoped permissions for deleting lock files
