### PR TITLE
Open firewall from analytical-platform-ingestion-development to Tariff UAT instance

### DIFF
--- a/terraform/environments/core-network-services/cidr-ranges.tf
+++ b/terraform/environments/core-network-services/cidr-ranges.tf
@@ -18,6 +18,7 @@ locals {
   other_cidr_ranges = {
     analytical-platform-airflow-dev  = "10.200.0.0/16"
     analytical-platform-airflow-prod = "10.201.0.0/16"
+    analytical-platform-ingest-dev   = "10.26.128.0/23"
     data-engineering-dev             = "172.24.0.0/16"
     data-engineering-prod            = "172.25.0.0/16"
     data-engineering-stage           = "172.26.0.0/16"

--- a/terraform/environments/core-network-services/firewall-rules/development_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/development_rules.json
@@ -608,16 +608,16 @@
     "destination_port": "ANY",
     "protocol": "TCP"
   },
-  "mp_to_cica_tariff_uat": {
+  "ap-ingest-dev_to_cica_tariff_uat": {
     "action": "PASS",
-    "source_ip": "${mp-development-test}",
+    "source_ip": "${analytical-platform-ingest-dev}",
     "destination_ip": "${cica-aws-uat-a}",
     "destination_port": "1521",
     "protocol": "TCP"
   },
-  "mp-dev-test_to_cica_tariff_uat_icmp": {
+  "ap-ingest-dev-test_to_cica_tariff_uat_icmp": {
     "action": "PASS",
-    "source_ip": "${mp-development-test}",
+    "source_ip": "${analytical-platform-ingest-dev}",
     "destination_ip": "${cica-aws-uat-a}",
     "destination_port": "ANY",
     "protocol": "ICMP"

--- a/terraform/environments/core-network-services/firewall-rules/development_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/development_rules.json
@@ -608,6 +608,20 @@
     "destination_port": "ANY",
     "protocol": "TCP"
   },
+  "mp_to_cica_tariff_uat": {
+    "action": "PASS",
+    "source_ip": "${mp-development-test}",
+    "destination_ip": "${cica-aws-uat-a}",
+    "destination_port": "1521",
+    "protocol": "TCP"
+  },
+  "mp-dev-test_to_cica_tariff_uat_icmp": {
+    "action": "PASS",
+    "source_ip": "${mp-development-test}",
+    "destination_ip": "${cica-aws-uat-a}",
+    "destination_port": "ANY",
+    "protocol": "ICMP"
+  },
   "mojo_alz_to_laa_development": {
     "action": "PASS",
     "source_ip": "${mojo-azure-landing-zone}",


### PR DESCRIPTION

## A reference to the issue / Description of it

We need to enable connectivity between an AWS DMS service within `analytical-platform-ingestion-development` to a CICA Tariff UAT instance (AWS-UAT6) in order to test the replication of data from Tariff in a non-prod context
This is part of a project to make Tariff data available in the Analytical Platform

## How does this PR fix the problem?

It sets `PASS` rules between the CIDR that encompasses `analytical-platform-ingestion-development` to the CIDR encompassing the `AWS-UAT6` instance, on the correct port.
It also allows ICMP traffic to enable `ping`

## How has this been tested?

I lack the permissions to test this change within the Modernisation platform. I have followed precedent as closely as possible.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [?] All checks have passed
- [N/A] I have made corresponding changes to the documentation
- [N/A] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

This is my first PR in this context, and I have made it without the permissions to validate it from any point of view other than syntax. Therefore if I have missed anything, or made an incorrect assumption when following precedent, please let me know. 
