### PR TITLE
Update provider to `modernisation-secrets-read` and add `modernisation-secrets-read` provider

### DIFF
--- a/terraform/environments/analytical-platform-common/providers.tf
+++ b/terraform/environments/analytical-platform-common/providers.tf
@@ -31,3 +31,12 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/analytical-platform-common/secrets.tf
+++ b/terraform/environments/analytical-platform-common/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/analytical-platform-compute/providers.tf
+++ b/terraform/environments/analytical-platform-compute/providers.tf
@@ -31,3 +31,12 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/analytical-platform-compute/secrets.tf
+++ b/terraform/environments/analytical-platform-compute/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/analytical-platform-data-engineering/providers.tf
+++ b/terraform/environments/analytical-platform-data-engineering/providers.tf
@@ -31,3 +31,12 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/analytical-platform-data-engineering/secrets.tf
+++ b/terraform/environments/analytical-platform-data-engineering/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/analytical-platform-data/providers.tf
+++ b/terraform/environments/analytical-platform-data/providers.tf
@@ -31,3 +31,12 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/analytical-platform-data/secrets.tf
+++ b/terraform/environments/analytical-platform-data/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/analytical-platform-ingestion/providers.tf
+++ b/terraform/environments/analytical-platform-ingestion/providers.tf
@@ -31,3 +31,12 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/analytical-platform-ingestion/secrets.tf
+++ b/terraform/environments/analytical-platform-ingestion/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/analytical-platform-landing/providers.tf
+++ b/terraform/environments/analytical-platform-landing/providers.tf
@@ -31,3 +31,12 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/analytical-platform-landing/secrets.tf
+++ b/terraform/environments/analytical-platform-landing/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/analytical-platform-management/providers.tf
+++ b/terraform/environments/analytical-platform-management/providers.tf
@@ -31,3 +31,12 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/analytical-platform-management/secrets.tf
+++ b/terraform/environments/analytical-platform-management/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/analytical-platform/providers.tf
+++ b/terraform/environments/analytical-platform/providers.tf
@@ -35,3 +35,12 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/analytical-platform/secrets.tf
+++ b/terraform/environments/analytical-platform/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/apex/providers.tf
+++ b/terraform/environments/apex/providers.tf
@@ -31,3 +31,12 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/apex/secrets.tf
+++ b/terraform/environments/apex/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/bacway/providers.tf
+++ b/terraform/environments/bacway/providers.tf
@@ -31,3 +31,12 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/bacway/secrets.tf
+++ b/terraform/environments/bacway/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/bichard7/providers.tf
+++ b/terraform/environments/bichard7/providers.tf
@@ -31,3 +31,12 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/bichard7/secrets.tf
+++ b/terraform/environments/bichard7/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/ccms-ebs-upgrade/providers.tf
+++ b/terraform/environments/ccms-ebs-upgrade/providers.tf
@@ -35,3 +35,12 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/ccms-ebs-upgrade/secrets.tf
+++ b/terraform/environments/ccms-ebs-upgrade/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/ccms-ebs/providers.tf
+++ b/terraform/environments/ccms-ebs/providers.tf
@@ -34,3 +34,12 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/ccms-ebs/secrets.tf
+++ b/terraform/environments/ccms-ebs/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/cdpt-chaps/providers.tf
+++ b/terraform/environments/cdpt-chaps/providers.tf
@@ -35,3 +35,12 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/cdpt-chaps/secrets.tf
+++ b/terraform/environments/cdpt-chaps/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/cdpt-ifs/providers.tf
+++ b/terraform/environments/cdpt-ifs/providers.tf
@@ -35,3 +35,12 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/cdpt-ifs/secrets.tf
+++ b/terraform/environments/cdpt-ifs/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/cica-copilot/providers.tf
+++ b/terraform/environments/cica-copilot/providers.tf
@@ -35,3 +35,12 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/cica-copilot/secrets.tf
+++ b/terraform/environments/cica-copilot/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/cica-data-extraction/providers.tf
+++ b/terraform/environments/cica-data-extraction/providers.tf
@@ -35,3 +35,12 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/cica-data-extraction/secrets.tf
+++ b/terraform/environments/cica-data-extraction/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/cica-tariff/providers.tf
+++ b/terraform/environments/cica-tariff/providers.tf
@@ -35,3 +35,12 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/cica-tariff/secrets.tf
+++ b/terraform/environments/cica-tariff/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/contract-work-administration/providers.tf
+++ b/terraform/environments/contract-work-administration/providers.tf
@@ -35,3 +35,12 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/contract-work-administration/secrets.tf
+++ b/terraform/environments/contract-work-administration/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/cooker/providers.tf
+++ b/terraform/environments/cooker/providers.tf
@@ -44,3 +44,12 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/cooker/secrets.tf
+++ b/terraform/environments/cooker/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/core-logging/providers.tf
+++ b/terraform/environments/core-logging/providers.tf
@@ -28,3 +28,12 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/core-logging/secrets.tf
+++ b/terraform/environments/core-logging/secrets.tf
@@ -1,22 +1,28 @@
+# Get modernisation account id from ssm parameter
+data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
+  name = "modernisation_platform_account_id"
+}
+
 # Get secret by name for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
 
 # Get the map of pagerduty integration keys
 data "aws_secretsmanager_secret" "pagerduty_integration_keys" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "pagerduty_integration_keys"
 }
 
 data "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.pagerduty_integration_keys.id
 }

