### PR TITLE
Move nuke action key

### DIFF
--- a/environments/analytical-platform-compute.json
+++ b/environments/analytical-platform-compute.json
@@ -12,8 +12,7 @@
         },
         {
           "sso_group_name": "analytical-platform-engineers",
-          "level": "sandbox",
-          "nuke": "exclude"
+          "level": "sandbox"
         },
         {
           "sso_group_name": "analytical-platform-engineers",
@@ -32,7 +31,8 @@
           "level": "security-audit"
         }
       ],
-      "instance_scheduler_skip": ["true"]
+      "instance_scheduler_skip": ["true"],
+      "nuke": "exclude"
     },
     {
       "name": "test",

--- a/environments/analytical-platform-ingestion.json
+++ b/environments/analytical-platform-ingestion.json
@@ -9,21 +9,19 @@
       "access": [
         {
           "sso_group_name": "analytical-platform-engineers",
-          "level": "platform-engineer-admin",
-          "nuke": "exclude"
+          "level": "platform-engineer-admin"
         },
         {
           "sso_group_name": "analytical-platform-engineers",
-          "level": "sandbox",
-          "nuke": "exclude"
+          "level": "sandbox"
         },
         {
           "sso_group_name": "data-platform-audit-and-security",
-          "level": "security-audit",
-          "nuke": "exclude"
+          "level": "security-audit"
         }
       ],
-      "instance_scheduler_skip": ["true"]
+      "instance_scheduler_skip": ["true"],
+      "nuke": "exclude"
     },
     {
       "name": "production",

--- a/environments/ccms-ebs-upgrade.json
+++ b/environments/ccms-ebs-upgrade.json
@@ -16,10 +16,10 @@
       "access": [
         {
           "sso_group_name": "laa-ccms-migration-team",
-          "level": "sandbox",
-          "nuke": "exclude"
+          "level": "sandbox"
         }
-      ]
+      ],
+      "nuke": "exclude"
     },
     {
       "name": "test",

--- a/environments/ccms-ebs.json
+++ b/environments/ccms-ebs.json
@@ -6,14 +6,14 @@
       "access": [
         {
           "sso_group_name": "laa-ccms-migration-team",
-          "level": "sandbox",
-          "nuke": "exclude"
+          "level": "sandbox"
         },
         {
           "sso_group_name": "modernisation-platform-security",
           "level": "view-only"
         }
-      ]
+      ],
+      "nuke": "exclude"
     },
     {
       "name": "test",

--- a/environments/cica-copilot.json
+++ b/environments/cica-copilot.json
@@ -6,10 +6,10 @@
       "access": [
         {
           "sso_group_name": "cica-copilot-llm-maintainers",
-          "level": "sandbox",
-          "nuke": "exclude"
+          "level": "sandbox"
         }
-      ]
+      ],
+      "nuke": "exclude"
     }
   ],
   "tags": {

--- a/environments/cica-data-extraction.json
+++ b/environments/cica-data-extraction.json
@@ -6,10 +6,10 @@
       "access": [
         {
           "sso_group_name": "cica-extract-tool-admins",
-          "level": "sandbox",
-          "nuke": "rebuild"
+          "level": "sandbox"
         }
-      ]
+      ],
+      "nuke": "rebuild"
     }
   ],
   "tags": {

--- a/environments/contract-work-administration.json
+++ b/environments/contract-work-administration.json
@@ -6,8 +6,7 @@
       "access": [
         {
           "sso_group_name": "laa-aws-infrastructure",
-          "level": "sandbox",
-          "nuke": "exclude"
+          "level": "sandbox"
         },
         {
           "sso_group_name": "laa-cwa-developer",
@@ -19,7 +18,8 @@
           "level": "developer",
           "github_action_reviewer": "false"
         }
-      ]
+      ],
+      "nuke": "exclude"
     },
     {
       "name": "test",

--- a/environments/cooker.json
+++ b/environments/cooker.json
@@ -6,27 +6,24 @@
       "access": [
         {
           "sso_group_name": "modernisation-platform",
-          "level": "developer",
-          "nuke": "rebuild"
+          "level": "developer"
         },
         {
           "sso_group_name": "modernisation-platform",
-          "level": "instance-management",
-          "nuke": "rebuild"
+          "level": "instance-management"
         },
         {
           "sso_group_name": "modernisation-platform",
-          "level": "sandbox",
-          "nuke": "rebuild"
+          "level": "sandbox"
         },
         {
           "sso_group_name": "tvm-purple-team",
-          "level": "sandbox",
-          "nuke": "rebuild"
+          "level": "sandbox"
         }
       ],
       "additional_reviewers": ["astrobinson"],
-      "instance_scheduler_skip": ["true"]
+      "instance_scheduler_skip": ["true"],
+      "nuke": "rebuild"
     }
   ],
   "tags": {

--- a/environments/corporate-information-system.json
+++ b/environments/corporate-information-system.json
@@ -7,7 +7,6 @@
         {
           "sso_group_name": "laa-aws-infrastructure",
           "level": "sandbox",
-          "nuke": "exclude",
           "github_action_reviewer": "true"
         },
         {
@@ -16,10 +15,10 @@
         },
         {
           "sso_group_name": "laa-cis-dbas",
-          "level": "sandbox",
-          "nuke": "exclude"
+          "level": "sandbox"
         }
-      ]
+      ],
+      "nuke": "exclude"
     },
     {
       "name": "test",

--- a/environments/corporate-staff-rostering.json
+++ b/environments/corporate-staff-rostering.json
@@ -17,7 +17,7 @@
           "level": "developer"
         }
       ],
