### PR TITLE
DPR2-1774: Update actions for reporting roles

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -1213,6 +1213,7 @@ data "aws_iam_policy_document" "reporting-operations" {
       "dms:StopReplicationTask",
       "dms:TestConnection",
       "dms:ReloadTables",
+      "dms:RebootReplicationInstance",
       "sqlworkbench:CreateFolder",
       "sqlworkbench:PutTab",
       "sqlworkbench:BatchDeleteFolder",

--- a/terraform/environments/digital-prison-reporting/iam.tf
+++ b/terraform/environments/digital-prison-reporting/iam.tf
@@ -233,6 +233,7 @@ data "aws_iam_policy_document" "circleci_iam_policy" {
       "logs:CreateLogGroup",
       "logs:DeleteLogGroup",
       "logs:TagLogGroup",
+      "logs:TagResource",
       "glue:CreateSecurityConfiguration",
       "glue:DeleteSecurityConfiguration",
       "glue:CreateUserDefinedFunction",


### PR DESCRIPTION
## A reference to the issue / Description of it

This fixes the issue with failing pipeline:
```
│ Error: updating tags for CloudWatch Logs Log Group (arn:aws:logs:eu-west-2:771283872747:log-group:/aws/vendedlogs/states/log-group-dpr-replay-pipeline-dps-dps-testing2-development): tagging resource (arn:aws:logs:eu-west-2:771283872747:log-group:/aws/vendedlogs/states/log-group-dpr-replay-pipeline-dps-dps-testing2-development): operation error CloudWatch Logs: TagResource, https response error StatusCode: 400, RequestID: dbc98a00-7e58-446b-ab65-9b64e1e2cad5, api error AccessDeniedException: User: arn:aws:sts::771283872747:assumed-role/circleci_iam_role/circleci-oidc-session is not authorized to perform: logs:TagResource on resource: arn:aws:logs:eu-west-2:771283872747:log-group:/aws/vendedlogs/states/log-group-dpr-replay-pipeline-dps-dps-testing2-development because no identity-based policy allows the logs:TagResource action
```
https://app.circleci.com/pipelines/github/ministryofjustice/digital-prison-reporting-domains/2858/workflows/1719f086-681d-4ed0-9d2c-a7fe801ca6cd/jobs/9230

## How does this PR fix the problem?

This fixes the issue by granting the `logs:TagResource` permission to the circleci role and the `dms:RebootReplicationInstance` permission to the reporting role.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.
The job will be re-ran to verify it is fixed.


## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (Not needed)

## Additional comments (if any)

N/A
