### PR TITLE
Allow developers to update SecurityHub findings

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -177,6 +177,7 @@ data "aws_iam_policy_document" "member-access" {
       "route53resolver:*",
       "s3:*",
       "secretsmanager:*",
+      "securityhub:BatchUpdateFindings",
       "ses:*",
       "shield:*",
       "signer:*",


### PR DESCRIPTION
## A reference to the issue / Description of it

https://mojdt.slack.com/archives/C01A7QK5VM1/p1741943875017419

## How does this PR fix the problem?

Allows application developer teams to update their own SecurityHub findings.

## How has this been tested?

Tested through CI pipeline deployment to Sprinkler

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
