### PR TITLE
Grant delius-pdm-uplift-scripts repo access

### DIFF
--- a/environments/delius-core.json
+++ b/environments/delius-core.json
@@ -135,6 +135,7 @@
     "ministryofjustice/hmpps-openldap-container",
     "ministryofjustice/hmpps-delius-docker-images",
     "ministryofjustice/hmpps-pwm",
-    "ministryofjustice/ndelius-um"
+    "ministryofjustice/ndelius-um",
+    "ministryofjustice/delius-pdm-uplift-scripts"
   ]
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

[DST-19341](https://jira.engineering-dev.probation.hmpps.dsd.io/browse/DST-19341) - National Delius database uplift pipeline in Modernisation Platform.

## How does this PR fix the problem?

Grants the delius-pdm-uplift-scripts repo access to upload uplift scripts to S3 buckets for use by the deployment pipeline.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

N/A

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

N/A

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)
