### PR TITLE
Set up guardduty malware protection alerting 

### DIFF
--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -36,6 +36,8 @@ misconfigurations:
 - id: AVD-AWS-0039
 - id: AVD-AWS-0057
 - id: AVD-AWS-0132
+- id: AVD-AWS-0095
+
 
 secrets:
 

--- a/terraform/environments/core-shared-services/s3_malware_protection.tf
+++ b/terraform/environments/core-shared-services/s3_malware_protection.tf
@@ -30,6 +30,8 @@ data "aws_iam_role" "guardduty_malware_protection_role" {
 ###  S3 Malware Scan Alerts using GuardDuty Malware Protection Object scan result.
 
 # Create an SNS Topic for Malware Alerts
+#checkov:skip=CKV_AWS_26:"encrypted topics do not work with pagerduty subscription"
+
 resource "aws_sns_topic" "s3_malware_scan_alerts" {
   name = "s3-malware-scan-alerts"
 }

--- a/terraform/environments/core-shared-services/s3_malware_protection.tf
+++ b/terraform/environments/core-shared-services/s3_malware_protection.tf
@@ -38,6 +38,7 @@ resource "aws_sns_topic" "s3_malware_scan_alerts" {
 
 # link the sns topics to the pagerduty service
 module "pagerduty_malware_alerts" {
+  depends_on                = [aws_sns_topic.s3_malware_scan_alerts]
   source                    = "github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration?ref=0179859e6fafc567843cd55c0b05d325d5012dc4" # v2.0.0
   sns_topics                = [aws_sns_topic.s3_malware_scan_alerts.name]
   pagerduty_integration_key = local.pagerduty_integration_keys["core_alerts_cloudwatch"]

--- a/terraform/environments/core-shared-services/s3_malware_protection.tf
+++ b/terraform/environments/core-shared-services/s3_malware_protection.tf
@@ -27,3 +27,64 @@ resource "aws_guardduty_malware_protection_plan" "malware_protection_plan" {
 data "aws_iam_role" "guardduty_malware_protection_role" {
   name = "GuardDutyS3MalwareProtectionRole"
 }
+###  S3 Malware Scan Alerts using GuardDuty Malware Protection Object scan result.
+
+# Create an SNS Topic for Malware Alerts
+resource "aws_sns_topic" "s3_malware_scan_alerts" {
+  name = "s3-malware-scan-alerts"
+}
+
+# link the sns topics to the pagerduty service
+module "pagerduty_malware_alerts" {
+  depends_on = [
+    aws_sns_topic.s3_malware_scan_alerts
+  ]
+  source                    = "github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration?ref=0179859e6fafc567843cd55c0b05d325d5012dc4" # v2.0.0
+  sns_topics                = [aws_sns_topic.s3_malware_scan_alerts.name]
+  pagerduty_integration_key = local.pagerduty_integration_keys["core_alerts_cloudwatch"]
+}
+
+# EventBridge Rule for GuardDuty S3 Malware Scan Alerts
+resource "aws_cloudwatch_event_rule" "guardduty_s3_malware_scan" {
+  name        = "guardduty-s3-malware-scan"
+  description = "Triggers when GuardDuty detects malware in an S3 object"
+
+  event_pattern = <<EOF
+{
+  "source": ["aws.guardduty"],
+  "detail-type": ["GuardDuty Malware Protection Object Scan Result"],
+  "detail": {
+    "scanResultDetails": {
+      "scanResultStatus": ["THREATS_FOUND"]
+    }
+  }
+}
+EOF
+}
+
+# Link EventBridge Rule to SNS
+resource "aws_cloudwatch_event_target" "sns_target" {
+  rule      = aws_cloudwatch_event_rule.guardduty_s3_malware_scan.name
+  target_id = "SendToSNS"
+  arn       = aws_sns_topic.s3_malware_scan_alerts.arn
+}
+
+# Allow EventBridge to Publish to SNS
+resource "aws_sns_topic_policy" "sns_policy" {
+  arn    = aws_sns_topic.s3_malware_scan_alerts.arn
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "events.amazonaws.com"
+      },
+      "Action": "SNS:Publish",
+      "Resource": "${aws_sns_topic.s3_malware_scan_alerts.arn}"
+    }
+  ]
+}
+EOF
+}

