### PR TITLE
Restrict Terraform Apply to Main for Preprod and Prod Environments

### DIFF
--- a/.github/workflows/terraform-member-environment.yml
+++ b/.github/workflows/terraform-member-environment.yml
@@ -6,17 +6,17 @@ on:
     branches:
       - main
     paths:
-      - 'terraform/environments/*/*.tf'
-      - '!terraform/environments/bootstrap/*/*.tf'
-      - '!terraform/environments/core-*/*.tf'
+      - "terraform/environments/*/*.tf"
+      - "!terraform/environments/bootstrap/*/*.tf"
+      - "!terraform/environments/core-*/*.tf"
   pull_request:
     types: [opened, edited, reopened, synchronize]
     branches-ignore:
-      - 'date*'
+      - "date*"
     paths:
-      - 'terraform/environments/*/*.tf'
-      - '!terraform/environments/bootstrap/*/*.tf'
-      - '!terraform/environments/core-*/*.tf'
+      - "terraform/environments/*/*.tf"
+      - "!terraform/environments/bootstrap/*/*.tf"
+      - "!terraform/environments/core-*/*.tf"
   workflow_dispatch:
 
 defaults:
@@ -39,14 +39,18 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Get changed directories
-        id:   directories
-        run:  |
+        id: directories
+        run: |
           git fetch origin main --unshallow
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            echo "CHANGED_DIRECTORIES=$(git diff HEAD origin/main --name-only | awk '{print $1}' | grep ".tf" | grep -a "environments//*" | cut -f1-3 -d"/" | uniq | base64 -w 0 )"
+            CHANGED_DIRECTORIES=$(git diff HEAD origin/main --name-only | awk '{print $1}' | grep ".tf" | grep -a "environments//*" | cut -f1-3 -d"/" | uniq | base64 -w 0 )
+            CHANGED_DIRECTORY_NAMES=$(git diff HEAD origin/main --name-only | awk '{print $1}' | grep ".tf" | grep -a "environments//*" | cut -f3 -d"/" | uniq | jq -R -s -c 'split("\n")[:-1]')
           else
-            echo "CHANGED_DIRECTORIES=$(git diff HEAD^ HEAD --name-only | awk '{print $1}' | grep ".tf" | grep -a "environments//*" | cut -f1-3 -d"/" | uniq | base64 -w 0)"
-          fi >> $GITHUB_OUTPUT
+            CHANGED_DIRECTORIES=$(git diff HEAD^ HEAD --name-only | awk '{print $1}' | grep ".tf" | grep -a "environments//*" | cut -f1-3 -d"/" | uniq | base64 -w 0)
+            CHANGED_DIRECTORY_NAMES=$(git diff HEAD^ HEAD --name-only | awk '{print $1}' | grep ".tf" | grep -a "environments//*" | cut -f3 -d"/" | uniq | jq -R -s -c 'split("\n")[:-1]')
+          fi
+          echo "CHANGED_DIRECTORIES=$CHANGED_DIRECTORIES" >> $GITHUB_OUTPUT
+          echo "CHANGED_DIRECTORY_NAMES=$CHANGED_DIRECTORY_NAMES" >> $GITHUB_OUTPUT
       - name: Display changed directories
         run: echo "Directories in scope:" ${{ steps.directories.outputs.CHANGED_DIRECTORIES }}
       - name: Slack failure notification
@@ -60,14 +64,74 @@ jobs:
         if: ${{ failure() && (github.event.ref == 'refs/heads/main') }}
     outputs:
       directories: ${{ steps.directories.outputs.CHANGED_DIRECTORIES }}
+      directory_names: ${{ steps.directories.outputs.CHANGED_DIRECTORY_NAMES }}
 
-  terraform-plan:
+  terraform-plan-dev-test:
     runs-on: ubuntu-latest
     needs: find-environments
     strategy:
       fail-fast: false
       matrix:
