### PR TITLE
#9831 - Adds new pagerduty resources for routing high priority alerts without on-call workflow.

### DIFF
--- a/terraform/pagerduty/aws.tf
+++ b/terraform/pagerduty/aws.tf
@@ -17,6 +17,7 @@ resource "aws_secretsmanager_secret" "pagerduty_integration_keys" {
 resource "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {
   secret_id = aws_secretsmanager_secret.pagerduty_integration_keys.id
   secret_string = jsonencode(merge({
+    core_alerts_high_priority_cloudwatch  = pagerduty_service_integration.core_alerts_high_priority_cloudwatch.integration_key,
     core_alerts_cloudwatch            = pagerduty_service_integration.core_alerts_cloudwatch.integration_key,
     security_hub                      = pagerduty_service_integration.security_hub.integration_key,
     security_hub_members              = pagerduty_service_integration.security_hub_members.integration_key,

--- a/terraform/pagerduty/policy-schedules.tf
+++ b/terraform/pagerduty/policy-schedules.tf
@@ -19,6 +19,19 @@ resource "pagerduty_escalation_policy" "on_call" {
   }
 }
 
+resource "pagerduty_escalation_policy" "high_priority" {
+  name  = "Modernisation Platform High Priority Policy"
+  teams = [pagerduty_team.modernisation_platform.id]
+
+  rule {
+    escalation_delay_in_minutes = 10
+    target {
+      type = "user_reference"
+      id   = pagerduty_user.pager_duty_users["modernisation_platform"].id
+    }
+  }
+}
+
 resource "pagerduty_escalation_policy" "low_priority" {
   name  = "Modernisation Platform Low Priority Policy"
   teams = [pagerduty_team.modernisation_platform.id]


### PR DESCRIPTION
## A reference to the issue / Description of it

#9831 

## How does this PR fix the problem?

Adds new PagerDuty service & slack integration for the handling of high priority alerts that are not to trigger the on-call workflow. I've attempted to follow the existing naming convention.

A further PR will follow later that covers the SNS & cloudwatch changes.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
