### PR TITLE
VPC endpoints for youth justice

### DIFF
--- a/environments-networks/yjb-development.json
+++ b/environments-networks/yjb-development.json
@@ -10,7 +10,7 @@
   "options": {
     "bastion_linux": true,
     "additional_cidrs": [],
-    "additional_endpoints": ["com.amazonaws.eu-west-2.secretsmanager"],
+    "additional_endpoints": ["com.amazonaws.eu-west-2.secretsmanager", "com.amazonaws.eu-west-2.email-smtp"],
     "additional_private_zones": ["development.yjaf"],
     "additional_vpcs": [],
     "dns_zone_extend": []

--- a/environments-networks/yjb-preproduction.json
+++ b/environments-networks/yjb-preproduction.json
@@ -10,7 +10,7 @@
   "options": {
     "bastion_linux": true,
     "additional_cidrs": [],
-    "additional_endpoints": ["com.amazonaws.eu-west-2.secretsmanager"],
+    "additional_endpoints": ["com.amazonaws.eu-west-2.secretsmanager", "com.amazonaws.eu-west-2.email-smtp"],
     "additional_private_zones": ["preproduction.yjaf"],
     "additional_vpcs": [],
     "dns_zone_extend": []

--- a/environments-networks/yjb-production.json
+++ b/environments-networks/yjb-production.json
@@ -10,7 +10,7 @@
   "options": {
     "bastion_linux": true,
     "additional_cidrs": [],
-    "additional_endpoints": ["com.amazonaws.eu-west-2.secretsmanager"],
+    "additional_endpoints": ["com.amazonaws.eu-west-2.secretsmanager", "com.amazonaws.eu-west-2.email-smtp"],
     "additional_private_zones": ["production.yjaf"],
     "additional_vpcs": [],
     "dns_zone_extend": []

--- a/environments-networks/yjb-test.json
+++ b/environments-networks/yjb-test.json
@@ -10,7 +10,7 @@
   "options": {
     "bastion_linux": true,
     "additional_cidrs": [],
-    "additional_endpoints": ["com.amazonaws.eu-west-2.secretsmanager"],
+    "additional_endpoints": ["com.amazonaws.eu-west-2.secretsmanager", "com.amazonaws.eu-west-2.email-smtp"],
     "additional_private_zones": ["test.yjaf"],
     "additional_vpcs": [],
     "dns_zone_extend": []


### PR DESCRIPTION
## A reference to the issue / Description of it

as part of member request 
Greg Whiting
  11:08
Morning, could I please have the following endpoint added to our vpcs for yjaf
under additional_endpoints add "com.amazonaws.eu-west-2.email-smtp"
I believe it is these files under environments-networks in https://github.com/ministryofjustice/modernisation-platform
image.png
 
image.png


ministryofjustice/modernisation-platform
A place for the core work of the Modernisation Platform • This repository is defined and managed in Terraform
Website
https://user-guide.modernisation-platform.service.justice.gov.uk
Stars
697
Added by https://mojdt.slack.com/services/B08L6LF38E6

## How does this PR fix the problem?

Adds the vpc endpoints  to the youth justice vpc's

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
