### PR TITLE
add ecs commands to oidc role

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -517,6 +517,7 @@ data "aws_iam_policy_document" "policy" {
       "ds-data:*",
       "dynamodb:GetItem",
       "dynamodb:PutItem",
+      "ecs:ExecuteCommand",
       "ecs:*Service*",
       "ecs:*Task*",
       "ecs:*Tag*",


### PR DESCRIPTION
## A reference to the issue / Description of it

OIDC role cannot currently run commands against ECS

## How does this PR fix the problem?

Adds permission to OIDC role

## How has this been tested?

Just the github runs

## Deployment Plan / Instructions

People will be able to run commands against ECS

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)
