### PR TITLE
Move IAM permission for SecurityHub to correct policy

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -166,7 +166,6 @@ data "aws_iam_policy_document" "member-access" {
       "route53resolver:*",
       "s3:*",
       "secretsmanager:*",
-      "securityhub:BatchUpdateFindings",
       "ses:*",
       "shield:*",
       "signer:*",

--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -274,6 +274,7 @@ data "aws_iam_policy_document" "developer_additional" {
       "secretsmanager:UpdateSecret",
       "secretsmanager:RestoreSecret",
       "secretsmanager:RotateSecret",
+      "securityhub:BatchUpdateFindings",
       "servicequotas:*",
       "ses:DeleteSuppressedDestination",
       "ses:PutAccountDetails",


### PR DESCRIPTION
## A reference to the issue / Description of it

Reverts #9545 and resolves [this Slack request](https://mojdt.slack.com/archives/C01A7QK5VM1/p1742460615254379).

## How does this PR fix the problem?

Moves IAM permission to correct policy

## How has this been tested?

Tested through CI pipeline

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
