### PR TITLE
Adjusted cidr allocations to handle /20 blocks

### DIFF
--- a/terraform/modules/vpc-hub/main.tf
+++ b/terraform/modules/vpc-hub/main.tf
@@ -13,7 +13,10 @@ data "aws_availability_zones" "available" {
 
 locals {
   az    = sort(data.aws_availability_zones.available.names)
-  cidrs = cidrsubnets(var.vpc_cidr, 9, 9, 9, 4, 4, 4, 4, 4, 4, 4, 4, 4)
+  cidrs = (can(regex("/20$", var.vpc_cidr)) ?
+  cidrsubnets(var.vpc_cidr, 8, 8, 8, 4, 4, 4, 4, 4, 4, 4, 4, 4) :
+  cidrsubnets(var.vpc_cidr, 9, 9, 9, 4, 4, 4, 4, 4, 4, 4, 4, 4)
+  )
   types = ["transit-gateway", "data", "private", "public"]
 
   # SAMPLE OUTPUT OF: types_and_az_and_cidrs


### PR DESCRIPTION
## A reference to the issue / Description of it

#9366 

## How does this PR fix the problem?

Adds conditional logic to correctly size transit gateway subnets when the VPC CIDR is a `/20`, without affecting existing `/19` allocations

## How has this been tested?

Tested with local plan. Will also test with CI pipeline checks

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