-        environment: [development, test, preproduction, production]
+        application: ${{ fromJson(needs.find-environments.outputs.directory_names) }}
+        environment: [development, test]
+    env:
+      TF_IN_AUTOMATION: "true"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Set account number
+        run: |
+          APPLICATION_ENVIRONMENT="${{ matrix.application }}-${{ matrix.environment }}"
+          echo "Application: $APPLICATION_ENVIRONMENT"
+          ACCOUNT_NUMBER=$(echo "$ENVIRONMENT_MANAGEMENT" | jq -r --arg app_env "$APPLICATION_ENVIRONMENT" '.account_ids[$app_env] // empty')
+          echo $ACCOUNT_NUMBER
+          if [ -z "$ACCOUNT_NUMBER" ]; then
+            echo "::warning::Account number not found for $APPLICATION_ENVIRONMENT, skipping..."
+            echo "SKIP=true" >> $GITHUB_ENV
+          else
+            echo "::add-mask::$ACCOUNT_NUMBER"
+            echo ACCOUNT_NUMBER=$ACCOUNT_NUMBER >> $GITHUB_ENV
+            echo "SKIP=false" >> $GITHUB_ENV
+          fi
+      - name: Configure AWS credentials
+        if: env.SKIP == 'false'
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions-dev-test"
+          role-session-name: githubactionsrolesession
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Setup Terraform
+        if: env.SKIP == 'false'
+        id: setup
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+        with:
+          terraform_version: "~1"
+          terraform_wrapper: false
+      - name: Terraform init
+        if: env.SKIP == 'false'
+        id: init
+        run: |
+          echo "Running 'terraform init' in terraform/environments/${{ matrix.application }}" 
+          scripts/terraform-init.sh terraform/environments/${{ matrix.application }}
+      - name: Terraform workspace
+        if: env.SKIP == 'false'
+        id: workspace
+        run: |
+          workspace="${{ matrix.application }}-${{ matrix.environment }}"
+          terraform -chdir="terraform/environments/${{ matrix.application }}" workspace select "$workspace"
+      - name: Terraform plan
+        if: env.SKIP == 'false'
+        id: plan
+        run: |
+          scripts/terraform-plan.sh terraform/environments/${{ matrix.application }}
+
+  terraform-plan-preprod-prod:
+    runs-on: ubuntu-latest
+    needs: find-environments
+    strategy:
+      fail-fast: false
+      matrix:
+        environment: [preproduction, production]
     env:
       TF_IN_AUTOMATION: "true"
     steps:
@@ -81,7 +145,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
         with:
-          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions-plan"
           role-session-name: githubactionsrolesession
           aws-region: ${{ env.AWS_REGION }}
       - name: Setup Terraform
@@ -126,15 +190,6 @@ jobs:
             scripts/terraform-plan.sh $directory
             unset workspace
           done
-      - name: Slack failure notification
-        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
-        with:
-          webhook-type: incoming-webhook
-          payload: |
-            {"blocks":[{"type": "section","text": {"type": "mrkdwn","text": ":no_entry: Failed GitHub Action:"}},{"type": "section","fields":[{"type": "mrkdwn","text": "*Workflow:*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>"},{"type": "mrkdwn","text": "*Job:*\n${{ github.job }}"},{"type": "mrkdwn","text": "*Repo:*\n${{ github.repository }}"}]}]}
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        if: ${{ failure() && (github.event.ref == 'refs/heads/main') }}
       - name: Mark job skipped
         if: ${{ steps.workspace.outputs.skip_plan == 'true' }}
         run: |
@@ -143,10 +198,11 @@ jobs:
   terraform-apply-dev-test:
     if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
-    needs: [find-environments, terraform-plan]
+    needs: [find-environments, terraform-plan-dev-test]
     strategy:
       fail-fast: false
       matrix:
+        application: ${{ fromJson(needs.find-environments.outputs.directory_names) }}
         environment: [development, test]
     environment: ${{ matrix.environment }}
     env:
@@ -156,77 +212,53 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Set account number
         run: |
-          ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< $ENVIRONMENT_MANAGEMENT)
-          echo "::add-mask::$ACCOUNT_NUMBER"
-          echo ACCOUNT_NUMBER=$ACCOUNT_NUMBER >> $GITHUB_ENV
+          APPLICATION_ENVIRONMENT="${{ matrix.application }}-${{ matrix.environment }}"
+          echo "Application: $APPLICATION_ENVIRONMENT"
+          ACCOUNT_NUMBER=$(echo "$ENVIRONMENT_MANAGEMENT" | jq -r --arg app_env "$APPLICATION_ENVIRONMENT" '.account_ids[$app_env] // empty')
+          echo $ACCOUNT_NUMBER
+          if [ -z "$ACCOUNT_NUMBER" ]; then
+            echo "::warning::Account number not found for $APPLICATION_ENVIRONMENT, skipping..."
+            echo "SKIP=true" >> $GITHUB_ENV
+          else
+            echo "::add-mask::$ACCOUNT_NUMBER"
+            echo ACCOUNT_NUMBER=$ACCOUNT_NUMBER >> $GITHUB_ENV
+            echo "SKIP=false" >> $GITHUB_ENV
       - name: Configure AWS credentials
