### PR TITLE
resolve script errors and Bump secrets action to latest

### DIFF
--- a/.github/workflows/new-environment.yml
+++ b/.github/workflows/new-environment.yml
@@ -465,19 +465,16 @@ jobs:
           SLACK_WEBHOOKS: ${{ env.SLACK_WEBHOOKS }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
       - name: Validate Notify Template Version
-        env:
-          API_KEY: ${{ env.GOV_UK_NOTIFY_API_KEY }}
-          TEMPLATE_ID: ${{ env.TEMPLATE_ID }}
-          EXPECTED_TEMPLATE_VERSION: ${{ env.EXPECTED_TEMPLATE_VERSION }}
         if: steps.environment_json_changes.outputs.files != ''
         run: |
           python <<EOF
           from notifications_python_client.notifications import NotificationsAPIClient
           import sys
+          import os
       
-          api_key = $GOV_UK_NOTIFY_API_KEY
-          template_id = "${{ env.TEMPLATE_ID }}"
-          expected_version = int("${{ env.EXPECTED_TEMPLATE_VERSION }}")
+          api_key = os.getenv('GOV_UK_NOTIFY_API_KEY')
+          template_id = os.getenv('TEMPLATE_ID')
+          expected_version = int(os.environ.get('EXPECTED_TEMPLATE_VERSION'))
     
           client = NotificationsAPIClient(api_key)
           try:

--- a/.github/workflows/new-environment.yml
+++ b/.github/workflows/new-environment.yml
@@ -36,7 +36,7 @@ defaults:
 
 jobs:
   fetch-secrets:
-    uses: ministryofjustice/modernisation-platform-github-actions/.github/workflows/aws-secrets-management.yml@13cdf226e358ae839c27c7c8ab985bf374270418 # v2.0.0
+    uses: ministryofjustice/modernisation-platform-github-actions/.github/workflows/aws-secrets-management.yml@14db114ed50a5ab565c3a134cf9efac0627e75e6 # v2.0.1
     secrets:
       MODERNISATION_PLATFORM_ACCOUNT_NUMBER: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_NUMBER }}
       PASSPHRASE: ${{ secrets.PASSPHRASE }}
@@ -47,7 +47,7 @@ jobs:
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Decrypt Secrets
-        uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@13cdf226e358ae839c27c7c8ab985bf374270418 # v2.0.0
+        uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@14db114ed50a5ab565c3a134cf9efac0627e75e6 # v2.0.1
         with:
           environment_management: ${{ needs.fetch-secrets.outputs.environment_management }}
           modernisation_pat_multirepo: ${{ needs.fetch-secrets.outputs.modernisation_pat_multirepo }}
@@ -104,7 +104,7 @@ jobs:
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Decrypt Secrets
-        uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@13cdf226e358ae839c27c7c8ab985bf374270418 # v2.0.0
+        uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@14db114ed50a5ab565c3a134cf9efac0627e75e6 # v2.0.1
         with:
           environment_management: ${{ needs.fetch-secrets.outputs.environment_management }}
           slack_webhook_url: ${{ needs.fetch-secrets.outputs.slack_webhook_url }}
@@ -150,7 +150,7 @@ jobs:
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Decrypt Secrets
-        uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@13cdf226e358ae839c27c7c8ab985bf374270418 # v2.0.0
+        uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@14db114ed50a5ab565c3a134cf9efac0627e75e6 # v2.0.1
         with:
           environment_management: ${{ needs.fetch-secrets.outputs.environment_management }}
           slack_webhook_url: ${{ needs.fetch-secrets.outputs.slack_webhook_url }}
@@ -194,7 +194,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Decrypt Secrets
-        uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@13cdf226e358ae839c27c7c8ab985bf374270418 # v2.0.0
+        uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@14db114ed50a5ab565c3a134cf9efac0627e75e6 # v2.0.1
         with:
           environment_management: ${{ needs.fetch-secrets.outputs.environment_management }}
           slack_webhook_url: ${{ needs.fetch-secrets.outputs.slack_webhook_url }}
@@ -250,7 +250,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Decrypt Secrets
-        uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@13cdf226e358ae839c27c7c8ab985bf374270418 # v2.0.0
+        uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@14db114ed50a5ab565c3a134cf9efac0627e75e6 # v2.0.1
         with:
           environment_management: ${{ needs.fetch-secrets.outputs.environment_management }}
           slack_webhook_url: ${{ needs.fetch-secrets.outputs.slack_webhook_url }}
@@ -305,7 +305,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Decrypt Secrets
-        uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@13cdf226e358ae839c27c7c8ab985bf374270418 # v2.0.0
+        uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@14db114ed50a5ab565c3a134cf9efac0627e75e6 # v2.0.1
         with:
           environment_management: ${{ needs.fetch-secrets.outputs.environment_management }}
           slack_webhook_url: ${{ needs.fetch-secrets.outputs.slack_webhook_url }}
@@ -361,7 +361,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Decrypt Secrets
-        uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@13cdf226e358ae839c27c7c8ab985bf374270418 # v2.0.0
+        uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@14db114ed50a5ab565c3a134cf9efac0627e75e6 # v2.0.0
         with:
           environment_management: ${{ needs.fetch-secrets.outputs.environment_management }}
           slack_webhook_url: ${{ needs.fetch-secrets.outputs.slack_webhook_url }}
@@ -417,7 +417,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Decrypt Secrets
-        uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@13cdf226e358ae839c27c7c8ab985bf374270418 # v2.0.0
+        uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@14db114ed50a5ab565c3a134cf9efac0627e75e6 # v2.0.1
         with:
           slack_webhooks: ${{ needs.fetch-secrets.outputs.slack_webhooks }}
           gov_uk_notify_api_key: ${{ needs.fetch-secrets.outputs.gov_uk_notify_api_key }}
@@ -507,7 +507,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Decrypt Secrets
-        uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@13cdf226e358ae839c27c7c8ab985bf374270418 # v2.0.0
+        uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@14db114ed50a5ab565c3a134cf9efac0627e75e6 # v2.0.1
         with:
           environment_management: ${{ needs.fetch-secrets.outputs.environment_management }}
           slack_webhook_url: ${{ needs.fetch-secrets.outputs.slack_webhook_url }}

--- a/scripts/json-changes-notifier.py
+++ b/scripts/json-changes-notifier.py
@@ -44,8 +44,8 @@ def main(file_names):
     Args:
         file_names: List of JSON file names.
     """
-    api_key = os.environ["API_KEY"]
-    template_id = os.environ["TEMPLATE_ID"]
+    api_key = os.environ.get("GOV_UK_NOTIFY_API_KEY")
+    template_id = os.environ.get("TEMPLATE_ID")
     # Create a NotificationsAPIClient instance
     client = NotificationsAPIClient(api_key=api_key)
     # Iterate over each JSON file name provided as arguments


### PR DESCRIPTION
## A reference to the issue / Description of it

This PR addresses issues in the notification scripts and updates the secrets action to the latest version. 

- Scripts were failing due to missing or incorrectly accessed environment variables.
- The NoneType error in the email script caused crashes, preventing notifications from being sent.


## How does this PR fix the problem?

By using **os.environ.get**, the scripts now safely handle missing environment variables and provide meaningful error messages. The updated module version ensures the scripts work with the latest fixes.

## How has this been tested?

https://github.com/ministryofjustice/modernisation-platform/actions/runs/13921759785/job/38956486284

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
