### PR TITLE
remove trust policy and passrole for MemberInfrastructureAccess role

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -22,16 +22,7 @@ module "member-access-sprinkler" {
   role_name                   = "MemberInfrastructureAccess"
   additional_trust_statements = [data.aws_iam_policy_document.additional_trust_policy.json]
 }
-data "aws_iam_policy_document" "additional_trust_policy" {
-  statement {
-    effect  = "Allow"
-    actions = ["sts:AssumeRole"]
-    principals {
-      type        = "Service"
-      identifiers = ["malware-protection-plan.guardduty.amazonaws.com"]
-    }
-  }
-}
+
 # lots of SCA ignores and skips on this one as it is the main role allowing members to build most things in the platform
 #tfsec:ignore:aws-iam-no-policy-wildcards
 data "aws_iam_policy_document" "member-access" {
@@ -320,7 +311,6 @@ data "aws_iam_policy_document" "member-access" {
     actions = ["iam:PassRole"]
     effect  = "Deny"
     resources = [
-      "arn:aws:iam::*:role/MemberInfrastructureAccess",
       "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/GuardDutyS3MalwareProtectionRole"
     ]
     condition {

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -4,23 +4,21 @@ locals {
 }
 
 module "member-access" {
-  count                       = (local.account_data.account-type == "member" && terraform.workspace != "testing-test" && terraform.workspace != "sprinkler-development") ? 1 : 0
-  source                      = "github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access?ref=6819b090bce6d3068d55c7c7b9b3fd18c9dca648" #v3.0.0
-  account_id                  = data.aws_ssm_parameter.modernisation_platform_account_id.value
-  additional_trust_roles      = [module.github-oidc[0].github_actions_role, one(data.aws_iam_roles.member-sso-admin-access.arns)]
-  policy_arn                  = aws_iam_policy.member-access[0].id
-  role_name                   = "MemberInfrastructureAccess"
-  additional_trust_statements = [data.aws_iam_policy_document.additional_trust_policy.json]
+  count                  = (local.account_data.account-type == "member" && terraform.workspace != "testing-test" && terraform.workspace != "sprinkler-development") ? 1 : 0
+  source                 = "github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access?ref=6819b090bce6d3068d55c7c7b9b3fd18c9dca648" #v3.0.0
+  account_id             = data.aws_ssm_parameter.modernisation_platform_account_id.value
+  additional_trust_roles = [module.github-oidc[0].github_actions_role, one(data.aws_iam_roles.member-sso-admin-access.arns)]
+  policy_arn             = aws_iam_policy.member-access[0].id
+  role_name              = "MemberInfrastructureAccess"
 }
 
 module "member-access-sprinkler" {
-  count                       = (terraform.workspace == "sprinkler-development") ? 1 : 0
-  source                      = "github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access?ref=6819b090bce6d3068d55c7c7b9b3fd18c9dca648" #v3.0.0
-  account_id                  = data.aws_ssm_parameter.modernisation_platform_account_id.value
-  additional_trust_roles      = [data.aws_iam_role.sprinkler_oidc[0].arn, one(data.aws_iam_roles.member-sso-admin-access.arns)]
-  policy_arn                  = aws_iam_policy.member-access[0].id
-  role_name                   = "MemberInfrastructureAccess"
-  additional_trust_statements = [data.aws_iam_policy_document.additional_trust_policy.json]
+  count                  = (terraform.workspace == "sprinkler-development") ? 1 : 0
+  source                 = "github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access?ref=6819b090bce6d3068d55c7c7b9b3fd18c9dca648" #v3.0.0
+  account_id             = data.aws_ssm_parameter.modernisation_platform_account_id.value
+  additional_trust_roles = [data.aws_iam_role.sprinkler_oidc[0].arn, one(data.aws_iam_roles.member-sso-admin-access.arns)]
+  policy_arn             = aws_iam_policy.member-access[0].id
+  role_name              = "MemberInfrastructureAccess"
 }
 
 # lots of SCA ignores and skips on this one as it is the main role allowing members to build most things in the platform


### PR DESCRIPTION
## A reference to the issue / Description of it

We've separated the roles for enabling s3 malware protection to make things clearer and more secure. GuardDutyS3MalwareProtectionRole now handles enabling malware protection, while MemberInfrastructureAccess is only responsible for managing GuardDuty configurations like creation and deletion.

## How does this PR fix the problem?

This PR removes the unnecessary trust policy and iam:PassRole permission, as they are no longer required now that we have a dedicated GuardDutyS3MalwareProtectionRole.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
