### PR TITLE
Issue/9306 pagerduty

### DIFF
--- a/terraform/pagerduty/aws.tf
+++ b/terraform/pagerduty/aws.tf
@@ -19,6 +19,7 @@ resource "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {
   secret_string = jsonencode(merge({
     core_alerts_cloudwatch            = pagerduty_service_integration.core_alerts_cloudwatch.integration_key,
     security_hub                      = pagerduty_service_integration.security_hub.integration_key,
+    security_hub_members              = pagerduty_service_integration.security_hub_members.integration_key,
     ddos_cloudwatch                   = pagerduty_service_integration.ddos_cloudwatch.integration_key,
     tgw_cloudwatch                    = pagerduty_service_integration.tgw_cloudwatch.integration_key,
     networking_cloudwatch             = pagerduty_service_integration.networking_cloudwatch.integration_key,

--- a/terraform/pagerduty/services.tf
+++ b/terraform/pagerduty/services.tf
@@ -92,7 +92,7 @@ resource "pagerduty_slack_connection" "security_hub_members" {
   source_id         = pagerduty_service.security_hub_members.id
   source_type       = "service_reference"
   workspace_id      = local.slack_workspace_id
-  channel_id        = "C07SNBJBVC6" # Slack channel: #modernisation-platform-members-security-hub-alerts
+  channel_id        = "C08GRKZ1W4F" # Slack channel: #modernisation-platform-members-security-hub-alerts
   notification_type = "responder"
   config {
     events = [

--- a/terraform/pagerduty/services.tf
+++ b/terraform/pagerduty/services.tf
@@ -69,6 +69,55 @@ resource "pagerduty_slack_connection" "security_hub" {
   }
 }
 
+resource "pagerduty_service" "security_hub_members" {
+  name                    = "Security Hub Alerts - Modernisation Platform Member Accounts"
+  description             = "Security Hub Alerts - Member Accounts"
+  auto_resolve_timeout    = 14400
+  acknowledgement_timeout = "null"
+  escalation_policy       = pagerduty_escalation_policy.low_priority.id
+  alert_creation          = "create_alerts_and_incidents"
+  incident_urgency_rule {
+    type    = "constant"
+    urgency = "low"
+  }
+}
+
+resource "pagerduty_service_integration" "security_hub_members" {
+  name    = data.pagerduty_vendor.security_hub.name
+  service = pagerduty_service.security_hub_members.id
+  vendor  = data.pagerduty_vendor.security_hub.id
+}
+
+resource "pagerduty_slack_connection" "security_hub_members" {
+  source_id         = pagerduty_service.security_hub_members.id
+  source_type       = "service_reference"
+  workspace_id      = local.slack_workspace_id
+  channel_id        = "C07SNBJBVC6" # Slack channel: #modernisation-platform-members-security-hub-alerts
+  notification_type = "responder"
+  config {
+    events = [
+      "incident.triggered",
+      "incident.acknowledged",
+      "incident.escalated",
+      "incident.resolved",
+      "incident.reassigned",
+      "incident.annotated",
+      "incident.unacknowledged",
+      "incident.delegated",
+      "incident.priority_updated",
+      "incident.responder.added",
+      "incident.responder.replied",
+      "incident.action_invocation.created",
+      "incident.action_invocation.terminated",
+      "incident.action_invocation.updated",
+      "incident.status_update_published",
+      "incident.reopened"
+    ]
+    priorities = ["*"]
+  }
+}
+
+
 resource "pagerduty_service_event_rule" "mfa-console-access" {
   service  = pagerduty_service.core_alerts.id
   position = 0


### PR DESCRIPTION
## A reference to the issue / Description of it

#9306 

## How does this PR fix the problem?

This PR creates new PagerDuty resources required to route SecurityHub alerts for member accounts to a new slack channel. 

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

These changes are based on existing PagerDuty resources for existing SecurityHub alerts.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

None.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
