### PR TITLE
#9306 - Redirects the SecurityHub alerts for testing-test, sprinkler, cooker, example to the members slack channel.

### DIFF
--- a/terraform/environments/bootstrap/secure-baselines/locals.tf
+++ b/terraform/environments/bootstrap/secure-baselines/locals.tf
@@ -28,11 +28,7 @@ locals {
   root_account           = data.aws_organizations_organization.root_account
   environment_management = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
   mp_owned_workspaces = [
-    "cooker-development",
-    "example-development",
     "long-term-storage-production",
-    "sprinkler-development",
-    "testing-test",
     "^core-.*"
   ]
   is_core_account = length(regexall(join("|", local.mp_owned_workspaces), terraform.workspace)) > 0


### PR DESCRIPTION

## A reference to the issue / Description of it

#9306 

## How does this PR fix the problem?

Restricts list of mp_owned_workspaces to just the core accounts to move critical SecurityHub alerts from test accounts to the members channel. This will cut down the noise of alerts being generated by unit tests & development work in the main SecurityHub alerts channel.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Amendment of the previous PR https://github.com/ministryofjustice/modernisation-platform/pull/9518

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

--

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
