### PR TITLE
Fix capitalisation of collaborator github username

### DIFF
--- a/collaborators.json
+++ b/collaborators.json
@@ -790,7 +790,7 @@
     },
     {
       "username": "ryan.smith",
-      "github-username": "RyanSmith",
+      "github-username": "ryansmith",
       "accounts": [
         {
           "account-name": "youth-justice-app-framework-preproduction",


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/actions/runs/14311493150/job/40107423240#step:13:461

## How does this PR fix the problem?

Corrects the capitalisation of a collaborator GitHub slug

## How has this been tested?

Test through CI

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
