### PR TITLE
Add secret to limied read IAM policy

### DIFF
--- a/terraform/modernisation-platform-account/iam.tf
+++ b/terraform/modernisation-platform-account/iam.tf
@@ -163,6 +163,7 @@ data "aws_iam_policy_document" "modernisation_account_limited_read" {
       "arn:aws:secretsmanager:eu-west-2:${data.aws_caller_identity.current.account_id}:secret:environment_management-??????",
       "arn:aws:secretsmanager:eu-west-2:${data.aws_caller_identity.current.account_id}:secret:pagerduty_integration_keys-??????",
       "arn:aws:secretsmanager:eu-west-2:${data.aws_caller_identity.current.account_id}:secret:mod-platform-circleci-??????",
+      "arn:aws:secretsmanager:eu-west-2:${data.aws_caller_identity.current.account_id}:secret:nonmp-account-ids-??????",
     ]
   }
   statement {


### PR DESCRIPTION
Add secret to `modernisation-account-limited-read-member-access` role IAM policy so that the observability-platform workflow can read the secret from the Modernisation-Platform account