### PR TITLE
Add prod CIDRs for AP/cica, open firewall on 1521 between these cidrs

### DIFF
--- a/terraform/environments/core-network-services/cidr-ranges.tf
+++ b/terraform/environments/core-network-services/cidr-ranges.tf
@@ -19,6 +19,7 @@ locals {
     analytical-platform-airflow-dev  = "10.200.0.0/16"
     analytical-platform-airflow-prod = "10.201.0.0/16"
     analytical-platform-ingest-dev   = "10.26.128.0/23"
+    analytical-platform-ingest-prod  = "10.27.128.0/23"
     data-engineering-dev             = "172.24.0.0/16"
     data-engineering-prod            = "172.25.0.0/16"
     data-engineering-stage           = "172.26.0.0/16"
@@ -99,6 +100,10 @@ locals {
     cica-onprem-prod      = "10.2.30.0/24"
     cica-end-user-devices = "10.9.14.0/23"
     cica-ras-nat          = "10.7.14.224/28"
+    cica-aws-prod-a       = "10.13.10.0/24"
+    cica-aws-prod-b       = "10.13.110.0/24"
+    cica-aws-prod-c       = "10.13.20.0/24"
+    cica-aws-prod-d       = "10.13.120.0/24"
 
 
 

--- a/terraform/environments/core-network-services/firewall-rules/production_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/production_rules.json
@@ -677,5 +677,33 @@
     "destination_ip": "${laa-production}",
     "destination_port": "1521",
     "protocol": "TCP"
+  },
+  "ap-ingest-prod_to_cica_tariff_prod_a": {
+    "action": "PASS",
+    "source_ip": "${analytical-platform-ingest-prod}",
+    "destination_ip": "${cica-aws-prod-a}",
+    "destination_port": "1521",
+    "protocol": "TCP"
+  },
+  "ap-ingest-prod_to_cica_tariff_prod_b": {
+    "action": "PASS",
+    "source_ip": "${analytical-platform-ingest-prod}",
+    "destination_ip": "${cica-aws-prod-b}",
+    "destination_port": "1521",
+    "protocol": "TCP"
+  },
+  "ap-ingest-prod_to_cica_tariff_prod_c": {
+    "action": "PASS",
+    "source_ip": "${analytical-platform-ingest-prod}",
+    "destination_ip": "${cica-aws-prod-c}",
+    "destination_port": "1521",
+    "protocol": "TCP"
+  },
+  "ap-ingest-prod_to_cica_tariff_prod_d": {
+    "action": "PASS",
+    "source_ip": "${analytical-platform-ingest-prod}",
+    "destination_ip": "${cica-aws-prod-d}",
+    "destination_port": "1521",
+    "protocol": "TCP"
   }
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

We need to enable connectivity between an AWS DMS service within `analytical-platform-ingestion-production` to a CICA Tariff Production instance in order to replicate data from Tariff in a prod context
This is part of a project to make Tariff data available in the Analytical Platform

## How does this PR fix the problem?

It sets `PASS` rules between the CIDR that encompasses `analytical-platform-ingestion-production` to the CIDRs we have been given corresponding to CICA Tariff Production instance(s), on the correct port.

## How has this been tested?

I lack the permissions to test this change within the Modernisation platform. I have followed precedent as closely as possible.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [?] All checks have passed
- [N/A] I have made corresponding changes to the documentation
- [N/A] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)