--- a/terraform/environments/core-network-services/providers.tf
+++ b/terraform/environments/core-network-services/providers.tf
@@ -26,3 +26,12 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/core-network-services/secrets.tf
+++ b/terraform/environments/core-network-services/secrets.tf
@@ -1,23 +1,29 @@
+# Get modernisation account id from ssm parameter
+data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
+  name = "modernisation_platform_account_id"
+}
+
 # Get secret by name for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
 
 # Get the map of pagerduty integration keys
 data "aws_secretsmanager_secret" "pagerduty_integration_keys" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "pagerduty_integration_keys"
 }
 
 data "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.pagerduty_integration_keys.id
 }
 

--- a/terraform/environments/core-sandbox/providers.tf
+++ b/terraform/environments/core-sandbox/providers.tf
@@ -31,3 +31,12 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/core-sandbox/secrets.tf
+++ b/terraform/environments/core-sandbox/secrets.tf
@@ -1,11 +1,17 @@
+# Get modernisation account id from ssm parameter
+data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
+  name = "modernisation_platform_account_id"
+}
+
 # Get secret by name for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }

--- a/terraform/environments/core-security/providers.tf
+++ b/terraform/environments/core-security/providers.tf
@@ -18,3 +18,12 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/core-security/secrets.tf
+++ b/terraform/environments/core-security/secrets.tf
@@ -1,22 +1,28 @@
+# Get modernisation account id from ssm parameter
+data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
+  name = "modernisation_platform_account_id"
+}
+
 # Get secret by name for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
 
 # Get the map of pagerduty integration keys
 data "aws_secretsmanager_secret" "pagerduty_integration_keys" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "pagerduty_integration_keys"
 }
 
 data "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.pagerduty_integration_keys.id
 }

--- a/terraform/environments/core-shared-services/providers.tf
+++ b/terraform/environments/core-shared-services/providers.tf
@@ -34,3 +34,12 @@ provider "aws" {
   alias  = "bucket-replication"
   region = "eu-west-1"
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/core-shared-services/secrets.tf
+++ b/terraform/environments/core-shared-services/secrets.tf
@@ -1,22 +1,28 @@
+# Get modernisation account id from ssm parameter
+data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
+  name = "modernisation_platform_account_id"
+}
+
 # Get secret by name for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
 
 # Get the map of pagerduty integration keys
 data "aws_secretsmanager_secret" "pagerduty_integration_keys" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "pagerduty_integration_keys"
 }
 
 data "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.pagerduty_integration_keys.id
 }

