### PR TITLE
Feature 9556 auto pruning of stale branches

### DIFF
--- a/.github/workflows/prune-stale-branches.yml
+++ b/.github/workflows/prune-stale-branches.yml
@@ -1,0 +1,112 @@
+name: Cleanup of Stale Branches (Deletes if branch and commits are 2+ months old)
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  cleanup:
+    name: Cleanup Stale Branches in Modernisation Platform Repos
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Ensure CLI tools are installed
+        run: |
+          command -v gh >/dev/null || (echo "❌ GitHub CLI (gh) is not installed" && exit 1)
+          command -v jq >/dev/null || (echo "❌ jq is not installed" && exit 1)
+
+      - name: Authenticate GitHub CLI
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
+
+      - name: Cleanup stale branches across repositories
+        run: |
+          set -eo pipefail
+          DEBUG=false
+          DRY_RUN=false
+
+          # Exclusion list
+          exclude_repos=(
+            "modernisation-platform-environments"
+            "modernisation-platform-ami-builds"
+            "modernisation-platform-configuration-management"
+          )
+
+          # Fetch all repositories starting with "modernisation-platform" and exclude archived ones
+          repos=$(gh repo list ministryofjustice --limit 1000 --json name,isArchived --jq '.[] | select(.name | startswith("modernisation-platform")) | select(.isArchived == false) | .name')
+
+          for repo in $repos; do
+            # Skip excluded repositories
+            if [[ " ${exclude_repos[@]} " =~ " $repo " ]]; then
+              echo "⏭️ Skipping excluded repository: $repo"
+              continue
+            fi
+
+            echo ""
+            echo ""
+            echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+            echo "🔍 STARTING REPO: ministryofjustice/$repo"
+            echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+            {
+              branches=$(gh api repos/ministryofjustice/$repo/branches --jq '.[].name')
+              repo_summary="| Branch | Status | Reason |\n|--------|--------|--------|"
+              for branch in $branches; do
+                if [[ "$branch" == "main" ]]; then
+                  repo_summary+="\n| \`$branch\` | ⏭️ Skipped | Main branch |"
+                  continue
+                fi
+
+                allow_delete=$(gh api repos/ministryofjustice/$repo/branches/$branch/protection --silent 2>/dev/null | jq -r '.allow_deletions.enabled // "true"')
+                if [[ "$allow_delete" == "false" ]]; then
+                  repo_summary+="\n| \`$branch\` | ⏭️ Skipped | Protected from deletion |"
+                  continue
+                fi
+
+                if gh api repos/ministryofjustice/$repo/git/ref/tags/do-not-prune/$branch --silent >/dev/null 2>&1; then
+                  repo_summary+="\n| \`$branch\` | ⏭️ Skipped | Tagged do-not-prune |"
+                  continue
+                fi
+
+                last_commit_date=$(gh api "repos/ministryofjustice/$repo/commits?sha=$branch" --jq '.[0].commit.committer.date' || echo "")
+                last_commit_timestamp=$(date -d "$last_commit_date" +%s 2>/dev/null || echo 0)
+                two_months_ago_timestamp=$(date -d "2 months ago" +%s)
+
+                if [[ "$last_commit_timestamp" -eq 0 || "$last_commit_timestamp" -ge "$two_months_ago_timestamp" ]]; then
+                  repo_summary+="\n| \`$branch\` | ✅ Active | Recent commit |"
+                  continue
+                fi
+
+                first_commit=$(gh api "repos/ministryofjustice/$repo/commits?sha=$branch" --paginate --jq '.[].commit.committer.date' | tail -n 1)
+                branch_creation_timestamp=$(date -d "$first_commit" +%s 2>/dev/null || echo 0)
+
+                if [[ "$branch_creation_timestamp" -eq 0 || "$branch_creation_timestamp" -ge "$two_months_ago_timestamp" ]]; then
+                  repo_summary+="\n| \`$branch\` | ⏭️ Skipped | Too new |"
+                  continue
+                fi
+
+                echo "🗑️ Deleting branch: $branch from ministryofjustice/$repo"
+                if [[ "$DRY_RUN" == "true" ]]; then
+                  echo "Dry Run: Skipping actual deletion of branch $branch"
+                  repo_summary+="\n| \`$branch\` | 📝 Dry Run | Branch and commits are 2+ months old |"
+                else
+                  if gh api -X DELETE repos/ministryofjustice/$repo/git/refs/heads/$branch; then
+                    repo_summary+="\n| \`$branch\` | 🔥 Deleted | Branch and commits are 2+ months old |"
+                  else
+                    repo_summary+="\n| \`$branch\` | ⚠️ Failed | GitHub API deletion failed |"
+                  fi
+                fi
+              done
+
+              echo -e "$repo_summary"
+              echo "✅ DONE with ministryofjustice/$repo"
+              echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+            } || {
+              echo "❌ Failed to process ministryofjustice/$repo — skipping to next."
+              continue
+            }
+          done


### PR DESCRIPTION
## A reference to the issue / Description of it

[#9556](https://github.com/ministryofjustice/modernisation-platform/issues/9556)

## How does this PR fix the problem?

This prunes branches which are at least 2 months old and have not had any commits within 2 months. The workflow Loops through a list of Modernisation Platform Repositories and fetches all branches in each repository.

For each branch, it checks:

- 🚫 Is it main? → Skip
- 🔐 Is it protected from deletion? → Skip
- 🏷️ Is it tagged `do-not-prune/<branch-name>`? → Skip

## How has this been tested?

Tested with dry runs in mod platform repos and got expected result and also tried to delete protected and tagged branches which failed as expected.

Please see below for modernisation-platform-terraform-s3-bucket and the rest of the repos for how it works genrally.

https://github.com/ministryofjustice/modernisation-platform/actions/runs/14245583018/job/39925574117#step:4:99

<img width="1481" alt="Screenshot 2025-04-03 at 16 43 27" src="https://github.com/user-attachments/assets/7bcccaec-a584-4ed6-95af-00e8c7fae3d9" />


See unit tests below.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed