### PR TITLE
Create OIDC Role for GitHub Actions to Access Secrets from Secrets Manager

### DIFF
--- a/terraform/modernisation-platform-account/iam.tf
+++ b/terraform/modernisation-platform-account/iam.tf
@@ -271,6 +271,58 @@ data "aws_iam_policy_document" "oidc-deny-specific-actions" {
   }
 }
 
+# OIDC Provider for GitHub Actions Secrets Reader
+
+module "github_actions_read_secrets_role" {
+  source = "github.com/ministryofjustice/modernisation-platform-github-oidc-role?ref=62b8a16c73d8e4422cd81923e46948e8f4b5cf48" # v3.2.0
+  github_repositories = [
+    "ministryofjustice/modernisation-platform",
+    "ministryofjustice/modernisation-platform-environments",
+    "ministryofjustice/modernisation-platform-terraform-baselines",
+    "ministryofjustice/modernisation-platform-ami-builds",
+    "ministryofjustice/modernisation-platform-terraform-bastion-linux",
+    "ministryofjustice/modernisation-platform-terraform-s3-bucket",
+    "ministryofjustice/modernisation-platform-terraform-aws-vm-import",
+    "ministryofjustice/modernisation-platform-terraform-ec2-instance",
+    "ministryofjustice/modernisation-platform-terraform-pagerduty-integration",
+    "ministryofjustice/modernisation-platform-terraform-iam-superadmins",
+    "ministryofjustice/modernisation-platform-terraform-ec2-autoscaling-group",
+    "ministryofjustice/modernisation-platform-terraform-member-vpc",
+    "ministryofjustice/modernisation-platform-terraform-module-template",
+    "ministryofjustice/modernisation-platform-github-oidc-role",
+    "ministryofjustice/modernisation-platform-terraform-environments",
+    "ministryofjustice/modernisation-platform-terraform-ecs-cluster",
+    "ministryofjustice/modernisation-platform-github-oidc-provider",
+    "ministryofjustice/modernisation-platform-terraform-ssm-patching",
+    "ministryofjustice/modernisation-platform-terraform-aws-chatbot",
+    "ministryofjustice/modernisation-platform-terraform-lambda-function",
+    "ministryofjustice/modernisation-platform-terraform-dns-certificates",
+    "ministryofjustice/modernisation-platform-instance-scheduler",
+    "ministryofjustice/modernisation-platform-terraform-loadbalancer",
+    "ministryofjustice/modernisation-platform-terraform-aws-data-firehose",
+    "ministryofjustice/modernisation-platform-terraform-cross-account-access"
+    "ministryofjustice/modernisation-platform-security"
+  ]
+  role_name    = "github-actions-read-secrets"
+  policy_jsons = [data.aws_iam_policy_document.oidc_assume_read_secrets_role_member.json]
+  tags         = { "Name" = "GitHub Actions Read Secrets" }
+}
+
+data "aws_iam_policy_document" "oidc_assume_read_secrets_role_member" {
+  # checkov:skip=CKV_AWS_111: "Cannot restrict by KMS alias so leaving open"
+  # checkov:skip=CKV_AWS_356: "Cannot restrict by KMS alias so leaving open"
+  # checkov:skip=CKV_AWS_108: "Allowing secretsmanager:GetSecretValue with open resource due to specific use case"
+  statement {
+    effect    = "Allow"
+    resources = ["*"]
+    actions = [
+      "kms:Decrypt",
+      "secretsmanager:GetSecretValue"
+    ]
+  }
+}
+
+
 #tfsec:ignore:aws-iam-no-policy-wildcards
 data "aws_iam_policy_document" "sso_customer_managed_policy_engineer" {
   #checkov:skip=CKV_AWS_356: Allows access to multiple unknown resources

--- a/terraform/modernisation-platform-account/iam.tf
+++ b/terraform/modernisation-platform-account/iam.tf
@@ -300,7 +300,7 @@ module "github_actions_read_secrets_role" {
     "ministryofjustice/modernisation-platform-instance-scheduler",
     "ministryofjustice/modernisation-platform-terraform-loadbalancer",
     "ministryofjustice/modernisation-platform-terraform-aws-data-firehose",
-    "ministryofjustice/modernisation-platform-terraform-cross-account-access"
+    "ministryofjustice/modernisation-platform-terraform-cross-account-access",
     "ministryofjustice/modernisation-platform-security"
   ]
   role_name    = "github-actions-read-secrets"


### PR DESCRIPTION
## A reference to the issue / Description of it

As part of the migration to use AWS Secrets Manager for retrieving secrets in GitHub Actions, we encountered an issue where the existing OIDC role is restricted to a small set of repositories. This restriction prevents other repositories owned by `modernisation-platform` from assuming the role, leading to failures when trying to fetch secrets.

This PR introduces a new **OIDC role** intended specifically for GitHub Actions to retrieve secrets from AWS Secrets Manager. #9804 

## How does this PR fix the problem?

This PR resolves the issue by:

- Creating a new, purpose-built OIDC role that is **restricted to Secrets Manager permissions only**
- Updating the trust policy to allow **all repositories owned by `modernisation-platform`** to assume the role via GitHub Actions
- Enabling broader access while maintaining least-privilege principles

With this change, all MP-owned repos will be able to securely fetch secrets without relying on the previously restricted role.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