--- a/terraform/environments/core-vpc/providers.tf
+++ b/terraform/environments/core-vpc/providers.tf
@@ -28,3 +28,12 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/core-vpc/secrets.tf
+++ b/terraform/environments/core-vpc/secrets.tf
@@ -1,22 +1,28 @@
+# Get modernisation account id from ssm parameter
+data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
+  name = "modernisation_platform_account_id"
+}
+
 # Get secret by name for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
 
 # Get the map of pagerduty integration keys
 data "aws_secretsmanager_secret" "pagerduty_integration_keys" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "pagerduty_integration_keys"
 }
 
 data "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.pagerduty_integration_keys.id
 }

--- a/terraform/environments/corporate-information-system/providers.tf
+++ b/terraform/environments/corporate-information-system/providers.tf
@@ -35,3 +35,12 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/corporate-information-system/secrets.tf
+++ b/terraform/environments/corporate-information-system/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/corporate-staff-rostering/providers.tf
+++ b/terraform/environments/corporate-staff-rostering/providers.tf
@@ -31,3 +31,12 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/corporate-staff-rostering/secrets.tf
+++ b/terraform/environments/corporate-staff-rostering/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/dacp/providers.tf
+++ b/terraform/environments/dacp/providers.tf
@@ -35,3 +35,12 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/dacp/secrets.tf
+++ b/terraform/environments/dacp/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/data-platform-apps-and-tools/providers.tf
+++ b/terraform/environments/data-platform-apps-and-tools/providers.tf
@@ -35,3 +35,12 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/data-platform-apps-and-tools/secrets.tf
+++ b/terraform/environments/data-platform-apps-and-tools/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/data-platform/providers.tf
+++ b/terraform/environments/data-platform/providers.tf
@@ -35,3 +35,12 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/data-platform/secrets.tf
+++ b/terraform/environments/data-platform/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/delete-account/providers.tf
+++ b/terraform/environments/delete-account/providers.tf
@@ -31,3 +31,12 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/delete-account/secrets.tf
+++ b/terraform/environments/delete-account/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/delius-alfresco/providers.tf
+++ b/terraform/environments/delius-alfresco/providers.tf
@@ -35,3 +35,12 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/delius-alfresco/secrets.tf
+++ b/terraform/environments/delius-alfresco/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/delius-core/providers.tf
+++ b/terraform/environments/delius-core/providers.tf
@@ -35,3 +35,12 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/delius-core/secrets.tf
+++ b/terraform/environments/delius-core/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/delius-iaps/providers.tf
+++ b/terraform/environments/delius-iaps/providers.tf
@@ -35,3 +35,12 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/delius-iaps/secrets.tf
+++ b/terraform/environments/delius-iaps/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/delius-jitbit/providers.tf
+++ b/terraform/environments/delius-jitbit/providers.tf
@@ -35,3 +35,12 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/delius-jitbit/secrets.tf
+++ b/terraform/environments/delius-jitbit/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/delius-mis/providers.tf
+++ b/terraform/environments/delius-mis/providers.tf
@@ -35,3 +35,12 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/delius-mis/secrets.tf
+++ b/terraform/environments/delius-mis/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/digital-prison-reporting/providers.tf
+++ b/terraform/environments/digital-prison-reporting/providers.tf
@@ -37,6 +37,15 @@ provider "aws" {
   default_tags { tags = local.tags }
 }
 
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}
+
 ############################
 # OpenID Connect providers #
 ############################
@@ -65,3 +74,4 @@ resource "aws_iam_openid_connect_provider" "circleci_oidc_provider" {
     ignore_changes = [thumbprint_list]
   }
 }
+

