### PR TITLE
TM-946: add fileshare for preprod-prod hmpp AD

### DIFF
--- a/terraform/environments/core-shared-services/ad-fixngo.tf
+++ b/terraform/environments/core-shared-services/ad-fixngo.tf
@@ -323,7 +323,7 @@ locals {
           module.ad_fixngo_ip_addresses.azure_fixngo_ip.PCMCW0012,
         ]
         ad_domain_name                      = "azure.hmpp.root"
-        ad_file_system_administrators_group = "Domain Join"
+        ad_file_system_administrators_group = "AWS FSx Admins"
         ad_username                         = "svc_fsx_windows"
         deployment_type                     = "MULTI_AZ_1"
         security_group_name                 = "ad_hmpp_fsx_sg"

--- a/terraform/environments/core-shared-services/ad-fixngo.tf
+++ b/terraform/environments/core-shared-services/ad-fixngo.tf
@@ -326,7 +326,7 @@ locals {
         ad_file_system_administrators_group = "Domain Join"
         ad_username                         = "svc_fsx_windows"
         deployment_type                     = "MULTI_AZ_1"
-        security_group_name                 = "az_hmpp_fsx_sg"
+        security_group_name                 = "ad_hmpp_fsx_sg"
         storage_capacity                    = 100
         subnet_ids                          = module.vpc["live_data"].non_tgw_subnet_ids_map.private
         throughput_capacity                 = 32

--- a/terraform/environments/core-shared-services/ad-fixngo.tf
+++ b/terraform/environments/core-shared-services/ad-fixngo.tf
@@ -317,21 +317,21 @@ locals {
         throughput_capacity                 = 32
         weekly_maintenance_start_time       = "2:04:00" # tue 4am
       }
-      # ad-hmpp-fsx = {
-      #   ad_dns_ips = [
-      #     module.ad_fixngo_ip_addresses.azure_fixngo_ip.PCMCW0011,
-      #     module.ad_fixngo_ip_addresses.azure_fixngo_ip.PCMCW0012,
-      #   ]
-      #   ad_domain_name                      = "azure.hmpp.root"
-      #   ad_file_system_administrators_group = "Domain Join"
-      #   ad_username                         = "svc_fsx_windows"
-      #   deployment_type                     = "MULTI_AZ_1"
-      #   security_group_name                 = "az_hmpp_fsx_sg"
-      #   storage_capacity                    = 100
-      #   subnet_ids                          = module.vpc["live_data"].non_tgw_subnet_ids_map.private
-      #   throughput_capacity                 = 32
-      #   weekly_maintenance_start_time       = "4:04:00" # thu 4am
-      # }
+      ad-hmpp-fsx = {
+        ad_dns_ips = [
+          module.ad_fixngo_ip_addresses.azure_fixngo_ip.PCMCW0011,
+          module.ad_fixngo_ip_addresses.azure_fixngo_ip.PCMCW0012,
+        ]
+        ad_domain_name                      = "azure.hmpp.root"
+        ad_file_system_administrators_group = "Domain Join"
+        ad_username                         = "svc_fsx_windows"
+        deployment_type                     = "MULTI_AZ_1"
+        security_group_name                 = "az_hmpp_fsx_sg"
+        storage_capacity                    = 100
+        subnet_ids                          = module.vpc["live_data"].non_tgw_subnet_ids_map.private
+        throughput_capacity                 = 32
+        weekly_maintenance_start_time       = "4:04:00" # thu 4am
+      }
     }
 
     route53_resolver_endpoints = {

--- a/terraform/environments/core-shared-services/ad-fixngo.tf
+++ b/terraform/environments/core-shared-services/ad-fixngo.tf
@@ -310,6 +310,7 @@ locals {
         ad_domain_name                      = "azure.noms.root"
         ad_file_system_administrators_group = null
         ad_username                         = "svc_join_domain"
+        aliases                             = ["fs.azure.noms.root"]
         deployment_type                     = "SINGLE_AZ_1"
         security_group_name                 = "ad_azure_fsx_sg"
         storage_capacity                    = 100
@@ -325,6 +326,7 @@ locals {
         ad_domain_name                      = "azure.hmpp.root"
         ad_file_system_administrators_group = "AWS FSx Admins"
         ad_username                         = "svc_fsx_windows"
+        aliases                             = ["fs.azure.hmpp.root"]
         deployment_type                     = "MULTI_AZ_1"
         security_group_name                 = "ad_hmpp_fsx_sg"
         storage_capacity                    = 100
@@ -1073,6 +1075,7 @@ resource "aws_instance" "ad_fixngo" {
 resource "aws_fsx_windows_file_system" "ad_fixngo" {
   for_each = local.ad_fixngo.fsx_windows_file_systems
 
+  aliases                         = each.value.aliases
   automatic_backup_retention_days = 0
   deployment_type                 = each.value.deployment_type
   kms_key_id                      = module.kms["hmpps"].key_arns["general"]


### PR DESCRIPTION
## A reference to the issue / Description of it

Background see https://github.com/ministryofjustice/modernisation-platform/issues/5970
Follow up to https://github.com/ministryofjustice/modernisation-platform/pull/9551 and https://github.com/ministryofjustice/modernisation-platform/pull/9553

For business objects reporting systems (both nomis and oasys), a promotion management process is used to promote changes from preproduction into production. For example, configuration from preproduction is saved onto multiple file(s) using a preprod web interface, and subsequently uploaded to production also using a prod web interface.

Putting file shares into the usual member environments won't work for this as the environments are network isolated, and a S3 based solution will be too cumbersome for the end users. A file share which sits alongside the DCs is the proposed solution. This can be mounted by jump servers in both preproduction and production. A separate files share will be used for dev and test.

This PR adds the preprod-prod fileshare for azure.hmpp.root domain.

## How does this PR fix the problem?

Adds a file share that can be access by both preproduction and production HMPPS accounts

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

The devtest file share, stood up in previous PR, is working OK.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

See slack thread on Friday re 1st PR https://mojdt.slack.com/archives/C01A7QK5VM1/p1741963642307969
