### PR TITLE
#9306 - Adds use of alternate integration key for SecurityHub alerts depending on account type.

### DIFF
--- a/terraform/environments/bootstrap/secure-baselines/locals.tf
+++ b/terraform/environments/bootstrap/secure-baselines/locals.tf
@@ -27,4 +27,13 @@ locals {
   }
   root_account           = data.aws_organizations_organization.root_account
   environment_management = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
+  mp_owned_workspaces = [
+    "cooker-development",
+    "example-development",
+    "long-term-storage-production",
+    "sprinkler-development",
+    "testing-test",
+    "^core-.*"
+  ]
+  is_core_account = length(regexall(join("|", local.mp_owned_workspaces), terraform.workspace)) > 0
 }

--- a/terraform/environments/bootstrap/secure-baselines/main.tf
+++ b/terraform/environments/bootstrap/secure-baselines/main.tf
@@ -79,7 +79,7 @@ module "baselines" {
   enable_securityhub_alerts = true
 
   # Pass in pagerduty integration key for security hub alerts
-  pagerduty_integration_key = local.pagerduty_integration_keys["security_hub"]
+  pagerduty_integration_key = local.is_core_account? local.pagerduty_integration_keys["security_hub"] : local.pagerduty_integration_keys["security_hub_members"]
 }
 
 # Keys for pagerduty


### PR DESCRIPTION

## A reference to the issue / Description of it

#9306 

## How does this PR fix the problem?

Adds the means to pass a different pagerduty integration key depending on the account type. This is useful for routing securityhub alerts from member accounts to new different slack channel - `modernisation-platform-members-security-hub-alerts`

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

See tests below. Also ref #9514 for the creation of the pagerduty rules and the new integration key.

## Deployment Plan / Instructions

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