--- a/terraform/environments/digital-prison-reporting/secrets.tf
+++ b/terraform/environments/digital-prison-reporting/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/edw/providers.tf
+++ b/terraform/environments/edw/providers.tf
@@ -35,3 +35,12 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/edw/secrets.tf
+++ b/terraform/environments/edw/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/electronic-monitoring-data/providers.tf
+++ b/terraform/environments/electronic-monitoring-data/providers.tf
@@ -35,3 +35,12 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/electronic-monitoring-data/secrets.tf
+++ b/terraform/environments/electronic-monitoring-data/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/equip/providers.tf
+++ b/terraform/environments/equip/providers.tf
@@ -35,3 +35,12 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/equip/secrets.tf
+++ b/terraform/environments/equip/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/eric/providers.tf
+++ b/terraform/environments/eric/providers.tf
@@ -35,3 +35,12 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/eric/secrets.tf
+++ b/terraform/environments/eric/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/example/providers.tf
+++ b/terraform/environments/example/providers.tf
@@ -35,3 +35,12 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/example/secrets.tf
+++ b/terraform/environments/example/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/genesys-call-centre-data/providers.tf
+++ b/terraform/environments/genesys-call-centre-data/providers.tf
@@ -35,3 +35,12 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/genesys-call-centre-data/secrets.tf
+++ b/terraform/environments/genesys-call-centre-data/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/hmpps-domain-services/providers.tf
+++ b/terraform/environments/hmpps-domain-services/providers.tf
@@ -35,3 +35,12 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/hmpps-domain-services/secrets.tf
+++ b/terraform/environments/hmpps-domain-services/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/hmpps-oem/providers.tf
+++ b/terraform/environments/hmpps-oem/providers.tf
@@ -35,3 +35,12 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/hmpps-oem/secrets.tf
+++ b/terraform/environments/hmpps-oem/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/laa-ccms-infra-azure-ad-sso/providers.tf
+++ b/terraform/environments/laa-ccms-infra-azure-ad-sso/providers.tf
@@ -35,3 +35,12 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/laa-ccms-infra-azure-ad-sso/secrets.tf
+++ b/terraform/environments/laa-ccms-infra-azure-ad-sso/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/laa-mail-relay/providers.tf
+++ b/terraform/environments/laa-mail-relay/providers.tf
@@ -35,3 +35,12 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/laa-mail-relay/secrets.tf
+++ b/terraform/environments/laa-mail-relay/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/laa-oem/providers.tf
+++ b/terraform/environments/laa-oem/providers.tf
@@ -35,3 +35,12 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/laa-oem/secrets.tf
+++ b/terraform/environments/laa-oem/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/laa-stabilisation-cdc-poc/providers.tf
+++ b/terraform/environments/laa-stabilisation-cdc-poc/providers.tf
@@ -35,3 +35,12 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/laa-stabilisation-cdc-poc/secrets.tf
+++ b/terraform/environments/laa-stabilisation-cdc-poc/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/long-term-storage/providers.tf
+++ b/terraform/environments/long-term-storage/providers.tf
@@ -35,3 +35,12 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/long-term-storage/secrets.tf
+++ b/terraform/environments/long-term-storage/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/maat/providers.tf
+++ b/terraform/environments/maat/providers.tf
@@ -35,3 +35,12 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/maat/secrets.tf
+++ b/terraform/environments/maat/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/maatdb/providers.tf
+++ b/terraform/environments/maatdb/providers.tf
@@ -35,3 +35,12 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/maatdb/secrets.tf
+++ b/terraform/environments/maatdb/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/mi-platform/providers.tf
+++ b/terraform/environments/mi-platform/providers.tf
@@ -35,3 +35,12 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/mi-platform/secrets.tf
+++ b/terraform/environments/mi-platform/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/mlra/providers.tf
+++ b/terraform/environments/mlra/providers.tf
@@ -35,3 +35,12 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/mlra/secrets.tf
+++ b/terraform/environments/mlra/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/moj-network-operations-centre/providers.tf
+++ b/terraform/environments/moj-network-operations-centre/providers.tf
@@ -35,3 +35,12 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/moj-network-operations-centre/secrets.tf
+++ b/terraform/environments/moj-network-operations-centre/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/mojfin/providers.tf
+++ b/terraform/environments/mojfin/providers.tf
@@ -35,3 +35,12 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/mojfin/secrets.tf
+++ b/terraform/environments/mojfin/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/ncas/providers.tf
+++ b/terraform/environments/ncas/providers.tf
@@ -35,3 +35,12 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/ncas/secrets.tf
+++ b/terraform/environments/ncas/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/nomis-combined-reporting/providers.tf
+++ b/terraform/environments/nomis-combined-reporting/providers.tf
@@ -35,3 +35,12 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/nomis-combined-reporting/secrets.tf
+++ b/terraform/environments/nomis-combined-reporting/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/nomis-data-hub/providers.tf
+++ b/terraform/environments/nomis-data-hub/providers.tf
@@ -35,3 +35,12 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/nomis-data-hub/secrets.tf
+++ b/terraform/environments/nomis-data-hub/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/nomis/providers.tf
+++ b/terraform/environments/nomis/providers.tf
@@ -35,3 +35,12 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/nomis/secrets.tf
+++ b/terraform/environments/nomis/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/oas/providers.tf
+++ b/terraform/environments/oas/providers.tf
@@ -35,3 +35,12 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/oas/secrets.tf
+++ b/terraform/environments/oas/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/oasys-national-reporting/providers.tf
+++ b/terraform/environments/oasys-national-reporting/providers.tf
@@ -35,3 +35,12 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/oasys-national-reporting/secrets.tf
+++ b/terraform/environments/oasys-national-reporting/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/oasys/providers.tf
+++ b/terraform/environments/oasys/providers.tf
@@ -35,3 +35,12 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/oasys/secrets.tf
+++ b/terraform/environments/oasys/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/observability-platform/providers.tf
+++ b/terraform/environments/observability-platform/providers.tf
@@ -35,3 +35,12 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/observability-platform/secrets.tf
+++ b/terraform/environments/observability-platform/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/operations-engineering/providers.tf
+++ b/terraform/environments/operations-engineering/providers.tf
@@ -32,3 +32,12 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/operations-engineering/secrets.tf
+++ b/terraform/environments/operations-engineering/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/opg-lpa-data-store/providers.tf
+++ b/terraform/environments/opg-lpa-data-store/providers.tf
@@ -35,3 +35,12 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/opg-lpa-data-store/secrets.tf
+++ b/terraform/environments/opg-lpa-data-store/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/panda-cyber-appsec-lab/providers.tf
+++ b/terraform/environments/panda-cyber-appsec-lab/providers.tf
@@ -35,3 +35,12 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/panda-cyber-appsec-lab/secrets.tf
+++ b/terraform/environments/panda-cyber-appsec-lab/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/performance-hub/providers.tf
+++ b/terraform/environments/performance-hub/providers.tf
@@ -35,3 +35,12 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/performance-hub/secrets.tf
+++ b/terraform/environments/performance-hub/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/planetfm/providers.tf
+++ b/terraform/environments/planetfm/providers.tf
@@ -35,3 +35,12 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/planetfm/secrets.tf
+++ b/terraform/environments/planetfm/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/portal/providers.tf
+++ b/terraform/environments/portal/providers.tf
@@ -35,3 +35,12 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/portal/secrets.tf
+++ b/terraform/environments/portal/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/ppud/providers.tf
+++ b/terraform/environments/ppud/providers.tf
@@ -35,3 +35,12 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/ppud/secrets.tf
+++ b/terraform/environments/ppud/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/pra-register/providers.tf
+++ b/terraform/environments/pra-register/providers.tf
@@ -35,3 +35,12 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/pra-register/secrets.tf
+++ b/terraform/environments/pra-register/secrets.tf
@@ -1,17 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
 

