### PR TITLE
Add ssm-session-access role to sprinkler

### DIFF
--- a/.github/workflows/terraform-github.yml
+++ b/.github/workflows/terraform-github.yml
@@ -42,10 +42,16 @@ jobs:
       - name: Check GitHub status
         run: |
           response=$(curl -s https://www.githubstatus.com/api/v2/summary.json)
-          status_indicator=$(echo "$response" | jq -r '.status.indicator')
-            
-          if [ "$status_indicator" != "none" ]; then
-            echo "GitHub Status check failed"
+
+          # Check status of key components
+          git_operations_status=$(echo "$response" | jq -r '.components[] | select(.name == "Git Operations") | .status')
+          api_status=$(echo "$response" | jq -r '.components[] | select(.name == "API Requests") | .status')
+    
+          # Only fail if components are not operational
+          if [ "$git_operations_status" = "operational" ] && [ "$api_status" = "operational" ]; then
+            echo "GitHub components are operational"
+          else
+            echo "GitHub components not fully operational - Git Operations: $git_operations_status, API: $api_status"
             exit 1
           fi
 

--- a/environments/sprinkler.json
+++ b/environments/sprinkler.json
@@ -44,6 +44,10 @@
         {
           "sso_group_name": "azure-aws-sso-modernisation-platform",
           "level": "developer"
+        },
+        {
+          "sso_group_name": "modernisation-platform",
+          "level": "ssm-session-access"
         }
       ],
       "nuke": "rebuild"


### PR DESCRIPTION
This PR aims to facilitate testing of the `ssm-session-access` role deployed to the `Sprinkler` environment. Currently, there's a need to verify the functionality and permissions associated with this role. #9630 

**This PR also improves our GitHub status check to:**

**Probelm**: 
Currently, our [workflows fail](https://github.com/ministryofjustice/modernisation-platform/actions/runs/14243024595/job/39917283083#step:2:11) during GitHub maintenance even when core services are operational

**Fix**

Handle maintenance periods gracefully by accepting both `none` and `maintenance` status indicators

Add more precise component status checks (focusing on Git Operations)

Make our CI pipeline more resilient during GitHub's scheduled maintenance

