### PR TITLE
Add documentation for new `SSM Session Access` Role

### DIFF
--- a/source/user-guide/platform-user-roles.html.md.erb
+++ b/source/user-guide/platform-user-roles.html.md.erb
@@ -148,6 +148,14 @@ This is a role designed for application processing, the first platform to be hos
 - Almost administrator access
 - Includes common policy
 
+## ssm-session-access
+
+The ssm-session-access role provides secure, restricted access to EC2 instances exclusively through AWS Systems Manager (SSM) Session Manager.
+
+- Establish secure shell sessions to EC2 instances via SSM
+- Terminate/resume own sessions
+- View active session status
+
 ## Assigning Roles to Environments
 
 Roles are assigned to environments through modifying the relevant `environments/*.json` file for an application.


### PR DESCRIPTION
This PR updates the documentation to include a new `SSM Session Access` Role #9630 