--- a/terraform/environments/refer-monitor/providers.tf
+++ b/terraform/environments/refer-monitor/providers.tf
@@ -35,3 +35,12 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/refer-monitor/secrets.tf
+++ b/terraform/environments/refer-monitor/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/sprinkler/providers.tf
+++ b/terraform/environments/sprinkler/providers.tf
@@ -35,3 +35,12 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/sprinkler/secrets.tf
+++ b/terraform/environments/sprinkler/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/testing/providers.tf
+++ b/terraform/environments/testing/providers.tf
@@ -35,3 +35,12 @@ provider "aws" {
   }
   default_tags { tags = local.ignore_tags }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/testing/secrets.tf
+++ b/terraform/environments/testing/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/tipstaff/providers.tf
+++ b/terraform/environments/tipstaff/providers.tf
@@ -35,3 +35,12 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/tipstaff/secrets.tf
+++ b/terraform/environments/tipstaff/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/tribunals/providers.tf
+++ b/terraform/environments/tribunals/providers.tf
@@ -35,3 +35,12 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/tribunals/secrets.tf
+++ b/terraform/environments/tribunals/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/wardship/providers.tf
+++ b/terraform/environments/wardship/providers.tf
@@ -35,3 +35,12 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/wardship/secrets.tf
+++ b/terraform/environments/wardship/secrets.tf
@@ -1,5 +1,6 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
@@ -7,13 +8,13 @@ data "aws_ssm_parameter" "modernisation_platform_account_id" {
 data "aws_secretsmanager_secret" "environment_management" {
   # checkov:skip=CKV2_AWS_57:Auto rotation not possible
   # checkov:skip=CKV_AWS_149:No requirement currently to encrypt this secret with customer-managed KMS key
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
 

--- a/terraform/environments/xhibit-portal/providers.tf
+++ b/terraform/environments/xhibit-portal/providers.tf
@@ -35,3 +35,12 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/xhibit-portal/secrets.tf
+++ b/terraform/environments/xhibit-portal/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/youth-justice-app-framework/providers.tf
+++ b/terraform/environments/youth-justice-app-framework/providers.tf
@@ -64,3 +64,12 @@ resource "aws_iam_openid_connect_provider" "circleci_oidc_provider" {
     ignore_changes = [thumbprint_list]
   }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/youth-justice-app-framework/secrets.tf
+++ b/terraform/environments/youth-justice-app-framework/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/environments/youth-justice-networking/providers.tf
+++ b/terraform/environments/youth-justice-networking/providers.tf
@@ -31,3 +31,12 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/environments/youth-justice-networking/secrets.tf
+++ b/terraform/environments/youth-justice-networking/secrets.tf
@@ -1,16 +1,18 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+

--- a/terraform/templates/modernisation-platform/providers.tf
+++ b/terraform/templates/modernisation-platform/providers.tf
@@ -31,3 +31,12 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
 }
+
+# AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
+provider "aws" {
+  alias  = "modernisation-secrets-read"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
+  }
+}

--- a/terraform/templates/modernisation-platform/secrets.tf
+++ b/terraform/templates/modernisation-platform/secrets.tf
@@ -1,16 +1,17 @@
 # Get modernisation account id from ssm parameter
 data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.modernisation-platform
   name = "modernisation_platform_account_id"
 }
 
 # Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "environment_management"
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

Recently, we created separate GitHub Actions roles for development and test accounts. In the current setup (a PR will be raised soon), an issue arose when running [Member Environments](https://github.com/ministryofjustice/modernisation-platform/actions/workflows/terraform-member-environment.yml) workflow —secrets could not be accessed from the Modernisation Platform (MP) account due to the OIDC connection pointing to each member account. This resulted in failures to retrieve the necessary secrets. #8590 

## How does this PR fix the problem?

To resolve this issue, we have added a provider to assume a role in the MP account that has the necessary permissions to read the secrets. This ensures that secrets are accessed from the MP account regardless of the active OIDC connection in the Member account.

## How has this been tested?

Tested Manually and also tested on Member Environment workflow


## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
