### PR TITLE
Add `github-actions-dev-test` role to cross-account access and state bucket permissions

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -10,6 +10,7 @@ module "cross-account-access" {
     [
       "arn:aws:iam::${local.environment_management.account_ids["sprinkler-development"]}:role/github-actions"
     ],
-    terraform.workspace == "testing-test" ? ["arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:user/testing-ci"] : []
+    terraform.workspace == "testing-test" ? ["arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:user/testing-ci"] : [],
+    length(regexall("(development|test)$", terraform.workspace)) > 0 ? ["arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/github-actions-dev-test"] : []
   )
 }

--- a/terraform/modernisation-platform-account/iam.tf
+++ b/terraform/modernisation-platform-account/iam.tf
@@ -162,6 +162,7 @@ data "aws_iam_policy_document" "modernisation_account_limited_read" {
     resources = [
       "arn:aws:secretsmanager:eu-west-2:${data.aws_caller_identity.current.account_id}:secret:environment_management-??????",
       "arn:aws:secretsmanager:eu-west-2:${data.aws_caller_identity.current.account_id}:secret:pagerduty_integration_keys-??????",
+      "arn:aws:secretsmanager:eu-west-2:${data.aws_caller_identity.current.account_id}:secret:mod-platform-circleci-??????",
     ]
   }
   statement {

--- a/terraform/modernisation-platform-account/s3.tf
+++ b/terraform/modernisation-platform-account/s3.tf
@@ -511,6 +511,32 @@ data "aws_iam_policy_document" "allow-state-access-from-root-account" {
       ]
     }
   }
+
+  statement {
+    sid       = "AllowDevTestGithubActionsRole"
+    effect    = "Allow"
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:PutObjectAcl"
+    ]
+    resources = ["${module.state-bucket.bucket.arn}/environments/accounts/*"]
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+    condition {
+      test     = "ForAnyValue:StringLike"
+      variable = "aws:PrincipalOrgPaths"
+      values   = ["${data.aws_organizations_organization.root_account.id}/*/${local.environment_management.modernisation_platform_organisation_unit_id}/*"]
+    }
+    condition {
+      test     = "ForAnyValue:StringLike"
+      variable = "aws:PrincipalArn"
+      values   = ["arn:aws:iam::*:role/github-actions-dev-test"]
+    }
+  }
+
 }
 
 module "cost-management-bucket" {


### PR DESCRIPTION
## A reference to the issue / Description of it

This PR adds the `github-actions-dev-test` role to the cross-account access module and updates the state bucket permissions to allow access for this role. #8590 

## How does this PR fix the problem?

- **Cross-Account Access**: Ensures the `github-actions-dev-test` role is trusted only in the appropriate environments, preventing unnecessary access in other environments.

- **State Bucket Permissions**: Enables the `github-actions-dev-test` role to read/write Terraform state files while restricting access to authorized roles within the organization.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
