### PR TITLE
Updates terraform-baselnes module ref to 7.13.1 re issue/9609.

### DIFF
--- a/terraform/environments/bootstrap/secure-baselines/main.tf
+++ b/terraform/environments/bootstrap/secure-baselines/main.tf
@@ -6,7 +6,7 @@ data "aws_kms_key" "cloudtrail_key" {
 
 #trivy:ignore:AVD-AWS-0136
 module "baselines" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=33a50a01902a6de0639a2655557ac50fea45b241" # v7.13.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=f510447a38aec4e7b732586c5e682de351b4c785" # v7.13.1
 
   providers = {
     # Default and replication regions


### PR DESCRIPTION
## A reference to the issue / Description of it

#9679 

## How does this PR fix the problem?

This introduces monitoring for the use of `OrganizationAccountAccessRole` by SSO (*.justice.gov.uk) users from the MOJ-Master account to assume Admin level permissions in org member accounts. The securityhub-alerts sns topic is used to slack alerting via PagerDuty.

Note that the metric filter will exclude any us of the role by automation (github actions) or internal AWS events.

## How has this been tested?

This was tested in Sprinkler with the help of @connormaglynn who kindly triggered the event by assuming the role from MOJ-Master.

The image below shows the PagerDuty alert fired from the cloudwatch alarm. 

![image](https://github.com/user-attachments/assets/be5cc000-2302-466f-bdf8-2c7385dc9bd9)

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