-          "nuke": "rebuild"
+      "nuke": "rebuild"
     },
     {
       "name": "test",

--- a/environments/corporate-staff-rostering.json
+++ b/environments/corporate-staff-rostering.json
@@ -6,19 +6,18 @@
       "access": [
         {
           "sso_group_name": "hosting-migrations",
-          "level": "sandbox",
-          "nuke": "rebuild"
+          "level": "sandbox"
         },
         {
           "sso_group_name": "studio-webops",
-          "level": "sandbox",
-          "nuke": "rebuild"
+          "level": "sandbox"
         },
         {
           "sso_group_name": "azure-aws-sso-digital-studio-operations",
           "level": "developer"
         }
-      ]
+      ],
+          "nuke": "rebuild"
     },
     {
       "name": "test",

--- a/environments/data-platform-apps-and-tools.json
+++ b/environments/data-platform-apps-and-tools.json
@@ -7,20 +7,18 @@
       "access": [
         {
           "sso_group_name": "data-platform-apps-and-tools-development-sandbox",
-          "level": "sandbox",
-          "nuke": "exclude"
+          "level": "sandbox"
         },
         {
           "sso_group_name": "data-platform-apps-and-tools-airflow-users",
-          "level": "mwaa-user",
-          "nuke": "exclude"
+          "level": "mwaa-user"
         },
         {
           "sso_group_name": "data-platform-audit-and-security",
-          "level": "security-audit",
-          "nuke": "exclude"
+          "level": "security-audit"
         }
-      ]
+      ],
+      "nuke": "exclude"
     },
     {
       "name": "production",

--- a/environments/data-platform.json
+++ b/environments/data-platform.json
@@ -7,15 +7,14 @@
       "access": [
         {
           "sso_group_name": "data-platform-development-sandbox",
-          "level": "sandbox",
-          "nuke": "exclude"
+          "level": "sandbox"
         },
         {
           "sso_group_name": "data-platform-audit-and-security",
-          "level": "security-audit",
-          "nuke": "exclude"
+          "level": "security-audit"
         }
-      ]
+      ],
+      "nuke": "exclude"
     },
     {
       "name": "test",

--- a/environments/delius-alfresco.json
+++ b/environments/delius-alfresco.json
@@ -8,10 +8,10 @@
       "access": [
         {
           "sso_group_name": "hosting-migrations",
-          "level": "sandbox",
-          "nuke": "exclude"
+          "level": "sandbox"
         }
-      ]
+      ],
+      "nuke": "exclude"
     },
     {
       "name": "test",

--- a/environments/delius-core.json
+++ b/environments/delius-core.json
@@ -8,39 +8,34 @@
         {
           "sso_group_name": "hmpps-migration",
           "level": "sandbox",
-          "nuke": "exclude",
           "github_action_reviewer": "true"
         },
         {
           "sso_group_name": "hosting-migrations",
           "level": "sandbox",
-          "nuke": "exclude",
           "github_action_reviewer": "true"
         },
         {
           "sso_group_name": "hmpps-dba",
           "level": "developer",
-          "nuke": "exclude",
           "github_action_reviewer": "true"
         },
         {
           "sso_group_name": "hmpps-dba",
           "level": "reporting-operations",
-          "nuke": "exclude",
           "github_action_reviewer": "true"
         },
         {
           "sso_group_name": "unilink",
           "level": "developer",
-          "nuke": "exclude",
           "github_action_reviewer": "true"
         },
         {
           "sso_group_name": "zaizi-devs",
-          "level": "developer",
           "github_action_reviewer": "false"
         }
-      ]
+      ],
+      "nuke": "exclude"
     },
     {
       "name": "test",

--- a/environments/delius-iaps.json
+++ b/environments/delius-iaps.json
@@ -7,19 +7,18 @@
       "access": [
         {
           "sso_group_name": "hmpps-migration",
-          "level": "sandbox",
-          "nuke": "include"
+          "level": "sandbox"
         },
         {
           "sso_group_name": "hosting-migrations",
-          "level": "sandbox",
-          "nuke": "include"
+          "level": "sandbox"
         },
         {
           "sso_group_name": "hmpps-dba",
           "level": "instance-management"
         }
-      ]
+      ],
+      "nuke": "include"
     },
     {
       "name": "production",

--- a/environments/delius-mis.json
+++ b/environments/delius-mis.json
@@ -8,13 +8,11 @@
         {
           "sso_group_name": "hmpps-migration",
           "level": "sandbox",
-          "nuke": "exclude",
           "github_action_reviewer": "true"
         },
         {
           "sso_group_name": "hosting-migrations",
           "level": "sandbox",
-          "nuke": "exclude",
           "github_action_reviewer": "true"
         },
         {
@@ -26,7 +24,8 @@
           "sso_group_name": "hmpps-delius-mis",
           "level": "fleet-manager"
         }
-      ]
+      ],
+      "nuke": "exclude"
     },
     {
       "name": "preproduction",

--- a/environments/digital-prison-reporting.json
+++ b/environments/digital-prison-reporting.json
@@ -6,8 +6,7 @@
       "access": [
         {
           "sso_group_name": "hmpps-digital-prison-reporting",
-          "level": "sandbox",
-          "nuke": "exclude"
+          "level": "sandbox"
         },
         {
           "sso_group_name": "hmpps-digital-prison-reporting",
@@ -25,7 +24,8 @@
           "sso_group_name": "digital-prisons-reporting-development-data-engineer",
           "level": "data-engineer"
         }
-      ]
+      ],
+      "nuke": "exclude"
     },
     {
       "name": "test",

--- a/environments/electronic-monitoring-data.json
+++ b/environments/electronic-monitoring-data.json
@@ -6,15 +6,14 @@
       "access": [
         {
           "sso_group_name": "hmpps-electronic-monitoring-data-store",
-          "level": "sandbox",
-          "nuke": "exclude"
+          "level": "sandbox"
         },
         {
           "sso_group_name": "azure-aws-sso-electronic-monitoring-data",
-          "level": "sandbox",
-          "nuke": "exclude"
+          "level": "sandbox"
         }
-      ]
+      ],
+      "nuke": "exclude"
     },
     {
       "name": "test",

--- a/environments/example.json
+++ b/environments/example.json
@@ -6,15 +6,14 @@
       "access": [
         {
           "sso_group_name": "modernisation-platform",
-          "level": "developer",
-          "nuke": "exclude"
+          "level": "developer"
         },
         {
           "sso_group_name": "green-ops",
-          "level": "data-engineer",
-          "nuke": "exclude"
+          "level": "data-engineer"
         }
-      ]
+      ],
+      "nuke": "exclude"
     }
   ],
   "tags": {

--- a/environments/laa-ccms-infra-azure-ad-sso.json
+++ b/environments/laa-ccms-infra-azure-ad-sso.json
@@ -6,14 +6,14 @@
       "access": [
         {
           "sso_group_name": "laa-ccms-webops",
-          "level": "sandbox",
-          "nuke": "exclude"
+          "level": "sandbox"
         },
         {
           "sso_group_name": "modernisation-platform-security",
           "level": "view-only"
         }
-      ]
+      ],
+      "nuke": "exclude"
     }
   ],
   "tags": {

--- a/environments/laa-mail-relay.json
+++ b/environments/laa-mail-relay.json
@@ -6,10 +6,10 @@
       "access": [
         {
           "sso_group_name": "laa-aws-infrastructure",
-          "level": "sandbox",
-          "nuke": "exclude"
+          "level": "sandbox"
         }
-      ]
+      ],
+      "nuke": "exclude"
     },
     {
       "name": "test",

--- a/environments/laa-oem.json
+++ b/environments/laa-oem.json
@@ -6,10 +6,10 @@
       "access": [
         {
           "sso_group_name": "laa-ccms-migration-team",
-          "level": "sandbox",
-          "nuke": "exclude"
+          "level": "sandbox"
         }
-      ]
+      ],
+      "nuke": "exclude"
     },
     {
       "name": "test",

--- a/environments/laa-stabilisation-cdc-poc.json
+++ b/environments/laa-stabilisation-cdc-poc.json
@@ -6,10 +6,10 @@
       "access": [
         {
           "sso_group_name": "laa-stabilisation-cdc",
-          "level": "sandbox",
-          "nuke": "exclude"
+          "level": "sandbox"
         }
-      ]
+      ],
+      "nuke": "exclude"
     }
   ],
   "tags": {

--- a/environments/maat.json
+++ b/environments/maat.json
@@ -6,7 +6,7 @@
       "access": [
         {
           "sso_group_name": "laa-aws-infrastructure",
-          "level": "sandbox",
+          "level": "sandbox"
         }
       ],
       "nuke": "exclude"

--- a/environments/maat.json
+++ b/environments/maat.json
@@ -7,9 +7,9 @@
         {
           "sso_group_name": "laa-aws-infrastructure",
           "level": "sandbox",
-          "nuke": "exclude"
         }
-      ]
+      ],
+      "nuke": "exclude"
     },
     {
       "name": "test",

--- a/environments/nomis-combined-reporting.json
+++ b/environments/nomis-combined-reporting.json
@@ -12,14 +12,12 @@
         {
           "sso_group_name": "hosting-migrations",
           "level": "sandbox",
-          "github_action_reviewer": "true",
-          "nuke": "exclude"
+          "github_action_reviewer": "true"
         },
         {
           "sso_group_name": "studio-webops",
           "level": "sandbox",
-          "github_action_reviewer": "true",
-          "nuke": "exclude"
+          "github_action_reviewer": "true"
         },
         {
           "sso_group_name": "csr-application-support",
@@ -29,7 +27,8 @@
           "sso_group_name": "azure-aws-sso-digital-studio-operations",
           "level": "developer"
         }
-      ]
+      ],
+      "nuke": "exclude"
     },
     {
       "name": "test",

--- a/environments/oasys-national-reporting.json
+++ b/environments/oasys-national-reporting.json
@@ -8,20 +8,19 @@
         {
           "sso_group_name": "hosting-migrations",
           "level": "sandbox",
-          "nuke": "exclude",
           "github_action_reviewer": "true"
         },
         {
           "sso_group_name": "studio-webops",
           "level": "sandbox",
-          "nuke": "exclude",
           "github_action_reviewer": "true"
         },
         {
           "sso_group_name": "azure-aws-sso-digital-studio-operations",
           "level": "developer"
         }
-      ]
+      ],
+      "nuke": "exclude"
     },
     {
       "name": "test",

--- a/environments/oasys.json
+++ b/environments/oasys.json
@@ -8,13 +8,11 @@
         {
           "sso_group_name": "hosting-migrations",
           "level": "sandbox",
-          "nuke": "rebuild",
           "github_action_reviewer": "true"
         },
         {
           "sso_group_name": "studio-webops",
           "level": "sandbox",
-          "nuke": "rebuild",
           "github_action_reviewer": "true"
         },
         {
@@ -25,7 +23,8 @@
           "sso_group_name": "azure-aws-sso-digital-studio-operations",
           "level": "developer"
         }
-      ]
+      ],
+      "nuke": "rebuild"
     },
     {
       "name": "test",

--- a/environments/operations-engineering.json
+++ b/environments/operations-engineering.json
@@ -6,10 +6,10 @@
       "access": [
         {
           "sso_group_name": "operations-engineering",
-          "level": "sandbox",
-          "nuke": "exclude"
+          "level": "sandbox"
         }
-      ]
+      ],
+      "nuke": "exclude"
     }
   ],
   "tags": {

--- a/environments/panda-cyber-appsec-lab.json
+++ b/environments/panda-cyber-appsec-lab.json
@@ -7,10 +7,10 @@
       "access": [
         {
           "sso_group_name": "panda-cyber-team",
-          "level": "sandbox",
-          "nuke": "exclude"
+          "level": "sandbox"
         }
-      ]
+      ],
+      "nuke": "exclude"
     }
   ],
   "tags": {

--- a/environments/performance-hub.json
+++ b/environments/performance-hub.json
@@ -6,10 +6,10 @@
       "access": [
         {
           "sso_group_name": "performance-hub-developers",
-          "level": "sandbox",
-          "nuke": "exclude"
+          "level": "sandbox"
         }
-      ]
+      ],
+      "nuke": "exclude"
     },
     {
       "name": "preproduction",

--- a/environments/planetfm.json
+++ b/environments/planetfm.json
@@ -6,19 +6,18 @@
       "access": [
         {
           "sso_group_name": "hosting-migrations",
-          "level": "sandbox",
-          "nuke": "rebuild"
+          "level": "sandbox"
         },
         {
           "sso_group_name": "studio-webops",
-          "level": "sandbox",
-          "nuke": "rebuild"
+          "level": "sandbox"
         },
         {
           "sso_group_name": "azure-aws-sso-digital-studio-operations",
           "level": "developer"
         }
-      ]
+      ],
+      "nuke": "rebuild"
     },
     {
       "name": "test",

--- a/environments/portal.json
+++ b/environments/portal.json
@@ -6,10 +6,10 @@
       "access": [
         {
           "sso_group_name": "laa-aws-infrastructure",
-          "level": "sandbox",
-          "nuke": "exclude"
+          "level": "sandbox"
         }
-      ]
+      ],
+      "nuke": "exclude"
     },
     {
       "name": "test",

--- a/environments/sprinkler.json
+++ b/environments/sprinkler.json
@@ -15,45 +15,38 @@
       "access": [
         {
           "sso_group_name": "modernisation-platform",
-          "level": "developer",
-          "nuke": "rebuild"
+          "level": "developer"
         },
         {
           "sso_group_name": "modernisation-platform",
-          "level": "reporting-operations",
-          "nuke": "rebuild"
+          "level": "reporting-operations"
         },
         {
           "sso_group_name": "modernisation-platform",
-          "level": "migration",
-          "nuke": "rebuild"
+          "level": "migration"
         },
         {
           "sso_group_name": "modernisation-platform",
-          "level": "data-engineer",
-          "nuke": "rebuild"
+          "level": "data-engineer"
         },
         {
           "sso_group_name": "modernisation-platform-security",
-          "level": "instance-management",
-          "nuke": "rebuild"
+          "level": "instance-management"
         },
         {
           "sso_group_name": "modernisation-platform",
-          "level": "fleet-manager",
-          "nuke": "rebuild"
+          "level": "fleet-manager"
         },
         {
           "sso_group_name": "modernisation-platform",
-          "level": "quicksight-admin",
-          "nuke": "rebuild"
+          "level": "quicksight-admin"
         },
         {
           "sso_group_name": "azure-aws-sso-modernisation-platform",
-          "level": "developer",
-          "nuke": "rebuild"
+          "level": "developer"
         }
-      ]
+      ],
+      "nuke": "rebuild"
     }
   ],
   "tags": {

--- a/environments/tipstaff.json
+++ b/environments/tipstaff.json
@@ -6,10 +6,10 @@
       "access": [
         {
           "sso_group_name": "dts-legacy",
-          "level": "sandbox",
-          "nuke": "rebuild"
+          "level": "sandbox"
         }
-      ]
+      ],
+      "nuke": "rebuild"
     },
     {
       "name": "preproduction",

--- a/terraform/environments/environments.tf
+++ b/terraform/environments/environments.tf
@@ -1,5 +1,5 @@
 module "environments" {
-  source                             = "github.com/ministryofjustice/modernisation-platform-terraform-environments?ref=b17ca8d6c23a2c22d2efc6c5116a1328492c32bd" # v6.0.0
+  source                             = "github.com/ministryofjustice/modernisation-platform-terraform-environments?ref=32119ae1515dce784578a86e57c54471c0da86bb" # v7.0.0
   environment_directory              = "../../environments"
   environment_parent_organisation_id = local.modernisation_platform_ou_id
   environment_prefix                 = "modernisation-platform"

--- a/terraform/environments/environments.tf
+++ b/terraform/environments/environments.tf
@@ -1,5 +1,5 @@
 module "environments" {
-  source                             = "github.com/ministryofjustice/modernisation-platform-terraform-environments?ref=32119ae1515dce784578a86e57c54471c0da86bb" # v7.0.0
+  source                             = "github.com/ministryofjustice/modernisation-platform-terraform-environments?ref=0f15745396a2da4627f10ad48190e07032bb9888" # v7.0.0
   environment_directory              = "../../environments"
   environment_parent_organisation_id = local.modernisation_platform_ou_id
   environment_prefix                 = "modernisation-platform"


### PR DESCRIPTION
## A reference to the issue / Description of it

#9239 

## How does this PR fix the problem?

This PR uses an updated local in the `modernisation-platform-terraform-environments` repository. The updated local checks for the presence of the AWS Nuke `tag:key` value in a development environment block when an access level inside the environment block contains `sandbox` as a value.

The net result is that the AWS Nuke `tag:key` should be defined once in `development {}` making it more apparent what AWS Nuke action should be applied to the environment.

## How has this been tested?

Tested locally by opening the Terraform console and diff'ing the output of `module.environments` to confirm that my proposed PR and the current main branch return the same lists of accounts.

## Deployment Plan / Instructions

Deploy through CI once the draft PR in the `modernisation-platform-terraform-environments repository` has been merged in and a new tag has been raised

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
