### PR TITLE
Update generate-dependabot-file.sh

### DIFF
--- a/scripts/generate-dependabot-file.sh
+++ b/scripts/generate-dependabot-file.sh
@@ -45,8 +45,6 @@ if [[ -n "$tf_dirs" ]]; then
   
   echo "    schedule:" >> "$dependabot_file"
   echo "      interval: \"daily\"" >> "$dependabot_file"
-  echo "    ignore:" >> "$dependabot_file"
-  echo "      - dependency-name: \"integrations/github\"" >> "$dependabot_file"
 fi
 
 # Add Go module ecosystem entries (dynamically only for top-level directories containing go.mod)


### PR DESCRIPTION
removing as requested by GitHub and tested in environments repo as well (https://github.com/ministryofjustice/modernisation-platform-environments/pull/10334)

```
Hi Aaron,
 
The [PR](https://github.com/dependabot/dependabot-core/pull/12014) has been merged and the change has been included in version v0.308.0.
 
Can you please remove the ignore option for integrations/github in one of the affected repositories and let us know whether the Dependabot Version Update job succeeded?
```