### PR TITLE
Allow further repositories to receive full team access

### DIFF
--- a/terraform/github/locals.tf
+++ b/terraform/github/locals.tf
@@ -138,12 +138,18 @@ locals {
     "modernisation-platform-terraform-ssm-patching",
   ]
 
+  repositories_with_full_team_access = [
+    "modernisation-platform-configuration-management",
+    "modernisation-platform-environments"
+    # Add other repositories that need full team access here
+  ]
+
   map_permissions_to_repositories = {
     for repo in local.modernisation_platform_repositories : repo => {
       teams = merge(
         { "modernisation-platform" = "admin" },
         { "all-org-members" = "push" },
-      repo == "modernisation-platform-environments" ? { for team in local.application_github_group_names : team => "push" } : null),
+        contains(local.repositories_with_full_team_access, repo) ? { for team in local.application_github_group_names : team => "push" } : null),
       users = repo == "modernisation-platform-environments" ? { for user in local.collaborators : user => "push" } : {}
     }
   }

--- a/terraform/github/locals.tf
+++ b/terraform/github/locals.tf
@@ -139,6 +139,7 @@ locals {
   ]
 
   repositories_with_full_team_access = [
+    "modernisation-platform-ami-builds",
     "modernisation-platform-configuration-management",
     "modernisation-platform-environments"
     # Add other repositories that need full team access here


### PR DESCRIPTION
## A reference to the issue / Description of it

#8670

## How does this PR fix the problem?

The GitHub `CODEOWNERS` file can specify teams with the ability to approve PRs, but these teams need corresponding `push` access to a repository in order to approve said PRs.

This PR introduces a simple static list of repositories where we want to map all teams using MP to have access rights to the repositories in the list. This then allows them to approve PRs when the PRs affect paths they're specified in with `CODEOWNERS`.

## How has this been tested?

Tested with local plan

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
