### PR TITLE
🔧 add new components to Analytical Platform Compute

### DIFF
--- a/environments/analytical-platform-compute.json
+++ b/environments/analytical-platform-compute.json
@@ -12,6 +12,18 @@
     },
     {
       "name": "powerbi"
+    },
+    {
+      "name": "airflow"
+    },
+    {
+      "name": "mlflow"
+    },
+    {
+      "name": "sagemaker-ai"
+    },
+    {
+      "name": "actions-runner"
     }
   ],
   "codeowners": ["analytical-platform-engineers"],


### PR DESCRIPTION
## A reference to the issue / Description of it

This PR adds the following components to the analytical-platform-compute environment. This is needed so that workspaces can be created.

- airflow
- mlflow
- sagemaker-ai
- actions-runner

## How has this been tested?

This has not been tested, but follows instructions set out [here](https://user-guide.modernisation-platform.service.justice.gov.uk/runbooks/creating-components-for-member-applications.html#overview)

## Checklist

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation - N/A
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

