### PR TITLE
Allow GitHub Actions Plan to Assume `ModernisationPlatformAccess` Role

### DIFF
--- a/terraform/modernisation-platform-account/iam.tf
+++ b/terraform/modernisation-platform-account/iam.tf
@@ -218,6 +218,24 @@ data "aws_iam_policy_document" "oidc_assume_plan_role_member" {
   }
 
   statement {
+    sid     = "AssumeRole"
+    effect  = "Allow"
+    actions = [
+      "sts:AssumeRole",
+    ]
+    resources = [
+      "arn:aws:iam::*:role/ModernisationPlatformAccess",
+    ]
+    condition {
+      test     = "ForAnyValue:StringLike"
+      variable = "aws:PrincipalOrgPaths"
+      values = [
+       "${data.aws_organizations_organization.root_account.id}/*/${local.environment_management.modernisation_platform_organisation_unit_id}/*"
+      ]
+    }
+  }
+
+  statement {
     sid       = "AllowOIDCReadState"
     effect    = "Allow"
     resources = ["arn:aws:s3:::modernisation-platform-terraform-state/*", "arn:aws:s3:::modernisation-platform-terraform-state/"]


### PR DESCRIPTION
This PR updates the IAM policy to allow GitHub Actions Plan workflows to assume the `ModernisationPlatformAccess` role via `sts:AssumeRole`. It fixes the AccessDenied error encountered during Terraform runs where the role could not be assumed.

https://github.com/ministryofjustice/modernisation-platform/actions/runs/14599333409/job/40953310966?pr=9846#step:9:20