### PR TITLE
Rename PTTP transit gateway attachment

### DIFF
--- a/terraform/environments/core-network-services/locals.tf
+++ b/terraform/environments/core-network-services/locals.tf
@@ -27,7 +27,7 @@ locals {
   }
 
   active_tgw_peering_attachments = [
-    "MOJ-TGW-attachment-accepter"
+    "PTTP-Transit-Gateway-attachment-accepter"
   ]
 
   active_tgw_vpc_attachments = [

--- a/terraform/environments/core-network-services/locals.tf
+++ b/terraform/environments/core-network-services/locals.tf
@@ -27,7 +27,7 @@ locals {
   }
 
   active_tgw_peering_attachments = [
-    "PTTP-Transit-Gateway-attachment-accepter"
+    "MOJ-TGW-attachment-accepter"
   ]
 
   active_tgw_vpc_attachments = [

--- a/terraform/environments/core-network-services/locals.tf
+++ b/terraform/environments/core-network-services/locals.tf
@@ -26,6 +26,7 @@ locals {
     owner         = "Modernisation Platform: modernisation-platform@digital.justice.gov.uk"
   }
 
+  # We use the legacy name for the attachment because its defined in code outside of this repository
   active_tgw_peering_attachments = [
     "PTTP-Transit-Gateway-attachment-accepter"
   ]

--- a/terraform/environments/core-network-services/moved-rename-pttp-attachment.tf
+++ b/terraform/environments/core-network-services/moved-rename-pttp-attachment.tf
@@ -1,0 +1,41 @@
+# to be removed following merge of fix/rename-pttp-attachment branch
+
+moved {
+  from = aws_ec2_transit_gateway_peering_attachment_accepter.PTTP-Production
+  to   = aws_ec2_transit_gateway_peering_attachment_accepter.moj_tgw_production
+}
+
+moved {
+  from = aws_ec2_transit_gateway_route.tgw_external_egress_routes_for_live_data_to_PTTP["psn"]
+  to   = aws_ec2_transit_gateway_route.tgw_external_egress_routes_for_live_data_to_moj["psn"]
+}
+
+moved {
+  from = aws_ec2_transit_gateway_route.tgw_external_egress_routes_for_live_data_to_PTTP["rfc-1918-10.0.0.0/8"]
+  to   = aws_ec2_transit_gateway_route.tgw_external_egress_routes_for_live_data_to_moj["rfc-1918-10.0.0.0/8"]
+}
+
+moved {
+  from = aws_ec2_transit_gateway_route.tgw_external_egress_routes_for_live_data_to_PTTP["rfc-1918-172.16.0.0/12"]
+  to   = aws_ec2_transit_gateway_route.tgw_external_egress_routes_for_live_data_to_moj["rfc-1918-172.16.0.0/12"]
+}
+
+moved {
+  from = aws_ec2_transit_gateway_route.tgw_external_egress_routes_for_live_data_to_PTTP["rfc-1918-192.168.0.0/16"]
+  to   = aws_ec2_transit_gateway_route.tgw_external_egress_routes_for_live_data_to_moj["rfc-1918-192.168.0.0/16"]
+}
+
+moved {
+  from = aws_ec2_transit_gateway_route.tgw_external_egress_routes_for_non_live_data_to_PTTP["rfc-1918-10.0.0.0/8"]
+  to   = aws_ec2_transit_gateway_route.tgw_external_egress_routes_for_non_live_data_to_moj["rfc-1918-10.0.0.0/8"]
+}
+
+moved {
+  from = aws_ec2_transit_gateway_route.tgw_external_egress_routes_for_non_live_data_to_PTTP["rfc-1918-172.16.0.0/12"]
+  to   = aws_ec2_transit_gateway_route.tgw_external_egress_routes_for_non_live_data_to_moj["rfc-1918-172.16.0.0/12"]
+}
+
+moved {
+  from = aws_ec2_transit_gateway_route.tgw_external_egress_routes_for_non_live_data_to_PTTP["rfc-1918-192.168.0.0/16"]
+  to   = aws_ec2_transit_gateway_route.tgw_external_egress_routes_for_non_live_data_to_moj["rfc-1918-192.168.0.0/16"]
+}

--- a/terraform/environments/core-network-services/transit_gateway_connections.tf
+++ b/terraform/environments/core-network-services/transit_gateway_connections.tf
@@ -13,10 +13,10 @@ data "aws_ec2_transit_gateway_vpc_attachment" "transit_gateway_all" {
   id       = each.key
 }
 
-data "aws_ec2_transit_gateway_peering_attachment" "pttp-tgw" {
+data "aws_ec2_transit_gateway_peering_attachment" "moj_tgw" {
   filter {
     name   = "tag:Name"
-    values = ["PTTP-Transit-Gateway-attachment-accepter"]
+    values = ["MOJ-TGW-Gateway-attachment-accepter"]
   }
 }
 
@@ -96,10 +96,10 @@ locals {
 # TGW Peering  #
 ################
 
-resource "aws_ec2_transit_gateway_peering_attachment_accepter" "PTTP-Production" {
-  transit_gateway_attachment_id = data.aws_ec2_transit_gateway_peering_attachment.pttp-tgw.id
+resource "aws_ec2_transit_gateway_peering_attachment_accepter" "moj_tgw_production" {
+  transit_gateway_attachment_id = data.aws_ec2_transit_gateway_peering_attachment.moj_tgw.id
   tags = {
-    Name = "PTTP-Transit-Gateway-attachment-accepter"
+    Name = "MOJ-TGW-attachment-accepter"
     Side = "Acceptor"
   }
 
@@ -146,16 +146,16 @@ resource "aws_ec2_transit_gateway_route_table_propagation" "propagate_firewall" 
   transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.external_inspection_out.id
 }
 
-# add external egress routes for non-live-data TGW route table to PTTP attachment
-resource "aws_ec2_transit_gateway_route" "tgw_external_egress_routes_for_non_live_data_to_PTTP" {
+# add external egress routes for non-live-data TGW route table to MOJ attachment
+resource "aws_ec2_transit_gateway_route" "tgw_external_egress_routes_for_non_live_data_to_moj" {
   for_each                       = local.non_live_data_static_routes
   destination_cidr_block         = each.value
   transit_gateway_attachment_id  = aws_ec2_transit_gateway_vpc_attachment.external_inspection_in.id
   transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.route-tables["non_live_data"].id
 }
 
-# add external egress routes for live-data TGW route table to PTTP attachment
-resource "aws_ec2_transit_gateway_route" "tgw_external_egress_routes_for_live_data_to_PTTP" {
+# add external egress routes for live-data TGW route table to MOJ TGW attachment
+resource "aws_ec2_transit_gateway_route" "tgw_external_egress_routes_for_live_data_to_moj" {
   for_each                       = local.live_data_static_routes
   destination_cidr_block         = each.value
   transit_gateway_attachment_id  = aws_ec2_transit_gateway_vpc_attachment.external_inspection_in.id
@@ -172,13 +172,13 @@ resource "aws_ec2_transit_gateway_route" "external_static_routes" {
 resource "aws_ec2_transit_gateway_route" "inspection_static_routes" {
   for_each                       = local.inspection_static_routes
   destination_cidr_block         = each.value
-  transit_gateway_attachment_id  = data.aws_ec2_transit_gateway_peering_attachment.pttp-tgw.id
+  transit_gateway_attachment_id  = data.aws_ec2_transit_gateway_peering_attachment.moj_tgw.id
   transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.external_inspection_out.id
 }
 
-# associate tgw external-inspection-in routing table with PTTP peering attachment
+# associate tgw external-inspection-in routing table with MOJ-TGW peering attachment
 resource "aws_ec2_transit_gateway_route_table_association" "external_inspection_in" {
-  transit_gateway_attachment_id  = data.aws_ec2_transit_gateway_peering_attachment.pttp-tgw.id
+  transit_gateway_attachment_id  = data.aws_ec2_transit_gateway_peering_attachment.moj_tgw.id
   transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.external_inspection_in.id
 }
 

--- a/terraform/environments/core-network-services/transit_gateway_connections.tf
+++ b/terraform/environments/core-network-services/transit_gateway_connections.tf
@@ -16,7 +16,7 @@ data "aws_ec2_transit_gateway_vpc_attachment" "transit_gateway_all" {
 data "aws_ec2_transit_gateway_peering_attachment" "moj_tgw" {
   filter {
     name   = "tag:Name"
-    values = ["MOJ-TGW-Gateway-attachment-accepter"]
+    values = ["PTTP-Transit-Gateway-attachment-accepter"]
   }
 }
 

--- a/terraform/environments/core-network-services/transit_gateway_connections.tf
+++ b/terraform/environments/core-network-services/transit_gateway_connections.tf
@@ -13,6 +13,7 @@ data "aws_ec2_transit_gateway_vpc_attachment" "transit_gateway_all" {
   id       = each.key
 }
 
+# We use the legacy name for the attachment because its defined in code outside of this repository
 data "aws_ec2_transit_gateway_peering_attachment" "moj_tgw" {
   filter {
     name   = "tag:Name"

--- a/terraform/environments/core-network-services/vpn.tf
+++ b/terraform/environments/core-network-services/vpn.tf
@@ -86,7 +86,7 @@ resource "aws_ec2_transit_gateway_route_table_association" "vpn_attachments" {
 resource "aws_ec2_transit_gateway_route" "azure_static_routes" {
   for_each                       = toset(local.azure_static_routes)
   destination_cidr_block         = each.value
-  transit_gateway_attachment_id  = data.aws_ec2_transit_gateway_peering_attachment.pttp-tgw.id
+  transit_gateway_attachment_id  = data.aws_ec2_transit_gateway_peering_attachment.moj_tgw.id
   transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.external_inspection_out.id
 }
 


### PR DESCRIPTION
## A reference to the issue / Description of it

The PTTP transit gateway name is no longer accurate

## How does this PR fix the problem?

Renames all resources referring to PTTP to reflect the correct name.

Implements `moved {}` blocks for all renamed resources to minimise disruption.

## How has this been tested?

Tested through CI checks

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