+        if: env.SKIP == 'false'
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
         with:
-          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions-dev-test"
           role-session-name: githubactionsrolesession
           aws-region: ${{ env.AWS_REGION }}
       - name: Setup Terraform
+        if: env.SKIP == 'false'
         id: setup
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:
           terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform init
+        if: env.SKIP == 'false'
         id: init
         run: |
-          export CHANGED_DIRECTORIES=$(echo "${{ needs.find-environments.outputs.directories }}" | base64 --decode)
-          for directory in $CHANGED_DIRECTORIES; do
-            echo "Running 'terraform init' in" $directory
-            scripts/terraform-init.sh $directory
-          done
+          echo "Running 'terraform init' in terraform/environments/${{ matrix.application }}" 
+          scripts/terraform-init.sh terraform/environments/${{ matrix.application }}
       - name: Terraform workspace
+        if: env.SKIP == 'false'
         id: workspace
         run: |
-          export CHANGED_DIRECTORIES=$(echo "${{ needs.find-environments.outputs.directories }}" | base64 --decode)
-          for directory in $CHANGED_DIRECTORIES; do
-                workspace="$(basename $directory)-${{ matrix.environment }}"
-
-                if terraform -chdir="$directory" workspace list | grep "$workspace"; then
-                  terraform -chdir="$directory" workspace select "$workspace"
-
-                else
-                  echo "Workspace '$workspace' does not exist, skipping further processing"
-                  echo "skip_plan=true" >> $GITHUB_OUTPUT
-                fi
-
-                unset workspace
-          done
-          echo "Selected $(terraform -chdir="$directory" workspace show)"
-      - name: Terraform plan
-        id: plan
-        if: ${{ steps.workspace.outputs.skip_plan != 'true' }}
-        run: |
-          export CHANGED_DIRECTORIES=$(echo "${{ needs.find-environments.outputs.directories }}" | base64 --decode)
-          for directory in $CHANGED_DIRECTORIES; do
-            workspace="$(basename $directory)-${{ matrix.environment }}"
-            scripts/terraform-plan.sh $directory -out="$workspace.tfplan"
-            unset workspace
-          done
+          workspace="${{ matrix.application }}-${{ matrix.environment }}"
+          terraform -chdir="terraform/environments/${{ matrix.application }}" workspace select "$workspace"
       - name: Terraform apply
+        if: env.SKIP == 'false'
         id: apply
-        if: ${{ steps.plan.conclusion == 'success' }}
         run: |
-          export CHANGED_DIRECTORIES=$(echo "${{ needs.find-environments.outputs.directories }}" | base64 --decode)
-          for directory in $CHANGED_DIRECTORIES; do
-            workspace="$(basename $directory)-${{ matrix.environment }}"
-            scripts/terraform-apply.sh $directory "$workspace.tfplan"
-            unset workspace
-          done
-
-      - name: Mark job skipped
-        if: ${{ steps.workspace.outputs.skip_plan == 'true' }}
-        run: |
-          echo "::warning ::Terraform plan was skipped as no valid workspace was found."
+          scripts/terraform-apply.sh terraform/environments/${{ matrix.application }}
 
   terraform-apply-preprod-prod:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    needs: [find-environments, terraform-plan]
+    needs: [find-environments, terraform-plan-preprod-prod]
     strategy:
       fail-fast: false
       matrix:
@@ -245,7 +277,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
         with:
-          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions-apply"
           role-session-name: githubactionsrolesession
           aws-region: ${{ env.AWS_REGION }}
       - name: Setup Terraform


### PR DESCRIPTION
## A reference to the issue / Description of it

This PR updates the GitHub Actions workflow for Terraform to restrict the `terraform apply` step to only run on the `main` branch for pre-production and production environments. For pull requests, `terraform apply` will not be executed for pre-production or production environments, but the plan step will still run for these environments as well as for development and test environments. #8590 

## How does this PR fix the problem?

This PR addresses the issue where Terraform apply was running inappropriately on pull requests for `pre-production` and `production` environments. By introducing conditions that restrict the `terraform apply` to the `main` branch only for these environments, this PR ensures that Terraform changes are only applied to pre-prod and prod when intended, preventing potential errors or unintended deployments on feature branches or PRs.

The changes will:

1. Prevent terraform apply from executing on pull requests for `pre-production` and `production` environments.
2. Allow pull request deployments for `development` and `test` environments.
3. Ensure safe and controlled deployments to pre-production and production environments by only running the apply step on the main branch.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