--- a/terraform/environments/core-shared-services/s3_malware_protection.tf
+++ b/terraform/environments/core-shared-services/s3_malware_protection.tf
@@ -30,63 +30,34 @@ data "aws_iam_role" "guardduty_malware_protection_role" {
 ###  S3 Malware Scan Alerts using GuardDuty Malware Protection Object scan result.
 
 # Create an SNS Topic for Malware Alerts
-#checkov:skip=CKV_AWS_26:"encrypted topics do not work with pagerduty subscription"
 
 resource "aws_sns_topic" "s3_malware_scan_alerts" {
+  #checkov:skip=CKV_AWS_26:"encrypted topics do not work with pagerduty subscription"
   name = "s3-malware-scan-alerts"
 }
 
 # link the sns topics to the pagerduty service
 module "pagerduty_malware_alerts" {
-  depends_on = [
-    aws_sns_topic.s3_malware_scan_alerts
-  ]
   source                    = "github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration?ref=0179859e6fafc567843cd55c0b05d325d5012dc4" # v2.0.0
   sns_topics                = [aws_sns_topic.s3_malware_scan_alerts.name]
   pagerduty_integration_key = local.pagerduty_integration_keys["core_alerts_cloudwatch"]
 }
 
-# EventBridge Rule for GuardDuty S3 Malware Scan Alerts
-resource "aws_cloudwatch_event_rule" "guardduty_s3_malware_scan" {
-  name        = "guardduty-s3-malware-scan"
-  description = "Triggers when GuardDuty detects malware in an S3 object"
+# CloudWatch Metric Alarm for GuardDuty Malware Detections
+resource "aws_cloudwatch_metric_alarm" "guardduty_malware_detected" {
+  alarm_name        = "guardduty-malware-detected"
+  alarm_description = "Triggers an alert when GuardDuty detects malware in S3 bucket."
+  alarm_actions     = [aws_sns_topic.s3_malware_scan_alerts.arn]
 
-  event_pattern = <<EOF
-{
-  "source": ["aws.guardduty"],
-  "detail-type": ["GuardDuty Malware Protection Object Scan Result"],
-  "detail": {
-    "scanResultDetails": {
-      "scanResultStatus": ["THREATS_FOUND"]
-    }
-  }
-}
-EOF
-}
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "InfectedScanCount"
+  namespace           = "AWS/GuardDuty"
+  period              = "300"
+  statistic           = "Sum"
+  threshold           = "1"
+  treat_missing_data  = "notBreaching"
 
-# Link EventBridge Rule to SNS
-resource "aws_cloudwatch_event_target" "sns_target" {
-  rule      = aws_cloudwatch_event_rule.guardduty_s3_malware_scan.name
-  target_id = "SendToSNS"
-  arn       = aws_sns_topic.s3_malware_scan_alerts.arn
+  tags = local.tags
 }
 
-# Allow EventBridge to Publish to SNS
-resource "aws_sns_topic_policy" "sns_policy" {
-  arn    = aws_sns_topic.s3_malware_scan_alerts.arn
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "events.amazonaws.com"
-      },
-      "Action": "SNS:Publish",
-      "Resource": "${aws_sns_topic.s3_malware_scan_alerts.arn}"
-    }
-  ]
-}
-EOF
-}


### PR DESCRIPTION
## A reference to the issue / Description of it

#8605 
## How does this PR fix the problem?

This PR does the following for buckets in core shared services that have S3 malware protection enabled:

- Creates aws_sns_topic.s3_malware_scan_alerts for notifications.
- Links the SNS topic (s3-malware-scan-alerts) to PagerDuty.
- Monitors the InfectedScanCount metric in AWS/GuardDuty
- Triggers an alert when at least 1 malware infection is detected to make sure malware-infected files in S3 are detected immediately in our low priority alarms channel in slack.

AVD-AWS-0095 (HIGH): Topic does not have encryption enabled - added to trivyignore as encrypted topics do not work with pagerduty subscription.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
