### PR TITLE
Remove sandbox access from hosting migrations applications

### DIFF
--- a/environments/corporate-staff-rostering.json
+++ b/environments/corporate-staff-rostering.json
@@ -6,18 +6,17 @@
       "access": [
         {
           "sso_group_name": "hosting-migrations",
-          "level": "sandbox"
+          "level": "developer"
         },
         {
           "sso_group_name": "studio-webops",
-          "level": "sandbox"
+          "level": "developer"
         },
         {
           "sso_group_name": "azure-aws-sso-digital-studio-operations",
           "level": "developer"
         }
-      ],
-      "nuke": "rebuild"
+      ]
     },
     {
       "name": "test",

--- a/environments/delius-iaps.json
+++ b/environments/delius-iaps.json
@@ -7,18 +7,17 @@
       "access": [
         {
           "sso_group_name": "hmpps-migration",
-          "level": "sandbox"
+          "level": "developer"
         },
         {
           "sso_group_name": "hosting-migrations",
-          "level": "sandbox"
+          "level": "developer"
         },
         {
           "sso_group_name": "hmpps-dba",
           "level": "instance-management"
         }
-      ],
-      "nuke": "include"
+      ]
     },
     {
       "name": "production",

--- a/environments/nomis-data-hub.json
+++ b/environments/nomis-data-hub.json
@@ -7,12 +7,12 @@
       "access": [
         {
           "sso_group_name": "hosting-migrations",
-          "level": "sandbox",
+          "level": "developer",
           "github_action_reviewer": "true"
         },
         {
           "sso_group_name": "studio-webops",
-          "level": "sandbox",
+          "level": "developer",
           "github_action_reviewer": "true"
         },
         {

--- a/environments/oasys.json
+++ b/environments/oasys.json
@@ -23,7 +23,7 @@
           "sso_group_name": "azure-aws-sso-digital-studio-operations",
           "level": "developer"
         }
-      ],
+      ]
     },
     {
       "name": "test",

--- a/environments/oasys.json
+++ b/environments/oasys.json
@@ -7,12 +7,12 @@
       "access": [
         {
           "sso_group_name": "hosting-migrations",
-          "level": "sandbox",
+          "level": "developer",
           "github_action_reviewer": "true"
         },
         {
           "sso_group_name": "studio-webops",
-          "level": "sandbox",
+          "level": "developer",
           "github_action_reviewer": "true"
         },
         {
@@ -24,7 +24,6 @@
           "level": "developer"
         }
       ],
-      "nuke": "rebuild"
     },
     {
       "name": "test",

--- a/environments/planetfm.json
+++ b/environments/planetfm.json
@@ -6,18 +6,17 @@
       "access": [
         {
           "sso_group_name": "hosting-migrations",
-          "level": "sandbox"
+          "level": "developer"
         },
         {
           "sso_group_name": "studio-webops",
-          "level": "sandbox"
+          "level": "developer"
         },
         {
           "sso_group_name": "azure-aws-sso-digital-studio-operations",
           "level": "developer"
         }
-      ],
-      "nuke": "rebuild"
+      ]
     },
     {
       "name": "test",


### PR DESCRIPTION
## A reference to the issue / Description of it

N/A

## How does this PR fix the problem?

Noted that a number of now-live applications still have `sandbox` access, so I reached out to the infrastructure team to confirm that sandbox access was no longer required.

## How has this been tested?

Tested through CI pipeline / peer review

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
