### PR TITLE
Update CIDR block allocations for youth-justice-networking

### DIFF
--- a/cidr-allocation.md
+++ b/cidr-allocation.md
@@ -11,7 +11,7 @@
 ## Core Accounts CIDRs
 
 | CIDR        | mask | allocated to                        |
-|:------------|:-----| :---------------------------------- |
+|:------------|:-----|:------------------------------------|
 | 10.20.0.0   | /19  | core-network-services live_data     |
 | 10.20.32.0  | /19  | core-network-services non_live_data |
 | 10.20.64.0  | /19  | core-shared-services live_data      |
@@ -20,6 +20,7 @@
 | 10.20.160.0 | /19  | core-logging non_live_data          |
 | 10.20.192.0 | /20  | core-security live_data             |
 | 10.20.208.0 | /20  | core-security non_live_data         |
+| 10.20.224.0 | /21  | youth-justice-networking-production |
 |             |      |                                     |
 
 ### development and test /21s for member subnet-sets


### PR DESCRIPTION
## A reference to the issue / Description of it

#9366

## How does this PR fix the problem?

Assigns a block of sufficient size for `youth-justice-networking` to have 8 separate /24 blocks for their networking needs.

## How has this been tested?

N/A - document change only

## Deployment Plan / Instructions

N/A

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
