### PR TITLE
🛂 Add rules for CICA Dev. Remove CICA on-prem

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/development_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/development_rules.json
@@ -553,6 +553,13 @@
     "destination_port": "ANY",
     "protocol": "TCP"
   },
+  "cica_tariff_dev_to_cica_aws_dev_icmp": {
+    "action": "PASS",
+    "source_ip": "${cica-development}",
+    "destination_ip": "$CICA_AWS_DEV",
+    "destination_port": "ANY",
+    "protocol": "ICMP"
+  },
   "cica_aws_uat_a_to_cica_tariff_dev": {
     "action": "PASS",
     "source_ip": "${cica-aws-uat-a}",

--- a/terraform/environments/core-network-services/firewall-rules/development_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/development_rules.json
@@ -538,6 +538,21 @@
     "destination_port": "587",
     "protocol": "TCP"
   },
+  "cica_aws_dev_to_cica_tariff_dev": {
+    "action": "PASS",
+    "source_ip": "$CICA_AWS_DEV",
+    "destination_ip": "${cica-development}",
+    "destination_port": "$TARIFF_TCP",
+    "protocol": "TCP"
+
+  },
+  "cica_tariff_dev_to_cica_aws_dev": {
+    "action": "PASS",
+    "source_ip": "${cica-development}",
+    "destination_ip": "$CICA_AWS_DEV",
+    "destination_port": "ANY",
+    "protocol": "TCP"
+  },
   "cica_aws_uat_a_to_cica_tariff_dev": {
     "action": "PASS",
     "source_ip": "${cica-aws-uat-a}",
@@ -556,20 +571,6 @@
     "action": "PASS",
     "source_ip": "${cica-development}",
     "destination_ip": "${cica-aws-uat-a}",
-    "destination_port": "ANY",
-    "protocol": "TCP"
-  },
-  "cica_tariff_dev_to_cica_onprem_uat": {
-    "action": "PASS",
-    "source_ip": "${cica-development}",
-    "destination_ip": "${cica-onprem-uat}",
-    "destination_port": "ANY",
-    "protocol": "TCP"
-  },
-  "cica_onprem_uat_to_cica_tariff_dev": {
-    "action": "PASS",
-    "source_ip": "${cica-onprem-uat}",
-    "destination_ip": "${cica-development}",
     "destination_port": "ANY",
     "protocol": "TCP"
   },

--- a/terraform/environments/core-network-services/firewall-rules/sets.json
+++ b/terraform/environments/core-network-services/firewall-rules/sets.json
@@ -16,6 +16,12 @@
       "${data-engineering-dev}",
       "${data-engineering-prod}",
       "${data-engineering-stage}"
+    ],
+    "CICA_AWS_DEV": [
+      "${cica-aws-dev-a}", 
+      "${cica-aws-dev-b}", 
+      "${cica-aws-dev-data-a}", 
+      "${cica-aws-dev-data-b}"
     ]
   },
   "PORT_SETS": {


### PR DESCRIPTION
Add rules to allow ingress and egress for CICA Dev. Remove unnecessary rule for on-prem UAT.

## A reference to the issue / Description of it

Allow connectivity from Tariff to CICA AWS dev account for connectivity to Tempus system.



## How does this PR fix the problem?



## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x ] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
