### PR TITLE
Fixes issue with env vars not accessible to the python script.

### DIFF
--- a/.github/workflows/confirm-contacts-for-environments.yml
+++ b/.github/workflows/confirm-contacts-for-environments.yml
@@ -97,6 +97,9 @@ jobs:
 
       # Step 5: Create GitHub Issue and Notify Owners
       - name: Create Issue and Notify Owner  
+        env:
+          API_KEY: ${{ env.GOV_UK_NOTIFY_API_KEY }}
+          TEMPLATE_ID: ${{ env.TEMPLATE_ID }}
         run: |
           cd $GITHUB_WORKSPACE
           pwd


### PR DESCRIPTION

## A reference to the issue / Description of it

Amends how the environment variables are assigned for the notification step.

## How does this PR fix the problem?

The template_id and api_key vars were not available to the python script that sends the email notifications. This adds the env variables to the step.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Ran from feature branch successfully.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
