### PR TITLE
Allow sandbox users to update their securityhub findings

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -787,6 +787,7 @@ data "aws_iam_policy_document" "sandbox_additional" {
       "sagemaker:*",
       "scheduler:*",
       "secretsmanager:*",
+      "securityhub:BatchUpdateFindings",
       "ses:*",
       "sns:*",
       "sqlworkbench:*",


### PR DESCRIPTION
## A reference to the issue / Description of it

https://mojdt.slack.com/archives/C01A7QK5VM1/p1743678382327099

## How does this PR fix the problem?

Adds permissions already available to developer role users into sandbox policy

## How has this been tested?

Tested through CI checks

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
