### PR TITLE
Updates the doc to reference new role created for enabling s3 malware protection

### DIFF
--- a/source/runbooks/enabling-s3-malware-protection.html.md.erb
+++ b/source/runbooks/enabling-s3-malware-protection.html.md.erb
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#modernisation-platform"
 title: Enabling Malware Protection for S3
-last_reviewed_on: 2024-11-25
+last_reviewed_on: 2025-03-13
 review_in: 6 months
 ---
 
@@ -28,13 +28,13 @@ All Modernisation Platform accounts have GuardDuty enabled by default, which inc
 ### Steps to Enable Malware Protection for S3 with Terraform for your account
 
 1. **Define the Buckets to Protect**  
-   Begin by identifying the S3 buckets you want to enable malware protection for. Specify these buckets in your Terraform configuration as a variable or input list.
+   Begin by identifying the S3 buckets you want to enable malware protection for and specify these buckets in your Terraform configuration.
 
 2. **Create a Malware Protection Plan**  
    Set up a resource in Terraform to enable malware protection for each bucket in your list. This involves linking each bucket to a protection plan and ensuring that tagging or logging settings are properly configured for each bucket.
 
 3. **Assign IAM Permissions**  
-   Reference the `MemberInfrastructureAccess` IAM role, which provides GuardDuty the necessary permissions to access and scan the specified S3 buckets.
+   Reference the `GuardDutyS3MalwareProtectionRole` IAM role, which is specifically created to provides GuardDuty the necessary permissions to access and scan the specified S3 buckets.
 
 4. **Raise a PR for the Configuration**  
    Deploy your Terraform configuration. Validate your setup by running `terraform plan` to confirm the changes. Once validated, raise a Pull Request for review and approval to apply the configuration and enable malware protection for the specified buckets.
@@ -50,3 +50,4 @@ By following these steps, you can  enable Malware Protection for S3 using Terraf
 An example of enabling Malware Protection for S3 can be found [here](https://github.com/ministryofjustice/modernisation-platform-environments/blob/main/terraform/environments/example/s3_malware_protection.tf).
 
 ---
+

--- a/source/runbooks/enabling-s3-malware-protection.html.md.erb
+++ b/source/runbooks/enabling-s3-malware-protection.html.md.erb
@@ -34,7 +34,7 @@ All Modernisation Platform accounts have GuardDuty enabled by default, which inc
    Set up a resource in Terraform to enable malware protection for each bucket in your list. This involves linking each bucket to a protection plan and ensuring that tagging or logging settings are properly configured for each bucket.
 
 3. **Assign IAM Permissions**  
-   Reference the `GuardDutyS3MalwareProtectionRole` IAM role, which is specifically created to provides GuardDuty the necessary permissions to access and scan the specified S3 buckets.
+   Reference the `GuardDutyS3MalwareProtectionRole` IAM role, which is specifically created to provide GuardDuty the necessary permissions to access and scan the specified S3 buckets.
 
 4. **Raise a PR for the Configuration**  
    Deploy your Terraform configuration. Validate your setup by running `terraform plan` to confirm the changes. Once validated, raise a Pull Request for review and approval to apply the configuration and enable malware protection for the specified buckets.


### PR DESCRIPTION
## A reference to the issue / Description of it

#8605 
## How does this PR fix the problem?
We've separated the roles to make things clearer and more secure. GuardDutyS3MalwareProtectionRole now handles enabling malware protection, while MemberInfrastructureAccess is only responsible for managing GuardDuty configurations like creation and deletion.
## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
