### PR TITLE
Grant access to port forwarding session document in SSM policy

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -1555,6 +1555,7 @@ data "aws_iam_policy_document" "ssm_session_access" {
     actions = ["ssm:StartSession"]
     resources = [
       "arn:aws:ec2:*:*:instance/*",
+      "arn:aws:ssm:*:*:document/AWS-StartPortForwardingSessionToRemoteHost",
       "arn:aws:ssm:*:*:document/SSM-SessionManagerRunShell"
     ]
   }


### PR DESCRIPTION
This PR updates the IAM policy to grant permission to perform the `ssm:StartSession` action on the `AWS-StartPortForwardingSessionToRemoteHost` document. This permission is required to enable port forwarding sessions via SSM.
