### PR TITLE
Enhance cross-account trust policy with pattern-based role matching

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -11,13 +11,12 @@ module "cross-account-access" {
       "arn:aws:iam::${local.environment_management.account_ids["sprinkler-development"]}:role/github-actions"
     ],
     terraform.workspace == "testing-test" ? ["arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:user/testing-ci"] : [],
-    length(regexall("(development|test)$", terraform.workspace)) > 0 ? ["arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/github-actions-dev-test"] : [],
     terraform.workspace == "core-vpc-sandbox" ? [
       "arn:aws:iam::${local.environment_management.account_ids["sprinkler-development"]}:role/github-actions-dev-test",
       "arn:aws:iam::${local.environment_management.account_ids["cooker-development"]}:role/github-actions-dev-test"
     ] : []
   )
-  additional_trust_statements = contains(["core-network-services-production", "core-vpc-test", "core-vpc-development"], terraform.workspace) ? [data.aws_iam_policy_document.additional_trust_policy.json] : []
+  additional_trust_statements = concat(contains(["core-network-services-production", "core-vpc-test", "core-vpc-development"], terraform.workspace) ? [data.aws_iam_policy_document.additional_trust_policy.json] : [], length(regexall("(development|test)$", terraform.workspace)) > 0 ? [data.aws_iam_policy_document.additional_trust_policy.json] : [])
 }
 
 data "aws_iam_policy_document" "additional_trust_policy" {


### PR DESCRIPTION
## A reference to the issue / Description of it

The [new environment workflow](https://github.com/ministryofjustice/modernisation-platform/actions/runs/14173956405/job/39704597441#step:8:147) fails during delegate access because:  
- Trust policies reference CI/CD roles that don't exist yet  
- Terraform attempts to validate these roles during apply  

## How does this PR fix the problem?

Introduces dynamic role matching that:  
-  Works with roles created in later pipeline stages  
- Uses `arn:aws:iam::*:role/github-actions*` pattern  
- Maintains security via organizational path conditions 

## How has this been tested?

Tested on `cooker-development`

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [X] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
