### PR TITLE
Bump core-logging s3 modules to `v8.2.1`

### DIFF
--- a/terraform/environments/core-logging/cortex.tf
+++ b/terraform/environments/core-logging/cortex.tf
@@ -163,7 +163,9 @@ resource "aws_s3_bucket_lifecycle_configuration" "logging" {
       days_after_initiation = 7
     }
     id = "rule-1"
-    filter {}
+    filter {
+      prefix = ""
+    }
     expiration {
       days = 14
     }

--- a/terraform/environments/core-logging/observability.tf
+++ b/terraform/environments/core-logging/observability.tf
@@ -62,7 +62,7 @@ resource "aws_iam_role_policy_attachment" "grafana_athena_attachment" {
 
 # S3 bucket for CUR Reports
 module "s3_moj_cur_reports_modplatform" {
-  source              = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=4e17731f72ef24b804207f55b182f49057e73ec9" # v8.1.0
+  source              = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=474f27a3f9bf542a8826c76fb049cc84b5cf136f" # v8.2.1
   bucket_prefix       = "moj-cur-reports-modplatform-"
   versioning_enabled  = true
   ownership_controls  = "BucketOwnerEnforced"

--- a/terraform/environments/core-logging/s3_logging.tf
+++ b/terraform/environments/core-logging/s3_logging.tf
@@ -228,11 +228,6 @@ module "s3-bucket-cloudtrail" {
 
   tags = local.tags
 }
-# Required for updating s3 bucket module to >v8.2.0 without breaking changes 
-moved {
-  from = module.s3-bucket-cloudtrail.aws_s3_bucket_logging.default["modernisation-platform-logs-cloudtrail-logging"]
-  to   = module.s3-bucket-cloudtrail.aws_s3_bucket_logging.default_bucket_object[0]
-}
 
 # Allow access to the bucket from the MoJ root account
 # Policy extrapolated from:

--- a/terraform/environments/core-logging/s3_logging.tf
+++ b/terraform/environments/core-logging/s3_logging.tf
@@ -171,7 +171,7 @@ data "aws_iam_policy_document" "kms_logging_cloudtrail_replication" {
 
 
 module "s3-bucket-cloudtrail" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=cadab519b10a7d28dfa3b77d407725db6b37614a" # v8.0.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=474f27a3f9bf542a8826c76fb049cc84b5cf136f" # v8.2.1
   providers = {
     aws.bucket-replication = aws.modernisation-platform-eu-west-1
   }
@@ -190,6 +190,7 @@ module "s3-bucket-cloudtrail" {
     {
       id      = "main"
       enabled = "Enabled"
+      prefix  = ""
       tags    = {}
       transition = [
         {
@@ -218,8 +219,21 @@ module "s3-bucket-cloudtrail" {
     }
   ]
   log_bucket = module.s3-bucket-cloudtrail-logging.bucket.id
-  tags       = local.tags
+  log_buckets = tomap({
+    "log_bucket_name" : module.s3-bucket-cloudtrail-logging.bucket.id,
+    "log_bucket_arn" : module.s3-bucket-cloudtrail-logging.bucket.arn,
+    "log_bucket_policy" : module.s3-bucket-cloudtrail-logging.bucket_policy.policy,
+  })
+  log_prefix = ""
+
+  tags = local.tags
 }
+# Required for updating s3 bucket module to >v8.2.0 without breaking changes 
+moved {
+  from = module.s3-bucket-cloudtrail.aws_s3_bucket_logging.default["modernisation-platform-logs-cloudtrail-logging"]
+  to   = module.s3-bucket-cloudtrail.aws_s3_bucket_logging.default_bucket_object[0]
+}
+
 # Allow access to the bucket from the MoJ root account
 # Policy extrapolated from:
 # https://www.terraform.io/docs/backends/types/s3.html#s3-bucket-permissions
@@ -297,7 +311,7 @@ data "aws_iam_policy_document" "cloudtrail_bucket_policy" {
 }
 
 module "s3-bucket-cloudtrail-logging" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=cadab519b10a7d28dfa3b77d407725db6b37614a" # v8.0.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=474f27a3f9bf542a8826c76fb049cc84b5cf136f" # v8.2.1
   providers = {
     aws.bucket-replication = aws.modernisation-platform-eu-west-1
   }
@@ -317,6 +331,7 @@ module "s3-bucket-cloudtrail-logging" {
     {
       id      = "main"
       enabled = "Enabled"
+      prefix  = ""
       tags    = {}
       transition = [
         {


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/9571

## How does this PR fix the problem?

- Bumps s3 modules in `core-logging` to `v8.2.1` - doing this as dependabot doesn't seem to trigger PRs when pinning to commit SHAs. This included adding `prefix ""` to the lifecycle rules specified.

- Also I've fixed an issue with the athena lambda role which had an inline policy which is deprecated. This now has seperate policy defined and attachment.

- I've also added extra inputs to the `module.s3-bucket-cloudtrail` resource as when updating the module past v8.2.0 some changes meant that the logging bucket was being marked for deletion. This now doesn't show as a deletion in the plan.

- There is still a warning relating to the chatbot module which can be fixed in another PR.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

See checks below for TF plan.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
