### PR TITLE
Updated references to `nuke` keys in examples

### DIFF
--- a/source/concepts/environments/auto-nuke.html.md.erb
+++ b/source/concepts/environments/auto-nuke.html.md.erb
@@ -58,10 +58,10 @@ Eg:
       "access": [
         {
           "sso_group_name": "my-application",
-          "level": "sandbox",
-          "nuke": "rebuild"
+          "level": "sandbox"
         }
-      ]
+      ],
+      "nuke": "rebuild"
     }
 ```
 

--- a/source/concepts/environments/instance-scheduling.html.md.erb
+++ b/source/concepts/environments/instance-scheduling.html.md.erb
@@ -55,12 +55,12 @@ The example below shows this:
       "access": [
         {
           "sso_group_name": "modernisation-platform",
-          "level": "developer",
-          "nuke": "rebuild"
+          "level": "sandbox"
         },
         ---
       ],
-      "instance_scheduler_skip": ["true"]
+      "instance_scheduler_skip": ["true"],
+      "nuke": "rebuild"
     }
   ],
   "tags": {

--- a/source/runbooks/changing-environment-details.html.md.erb
+++ b/source/runbooks/changing-environment-details.html.md.erb
@@ -144,10 +144,10 @@ to
   "access": [
     {
       "sso_group_name": "modernisation-platform",
-      "level": "sandbox",
-      "nuke": "rebuild"
+      "level": "sandbox"
     }
-  ]
+  ],
+  "nuke": "rebuild"
 }
 ```
 

--- a/source/user-guide/creating-environments.html.md.erb
+++ b/source/user-guide/creating-environments.html.md.erb
@@ -126,15 +126,15 @@ Here are some examples of the environments JSON file that the Modernisation Plat
   "codeowners": [""],
   "environments": [
     {
-      "name": ""
+      "name": "",
       "access": [
         {
           "sso_group_name": "",
           "level": "",
-          "nuke": "",
           "github_action_reviewer": "true"
         }
-      ]
+      ],
+      "nuke": ""
     }
   ],
   "tags": {
@@ -163,11 +163,11 @@ An JSON definition for a nonsensical application called [`glados`](https://en.wi
       "access": [
         {
           "sso_group_name": "glados-team",
-          "level": "sandbox",
-          "nuke": "rebuild"
+          "level": "sandbox"
         }
       ],
-      "additional_reviewers": ["GitHubUsername1", "GitHubUsername2"]
+      "additional_reviewers": ["GitHubUsername1", "GitHubUsername2"], 
+      "nuke": "rebuild"
     },
     {
       "name": "production",


### PR DESCRIPTION
## A reference to the issue / Description of it

#9239 

## How does this PR fix the problem?

Updates documents with examples of nuke keys in the now-appropriate localtion

## How has this been tested?

Tested through CI pipeline checkes

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
