### PR TITLE
Fix incorrect references for additional private zones

### DIFF
--- a/environments-networks/yjb-preproduction.json
+++ b/environments-networks/yjb-preproduction.json
@@ -11,7 +11,7 @@
     "bastion_linux": true,
     "additional_cidrs": [],
     "additional_endpoints": [],
-    "additional_private_zones": ["preprod.yjaf"],
+    "additional_private_zones": ["preproduction.yjaf"],
     "additional_vpcs": [],
     "dns_zone_extend": []
   }

--- a/environments-networks/yjb-production.json
+++ b/environments-networks/yjb-production.json
@@ -11,7 +11,7 @@
     "bastion_linux": true,
     "additional_cidrs": [],
     "additional_endpoints": [],
-    "additional_private_zones": ["prod.yjaf"],
+    "additional_private_zones": ["production.yjaf"],
     "additional_vpcs": [],
     "dns_zone_extend": []
   }


### PR DESCRIPTION
This PR fixes an issue where the `additional_private_zones` were incorrectly referenced in the configuration. The zones were mistakenly linked to `preprod.yjaf` and `prod.yjaf` instead of the correct `preproduction.yjaf` and `production.yjaf`. This caused the "no matching Route 53 Hosted Zone found" error when extending DNS zones.

https://github.com/ministryofjustice/modernisation-platform/actions/runs/13652425862/job/38164501844#step:13:26
https://github.com/ministryofjustice/modernisation-platform/actions/runs/13652425857/job/38163878256#step:13:25
