### PR TITLE
tm-1154-fixngo-instance-patching-baseline

### DIFF
--- a/terraform/environments/core-shared-services/ad-fixngo.tf
+++ b/terraform/environments/core-shared-services/ad-fixngo.tf
@@ -886,7 +886,7 @@ locals {
         forth-thurs  = "cron(0 21 ? * THU#4 *)"
       }
       patch_classifications = {
-        WINDOWS = ["SecurityUpdates", "CriticalUpdates", "DefinitionUpdates"]
+        WINDOWS = ["SecurityUpdates", "CriticalUpdates"]
       }
     }
 


### PR DESCRIPTION
## A reference to the issue / Description of it

Removing Definition updates from the OS patch baseline as they should not be subject to the auto-approval setting delay associated with the environment.

## How has this been tested?

Tested in hmpps-domain-services account

## Deployment Plan / Instructions

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

This only effects DSO managed fixngo instances.
