### PR TITLE
Issue/9024 testing keys

### DIFF
--- a/terraform/modernisation-platform-account/secrets.tf
+++ b/terraform/modernisation-platform-account/secrets.tf
@@ -200,6 +200,28 @@ resource "aws_secretsmanager_secret" "slack_webhooks" {
   }
 }
 
+resource "aws_secretsmanager_secret" "testing_test_access_key_id" {
+  # checkov:skip=CKV2_AWS_57:Auto rotation not possible
+  name        = "testing_test_access_key_id"
+  description = "Used by unit tests in github repositories to access the testing-test account"
+  kms_key_id  = aws_kms_key.secrets_key_multi_region.id
+  tags        = local.tags
+  replica {
+    region = local.replica_region
+  }
+}
+
+resource "aws_secretsmanager_secret" "testing_test_access_key" {
+  # checkov:skip=CKV2_AWS_57:Auto rotation not possible
+  name        = "testing_test_access_key"
+  description = "Used by unit tests in github repositories to access the testing-test account"
+  kms_key_id  = aws_kms_key.secrets_key_multi_region.id
+  tags        = local.tags
+  replica {
+    region = local.replica_region
+  }
+}
+
 # Reflection of what is in member accounts, needed here as well so that the same code works for collaborators
 resource "aws_ssm_parameter" "modernisation_platform_account_id" {
   #checkov:skip=CKV_AWS_337: Standard key is fine here

--- a/terraform/modernisation-platform-account/secrets.tf
+++ b/terraform/modernisation-platform-account/secrets.tf
@@ -203,7 +203,7 @@ resource "aws_secretsmanager_secret" "slack_webhooks" {
 resource "aws_secretsmanager_secret" "testing_test_access_key_id" {
   # checkov:skip=CKV2_AWS_57:Auto rotation not possible
   name        = "testing_test_access_key_id"
-  description = "Used by unit tests in github repositories to access the testing-test account"
+  description = "Key ID used by unit tests in github repositories to access the testing-test account"
   kms_key_id  = aws_kms_key.secrets_key_multi_region.id
   tags        = local.tags
   replica {
@@ -214,7 +214,7 @@ resource "aws_secretsmanager_secret" "testing_test_access_key_id" {
 resource "aws_secretsmanager_secret" "testing_test_access_key" {
   # checkov:skip=CKV2_AWS_57:Auto rotation not possible
   name        = "testing_test_access_key"
-  description = "Used by unit tests in github repositories to access the testing-test account"
+  description = "Key value used by unit tests in github repositories to access the testing-test account"
   kms_key_id  = aws_kms_key.secrets_key_multi_region.id
   tags        = local.tags
   replica {


### PR DESCRIPTION
## A reference to the issue / Description of it

#9024 

## How does this PR fix the problem?

Adds two new secrets in Modernisation-Platform for use by the reusable secrets workflows that provide the IAM key pair for the testing-test account.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
