### PR TITLE
Reverts new-member-envrionment-files workflow to last known working version due to issue.

### DIFF
--- a/.github/workflows/new-member-environment-files.yml
+++ b/.github/workflows/new-member-environment-files.yml
@@ -34,15 +34,12 @@ jobs:
         run: bash ./core-repo/scripts/provision-member-directories.sh
       - name: Commit changes to GitHub
         run: bash ./core-repo/scripts/git-setup.sh ./modernisation-platform-environments
-      - name: Commit and Create PR with Signed Commit
-        uses: ministryofjustice/modernisation-platform-github-actions/signed-commit@f5d2ee4678dae4338fc5d9d7cb84b365863b216f # v1.1.1
-        with:
-          github_token: ${{ secrets.TERRAFORM_GITHUB_TOKEN }} # use this token as writing to a different repo
-          git_path: "terraform/environments"
-          remote_repository: "ministryofjustice/modernisation-platform-environments"
-          remote_repository_path: "./modernisation-platform-environments"
-          pr_title: "New files for terraform/environments"
-          pr_body: "> This PR was automatically created via a GitHub action workflow 🤖"
+      - run: bash ./core-repo/scripts/git-commit.sh . ./modernisation-platform-environments
+        env:  
+          TERRAFORM_GITHUB_TOKEN: ${{ secrets.TERRAFORM_GITHUB_TOKEN }} # use this token as writing to a different repo
+      - run: bash ./core-repo/scripts/git-pull-request.sh terraform/environments ./modernisation-platform-environments
+        env:
+          TERRAFORM_GITHUB_TOKEN: ${{ secrets.TERRAFORM_GITHUB_TOKEN }}
       - name: Slack failure notification
         uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
         with:


### PR DESCRIPTION
## A reference to the issue / Description of it

Reverts the workflow to the latest version to use unsigned commits due to some files being missed from the commit.

## How does this PR fix the problem?

Reverts to the last known working version as used on the 4th March 2025. As the environments repo has not implemented signed commits this will work correctly.

See issue from this action - https://github.com/ministryofjustice/modernisation-platform/actions/runs/14173956354/job/39704169161#step:6:51

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
