### PR TITLE
Add SSO account assignments for MP Entra ID group

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/main.tf
+++ b/terraform/environments/bootstrap/single-sign-on/main.tf
@@ -73,7 +73,7 @@ resource "aws_ssoadmin_account_assignment" "platform_admin" {
   target_id   = local.environment_management.account_ids[terraform.workspace]
   target_type = "AWS_ACCOUNT"
 }
-resource "aws_ssoadmin_account_assignment" "mp_azure_admin" {
+resource "aws_ssoadmin_account_assignment" "platform_admin_azure" {
   provider = aws.sso-management
 
   instance_arn       = local.sso_instance_arn
@@ -99,7 +99,19 @@ resource "aws_ssoadmin_account_assignment" "platform_engineer" {
   target_id   = local.environment_management.account_ids[terraform.workspace]
   target_type = "AWS_ACCOUNT"
 }
+resource "aws_ssoadmin_account_assignment" "platform_engineer_azure" {
 
+  provider = aws.sso-management
+
+  instance_arn       = local.sso_instance_arn
+  permission_set_arn = data.terraform_remote_state.mp-sso-permissions-sets.outputs.platform_engineer
+
+  principal_id   = data.aws_identitystore_group.mp_azure_aws_group.group_id
+  principal_type = "GROUP"
+
+  target_id   = local.environment_management.account_ids[terraform.workspace]
+  target_type = "AWS_ACCOUNT"
+}
 resource "aws_ssoadmin_account_assignment" "view_only" {
 
   for_each = {

--- a/terraform/environments/bootstrap/single-sign-on/main.tf
+++ b/terraform/environments/bootstrap/single-sign-on/main.tf
@@ -29,6 +29,18 @@ data "aws_identitystore_group" "platform_admin" {
     }
   }
 }
+data "aws_identitystore_group" "mp_azure_aws_group" {
+  provider = aws.sso-management
+
+  identity_store_id = local.sso_identity_store_id
+
+  alternate_identifier {
+    unique_attribute {
+      attribute_path  = "DisplayName"
+      attribute_value = "azure-aws-sso-modernisation-platform"
+    }
+  }
+}
 
 # Get Identity Store groups
 data "aws_identitystore_group" "member" {
@@ -56,6 +68,18 @@ resource "aws_ssoadmin_account_assignment" "platform_admin" {
   permission_set_arn = data.terraform_remote_state.mp-sso-permissions-sets.outputs.administrator
 
   principal_id   = data.aws_identitystore_group.platform_admin.group_id
+  principal_type = "GROUP"
+
+  target_id   = local.environment_management.account_ids[terraform.workspace]
+  target_type = "AWS_ACCOUNT"
+}
+resource "aws_ssoadmin_account_assignment" "mp_azure_admin" {
+  provider = aws.sso-management
+
+  instance_arn       = local.sso_instance_arn
+  permission_set_arn = data.terraform_remote_state.mp-sso-permissions-sets.outputs.administrator
+
+  principal_id   = data.aws_identitystore_group.mp_azure_aws_group.group_id
   principal_type = "GROUP"
 
   target_id   = local.environment_management.account_ids[terraform.workspace]


### PR DESCRIPTION
## A reference to the issue / Description of it

#9726 
## How does this PR fix the problem?

Added aws_ssoadmin_account_assignments resource to link the MP Entra ID group to the ModernisationPlatformEngineer & Administrator permission set and assign access to AWS accounts.

## How has this been tested?
Applied in sprinker and I can see permission sets have applied and account assignment can be seen in IAM Identity Center in master account.
 
![image](https://github.com/user-attachments/assets/477d11a5-efa1-4e38-9b9c-e1b43fa6dd65)

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
