### PR TITLE
Bug fix for use of signed-commits.

### DIFF
--- a/.github/workflows/new-member-environment-files.yml
+++ b/.github/workflows/new-member-environment-files.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           github_token: ${{ secrets.TERRAFORM_GITHUB_TOKEN }} # use this token as writing to a different repo
           git_path: "terraform/environments"
-          remote_repository: "modernisation-platform-environments"
+          remote_repository: "ministryofjustice/modernisation-platform-environments"
           remote_repository_path: "./modernisation-platform-environments"
           pr_title: "New files for terraform/environments"
           pr_body: "> This PR was automatically created via a GitHub action workflow 🤖"


### PR DESCRIPTION

## A reference to the issue / Description of it

Issue whereby if the org name is omitted from the remote repository name the branch action fails.

## How does this PR fix the problem?

Fixes bug whereby the required organisation name was not being passed with the remote repo.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
