### PR TITLE
Adding extra permissions for egineer role

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -651,16 +651,6 @@ data "aws_iam_policy_document" "platform_engineer_additional_additional" {
     ]
     resources = ["*"]
   }
-  statement {
-    sid    = "DetectiveDescribeOrganizationConfiguration"
-    effect = "Allow"
-    actions = [
-      "detective:DescribeOrganizationConfiguration"
-    ]
-    resources = [
-      "arn:aws:detective:eu-west-2:245753150946:graph:95e6ae38bd964bd3a9d4d60e0afd18db"
-    ]
-  }
 
 }
 

--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -588,6 +588,7 @@ data "aws_iam_policy_document" "platform_engineer_additional_additional" {
       "dbqms:*",
       "discovery:*",
       "detective:*",
+      "graph:*",
       "dlm:*",
       "dms:*",
       "drs:*",
@@ -650,6 +651,17 @@ data "aws_iam_policy_document" "platform_engineer_additional_additional" {
     ]
     resources = ["*"]
   }
+  statement {
+    sid    = "DetectiveDescribeOrganizationConfiguration"
+    effect = "Allow"
+    actions = [
+      "detective:DescribeOrganizationConfiguration"
+    ]
+    resources = [
+      "arn:aws:detective:eu-west-2:245753150946:graph:95e6ae38bd964bd3a9d4d60e0afd18db"
+    ]
+  }
+
 }
 
 # sandbox policy - member SSO and collaborators, development accounts only


### PR DESCRIPTION
## A reference to the issue / Description of it

as part of my investigation into aws detective i need to add some extra permissions for the modernisation engineer role to be able to see graphs in aws detective

## How does this PR fix the problem?

adds the required permissions to use graphs in aws detective

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
