### PR TITLE
🚑 Fix Analytical Platform GitHub Actions Reviewers

### DIFF
--- a/environments/analytical-platform-common.json
+++ b/environments/analytical-platform-common.json
@@ -1,7 +1,7 @@
 {
   "account-type": "member",
   "codeowners": ["analytical-platform-engineers"],
-  "github_action_reviewers": ["analytical-platform-engineers"],
+  "github_action_reviewer": ["analytical-platform-engineers"],
   "environments": [
     {
       "name": "production",

--- a/environments/analytical-platform-compute.json
+++ b/environments/analytical-platform-compute.json
@@ -12,7 +12,7 @@
     }
   ],
   "codeowners": ["analytical-platform-engineers"],
-  "github_action_reviewers": ["analytical-platform-engineers"],
+  "github_action_reviewer": ["analytical-platform-engineers"],
   "environments": [
     {
       "name": "development",

--- a/environments/analytical-platform-ingestion.json
+++ b/environments/analytical-platform-ingestion.json
@@ -7,7 +7,7 @@
     }
   ],
   "codeowners": ["analytical-platform-engineers"],
-  "github_action_reviewers": ["analytical-platform-engineers"],
+  "github_action_reviewer": ["analytical-platform-engineers"],
   "isolated-network": "true",
   "environments": [
     {


### PR DESCRIPTION
## A reference to the issue / Description of it

This pull request (https://github.com/ministryofjustice/modernisation-platform/pull/9336) should've introduced a change to allow only a specific team the ability to approve deployments, but it didn't

## How does this PR fix the problem?

Uses `github_action_reviewer` as its supposed to be used

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
