### PR TITLE
Cloudwatch metric & dashboard read only permissions.

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -908,6 +908,11 @@ data "aws_iam_policy_document" "instance-access-document" {
     actions = [
       "athena:StartQueryExecution",
       "athena:StopQueryExecution",
+      "cloudwatch:GetDashboard",
+      "cloudwatch:GetMetricData",
+      "cloudwatch:GetMetricStatistics",
+      "cloudwatch:ListDashboards",
+      "cloudwatch:ListMetrics",
       "ec2:GetPasswordData",
       "kms:Decrypt*",
       "kms:Encrypt",
@@ -1080,8 +1085,6 @@ data "aws_iam_policy_document" "instance-management-document" {
       ]
     }
 
-
-
   }
   statement {
     sid    = "databaseAllowNull"
@@ -1094,6 +1097,11 @@ data "aws_iam_policy_document" "instance-management-document" {
       "autoscaling:UpdateAutoScalingGroup",
       "autoscaling:SetDesiredCapacity",
       "aws-marketplace:ViewSubscriptions",
+      "cloudwatch:GetDashboard",
+      "cloudwatch:GetMetricData",
+      "cloudwatch:GetMetricStatistics",
+      "cloudwatch:ListDashboards",
+      "cloudwatch:ListMetrics",
       "ds:*Tags*",
       "ds:*Snapshot*",
       "ds:ResetUserPassword",


### PR DESCRIPTION

## A reference to the issue / Description of it

User request for additional metrics & dashboard read only permissions for the instance-access and management policies.

## How does this PR fix the problem?

Adds some basic cloudwatch metrics & dashboard read-only permissions to instance-access and instance-management policies as requested by Domonic Robinson.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
