### PR TITLE
Update README to use new GitHub-Community repository-standards badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ These modules are used by the Modernisation Platform's core infrastructure
 | [modernisation-platform-instance-scheduler](https://github.com/ministryofjustice/modernisation-platform-instance-scheduler) | A Go lambda function for stopping and starting instance, rds resources and autoscaling groups. The lambda is used by the core platform and can be reused outside of the platform with minimal changes |
 | [modernisation-platform-cp-network-test](https://github.com/ministryofjustice/modernisation-platform-cp-network-test)       | Container bundled with utilities for network testing                                                                                                                                                  |
 
-[Standards Link]: https://github-community.cloud-platform.service.justice.gov.uk/repository-standards/modernisation-platform "Repo standards badge."
-[Standards Icon]: https://github-community.cloud-platform.service.justice.gov.uk/repository-standards/api/modernisation-platform/badge
+[Standards Link]: https://github-community.service.justice.gov.uk/repository-standards/modernisation-platform "Repo standards badge."
+[Standards Icon]: https://github-community.service.justice.gov.uk/repository-standards/api/modernisation-platform/badge
 [Format Code Icon]: https://img.shields.io/github/actions/workflow/status/ministryofjustice/modernisation-platform/format-code.yml?labelColor=231f20&style=for-the-badge&label=Formate%20Code
 [Format Code Link]: https://github.com/ministryofjustice/modernisation-platform/actions/workflows/format-code.yml
 [Scorecards Icon]: https://img.shields.io/github/actions/workflow/status/ministryofjustice/modernisation-platform/scorecards.yml?branch=main&labelColor=231f20&style=for-the-badge&label=Scorecards


### PR DESCRIPTION
Fix-up - remove cloud-platform from badge URL 

This PR updates the README to use the new GitHub-Community repository-standards badge as per announcement: https://mojdt.slack.com/archives/C05L0KBA7RS/p1742897064793689
