### PR TITLE
Allow Platform Engineer Admin `tiros:*` IAM permissions

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -648,6 +648,7 @@ data "aws_iam_policy_document" "platform_engineer_additional_additional" {
       "sts:*",
       "support:*",
       "textract:*",
+      "tiros:*",
       "wafv2:*",
       "wellarchitected:*"
     ]

--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -1543,6 +1543,8 @@ data "aws_iam_policy_document" "s3_upload_policy_document" {
     ]
   }
   statement {
+    #checkov:skip=CKV_AWS_111 ListAliases only supports a wildcard
+    #checkov:skip=CKV_AWS_356 ListAliases only supports a wildcard
     sid    = "AllowS3UploadKms"
     effect = "Allow"
     actions = [

--- a/terraform/single-sign-on/outputs.tf
+++ b/terraform/single-sign-on/outputs.tf
@@ -1,13 +1,13 @@
+output "data_engineer" {
+  value = aws_ssoadmin_permission_set.modernisation_platform_data_engineer.arn
+}
+
 output "developer" {
   value = aws_ssoadmin_permission_set.modernisation_platform_developer.arn
 }
 
-output "sandbox" {
-  value = aws_ssoadmin_permission_set.modernisation_platform_sandbox.arn
-}
-
-output "migration" {
-  value = aws_ssoadmin_permission_set.modernisation_platform_migration.arn
+output "fleet_manager" {
+  value = aws_ssoadmin_permission_set.modernisation_platform_fleet_manager.arn
 }
 
 output "instance_access" {
@@ -18,12 +18,8 @@ output "instance_management" {
   value = aws_ssoadmin_permission_set.modernisation_platform_instance_management.arn
 }
 
-output "data_engineer" {
-  value = aws_ssoadmin_permission_set.modernisation_platform_data_engineer.arn
-}
-
-output "reporting_operations" {
-  value = aws_ssoadmin_permission_set.modernisation_platform_reporting_operations.arn
+output "migration" {
+  value = aws_ssoadmin_permission_set.modernisation_platform_migration.arn
 }
 
 output "mwaa_user" {
@@ -34,8 +30,12 @@ output "powerbi_user" {
   value = aws_ssoadmin_permission_set.modernisation_platform_powerbi_user.arn
 }
 
-output "fleet_manager" {
-  value = aws_ssoadmin_permission_set.modernisation_platform_fleet_manager.arn
+output "reporting_operations" {
+  value = aws_ssoadmin_permission_set.modernisation_platform_reporting_operations.arn
+}
+
+output "sandbox" {
+  value = aws_ssoadmin_permission_set.modernisation_platform_sandbox.arn
 }
 
 # Data outputs
@@ -43,34 +43,34 @@ output "administrator" {
   value = data.aws_ssoadmin_permission_set.administrator.arn
 }
 
-output "view-only" {
-  value = data.aws_ssoadmin_permission_set.view-only.arn
-}
-
 output "platform_engineer" {
   value = data.aws_ssoadmin_permission_set.platform_engineer.arn
-}
-
-output "security_audit" {
-  value = data.aws_ssoadmin_permission_set.security_audit.arn
-}
-
-output "read_only" {
-  value = data.aws_ssoadmin_permission_set.read_only.arn
-}
-
-output "quicksight_admin" {
-  value = aws_ssoadmin_permission_set.modernisation_platform_quicksight_admin.arn
-}
-
-output "ssoadmin_instances" {
-  value = data.aws_ssoadmin_instances.default
 }
 
 output "platform_engineer_admin" {
   value = aws_ssoadmin_permission_set.modernisation_platform_platform_engineer_admin.arn
 }
 
+output "quicksight_admin" {
+  value = aws_ssoadmin_permission_set.modernisation_platform_quicksight_admin.arn
+}
+
+output "read_only" {
+  value = data.aws_ssoadmin_permission_set.read_only.arn
+}
+
+output "security_audit" {
+  value = data.aws_ssoadmin_permission_set.security_audit.arn
+}
+
 output "ssm_session_access" {
   value = aws_ssoadmin_permission_set.modernisation_platform_ssm_session_access.arn
+}
+
+output "ssoadmin_instances" {
+  value = data.aws_ssoadmin_instances.default
+}
+
+output "view-only" {
+  value = data.aws_ssoadmin_permission_set.view-only.arn
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

This PR is tracked upstream by [📋 Add tiros:* to the platform-engineer-admin roles](https://github.com/ministryofjustice/analytical-platform/issues/7642#top)

## How does this PR fix the problem?

AWS Tiros is an internal service used by the AWS VPC Reachability Analyzer tool. In order to simplify reachability checks being conducted by platform administrators this IAM permission will allow them to use the reachability tool to pinpoint where traffic flows are failing within an account.

## How has this been tested?

Tested through CI pipeline checks

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
