### PR TITLE
documentation on how to add default tags to environments

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -60,6 +60,7 @@ This documentation is for anyone interested in the Modernisation Platform and it
 - [How to setup code scanning locally](user-guide/how-to-setup-code-scanning-locally.html)
 - [How to setup secure commit for git hub](/user-guide/how-to-setup-secure-commit.html)
 - [Managing Terraform State](user-guide/managing-terraform-state.html)
+- [How to add default tags](user-guide/how-to-add-default-tags.html)
 
 ## Concepts
 

--- a/source/user-guide/how-to-add-default-tags.html.md.erb
+++ b/source/user-guide/how-to-add-default-tags.html.md.erb
@@ -1,0 +1,53 @@
+---
+owner_slack: "#modernisation-platform"
+title: How to Add Default Tags
+last_reviewed_on: 2025-03-20
+review_in: 6 months
+---
+
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-NXTCMQ7ZX6"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-NXTCMQ7ZX6');
+</script>
+
+# <%= current_page.data.title %>
+
+## Background
+As part of keeping track of our infrastructure we can add default tags to AWS providers, this will mean that at if people forget to add tags that at least we can have a few basic tags such as this resource was created in terraform.
+
+New tag: business-unit has been introduced org-wide for cost allocation for better reporting.
+
+This will need to be applied as a default tag to all MP accounts (including member accounts).
+
+## How to Add Default Tags
+
+To add default tags to AWS providers, you can use the following Terraform code:
+
+```hcl
+provider "aws" {
+  region = "eu-west-2"
+  default_tags {
+    tags = { tags = local.tags
+    }
+  }
+}
+```
+
+by simply adding ```default_tags {
+  tags = { tags = local.tags
+  }
+  ``` to your provider blocks. This will add the tags to all resources created by that provider.
+
+## Important Note on Modules
+  
+  When adding default tags, it's important to ensure they are applied consistently across all resources, including those created by modules. While default tags are reflected in the `tags_all` value for locally-created resources during a Terraform plan, this may not always be the case for resources created by modules.
+  
+  For example, when using the `modernisation-platform-terraform-ecs-cluster` module, removing the `tags {}` variable did not result in the default tags being applied automatically.
+  
+### Recommendation
+  
+  To ensure default tags are applied consistently, you can take a light-touch approach by adding the `default_tags {}` block to the provider statements and referencing the local tags within it. This ensures that all resources, including those created by modules, inherit the default tags.


### PR DESCRIPTION
## A reference to the issue / Description of it

As part of Add default tags to terraform providers across the modernisation platform
#1519 i have created some documentation on how this can be added to the provider files in the modernisation platform envrionments repo

## How does this PR fix the problem?

Documentation created

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
