### PR TITLE
Fix cross-account access for sprinkler and cooker `github-actions-dev-test` roles

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -11,7 +11,11 @@ module "cross-account-access" {
       "arn:aws:iam::${local.environment_management.account_ids["sprinkler-development"]}:role/github-actions"
     ],
     terraform.workspace == "testing-test" ? ["arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:user/testing-ci"] : [],
-    length(regexall("(development|test)$", terraform.workspace)) > 0 ? ["arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/github-actions-dev-test"] : []
+    length(regexall("(development|test)$", terraform.workspace)) > 0 ? ["arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/github-actions-dev-test"] : [],
+    terraform.workspace == "core-vpc-sandbox" ? [
+      "arn:aws:iam::${local.environment_management.account_ids["sprinkler-development"]}:role/github-actions-dev-test",
+      "arn:aws:iam::${local.environment_management.account_ids["cooker-development"]}:role/github-actions-dev-test"
+    ] : []
   )
   additional_trust_statements = contains(["core-network-services-production", "core-vpc-test", "core-vpc-development"], terraform.workspace) ? [data.aws_iam_policy_document.additional_trust_policy.json] : []
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

When running the Member workflow on `sprinkler` and `cooker`, the `github-actions-dev-test` role is failing to assume the `ModernisationPlatformAccess` role. This is because the necessary trust relationships were not defined for these roles in the `core-vpc-sandbox` workspace. #8590 

## How does this PR fix the problem?

- Ensures that core-vpc-sandbox has the required roles allowed in its trust policy.
- Allows GitHub Actions and other automated systems to assume the correct IAM roles.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
