### PR TITLE
TM-946: azure.hmpp.root fsx fix

### DIFF
--- a/terraform/environments/core-shared-services/ad-fixngo.tf
+++ b/terraform/environments/core-shared-services/ad-fixngo.tf
@@ -330,9 +330,12 @@ locals {
         deployment_type                     = "MULTI_AZ_1"
         security_group_name                 = "ad_hmpp_fsx_sg"
         storage_capacity                    = 100
-        subnet_ids                          = module.vpc["live_data"].non_tgw_subnet_ids_map.private
-        throughput_capacity                 = 32
-        weekly_maintenance_start_time       = "4:04:00" # thu 4am
+        subnet_ids = [
+          module.vpc["live_data"].non_tgw_subnet_ids_map.private[0],
+          module.vpc["live_data"].non_tgw_subnet_ids_map.private[1],
+        ]
+        throughput_capacity           = 32
+        weekly_maintenance_start_time = "4:04:00" # thu 4am
       }
     }
 


### PR DESCRIPTION
## A reference to the issue / Description of it

Previous PR failed https://github.com/ministryofjustice/modernisation-platform/pull/9565

## How does this PR fix the problem?

Fixes issue - only uses 2 subnets instead of 3.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Not really possible to test, but was just a mistake in terraform and only new resources are being created.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)


