### PR TITLE
Add new OIDC role for GitHub Actions in dev-test environments

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -863,3 +863,75 @@ resource "aws_iam_account_alias" "alias" {
   count         = (local.account_data.account-type != "member-unrestricted") && !(contains(local.skip_alias, terraform.workspace)) ? 1 : 0
   account_alias = terraform.workspace
 }
+
+# Github OIDC provider for development and test environments
+
+module "github_actions_dev_test_role" {
+  count               = can(regex("development$|test$", terraform.workspace)) ? 1 : 0
+  source              = "github.com/ministryofjustice/modernisation-platform-github-oidc-role?ref=62b8a16c73d8e4422cd81923e46948e8f4b5cf48" # v3.2.0
+  github_repositories = ["ministryofjustice/modernisation-platform"]
+  role_name           = "github-actions-dev-test"
+  policy_arns         = ["arn:aws:iam::aws:policy/AdministratorAccess"]
+  policy_jsons        = [data.aws_iam_policy_document.oidc_assume_role_dev_test[0].json]
+  tags                = { "Name" = format("%s-oidc-dev-test", terraform.workspace) }
+}
+
+data "aws_iam_policy_document" "oidc_assume_role_dev_test" {
+  count = can(regex("development$|test$", terraform.workspace)) ? 1 : 0
+  statement {
+    sid    = "AllowOIDCToAssumeRoles"
+    effect = "Allow"
+    resources = [
+      format("arn:aws:iam::%s:role/ModernisationPlatformAccess", local.environment_management.account_ids[format("core-vpc-%s", local.application_environment)]),
+      format("arn:aws:iam::%s:role/ModernisationPlatformAccess", local.environment_management.account_ids["core-network-services-production"]),
+      format("arn:aws:iam::%s:role/modernisation-account-limited-read-member-access", local.environment_management.modernisation_platform_account_id)
+    ]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalOrgID"
+      values   = [data.aws_organizations_organization.root_account.id]
+    }
+    actions = ["sts:AssumeRole"]
+  }
+
+  # checkov:skip=CKV_AWS_111: "Cannot restrict by KMS alias so leaving open"
+  # checkov:skip=CKV_AWS_356: "Cannot restrict by KMS alias so leaving open"
+  statement {
+    sid       = "AllowOIDCToDecryptKMS"
+    effect    = "Allow"
+    resources = ["*"]
+    actions   = ["kms:Decrypt"]
+  }
+
+  statement {
+    sid    = "AllowOIDCReadState"
+    effect = "Allow"
+    resources = [
+      "arn:aws:s3:::modernisation-platform-terraform-state/*",
+      "arn:aws:s3:::modernisation-platform-terraform-state/"
+    ]
+    actions = [
+      "s3:Get*",
+      "s3:List*"
+    ]
+  }
+
+  statement {
+    sid       = "AllowOIDCWriteState"
+    effect    = "Allow"
+    resources = ["arn:aws:s3:::modernisation-platform-terraform-state/environments/accounts/*"]
+    actions = [
+      "s3:PutObject",
+      "s3:PutObjectAcl"
+    ]
+  }
+
+  statement {
+    sid       = "AllowOIDCDeleteLock"
+    effect    = "Allow"
+    resources = ["arn:aws:s3:::modernisation-platform-terraform-state/environments/accounts/*.tflock"]
+    actions = [
+      "s3:DeleteObject"
+    ]
+  }
+}


### PR DESCRIPTION
## A reference to the issue / Description of it

This PR adds a new OIDC role, github-actions-dev-test, to enable deployment workflows in the development and test environments for the modernisation-platform repository. #8590 

## How does this PR fix the problem?

Currently, the terraform-member-environments workflow in the Modernisation Platform (MP) account does not support deploying changes on pull requests. The existing setup (github-action-plan) is limited and does not allow for deployments during the PR process, which is critical for testing and validation in development and test environments.

This new OIDC role, github-actions-dev-test, will allow the terraform-member-environments workflow to deploy changes on pull requests in the development and test environments.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
