### PR TITLE
 Allow all branches in OIDC trust relationship for temporary workaround

### DIFF
--- a/terraform/modernisation-platform-account/iam.tf
+++ b/terraform/modernisation-platform-account/iam.tf
@@ -264,7 +264,6 @@ module "github_actions_apply_role" {
   role_name           = "github-actions-apply"
   policy_arns         = ["arn:aws:iam::aws:policy/AdministratorAccess"]
   policy_jsons        = [data.aws_iam_policy_document.oidc-deny-specific-actions.json]
-  subject_claim       = "ref:refs/heads/main"
   tags                = { "Name" = "GitHub Actions Apply" }
 }
 


### PR DESCRIPTION
## A reference to the issue / Description of it
The existing trust policy was too restrictive, expecting the `sub` claim to match only the exact branch `refs/heads/main`. However, the `sub` claim now includes additional fields (e.g., `workflow`, `job_workflow_ref`, etc.), which caused role assumption failures.

(https://mojdt.slack.com/archives/C013RM6MFFW/p1744198891546489?thread_ts=1744196862.994729&cid=C013RM6MFFW)
## How does this PR fix the problem?

- The original issue stemmed from the fact that the sub claim in the OIDC token now includes additional workflow-related metadata, causing role assumption failures when the policy expected a specific branch format (refs/heads/main).

- By allowing all branches (*) in the IAM trust policy, the fix ensures that role assumption will succeed regardless of the extended sub claim format, effectively bypassing the issue in the short term.



## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
