### PR TITLE
Add `github-actions-dev-test` role access to `core-vpc` and `core-network-services` workspaces

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -13,4 +13,26 @@ module "cross-account-access" {
     terraform.workspace == "testing-test" ? ["arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:user/testing-ci"] : [],
     length(regexall("(development|test)$", terraform.workspace)) > 0 ? ["arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/github-actions-dev-test"] : []
   )
+  additional_trust_statements = contains(["core-network-services-production", "core-vpc-test", "core-vpc-development"], terraform.workspace) ? [data.aws_iam_policy_document.additional_trust_policy.json] : []
+}
+
+data "aws_iam_policy_document" "additional_trust_policy" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+    condition {
+      test     = "ForAnyValue:StringLike"
+      variable = "aws:PrincipalArn"
+      values   = ["arn:aws:iam::*:role/github-actions-dev-test"]
+    }
+    condition {
+      test     = "ForAnyValue:StringLike"
+      variable = "aws:PrincipalOrgPaths"
+      values   = ["${data.aws_organizations_organization.root_account.id}/*/${local.environment_management.modernisation_platform_organisation_unit_id}/*"]
+    }
+  }
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

This PR adds the `github-actions-dev-test` role to the list of trusted roles that can assume the `ModernisationPlatformAccess` role in the following workspaces:
- `core-vpc-development`
- `core-vpc-test`
- `core-network-services-production`

Recently, new GitHub Actions roles were created for development and test accounts. The `github-actions-dev-test` role needs to assume the `ModernisationPlatformAccess` role in the specified workspaces to perform necessary operations.

#8590

## How does this PR fix the problem?

This change ensures that the newly created github-actions-dev-test role can assume the ModernisationPlatformAccess role in the core-vpc-development, core-vpc-test, and core-network-production workspaces. By conditionally applying the additional_trust_policy only to these workspaces

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
