### PR TITLE
SSM Session Access Role

### DIFF
--- a/policies/collaborators/collaborators.rego
+++ b/policies/collaborators/collaborators.rego
@@ -10,7 +10,8 @@ allowed_access := [
   "migration",
   "instance-management",
   "fleet-manager",
-  "platform-engineer-admin"
+  "platform-engineer-admin",
+  "ssm-session-access"
 ]
 
 deny contains msg if {

--- a/policies/collaborators/collaborators_test.rego
+++ b/policies/collaborators/collaborators_test.rego
@@ -30,5 +30,5 @@ test_empty_values if {
 }
 
 test_unexpected_access if {
-  deny["`example.json` uses an unexpected access: got `incorrect-access`, expected one of: read-only, developer, security-audit, sandbox, migration, instance-management, fleet-manager, platform-engineer-admin"] with input as { "filename": "example.json", "users": [{"accounts": [{"access": "incorrect-access"}]}] }
+  deny["`example.json` uses an unexpected access: got `incorrect-access`, expected one of: read-only, developer, security-audit, sandbox, migration, instance-management, fleet-manager, platform-engineer-admin, ssm-session-access"] with input as { "filename": "example.json", "users": [{"accounts": [{"access": "incorrect-access"}]}] }
 }

--- a/terraform/environments/bootstrap/member-bootstrap/collaborators.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/collaborators.tf
@@ -294,3 +294,28 @@ module "collaborator_reporting_operations_role" {
 data "aws_iam_policy" "reporting_operations" {
   name = "reporting_operations_policy"
 }
+
+# SSM Session Access role
+module "collaborator_ssm_session_access_role" {
+  # checkov:skip=CKV_TF_1:
+
+  count  = local.account_data.account-type == "member" ? 1 : 0
+  source = "github.com/terraform-aws-modules/terraform-aws-iam//modules/iam-assumable-role?ref=de95e21a3bc51cd3a44b3b95a4c2f61000649ebb" # v5.39.1
+
+  trusted_role_arns = [
+    data.aws_ssm_parameter.modernisation_platform_account_id.value
+  ]
+
+  create_role       = true
+  role_name         = "ssm-session-access"
+  role_requires_mfa = true
+
+  custom_role_policy_arns = [
+    data.aws_iam_policy.ssm_session_access.arn
+  ]
+  number_of_custom_role_policy_arns = 1
+}
+
+data "aws_iam_policy" "ssm_session_access" {
+  name = "ssm_session_access_policy"
+}

--- a/terraform/environments/bootstrap/single-sign-on/main.tf
+++ b/terraform/environments/bootstrap/single-sign-on/main.tf
@@ -444,3 +444,26 @@ resource "aws_ssoadmin_account_assignment" "platform_engineer_admin" {
   target_id   = local.environment_management.account_ids[terraform.workspace]
   target_type = "AWS_ACCOUNT"
 }
+
+resource "aws_ssoadmin_account_assignment" "ssm_session_access" {
+
+  for_each = {
+
+    for sso_assignment in local.sso_data[local.env_name][*] :
+
+    "${sso_assignment.sso_group_name}-${sso_assignment.level}" => sso_assignment
+
+    if(sso_assignment.level == "ssm-session-access")
+  }
+
+  provider = aws.sso-management
+
+  instance_arn       = local.sso_instance_arn
+  permission_set_arn = data.terraform_remote_state.mp-sso-permissions-sets.outputs.ssm_session_access
+
+  principal_id   = data.aws_identitystore_group.member[each.value.sso_group_name].group_id
+  principal_type = "GROUP"
+
+  target_id   = local.environment_management.account_ids[terraform.workspace]
+  target_type = "AWS_ACCOUNT"
+}

--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -1565,7 +1565,7 @@ data "aws_iam_policy_document" "ssm_session_access" {
       "ssm:TerminateSession",
       "ssm:ResumeSession"
     ]
-    resources = ["arn:aws:ssm:*:*:session/${aws:username}-*"]
+    resources = ["arn:aws:ssm:*:*:session/$${aws:username}-*"]
   }
 
   statement {

--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -1536,3 +1536,47 @@ data "aws_iam_policy_document" "s3_upload_policy_document" {
     ]
   }
 }
