### PR TITLE
Rename pttp attachment again

### DIFF
--- a/terraform/environments/core-network-services/locals.tf
+++ b/terraform/environments/core-network-services/locals.tf
@@ -28,7 +28,7 @@ locals {
 
   # We use the legacy name for the attachment because its defined in code outside of this repository
   active_tgw_peering_attachments = [
-    "PTTP-Transit-Gateway-attachment-accepter"
+    "MOJ-TGW-attachment-accepter"
   ]
 
   active_tgw_vpc_attachments = [

--- a/terraform/environments/core-network-services/locals.tf
+++ b/terraform/environments/core-network-services/locals.tf
@@ -26,7 +26,6 @@ locals {
     owner         = "Modernisation Platform: modernisation-platform@digital.justice.gov.uk"
   }
 
-  # We use the legacy name for the attachment because its defined in code outside of this repository
   active_tgw_peering_attachments = [
     "MOJ-TGW-attachment-accepter"
   ]

--- a/terraform/environments/core-network-services/moved-rename-pttp-attachment.tf
+++ b/terraform/environments/core-network-services/moved-rename-pttp-attachment.tf
@@ -39,3 +39,8 @@ moved {
   from = aws_ec2_transit_gateway_route.tgw_external_egress_routes_for_non_live_data_to_PTTP["rfc-1918-192.168.0.0/16"]
   to   = aws_ec2_transit_gateway_route.tgw_external_egress_routes_for_non_live_data_to_moj["rfc-1918-192.168.0.0/16"]
 }
+
+moved {
+  from = aws_flow_log.tgw_flowlog["PTTP-Transit-Gateway-attachment-accepter"]
+  to   = aws_flow_log.tgw_flowlog["MOJ-TGW-attachment-accepter"]
+}

--- a/terraform/environments/core-network-services/transit_gateway_connections.tf
+++ b/terraform/environments/core-network-services/transit_gateway_connections.tf
@@ -13,7 +13,6 @@ data "aws_ec2_transit_gateway_vpc_attachment" "transit_gateway_all" {
   id       = each.key
 }
 
-# We use the legacy name for the attachment because its defined in code outside of this repository
 data "aws_ec2_transit_gateway_peering_attachment" "moj_tgw" {
   filter {
     name   = "tag:Name"

--- a/terraform/environments/core-network-services/transit_gateway_connections.tf
+++ b/terraform/environments/core-network-services/transit_gateway_connections.tf
@@ -17,7 +17,7 @@ data "aws_ec2_transit_gateway_vpc_attachment" "transit_gateway_all" {
 data "aws_ec2_transit_gateway_peering_attachment" "moj_tgw" {
   filter {
     name   = "tag:Name"
-    values = ["PTTP-Transit-Gateway-attachment-accepter"]
+    values = ["MOJ-TGW-attachment-accepter"]
   }
 }
 


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/pull/9892

## How does this PR fix the problem?

Solves a chicken-and-egg problem around renaming an attachment.

## How has this been tested?

Tested with local plan. Will recreate some CloudWatch alarms but otherwise nondestructive

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
