### PR TITLE
Add secrets manager permissions required for Redshift query editor

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -1334,6 +1334,17 @@ data "aws_iam_policy_document" "reporting-operations" {
     resources = ["*"]
   }
 
+  statement {
+    effect = "Allow"
+    actions = [
+      "secretsmanager:CreateSecret",
+      "secretsmanager:GetSecretValue",
+      "secretsmanager:DeleteSecret",
+      "secretsmanager:TagResource"
+    ]
+    resources = ["arn:aws:secretsmanager:*:*:sqlworkbench!*"]
+  }
+
 }
 
 #tfsec:ignore:aws-iam-no-policy-wildcards


### PR DESCRIPTION
## A reference to the issue / Description of it

https://mojdt.slack.com/archives/C01A7QK5VM1/p1743613015578239


## How does this PR fix the problem?

Adds secrets manager permissions to `reporting-operations` role in line with the [aws-managed policy](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AmazonRedshiftQueryEditorV2FullAccess.html) scope for Redshift Query Editor


## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
