### PR TITLE
TM-946: ad-fixngo terraform warning fix

### DIFF
--- a/terraform/environments/core-shared-services/ad-fixngo.tf
+++ b/terraform/environments/core-shared-services/ad-fixngo.tf
@@ -1023,7 +1023,7 @@ resource "aws_iam_role" "ad_fixngo" {
 resource "aws_iam_role_policy_attachment" "ad_fixngo" {
   for_each = local.ad_fixngo_ec2_iam_roles_policy_attachments
 
-  role       = aws_iam_role.ad_fixngo[each.value.iam_role_name]
+  role       = aws_iam_role.ad_fixngo[each.value.iam_role_name].name
   policy_arn = try(aws_iam_policy.ad_fixngo[each.value.key_or_arn].arn, each.value.key_or_arn)
 }
 

--- a/terraform/environments/core-shared-services/ad-fixngo.tf
+++ b/terraform/environments/core-shared-services/ad-fixngo.tf
@@ -1015,10 +1015,6 @@ resource "aws_iam_role" "ad_fixngo" {
   max_session_duration = "3600"
   assume_role_policy   = each.value.assume_role_policy
 
-  managed_policy_arns = [
-    for key_or_arn in each.value.managed_policy_arns : try(aws_iam_policy.ad_fixngo[key_or_arn].arn, key_or_arn)
-  ]
-
   tags = merge(local.ad_fixngo.tags, {
     Name = each.key
   })

--- a/terraform/environments/core-shared-services/ad-fixngo.tf
+++ b/terraform/environments/core-shared-services/ad-fixngo.tf
@@ -932,7 +932,7 @@ locals {
   # since managed_policy_arns argument is now deprecated
   ad_fixngo_ec2_iam_roles_policy_attachment_list = flatten([
     for role_key, role_value in local.ad_fixngo.ec2_iam_roles : [
-      for policy_arn in value.managed_policy_arns : [{
+      for policy_arn in role_value.managed_policy_arns : [{
         key = "${role_key}-${policy_arn}"
         value = {
           iam_role_name = role_key
@@ -1024,7 +1024,7 @@ resource "aws_iam_role_policy_attachment" "ad_fixngo" {
   for_each = local.ad_fixngo_ec2_iam_roles_policy_attachments
 
   role       = aws_iam_role.ad_fixngo[each.value.iam_role_name]
-  policy_arn = try(aws_iam_policy.ad_fixngo[key_or_arn].arn, key_or_arn)
+  policy_arn = try(aws_iam_policy.ad_fixngo[each.value.key_or_arn].arn, each.value.key_or_arn)
 }
 
 resource "aws_iam_instance_profile" "ad_fixngo" {


### PR DESCRIPTION
## A reference to the issue / Description of it

The ad-fixngo terraform for HMPP DCs has a warning re role attachments. Noticed this during the recent file share PRs, e.g. https://github.com/ministryofjustice/modernisation-platform/pull/9569

## How does this PR fix the problem?

Fixes the attachments

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Same change has been made in ec2_instance module without issue

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No, since services are not currently in production.

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
