### PR TITLE
Resize core-security VPCs to release IP address space

### DIFF
--- a/cidr-allocation.md
+++ b/cidr-allocation.md
@@ -11,15 +11,15 @@
 ## Core Accounts CIDRs
 
 | CIDR        | mask | allocated to                        |
-| :---------- | :--- | :---------------------------------- |
+|:------------|:-----| :---------------------------------- |
 | 10.20.0.0   | /19  | core-network-services live_data     |
 | 10.20.32.0  | /19  | core-network-services non_live_data |
 | 10.20.64.0  | /19  | core-shared-services live_data      |
 | 10.20.96.0  | /19  | core-shared-services non_live_data  |
 | 10.20.128.0 | /19  | core-logging live_data              |
 | 10.20.160.0 | /19  | core-logging non_live_data          |
-| 10.20.192.0 | /19  | core-security live_data             |
-| 10.20.224.0 | /19  | core-security non_live_data         |
+| 10.20.192.0 | /20  | core-security live_data             |
+| 10.20.208.0 | /20  | core-security non_live_data         |
 |             |      |                                     |
 
 ### development and test /21s for member subnet-sets

--- a/terraform/environments/core-security/vpc.tf
+++ b/terraform/environments/core-security/vpc.tf
@@ -1,7 +1,7 @@
 locals {
   networking = {
-    live_data     = "10.20.192.0/19"
-    non_live_data = "10.20.224.0/19"
+    live_data     = "10.20.192.0/20"
+    non_live_data = "10.20.208.0/20"
   }
 }
 


### PR DESCRIPTION
## A reference to the issue / Description of it

#9366

## How does this PR fix the problem?

Resizes `core-security` VPCs to /20 blocks, releasing ~32 /24 blocks.

Of these we will assign two /22 blocks to YJAF for their vSRX appliances to perform source NAT on traffic into the YJAF environments

## How has this been tested?

Tested with local terraform plan

## Deployment Plan / Instructions

This will require us to manually remove the existing transit gateway attachments for both `core-security` VPCs and prune them from state. This is preferable to making two PRs to make the attachment resources destroyable and then non-destroyable.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
