### PR TITLE
🛂 Add smtp.office365.com to fqdn rules

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/fqdn_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/fqdn_rules.json
@@ -25,7 +25,8 @@
     "ccms-opa.uat.legalservices.gov.uk",
     "ccms-opa.stg.legalservices.gov.uk",
     "ccms-opa.legalservices.gov.uk",
-    ".csr.service.justice.gov.uk"
+    ".csr.service.justice.gov.uk",
+    "smtp.office365.com"
   ],
   "fw_home_net_ips": ["10.26.0.0/16", "10.27.0.0/16"]
 }


### PR DESCRIPTION


## A reference to the issue / Description of it
Require to be able to send emails related to tasks such as backups from EC2 instance using office365 login on port 587. 
As described in this [issue](https://github.com/ministryofjustice/modernisation-platform/issues/9755).

## How does this PR fix the problem?

Adds smtp.office365.com to fqdn rules, to allow sending of emails from the instance.


## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

Would allow other services to use O365 for mails. If required.

## Checklist (check `x` in `[ ]` of list items)

- [x ] I have performed a self-review of my own code
- [x ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [x ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
