### PR TITLE
core network services tags

### DIFF
--- a/terraform/environments/core-network-services/providers.tf
+++ b/terraform/environments/core-network-services/providers.tf
@@ -4,6 +4,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 provider "aws" {
   region = "eu-west-1"
@@ -11,12 +12,14 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
   alias  = "modernisation-platform"
   region = "eu-west-2"
+  default_tags { tags = local.tags }
 }
 
 provider "aws" {
@@ -25,6 +28,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
@@ -34,4 +38,5 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"
   }
+  default_tags { tags = local.tags }
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

as part of Add default tags to terraform providers across the modernisation platform
[#1519](https://github.com/ministryofjustice/modernisation-platform/issues/1519) we are adding 

## How does this PR fix the problem?

This Pr add the default atgging to the provider files for core network services

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
