### PR TITLE
core-vpc IP utilisation IAM roles

### DIFF
--- a/terraform/environments/core-vpc/iam.tf
+++ b/terraform/environments/core-vpc/iam.tf
@@ -64,7 +64,7 @@ resource "aws_iam_role" "ip_usage_metrics_read" {
     Statement = [{
       Effect = "Allow",
       Principal = {
-        AWS = "arn:aws:iam::${local.environment_management.account_ids["core-logging"]}:root"
+        AWS = "arn:aws:iam::${local.environment_management.account_ids["core-logging-production"]}:root"
       },
       Action = "sts:AssumeRole"
     }]


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/8334

## How does this PR fix the problem?

This adds a role to be used by a lambda function in the core-logging account to read IP utilisation metrics from the core-vpc accounts.

The lambda will be deployed in a subsequent PR.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
