### PR TITLE
Issue/8682 - Adds ecr repo to host AWS SigV4 Proxy image.

### DIFF
--- a/terraform/environments/core-shared-services/ecr_repos.tf
+++ b/terraform/environments/core-shared-services/ecr_repos.tf
@@ -1317,3 +1317,21 @@ module "yjaf_ecr_repo" {
   # Tags
   tags_common = local.tags
 }
+
+module "observability_platform_grafana_sigv4_proxy_ecr_repo" {
+  source = "../../modules/app-ecr-repo"
+
+  app_name = "observability-platform-grafana-sigv4-proxy"
+
+  pull_principals = [
+    local.environment_management.account_ids["observability-platform-development"],
+    local.environment_management.account_ids["observability-platform-production"]
+  ]
+
+  enable_retrieval_policy_for_lambdas = [
+    "arn:aws:lambda:eu-west-2:${local.environment_management.account_ids["observability-platform-development"]}:function:sigv4-proxy*",
+    "arn:aws:lambda:eu-west-2:${local.environment_management.account_ids["observability-platform-production"]}:function:sigv4-proxy*"
+  ]
+
+  tags_common = local.tags
+}


### PR DESCRIPTION

## A reference to the issue / Description of it

#8682 

## How does this PR fix the problem?

This adds an ecr repo to hold the SigV4 proxy docker image that will be used by a lambda in the observability-platform accounts to support the use of secure header information when calling a lambda function url.

Image will be built & uploaded to ecr manually so no requirement for push permissions using OIDC.

See https://github.com/awslabs/aws-sigv4-proxy

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
