### PR TITLE
TCP Port 1521 from APDEP to hmpps-test

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/test_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/test_rules.json
@@ -13,6 +13,13 @@
     "destination_port": "443",
     "protocol": "TCP"
   },
+  "apdep_to_hmpps_test_oracledb": {
+    "action": "PASS",
+    "source_ip": "${data-engineering-prod}",
+    "destination_ip": "${hmpps-test}",
+    "destination_port": "1521",
+    "protocol": "TCP"
+  },
   "az_noms_test_to_mp_hmpps_test_oracledb": {
     "action": "PASS",
     "source_ip": "${noms-test-vnet}",


### PR DESCRIPTION

## A reference to the issue / Description of it

As per the ask channel request from Siva Bathina requesting tcp on 1521 is opened from analytical-platforms-data-engineering-production to hmpps-test.

## How does this PR fix the problem?

Adds access from data-engineering-production to hmpps-test via tcp on port 1521.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
