### PR TITLE
Expand GlobalProtect CIDR range

### DIFF
--- a/terraform/environments/core-network-services/cidr-ranges.tf
+++ b/terraform/environments/core-network-services/cidr-ranges.tf
@@ -25,7 +25,7 @@ locals {
     atos_arkf_ras                    = "10.176.0.0/16" # for DOM1 devices connected to Cisco RAS VPN
     cloud-platform                   = "172.20.0.0/16"
     dom1-domain-controllers          = "10.172.68.146/29"
-    global-protect                   = "10.185.0.0/16"
+    global-protect                   = "10.184.0.0/14"
     i2n                              = "10.110.0.0/16"
     moj-core-azure-1                 = "10.50.25.0/27"
     moj-core-azure-2                 = "10.50.26.0/24"


### PR DESCRIPTION
## A reference to the issue / Description of it

GlobalProtect CIDR range has been expanded with the move into Prisma after discussion with Ian Norris

## How does this PR fix the problem?

Expands GlobalProtect CIDR range to currently assigned address range

## How has this been tested?

Tested with CI pipeline checks 

## Deployment Plan / Instructions

Deploy through GitHub Actions

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
