### PR TITLE
adding tags to the rest of the environments

### DIFF
--- a/terraform/environments/mi-platform/providers.tf
+++ b/terraform/environments/mi-platform/providers.tf
@@ -4,12 +4,14 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
   alias  = "modernisation-platform"
   region = "eu-west-2"
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
@@ -20,6 +22,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-network-services-production, to share VPCs into this account
@@ -30,4 +33,5 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }

--- a/terraform/environments/mlra/providers.tf
+++ b/terraform/environments/mlra/providers.tf
@@ -4,12 +4,14 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
   alias  = "modernisation-platform"
   region = "eu-west-2"
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
@@ -20,6 +22,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-network-services-production, to share VPCs into this account
@@ -30,4 +33,5 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }

--- a/terraform/environments/moj-network-operations-centre/providers.tf
+++ b/terraform/environments/moj-network-operations-centre/providers.tf
@@ -4,12 +4,14 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
   alias  = "modernisation-platform"
   region = "eu-west-2"
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
@@ -20,6 +22,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-network-services-production, to share VPCs into this account
@@ -30,4 +33,5 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }

--- a/terraform/environments/mojfin/providers.tf
+++ b/terraform/environments/mojfin/providers.tf
@@ -4,12 +4,14 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
   alias  = "modernisation-platform"
   region = "eu-west-2"
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
@@ -20,6 +22,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-network-services-production, to share VPCs into this account
@@ -30,4 +33,5 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }

--- a/terraform/environments/ncas/providers.tf
+++ b/terraform/environments/ncas/providers.tf
@@ -4,12 +4,14 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
   alias  = "modernisation-platform"
   region = "eu-west-2"
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
@@ -20,6 +22,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-network-services-production, to share VPCs into this account
@@ -30,4 +33,5 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }

--- a/terraform/environments/nomis-combined-reporting/providers.tf
+++ b/terraform/environments/nomis-combined-reporting/providers.tf
@@ -4,12 +4,14 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
   alias  = "modernisation-platform"
   region = "eu-west-2"
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
@@ -20,6 +22,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-network-services-production, to share VPCs into this account
@@ -30,4 +33,5 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }

--- a/terraform/environments/nomis-data-hub/providers.tf
+++ b/terraform/environments/nomis-data-hub/providers.tf
@@ -4,12 +4,14 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
   alias  = "modernisation-platform"
   region = "eu-west-2"
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
@@ -20,6 +22,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-network-services-production, to share VPCs into this account
@@ -30,4 +33,5 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }

--- a/terraform/environments/nomis/providers.tf
+++ b/terraform/environments/nomis/providers.tf
@@ -4,12 +4,14 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
   alias  = "modernisation-platform"
   region = "eu-west-2"
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
@@ -20,6 +22,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-network-services-production, to share VPCs into this account
@@ -30,4 +33,5 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }

--- a/terraform/environments/oas/providers.tf
+++ b/terraform/environments/oas/providers.tf
@@ -4,12 +4,14 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
   alias  = "modernisation-platform"
   region = "eu-west-2"
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
@@ -20,6 +22,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-network-services-production, to share VPCs into this account
@@ -30,4 +33,5 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }

--- a/terraform/environments/oasys-national-reporting/providers.tf
+++ b/terraform/environments/oasys-national-reporting/providers.tf
@@ -4,12 +4,14 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
   alias  = "modernisation-platform"
   region = "eu-west-2"
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
@@ -20,6 +22,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-network-services-production, to share VPCs into this account
@@ -30,4 +33,5 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }

--- a/terraform/environments/oasys/providers.tf
+++ b/terraform/environments/oasys/providers.tf
@@ -4,12 +4,14 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
   alias  = "modernisation-platform"
   region = "eu-west-2"
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
@@ -20,6 +22,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-network-services-production, to share VPCs into this account
@@ -30,4 +33,5 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }

--- a/terraform/environments/observability-platform/providers.tf
+++ b/terraform/environments/observability-platform/providers.tf
@@ -4,12 +4,14 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
   alias  = "modernisation-platform"
   region = "eu-west-2"
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
@@ -20,6 +22,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-network-services-production, to share VPCs into this account
@@ -30,4 +33,5 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }

--- a/terraform/environments/operations-engineering/providers.tf
+++ b/terraform/environments/operations-engineering/providers.tf
@@ -4,6 +4,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
+
 }
 
 # AWS provider for the Modernisation Platform, to get things from there if required

