### PR TITLE
Prevent GitHub Terraform from running during periods of degraded GitHub status

### DIFF
--- a/.github/workflows/terraform-github.yml
+++ b/.github/workflows/terraform-github.yml
@@ -36,6 +36,19 @@ permissions:
   pull-requests: write
   
 jobs:
+  github-status-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check GitHub status
+        run: |
+          response=$(curl -s https://www.githubstatus.com/api/v2/summary.json)
+          status_indicator=$(echo "$response" | jq -r '.status.indicator')
+            
+          if [ "$status_indicator" != "none" ]; then
+            echo "GitHub Status check failed"
+            exit 1
+          fi
+
   github-plan-and-apply:
     uses: ./.github/workflows/reusable_terraform_plan_apply.yml
     with:

--- a/.github/workflows/terraform-github.yml
+++ b/.github/workflows/terraform-github.yml
@@ -50,6 +50,7 @@ jobs:
           fi
 
   github-plan-and-apply:
+    needs: [ github-status-check ]
     uses: ./.github/workflows/reusable_terraform_plan_apply.yml
     with:
       working-directory: "terraform/github"


### PR DESCRIPTION
## A reference to the issue / Description of it

#8670

## How does this PR fix the problem?

Adds a simple `curl` / `jq` evaluation that will set an exit code to stop the workflow when a query of the GitHub status api returns a result for incidents other than `none`.

## How has this been tested?

Tested locally to evaluate output

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
