### PR TITLE
🔧 add components to Analytical Platform Compute

### DIFF
--- a/environments/analytical-platform-compute.json
+++ b/environments/analytical-platform-compute.json
@@ -1,11 +1,7 @@
 {
   "account-type": "member",
-  "codeowners": [
-    "analytical-platform-engineers"
-  ],
-  "github_action_reviewers": [
-    "analytical-platform-engineers"
-  ],
+  "codeowners": ["analytical-platform-engineers"],
+  "github_action_reviewers": ["analytical-platform-engineers"],
   "environments": [
     {
       "name": "development",
@@ -35,9 +31,7 @@
           "level": "security-audit"
         }
       ],
-      "instance_scheduler_skip": [
-        "true"
-      ],
+      "instance_scheduler_skip": ["true"],
       "nuke": "exclude"
     },
     {
@@ -68,9 +62,7 @@
           "level": "security-audit"
         }
       ],
-      "instance_scheduler_skip": [
-        "true"
-      ]
+      "instance_scheduler_skip": ["true"]
     },
     {
       "name": "production",
@@ -108,9 +100,7 @@
     "infrastructure-support": "analytical-platform@digital.justice.gov.uk",
     "owner": "Analytical Platform: analytical-platform@digital.justice.gov.uk"
   },
-  "github-oidc-team-repositories": [
-    ""
-  ],
+  "github-oidc-team-repositories": [""],
   "go-live-date": "",
   "components": [
     {

--- a/environments/analytical-platform-compute.json
+++ b/environments/analytical-platform-compute.json
@@ -1,5 +1,13 @@
 {
   "account-type": "member",
+  "components": [
+    {
+      "name": "quicksight"
+    },
+    {
+      "name": "lakeformation"
+    }
+  ],
   "codeowners": ["analytical-platform-engineers"],
   "github_action_reviewers": ["analytical-platform-engineers"],
   "environments": [
@@ -101,13 +109,5 @@
     "owner": "Analytical Platform: analytical-platform@digital.justice.gov.uk"
   },
   "github-oidc-team-repositories": [""],
-  "go-live-date": "",
-  "components": [
-    {
-      "name": "quicksight"
-    },
-    {
-      "name": "lakeformation"
-    }
-  ]
+  "go-live-date": ""
 }

--- a/environments/analytical-platform-compute.json
+++ b/environments/analytical-platform-compute.json
@@ -1,7 +1,11 @@
 {
   "account-type": "member",
-  "codeowners": ["analytical-platform-engineers"],
-  "github_action_reviewers": ["analytical-platform-engineers"],
+  "codeowners": [
+    "analytical-platform-engineers"
+  ],
+  "github_action_reviewers": [
+    "analytical-platform-engineers"
+  ],
   "environments": [
     {
       "name": "development",
@@ -31,7 +35,9 @@
           "level": "security-audit"
         }
       ],
-      "instance_scheduler_skip": ["true"],
+      "instance_scheduler_skip": [
+        "true"
+      ],
       "nuke": "exclude"
     },
     {
@@ -62,7 +68,9 @@
           "level": "security-audit"
         }
       ],
-      "instance_scheduler_skip": ["true"]
+      "instance_scheduler_skip": [
+        "true"
+      ]
     },
     {
       "name": "production",
@@ -100,6 +108,16 @@
     "infrastructure-support": "analytical-platform@digital.justice.gov.uk",
     "owner": "Analytical Platform: analytical-platform@digital.justice.gov.uk"
   },
-  "github-oidc-team-repositories": [""],
-  "go-live-date": ""
+  "github-oidc-team-repositories": [
+    ""
+  ],
+  "go-live-date": "",
+  "components": [
+    {
+      "name": "quicksight"
+    },
+    {
+      "name": "lakeformation"
+    }
+  ]
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

This PR adds the quicksight and lakeformation components to the analytical-platform-compute environment. This is needed so that workspaces can be created.

## How has this been tested?

This has not been tested, but follows instructions set out [here](https://user-guide.modernisation-platform.service.justice.gov.uk/runbooks/creating-components-for-member-applications.html#overview)

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

