### PR TITLE
DPR2-1774: Add iam:TagPolicy to digital-prison-reposrting circleci

### DIFF
--- a/terraform/environments/digital-prison-reporting/iam.tf
+++ b/terraform/environments/digital-prison-reporting/iam.tf
@@ -254,6 +254,7 @@ data "aws_iam_policy_document" "circleci_iam_policy" {
       "glue:GetConnection",
       "iam:TagRole",
       "iam:UpdateAssumeRolePolicy",
+      "iam:TagPolicy",
       "scheduler:CreateSchedule",
       "scheduler:DeleteSchedule",
       "scheduler:UpdateSchedule",


### PR DESCRIPTION
## A reference to the issue / Description of it

The Digital Prison Reporting circleci pipeline is failing with the error:
```
│ Error: updating tags for IAM (Identity & Access Management) Policy (arn:aws:iam::771283872747:policy/dpr-reconciliation-dps-testing2-development-policy): tagging resource (arn:aws:iam::771283872747:policy/dpr-reconciliation-dps-testing2-development-policy): operation error IAM: TagPolicy, https response error StatusCode: 403, RequestID: 4f73ccf2-8f3b-479e-a6e7-02ce576fb54e, api error AccessDenied: User: arn:aws:sts::771283872747:assumed-role/circleci_iam_role/circleci-oidc-session is not authorized to perform: iam:TagPolicy on resource: policy arn:aws:iam::771283872747:policy/dpr-reconciliation-dps-testing2-development-policy because no identity-based policy allows the iam:TagPolicy action
```
https://app.circleci.com/pipelines/github/ministryofjustice/digital-prison-reporting-domains/2861/workflows/74c442ad-12ba-4b47-8804-c2983c8468a0/jobs/9242

## How does this PR fix the problem?

This PR adds the required `iam:TagPolicy` permission to the Digital Prison Reporting circleci role

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.
The pipeline will be re-applied to verify the fix.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?
There will be no impact.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (Not needed)

## Additional comments (if any)

N/A
