### PR TITLE
Switch `r53-dns-firewall` module to `BLOCK`

### DIFF
--- a/terraform/modules/r53-dns-firewall/README.md
+++ b/terraform/modules/r53-dns-firewall/README.md
@@ -8,7 +8,7 @@ This module creates the following resources per VPC:
 - a custom list of allowed and blocked domains which can be defined via the `allowed_domains` and `blocked_domains` inputs
 - R53 Resolver Firewall Rules in the following priority:
   **1** - An allow rule for the `allowed_domains` list
-  **2-5** - a set of rules that ALERT on any domains that match the [AWS-managed threat lists](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resolver-dns-firewall-managed-domain-lists.html)
+  **2-5** - a set of rules that BLOCK any domains that match the [AWS-managed threat lists](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resolver-dns-firewall-managed-domain-lists.html)
   **6** - A Block rule for the `blocked_domains` list
 
 # Example usage

--- a/terraform/modules/r53-dns-firewall/main.tf
+++ b/terraform/modules/r53-dns-firewall/main.tf
@@ -17,14 +17,14 @@ resource "aws_route53_resolver_firewall_domain_list" "block" {
   tags    = var.tags_common
 }
 
-# Default rule to ALERT on AWS-managed bad domain lists - see https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resolver-dns-firewall-managed-domain-lists.html
-# These rules will be set to ALERT initially and enabled in production - after a period of monitoring we will switch to BLOCK
+# Default rule to BLOCK based on AWS-managed bad domain lists - see https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resolver-dns-firewall-managed-domain-lists.html
 data "external" "aws_managed_domain_lists" {
   program = ["bash", "${path.module}/fetch-aws-managed-domain-lists.sh"]
 }
 resource "aws_route53_resolver_firewall_rule" "default_alert" {
   for_each                = data.external.aws_managed_domain_lists.result
-  action                  = "ALERT"
+  action                  = "BLOCK"
+  block_response          = var.block_response
   firewall_domain_list_id = each.value
   priority                = each.key == "AWSManagedDomainsAggregateThreatList" ? 2 : each.key == "AWSManagedDomainsMalwareDomainList" ? 3 : each.key == "AWSManagedDomainsBotnetCommandandControl" ? 4 : 5
   firewall_rule_group_id  = aws_route53_resolver_firewall_rule_group.this.id


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/9037

## How does this PR fix the problem?

This switches the default rules in the `r53-dns-firewall` module to `BLOCK` any queries made to domains on the AWS-managed lists.

Over a period of 6 weeks or so we have had no matches whilst it's been operting in `ALERT` mode which is good news.

I am going to document this via a separate PR and communicate with customers accordingly (they were already made aware when it was set to `ALERT` mode in January).

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

CI pipelines show the changes to these rules.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
