### PR TITLE
Add concurrency group to prevent overlapping workflow runs

### DIFF
--- a/.github/workflows/scheduled-baseline.yml
+++ b/.github/workflows/scheduled-baseline.yml
@@ -25,6 +25,10 @@ defaults:
   run:
     shell: bash
 
+concurrency: 
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   fetch-secrets:
     uses: ministryofjustice/modernisation-platform-github-actions/.github/workflows/aws-secrets-management.yml@cf6e13565dc769b53644a230561ea14bfbc70008 # v1.1.1


### PR DESCRIPTION
## A reference to the issue / Description of it

This PR introduces concurrency control to the GitHub Actions workflow by adding a `concurrency` block. This ensures that multiple workflow runs do not execute simultaneously, which can help avoid race conditions. #8212 

## How does this PR fix the problem?

Previously, triggering the workflow multiple times in quick succession could result in runs being cancelled or overlapping. With this change:

- The first run executes normally and is protected from being cancelled.
- Any subsequent runs that are triggered will be queued, awaiting the completion of the first run.
- When a new run is triggered, it does not cancel the previous runs that are queued.
- **However, only the latest queued run will be executed once the current run completes**, and the other queued runs will be skipped.

This ensures that no two workflow runs will execute concurrently, but only the most recent queued run will be triggered when the current one finishes, rather than triggering all queued runs.

This change helps ensure predictable behaviour in workflows that should not run concurrently (e.g., deployments, long-running tasks, etc.), but it doesn't allow all queued jobs to run sequentially — only the most recent queued job is triggered.

## How has this been tested?

I have tested this change in my personal repository. The results are working as expected

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
