### PR TITLE
added EventBridge scheduler permissions to CI role policy

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -165,6 +165,7 @@ data "aws_iam_policy_document" "member-access" {
       "route53:*",
       "route53resolver:*",
       "s3:*",
+      "scheduler:*",
       "secretsmanager:*",
       "ses:*",
       "shield:*",


### PR DESCRIPTION
## A reference to the issue / Description of it

https://mojdt.slack.com/archives/C01A7QK5VM1/p1743589134311979

## How does this PR fix the problem?

Adds `scheduler:*` permissions to MemberInfrastructureAccess role

## How has this been tested?

Tested through CI pipeline

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
