### PR TITLE
starting point for additional sso-deny tag/policy

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -1037,12 +1037,12 @@ data "aws_iam_policy_document" "instance-access-document" {
     ]
     resources = ["*"]
     condition {
-      test = "StringEquals"
+      test     = "StringEquals"
       variable = "aws:ResourceTag/instance-access-policy"
-      values = ["sso-deny"]
+      values   = ["sso-deny"]
     }
     condition {
-      test = "StringEquals"
+      test     = "StringEquals"
       variable = "aws:userId"
       values = [
         "arn:aws:iam::*:user/sso-*"

--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -1030,6 +1030,26 @@ data "aws_iam_policy_document" "instance-access-document" {
     }
   }
 
+  statement {
+    effect = "Deny"
+    actions = [
+      "ec2:*"
+    ]
+    resources = ["*"]
+    condition {
+      test = "StringEquals"
+      variable = "aws:ResourceTag/instance-access-policy"
+      values = ["sso-deny"]
+    }
+    condition {
+      test = "StringEquals"
+      variable = "aws:userId"
+      values = [
+        "arn:aws:iam::*:user/sso-*"
+      ]
+    }
+  }
+
 }
 
 # instance management - member SSO and collaborators


### PR DESCRIPTION
## A reference to the issue / Description of it

There are ec2 instances, especially in hmpps-domain-services that are basically going to be jumpservers that we’d like NOT to be accessible via Fleetmanager’s SSO option… Other RDP options are fine though ’cause we still want RDP via domain credentials to work.

Now, we could probably do that via Group Policy (’cause they’ll be on the domain) but it would potentially be better to have an IAM policy that specifically denies sso-* users access to a few specific EC2 instances.
## How does this PR fix the problem?

## How has this been tested?

Need to apply the sso-deny instance-profile-policy tag to something and see if sso login fails but everything else works

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

See comment ref testing above. I'm not sure how you deploy stuff. 

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
