### PR TITLE
Add Dependabot Grouping

### DIFF
--- a/scripts/generate-dependabot-file.sh
+++ b/scripts/generate-dependabot-file.sh
@@ -60,6 +60,10 @@ if [[ -n "$all_env_test_folders" ]]; then
   done <<< "$all_env_test_folders"
   echo "    schedule:" >> "$dependabot_file"
   echo "      interval: \"daily\"" >> "$dependabot_file"
+  echo "    groups:" >> "$dependabot_file"
+  echo "      gomod-dependencies:" >> "$dependabot_file"
+  echo "        patterns:" >> "$dependabot_file"
+  echo "          - \"*\"" >> "$dependabot_file"
 fi
 
 echo "dependabot.yml has been successfully generated."


### PR DESCRIPTION
This PR updates the `genereate-dependabot-file.sh` to include grouping for the GoMod dependencies. 