### PR TITLE
Dependabot/Glob testing

### DIFF
--- a/scripts/generate-dependabot-file.sh
+++ b/scripts/generate-dependabot-file.sh
@@ -16,7 +16,7 @@ echo "Writing dependabot.yml file"
 
 cat > "$dependabot_file" << EOL
 # This file is auto-generated, do not manually amend.
-# https://github.com/ministryofjustice/modernisation-platform/blob/main/scripts/generate-dependabot.sh
+# https://github.com/ministryofjustice/modernisation-platform/blob/main/scripts/generate-dependabot-file.sh
 
 version: 2
 

--- a/scripts/generate-dependabot-file.sh
+++ b/scripts/generate-dependabot-file.sh
@@ -1,26 +1,19 @@
-#!/bin/bash
-
+#!/usr/bin/env bash
 set -euo pipefail
 
 dependabot_file=".github/dependabot.yml"
+echo "version: 2" > "$dependabot_file"
+echo "updates:" >> "$dependabot_file"
 
-# Clear the dependabot file
-> "$dependabot_file"
+echo "Scanning for Terraform files..."
+# Find all directories containing .tf files, excluding .terraform
+tf_dirs=$(find . -type f -name "*.tf" ! -path "*/.terraform/*" -exec dirname {} \; | sed 's|^\./||' | sort -u)
 
-# Get a list of unique Terraform directories, excluding `.terraform`
-all_tf_folders=$(find . -type f -name '*.tf' ! -path "*/.terraform/*" | sed 's#/[^/]*$##' | sed 's|^\./||' | sort -u)
-
-# Get a list of unique Go module directories, excluding `.terraform`
-all_env_test_folders=$(find . -type f -name 'go.mod' ! -path "*/.terraform/*" | sed 's#/[^/]*$##' | sed 's|^\./||' | sort -u)
-
-echo
-echo "All Terraform folders:"
-printf '%s\n' "$all_tf_folders"
-echo
-echo "All Go module folders:"
-printf '%s\n' "$all_env_test_folders"
+# Find all directories containing go.mod files, excluding .terraform
+gomod_dirs=$(find . -type f -name "go.mod" ! -path "*/.terraform/*" -exec dirname {} \; | sed 's|^\./||' | sort -u)
 
 echo "Writing dependabot.yml file"
+
 cat > "$dependabot_file" << EOL
 # This file is auto-generated, do not manually amend.
 # https://github.com/ministryofjustice/modernisation-platform/blob/main/scripts/generate-dependabot.sh
@@ -38,26 +31,34 @@ updates:
           - "*"
 EOL
 
-# Add Terraform ecosystem entries
-if [[ -n "$all_tf_folders" ]]; then
+# Add Terraform ecosystem entries (dynamically only for top-level directories containing .tf files)
+if [[ -n "$tf_dirs" ]]; then
   echo "Generating Terraform ecosystem entry..."
   echo "  - package-ecosystem: \"terraform\"" >> "$dependabot_file"
   echo "    directories:" >> "$dependabot_file"
-  while IFS= read -r folder; do
-    echo "      - \"/$folder\"" >> "$dependabot_file"
-  done <<< "$all_tf_folders"
+
+  # Extract only top-level directories and ensure we don't add duplicates
+  echo "$tf_dirs" | awk -F/ '{print $1}' | sort -u | while IFS= read -r dir; do
+    echo "      - \"$dir/**/*\"" >> "$dependabot_file"
+  done
+  
   echo "    schedule:" >> "$dependabot_file"
   echo "      interval: \"daily\"" >> "$dependabot_file"
+  echo "    ignore:" >> "$dependabot_file"
+  echo "      - dependency-name: \"integrations/github\"" >> "$dependabot_file"
 fi
 
-# Add Go module ecosystem entries
-if [[ -n "$all_env_test_folders" ]]; then
+# Add Go module ecosystem entries (dynamically only for top-level directories containing go.mod)
+if [[ -n "$gomod_dirs" ]]; then
   echo "Generating Go module ecosystem entry..."
   echo "  - package-ecosystem: \"gomod\"" >> "$dependabot_file"
   echo "    directories:" >> "$dependabot_file"
-  while IFS= read -r folder; do
-    echo "      - \"/$folder\"" >> "$dependabot_file"
-  done <<< "$all_env_test_folders"
+
+  # Extract only top-level directories and ensure we don't add duplicates
+  echo "$gomod_dirs" | awk -F/ '{print $1}' | sort -u | while IFS= read -r dir; do
+    echo "      - \"$dir/**/*\"" >> "$dependabot_file"
+  done
+
   echo "    schedule:" >> "$dependabot_file"
   echo "      interval: \"daily\"" >> "$dependabot_file"
   echo "    groups:" >> "$dependabot_file"

--- a/scripts/generate-dependabot-file.sh
+++ b/scripts/generate-dependabot-file.sh
@@ -2,8 +2,6 @@
 set -euo pipefail
 
 dependabot_file=".github/dependabot.yml"
-echo "version: 2" > "$dependabot_file"
-echo "updates:" >> "$dependabot_file"
 
 echo "Scanning for Terraform files..."
 # Find all directories containing .tf files, excluding .terraform

--- a/scripts/generate-dependabot-file.sh
+++ b/scripts/generate-dependabot-file.sh
@@ -3,6 +3,9 @@ set -euo pipefail
 
 dependabot_file=".github/dependabot.yml"
 
+# Clear the dependabot file
+> "$dependabot_file"
+
 echo "Scanning for Terraform files..."
 # Find all directories containing .tf files, excluding .terraform
 tf_dirs=$(find . -type f -name "*.tf" ! -path "*/.terraform/*" -exec dirname {} \; | sed 's|^\./||' | sort -u)


### PR DESCRIPTION
This PR updates the dependabot script to use globbing at this top level and also temporarily ignores the `integrations/github`update while GitHub support are investigating the bug 

script tested locally and outputs as:

```
# This file is auto-generated, do not manually amend.
# https://github.com/ministryofjustice/modernisation-platform/blob/main/scripts/generate-dependabot-file.sh

version: 2

updates:
  - package-ecosystem: "github-actions"
    directory: "/"
    schedule:
      interval: "daily"
    groups:
      action-dependencies:
        patterns:
          - "*"
  - package-ecosystem: "terraform"
    directories:
      - "terraform/**/*"
    schedule:
      interval: "daily"
    ignore:
      - dependency-name: "integrations/github"
  - package-ecosystem: "gomod"
    directories:
      - "scripts/**/*"
      - "terraform/**/*"
    schedule:
      interval: "daily"
    groups:
      gomod-dependencies:
        patterns:
          - "*"

```