--- a/terraform/environments/opg-lpa-data-store/providers.tf
+++ b/terraform/environments/opg-lpa-data-store/providers.tf
@@ -4,12 +4,14 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
   alias  = "modernisation-platform"
   region = "eu-west-2"
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
@@ -20,6 +22,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-network-services-production, to share VPCs into this account
@@ -30,4 +33,5 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }

--- a/terraform/environments/panda-cyber-appsec-lab/providers.tf
+++ b/terraform/environments/panda-cyber-appsec-lab/providers.tf
@@ -4,12 +4,14 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
   alias  = "modernisation-platform"
   region = "eu-west-2"
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
@@ -20,6 +22,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-network-services-production, to share VPCs into this account
@@ -30,4 +33,5 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }

--- a/terraform/environments/performance-hub/providers.tf
+++ b/terraform/environments/performance-hub/providers.tf
@@ -4,12 +4,14 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
   alias  = "modernisation-platform"
   region = "eu-west-2"
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
@@ -20,6 +22,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-network-services-production, to share VPCs into this account
@@ -30,4 +33,5 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }

--- a/terraform/environments/planetfm/providers.tf
+++ b/terraform/environments/planetfm/providers.tf
@@ -4,12 +4,14 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
   alias  = "modernisation-platform"
   region = "eu-west-2"
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
@@ -20,6 +22,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-network-services-production, to share VPCs into this account
@@ -30,4 +33,5 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }

--- a/terraform/environments/portal/providers.tf
+++ b/terraform/environments/portal/providers.tf
@@ -4,12 +4,14 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
   alias  = "modernisation-platform"
   region = "eu-west-2"
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
@@ -20,6 +22,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-network-services-production, to share VPCs into this account
@@ -30,4 +33,5 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }

--- a/terraform/environments/ppud/providers.tf
+++ b/terraform/environments/ppud/providers.tf
@@ -4,12 +4,14 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
   alias  = "modernisation-platform"
   region = "eu-west-2"
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
@@ -20,6 +22,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-network-services-production, to share VPCs into this account
@@ -30,4 +33,5 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }

--- a/terraform/environments/pra-register/providers.tf
+++ b/terraform/environments/pra-register/providers.tf
@@ -4,12 +4,14 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
   alias  = "modernisation-platform"
   region = "eu-west-2"
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
@@ -20,6 +22,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-network-services-production, to share VPCs into this account
@@ -30,4 +33,5 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }

--- a/terraform/environments/refer-monitor/providers.tf
+++ b/terraform/environments/refer-monitor/providers.tf
@@ -4,12 +4,14 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
   alias  = "modernisation-platform"
   region = "eu-west-2"
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
@@ -20,6 +22,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-network-services-production, to share VPCs into this account
@@ -30,4 +33,5 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }

--- a/terraform/environments/tipstaff/providers.tf
+++ b/terraform/environments/tipstaff/providers.tf
@@ -4,12 +4,14 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
   alias  = "modernisation-platform"
   region = "eu-west-2"
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
@@ -20,6 +22,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-network-services-production, to share VPCs into this account
@@ -30,4 +33,5 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }

--- a/terraform/environments/tribunals/providers.tf
+++ b/terraform/environments/tribunals/providers.tf
@@ -4,12 +4,14 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
   alias  = "modernisation-platform"
   region = "eu-west-2"
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
@@ -20,6 +22,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-network-services-production, to share VPCs into this account
@@ -30,4 +33,5 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }

--- a/terraform/environments/wardship/providers.tf
+++ b/terraform/environments/wardship/providers.tf
@@ -4,12 +4,14 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
   alias  = "modernisation-platform"
   region = "eu-west-2"
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
@@ -20,6 +22,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-network-services-production, to share VPCs into this account
@@ -30,4 +33,5 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }

--- a/terraform/environments/xhibit-portal/providers.tf
+++ b/terraform/environments/xhibit-portal/providers.tf
@@ -4,12 +4,14 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
   alias  = "modernisation-platform"
   region = "eu-west-2"
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
@@ -20,6 +22,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-network-services-production, to share VPCs into this account
@@ -30,4 +33,5 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }

--- a/terraform/environments/youth-justice-app-framework/providers.tf
+++ b/terraform/environments/youth-justice-app-framework/providers.tf
@@ -4,12 +4,14 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
   alias  = "modernisation-platform"
   region = "eu-west-2"
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
@@ -20,6 +22,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-network-services-production, to share VPCs into this account
@@ -30,6 +33,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 ############################


### PR DESCRIPTION
## A reference to the issue / Description of it

This work covers the environments that i could not add from the second PR due to the docker instance running out of space

## How does this PR fix the problem?

add the default tag to the provider files for the rest of the environments excluding the core accounts 

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