+
+resource "aws_iam_policy" "ssm_session_access" {
+  provider = aws.workspace
+  name     = "ssm_session_access_policy"
+  path     = "/"
+  policy   = data.aws_iam_policy_document.ssm_session_access.json
+}
+
+data "aws_iam_policy_document" "ssm_session_access" {
+  #checkov:skip=CKV_AWS_111 Needs to access multiple resources and the policy is attached to a role that is scoped to a specific account
+  #checkov:skip=CKV_AWS_356 Needs to access multiple resources and the policy is attached to a role that is scoped to a specific account
+
+  statement {
+    sid       = "AllowStartSessionOnEC2Instances"
+    effect    = "Allow"
+    actions   = ["ssm:StartSession"]
+    resources = [
+      "arn:aws:ec2:*:*:instance/*",
+      "arn:aws:ssm:*:*:document/SSM-SessionManagerRunShell"
+    ]
+  }
+
+  statement {
+    sid       = "AllowManageOwnSessions"
+    effect    = "Allow"
+    actions   = [
+      "ssm:TerminateSession",
+      "ssm:ResumeSession"
+    ]
+    resources = ["arn:aws:ssm:*:*:session/${aws:username}-*"]
+  }
+
+  statement {
+    sid       = "AllowDescribeForSessionManagement"
+    effect    = "Allow"
+    actions   = [
+      "ssm:DescribeSessions",
+      "ssm:GetConnectionStatus",
+      "ssm:DescribeInstanceProperties",
+      "ec2:DescribeInstances"
+    ]
+    resources = ["*"]
+  }
+}

--- a/terraform/single-sign-on/outputs.tf
+++ b/terraform/single-sign-on/outputs.tf
@@ -70,3 +70,7 @@ output "ssoadmin_instances" {
 output "platform_engineer_admin" {
   value = aws_ssoadmin_permission_set.modernisation_platform_platform_engineer_admin.arn
 }
+
+output "ssm_session_access" {
+  value = aws_ssoadmin_permission_set.modernisation_platform_ssm_session_access.arn
+}

--- a/terraform/single-sign-on/sso-permission-sets.tf
+++ b/terraform/single-sign-on/sso-permission-sets.tf
@@ -518,7 +518,7 @@ resource "aws_ssoadmin_customer_managed_policy_attachment" "modernisation_platfo
 # Modernisation Platform SSM Session Access role
 resource "aws_ssoadmin_permission_set" "modernisation_platform_ssm_session_access" {
   provider         = aws.sso-management
-  name             = "modernisation-platform-ssm-session-access"
+  name             = "mp-ssm-session-access"
   description      = "Modernisation Platform: ssm-session-access"
   instance_arn     = local.sso_admin_instance_arn
   session_duration = "PT8H"

--- a/terraform/single-sign-on/sso-permission-sets.tf
+++ b/terraform/single-sign-on/sso-permission-sets.tf
@@ -514,3 +514,23 @@ resource "aws_ssoadmin_customer_managed_policy_attachment" "modernisation_platfo
     path = "/"
   }
 }
+
+# Modernisation Platform SSM Session Access role
+resource "aws_ssoadmin_permission_set" "modernisation_platform_ssm_session_access" {
+  provider         = aws.sso-management
+  name             = "modernisation-platform-ssm-session-access"
+  description      = "Modernisation Platform: ssm-session-access"
+  instance_arn     = local.sso_admin_instance_arn
+  session_duration = "PT8H"
+  tags             = {}
+}
+
+resource "aws_ssoadmin_customer_managed_policy_attachment" "modernisation_platform_ssm_session_access" {
+  provider           = aws.sso-management
+  instance_arn       = local.sso_admin_instance_arn
+  permission_set_arn = aws_ssoadmin_permission_set.modernisation_platform_ssm_session_access.arn
+  customer_managed_policy_reference {
+    name = "ssm_session_access_policy"
+    path = "/"
+  }
+}


### PR DESCRIPTION
## A reference to the issue / Description of it

#9630 

## How does this PR fix the problem?

This change creates a new IAM role and policy that grants users only the necessary permissions to manage EC2 instances via AWS Systems Manager (SSM) Session Manager and are blocked from accessing other AWS services, including Secrets Manager and Parameter Store. It also adds an SSO permission set.

## How has this been tested?

Once the role is deployed, I will test this role on sprinkler

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
