### PR TITLE
Add firehose permissions to sandbox role

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -760,6 +760,7 @@ data "aws_iam_policy_document" "sandbox_additional" {
       "elasticfilesystem:*",
       "elasticloadbalancing:*",
       "events:*",
+      "firehose:*",
       "glacier:*",
       "glue:*",
       "guardduty:get*",


### PR DESCRIPTION
## A reference to the issue / Description of it

https://mojdt.slack.com/archives/C01A7QK5VM1/p1745922438486479

## How does this PR fix the problem?

Adds `firehose:*` permissions to sandbox role for clickops exploration

## How has this been tested?

Tested through CI checks

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
