### PR TITLE
update aws nuke refs to maintained repo

### DIFF
--- a/source/concepts/environments/auto-nuke.html.md.erb
+++ b/source/concepts/environments/auto-nuke.html.md.erb
@@ -36,7 +36,7 @@ An outline of the 'nuke' algorithm is as follows:
 
 Auto-nuke consumes the following dynamically generated Github secrets stored in the Modernisation Platorm Environments repository:
 
-- `MODERNISATION_PLATFORM_AUTONUKE_BLOCKLIST`: Account aliases to always exclude from auto-nuke. This takes precedence over all other configuration options. Due to the destructive nature of the tool, [AWS-Nuke](https://github.com/rebuy-de/aws-nuke) requires at least one account ID in the configured blocklist. Our blocklist contains all production, preproduction, and core accounts.
+- `MODERNISATION_PLATFORM_AUTONUKE_BLOCKLIST`: Account aliases to always exclude from auto-nuke. This takes precedence over all other configuration options. Due to the destructive nature of the tool, [AWS-Nuke](https://github.com/ekristen/aws-nuke) requires at least one account ID in the configured blocklist. Our blocklist contains all production, preproduction, and core accounts.
 
 - `MODERNISATION_PLATFORM_AUTONUKE`: Account aliases of sandbox accounts to be auto-nuked on weekly basis.
 

--- a/source/concepts/environments/auto-nuke.html.md.erb
+++ b/source/concepts/environments/auto-nuke.html.md.erb
@@ -22,7 +22,7 @@ This feature automatically destroys all resources in development environments on
 
 Every Sunday:
 
-- At 22:00 the [awsnuke.yml workflow](https://github.com/ministryofjustice/modernisation-platform-environments/blob/main/.github/workflows/awsnuke.yml) is triggered. This workflow nukes all the configured development environments using the [AWS Nuke tool](https://github.com/rebuy-de/aws-nuke).
+- At 22:00 the [awsnuke.yml workflow](https://github.com/ministryofjustice/modernisation-platform-environments/blob/main/.github/workflows/awsnuke.yml) is triggered. This workflow nukes all the configured development environments using the [AWS Nuke tool](https://github.com/ekristen/aws-nuke).
 - At 12:00 the [nuke-redeploy.yml workflow](https://github.com/ministryofjustice/modernisation-platform-environments/blob/main/.github/workflows/nuke-redeploy.yml) is triggered. If requested, this workflow redeploys IaC into the nuked environment using `terraform apply`.
 
 An outline of the 'nuke' algorithm is as follows:


### PR DESCRIPTION
## A reference to the issue / Description of it

#9557 
## How does this PR fix the problem?

Updates documentation references to the AWS Nuke tool to reflect the move from the deprecated [rebuy-de/aws-nuke](https://github.com/rebuy-de/aws-nuke) repo to the actively maintained [ekristen/aws-nuke](https://github.com/ekristen/aws-nuke).

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
