### PR TITLE
Further cleanup for `github_repository_collaborators`

### DIFF
--- a/collaborators.json
+++ b/collaborators.json
@@ -330,7 +330,7 @@
     },
     {
       "username": "carl.last",
-      "github-username": "carldevcap",
+      "github-username": "CarlDevCap",
       "accounts": [
         {
           "account-name": "oasys-development",
@@ -752,7 +752,7 @@
     },
     {
       "username": "toby.petty",
-      "github-username": "staberinde",
+      "github-username": "Staberinde",
       "accounts": [
         {
           "account-name": "analytical-platform-ingestion-development",

--- a/terraform/github/modules/team/variables.tf
+++ b/terraform/github/modules/team/variables.tf
@@ -8,12 +8,6 @@ variable "description" {
   type        = string
 }
 
-variable "repositories" {
-  description = "Repositories to give the team access to"
-  type        = set(string)
-  default     = []
-}
-
 variable "maintainers" {
   description = "GitHub team maintainers"
   type        = set(string)

--- a/terraform/github/permissions.tf
+++ b/terraform/github/permissions.tf
@@ -1,8 +1,9 @@
 # Because we manage team memberships and repositories through separate modules we use a standalone resource
 # to avoid any issues with circular dependencies
 resource "github_repository_collaborators" "this" {
-  for_each   = local.map_permissions_to_repositories
-  repository = each.key
+  for_each    = local.map_permissions_to_repositories
+  ignore_team = ["organisation-security-auditor"]
+  repository  = each.key
   dynamic "team" {
     for_each = each.value.teams
     content {

--- a/terraform/github/permissions.tf
+++ b/terraform/github/permissions.tf
@@ -2,8 +2,10 @@
 # to avoid any issues with circular dependencies
 resource "github_repository_collaborators" "this" {
   for_each    = local.map_permissions_to_repositories
-  ignore_team = ["organisation-security-auditor"]
   repository  = each.key
+  ignore_team {
+    team_id = "4380209" #organisation-security-auditor
+  }
   dynamic "team" {
     for_each = each.value.teams
     content {

--- a/terraform/github/teams.tf
+++ b/terraform/github/teams.tf
@@ -3,38 +3,6 @@ module "core-team" {
   source      = "./modules/team"
   name        = "modernisation-platform"
   description = "Modernisation Platform team"
-  repositories = [
-    module.core.repository.name,
-    module.terraform-module-baselines.repository.name,
-    module.terraform-module-cross-account-access.repository.name,
-    module.terraform-module-environments.repository.name,
-    module.terraform-module-iam-superadmins.repository.name,
-    module.terraform-module-s3-bucket.repository.name,
-    module.terraform-module-bastion-linux.repository.name,
-    module.terraform-module-aws-vm-import.repository.name,
-    module.modernisation-platform-instance-scheduler.repository.name,
-    module.terraform-module-aws-loadbalancer.repository.name,
-    module.modernisation-platform-ami-builds.repository.name,
-    module.modernisation-platform-environments.repository.name,
-    module.modernisation-platform-github-actions.repository.name,
-    module.modernisation-platform-terraform-member-vpc.repository.name,
-    module.modernisation-platform-cp-network-test.repository.name,
-    module.modernisation-platform-terraform-module-template.repository.name,
-    module.modernisation-platform-terraform-pagerduty-integration.repository.name,
-    module.terraform-module-github-oidc-provider.repository.name,
-    module.terraform-module-github-oidc-role.repository.name,
-    module.modernisation-platform-configuration-management.repository.name,
-    module.terraform-module-lambda-function.repository.name,
-    module.terraform-module-ssm-patching.repository.name,
-    module.terraform-module-ec2-instance.repository.name,
-    module.terraform-module-ec2-autoscaling-group.repository.name,
-    module.terraform-module-ecs-cluster.repository.name,
-    module.modernisation-platform-terraform-dns-certificates.repository.name,
-    module.modernisation-platform-security.repository.name,
-    module.modernisation-platform-terraform-aws-chatbot.repository.name,
-    module.modernisation-platform-terraform-aws-data-firehose.repository.name
-  ]
-
   maintainers = local.maintainers
   members     = local.everyone
   ci          = local.ci_users
@@ -45,11 +13,9 @@ module "aws-team" {
   source      = "./modules/team"
   name        = "modernisation-platform-engineers"
   description = "Modernisation Platform team: people who require AWS access"
-
   maintainers = local.maintainers
   members     = local.engineers
   ci          = local.ci_users
-
   parent_team_id = module.core-team.team_id
 }
 
@@ -57,7 +23,6 @@ module "security-team" {
   source      = "./modules/team"
   name        = "modernisation-platform-security"
   description = "Modernisation Platform security review team"
-
   maintainers = local.maintainers
   members     = local.security
 }
@@ -66,7 +31,6 @@ module "long-term-storage" {
   source      = "./modules/team"
   name        = "modernisation-platform-long-term-storage"
   description = "Modernisation Platform long term storage team"
-
   maintainers = local.maintainers
   members     = local.long-term-storage
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

#8670

## How does this PR fix the problem?

* Ignores teams added at the GitHub Org level
* Removes an unneeded variable from a module now that we don't use `github_team_repository` to manage repo access
* Removes population of unneeded variable
* Resolves some small typographical errors in collaborator GitHub slugs

## How has this been tested?

Tested through CI pipeline

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
