### PR TITLE
Remove Central Digital sandbox access for migrated applications

### DIFF
--- a/environments/dacp.json
+++ b/environments/dacp.json
@@ -6,7 +6,7 @@
       "access": [
         {
           "sso_group_name": "dts-legacy",
-          "level": "sandbox"
+          "level": "developer"
         }
       ]
     },

--- a/environments/ncas.json
+++ b/environments/ncas.json
@@ -6,7 +6,7 @@
       "access": [
         {
           "sso_group_name": "dts-legacy",
-          "level": "sandbox"
+          "level": "developer"
         }
       ]
     },

--- a/environments/pra-register.json
+++ b/environments/pra-register.json
@@ -6,7 +6,7 @@
       "access": [
         {
           "sso_group_name": "dts-legacy",
-          "level": "sandbox"
+          "level": "developer"
         }
       ]
     },

--- a/environments/tipstaff.json
+++ b/environments/tipstaff.json
@@ -6,10 +6,9 @@
       "access": [
         {
           "sso_group_name": "dts-legacy",
-          "level": "sandbox"
+          "level": "developer"
         }
-      ],
-      "nuke": "rebuild"
+      ]
     },
     {
       "name": "preproduction",

--- a/environments/wardship.json
+++ b/environments/wardship.json
@@ -6,7 +6,7 @@
       "access": [
         {
           "sso_group_name": "dts-legacy",
-          "level": "sandbox"
+          "level": "developer"
         }
       ]
     },


### PR DESCRIPTION
## A reference to the issue / Description of it

Our sandbox role exists for exploratory clickops prior to defining infrastructure fully through code.

## How does this PR fix the problem?

Following discussion with @mark-butler-solirius these migrated applications no longer need `sandbox` access. This will have the side effect of removing them from our regular AWS Nuke runs.

## How has this been tested?

Tested through CI pipeline checks

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
