### PR TITLE
Add IKE versions input and specify ike2 for yjb vpn tunnels

### DIFF
--- a/terraform/environments/core-network-services/locals.tf
+++ b/terraform/environments/core-network-services/locals.tf
@@ -56,7 +56,7 @@ locals {
   )
   firewall_sets = fileexists("./firewall-rules/sets.json") ? jsondecode(templatefile("./firewall-rules/sets.json", local.all_cidr_ranges)) : {}
 
-  vpn_attachments = fileexists("./vpn_attachments.json") ? jsondecode(file("./vpn_attachments.json")) : {}
+  vpn_attachments = fileexists("./vpn_attachments.json") ? jsondecode(file("./vpn_attachments.json")) : tomap({})
 
   noms_vpn_attachment_ids = toset([for k in aws_vpn_connection.this : k.transit_gateway_attachment_id if(length(regexall("(?:NOMS)", k.tags.Name)) > 0)])
 

--- a/terraform/environments/core-network-services/vpn.tf
+++ b/terraform/environments/core-network-services/vpn.tf
@@ -11,14 +11,17 @@ resource "aws_customer_gateway" "this" {
 }
 
 resource "aws_vpn_connection" "this" {
-  for_each                                = local.vpn_attachments
-  transit_gateway_id                      = aws_ec2_transit_gateway.transit-gateway.id
-  customer_gateway_id                     = aws_customer_gateway.this[each.key].id
-  static_routes_only                      = try(each.value.static_routes_only, false)
-  type                                    = "ipsec.1"
-  tunnel1_dpd_timeout_action              = try(each.value.tunnel_dpd_timeout_action, null)
-  tunnel1_dpd_timeout_seconds             = try(each.value.tunnel_dpd_timeout_seconds, "30")
-  tunnel1_ike_versions                    = [try(each.value.tunnel1_ike_versions, null)]
+  for_each                    = local.vpn_attachments
+  transit_gateway_id          = aws_ec2_transit_gateway.transit-gateway.id
+  customer_gateway_id         = aws_customer_gateway.this[each.key].id
+  static_routes_only          = try(each.value.static_routes_only, false)
+  type                        = "ipsec.1"
+  tunnel1_dpd_timeout_action  = try(each.value.tunnel_dpd_timeout_action, null)
+  tunnel1_dpd_timeout_seconds = try(each.value.tunnel_dpd_timeout_seconds, "30")
+  tunnel1_ike_versions = try(
+    each.value.tunnel1_ike_versions != null ? [each.value.tunnel1_ike_versions] : ["ikev1", "ikev2"],
+    ["ikev1", "ikev2"]
+  )
   tunnel1_inside_cidr                     = try(each.value.tunnel1_inside_cidr, null)
   tunnel1_phase1_dh_group_numbers         = [try(each.value.tunnel_phase1_dh_group_numbers, null)]
   tunnel1_phase1_encryption_algorithms    = [try(each.value.tunnel_phase1_encryption_algorithms, null)]
@@ -32,16 +35,19 @@ resource "aws_vpn_connection" "this" {
   tunnel1_enable_tunnel_lifecycle_control = try(each.value.tunnel1_enable_tunnel_lifecycle_control, false)
   tunnel2_dpd_timeout_action              = try(each.value.tunnel_dpd_timeout_action, null)
   tunnel2_dpd_timeout_seconds             = try(each.value.tunnel_dpd_timeout_seconds, "30")
-  tunnel2_ike_versions                    = [try(each.value.tunnel2_ike_versions, null)]
-  tunnel2_inside_cidr                     = try(each.value.tunnel2_inside_cidr, null)
-  tunnel2_phase1_dh_group_numbers         = [try(each.value.tunnel_phase1_dh_group_numbers, null)]
-  tunnel2_phase1_encryption_algorithms    = [try(each.value.tunnel_phase1_encryption_algorithms, null)]
-  tunnel2_phase1_integrity_algorithms     = [try(each.value.tunnel_phase1_integrity_algorithms, null)]
-  tunnel2_phase1_lifetime_seconds         = try(each.value.tunnel_phase1_lifetime_seconds, null)
-  tunnel2_phase2_dh_group_numbers         = [try(each.value.tunnel_phase2_dh_group_numbers, null)]
-  tunnel2_phase2_encryption_algorithms    = [try(each.value.tunnel_phase2_encryption_algorithms, null)]
-  tunnel2_phase2_integrity_algorithms     = [try(each.value.tunnel_phase2_integrity_algorithms, null)]
-  tunnel2_phase2_lifetime_seconds         = try(each.value.tunnel_phase2_lifetime_seconds, null)
+  tunnel2_ike_versions = try(
+    each.value.tunnel2_ike_versions != null ? [each.value.tunnel2_ike_versions] : ["ikev1", "ikev2"],
+    ["ikev1", "ikev2"]
+  )
+  tunnel2_inside_cidr                  = try(each.value.tunnel2_inside_cidr, null)
+  tunnel2_phase1_dh_group_numbers      = [try(each.value.tunnel_phase1_dh_group_numbers, null)]
+  tunnel2_phase1_encryption_algorithms = [try(each.value.tunnel_phase1_encryption_algorithms, null)]
+  tunnel2_phase1_integrity_algorithms  = [try(each.value.tunnel_phase1_integrity_algorithms, null)]
+  tunnel2_phase1_lifetime_seconds      = try(each.value.tunnel_phase1_lifetime_seconds, null)
+  tunnel2_phase2_dh_group_numbers      = [try(each.value.tunnel_phase2_dh_group_numbers, null)]
+  tunnel2_phase2_encryption_algorithms = [try(each.value.tunnel_phase2_encryption_algorithms, null)]
+  tunnel2_phase2_integrity_algorithms  = [try(each.value.tunnel_phase2_integrity_algorithms, null)]
+  tunnel2_phase2_lifetime_seconds      = try(each.value.tunnel_phase2_lifetime_seconds, null)
 
   tunnel2_startup_action                  = try(each.value.tunnel_startup_action, null)
   tunnel2_enable_tunnel_lifecycle_control = try(each.value.tunnel2_enable_tunnel_lifecycle_control, false)
@@ -70,9 +76,9 @@ resource "aws_vpn_connection" "this" {
 
   lifecycle {
     ignore_changes = [
-      tunnel1_ike_versions, tunnel1_phase1_dh_group_numbers, tunnel1_phase1_encryption_algorithms, tunnel1_phase1_integrity_algorithms,
+      tunnel1_phase1_dh_group_numbers, tunnel1_phase1_encryption_algorithms, tunnel1_phase1_integrity_algorithms,
       tunnel1_phase2_dh_group_numbers, tunnel1_phase2_encryption_algorithms, tunnel1_phase2_integrity_algorithms,
-      tunnel2_ike_versions, tunnel2_phase1_dh_group_numbers, tunnel2_phase1_encryption_algorithms, tunnel2_phase1_integrity_algorithms,
+      tunnel2_phase1_dh_group_numbers, tunnel2_phase1_encryption_algorithms, tunnel2_phase1_integrity_algorithms,
       tunnel2_phase2_dh_group_numbers, tunnel2_phase2_encryption_algorithms, tunnel2_phase2_integrity_algorithms,
     ]
   }

--- a/terraform/environments/core-network-services/vpn.tf
+++ b/terraform/environments/core-network-services/vpn.tf
@@ -18,7 +18,7 @@ resource "aws_vpn_connection" "this" {
   type                                    = "ipsec.1"
   tunnel1_dpd_timeout_action              = try(each.value.tunnel_dpd_timeout_action, null)
   tunnel1_dpd_timeout_seconds             = try(each.value.tunnel_dpd_timeout_seconds, "30")
-  tunnel1_ike_versions                    = try(each.value.tunnel_ike_versions, null)
+  tunnel1_ike_versions                    = [try(each.value.tunnel_ike_versions, null)]
   tunnel1_inside_cidr                     = try(each.value.tunnel1_inside_cidr, null)
   tunnel1_phase1_dh_group_numbers         = [try(each.value.tunnel_phase1_dh_group_numbers, null)]
   tunnel1_phase1_encryption_algorithms    = [try(each.value.tunnel_phase1_encryption_algorithms, null)]
@@ -32,7 +32,7 @@ resource "aws_vpn_connection" "this" {
   tunnel1_enable_tunnel_lifecycle_control = try(each.value.tunnel1_enable_tunnel_lifecycle_control, false)
   tunnel2_dpd_timeout_action              = try(each.value.tunnel_dpd_timeout_action, null)
   tunnel2_dpd_timeout_seconds             = try(each.value.tunnel_dpd_timeout_seconds, "30")
-  tunnel2_ike_versions                    = try(each.value.tunnel2_ike_versions, null)
+  tunnel2_ike_versions                    = [try(each.value.tunnel2_ike_versions, null)]
   tunnel2_inside_cidr                     = try(each.value.tunnel2_inside_cidr, null)
   tunnel2_phase1_dh_group_numbers         = [try(each.value.tunnel_phase1_dh_group_numbers, null)]
   tunnel2_phase1_encryption_algorithms    = [try(each.value.tunnel_phase1_encryption_algorithms, null)]

--- a/terraform/environments/core-network-services/vpn.tf
+++ b/terraform/environments/core-network-services/vpn.tf
@@ -18,6 +18,8 @@ resource "aws_vpn_connection" "this" {
   type                                    = "ipsec.1"
   tunnel1_dpd_timeout_action              = try(each.value.tunnel_dpd_timeout_action, null)
   tunnel1_dpd_timeout_seconds             = try(each.value.tunnel_dpd_timeout_seconds, "30")
+  tunnel1_ike_versions                    = try(each.value.tunnel_ike_versions, null)
+  tunnel1_inside_cidr                     = try(each.value.tunnel1_inside_cidr, null)
   tunnel1_phase1_dh_group_numbers         = [try(each.value.tunnel_phase1_dh_group_numbers, null)]
   tunnel1_phase1_encryption_algorithms    = [try(each.value.tunnel_phase1_encryption_algorithms, null)]
   tunnel1_phase1_integrity_algorithms     = [try(each.value.tunnel_phase1_integrity_algorithms, null)]
@@ -26,11 +28,12 @@ resource "aws_vpn_connection" "this" {
   tunnel1_phase2_encryption_algorithms    = [try(each.value.tunnel_phase2_encryption_algorithms, null)]
   tunnel1_phase2_integrity_algorithms     = [try(each.value.tunnel_phase2_integrity_algorithms, null)]
   tunnel1_phase2_lifetime_seconds         = try(each.value.tunnel_phase2_lifetime_seconds, null)
-  tunnel1_inside_cidr                     = try(each.value.tunnel1_inside_cidr, null)
   tunnel1_startup_action                  = try(each.value.tunnel_startup_action, null)
   tunnel1_enable_tunnel_lifecycle_control = try(each.value.tunnel1_enable_tunnel_lifecycle_control, false)
   tunnel2_dpd_timeout_action              = try(each.value.tunnel_dpd_timeout_action, null)
   tunnel2_dpd_timeout_seconds             = try(each.value.tunnel_dpd_timeout_seconds, "30")
+  tunnel2_ike_versions                    = try(each.value.tunnel2_ike_versions, null)
+  tunnel2_inside_cidr                     = try(each.value.tunnel2_inside_cidr, null)
   tunnel2_phase1_dh_group_numbers         = [try(each.value.tunnel_phase1_dh_group_numbers, null)]
   tunnel2_phase1_encryption_algorithms    = [try(each.value.tunnel_phase1_encryption_algorithms, null)]
   tunnel2_phase1_integrity_algorithms     = [try(each.value.tunnel_phase1_integrity_algorithms, null)]
@@ -39,7 +42,7 @@ resource "aws_vpn_connection" "this" {
   tunnel2_phase2_encryption_algorithms    = [try(each.value.tunnel_phase2_encryption_algorithms, null)]
   tunnel2_phase2_integrity_algorithms     = [try(each.value.tunnel_phase2_integrity_algorithms, null)]
   tunnel2_phase2_lifetime_seconds         = try(each.value.tunnel_phase2_lifetime_seconds, null)
-  tunnel2_inside_cidr                     = try(each.value.tunnel2_inside_cidr, null)
+
   tunnel2_startup_action                  = try(each.value.tunnel_startup_action, null)
   tunnel2_enable_tunnel_lifecycle_control = try(each.value.tunnel2_enable_tunnel_lifecycle_control, false)
   remote_ipv4_network_cidr                = try(each.value.remote_ipv4_network_cidr, local.core-vpcs[each.value.modernisation_platform_vpc].cidr.subnet_sets["general"].cidr)

--- a/terraform/environments/core-network-services/vpn.tf
+++ b/terraform/environments/core-network-services/vpn.tf
@@ -18,7 +18,7 @@ resource "aws_vpn_connection" "this" {
   type                                    = "ipsec.1"
   tunnel1_dpd_timeout_action              = try(each.value.tunnel_dpd_timeout_action, null)
   tunnel1_dpd_timeout_seconds             = try(each.value.tunnel_dpd_timeout_seconds, "30")
-  tunnel1_ike_versions                    = [try(each.value.tunnel_ike_versions, null)]
+  tunnel1_ike_versions                    = [try(each.value.tunnel1_ike_versions, null)]
   tunnel1_inside_cidr                     = try(each.value.tunnel1_inside_cidr, null)
   tunnel1_phase1_dh_group_numbers         = [try(each.value.tunnel_phase1_dh_group_numbers, null)]
   tunnel1_phase1_encryption_algorithms    = [try(each.value.tunnel_phase1_encryption_algorithms, null)]

--- a/terraform/environments/core-network-services/vpn.tf
+++ b/terraform/environments/core-network-services/vpn.tf
@@ -11,17 +11,14 @@ resource "aws_customer_gateway" "this" {
 }
 
 resource "aws_vpn_connection" "this" {
-  for_each                    = local.vpn_attachments
-  transit_gateway_id          = aws_ec2_transit_gateway.transit-gateway.id
-  customer_gateway_id         = aws_customer_gateway.this[each.key].id
-  static_routes_only          = try(each.value.static_routes_only, false)
-  type                        = "ipsec.1"
-  tunnel1_dpd_timeout_action  = try(each.value.tunnel_dpd_timeout_action, null)
-  tunnel1_dpd_timeout_seconds = try(each.value.tunnel_dpd_timeout_seconds, "30")
-  tunnel1_ike_versions = try(
-    each.value.tunnel1_ike_versions != null ? [each.value.tunnel1_ike_versions] : ["ikev1", "ikev2"],
-    ["ikev1", "ikev2"]
-  )
+  for_each                                = local.vpn_attachments
+  transit_gateway_id                      = aws_ec2_transit_gateway.transit-gateway.id
+  customer_gateway_id                     = aws_customer_gateway.this[each.key].id
+  static_routes_only                      = try(each.value.static_routes_only, false)
+  type                                    = "ipsec.1"
+  tunnel1_dpd_timeout_action              = try(each.value.tunnel_dpd_timeout_action, null)
+  tunnel1_dpd_timeout_seconds             = try(each.value.tunnel_dpd_timeout_seconds, "30")
+  tunnel1_ike_versions                    = try(toset(each.value.tunnel1_ike_versions), null)
   tunnel1_inside_cidr                     = try(each.value.tunnel1_inside_cidr, null)
   tunnel1_phase1_dh_group_numbers         = [try(each.value.tunnel_phase1_dh_group_numbers, null)]
   tunnel1_phase1_encryption_algorithms    = [try(each.value.tunnel_phase1_encryption_algorithms, null)]
@@ -35,20 +32,16 @@ resource "aws_vpn_connection" "this" {
   tunnel1_enable_tunnel_lifecycle_control = try(each.value.tunnel1_enable_tunnel_lifecycle_control, false)
   tunnel2_dpd_timeout_action              = try(each.value.tunnel_dpd_timeout_action, null)
   tunnel2_dpd_timeout_seconds             = try(each.value.tunnel_dpd_timeout_seconds, "30")
-  tunnel2_ike_versions = try(
-    each.value.tunnel2_ike_versions != null ? [each.value.tunnel2_ike_versions] : ["ikev1", "ikev2"],
-    ["ikev1", "ikev2"]
-  )
-  tunnel2_inside_cidr                  = try(each.value.tunnel2_inside_cidr, null)
-  tunnel2_phase1_dh_group_numbers      = [try(each.value.tunnel_phase1_dh_group_numbers, null)]
-  tunnel2_phase1_encryption_algorithms = [try(each.value.tunnel_phase1_encryption_algorithms, null)]
-  tunnel2_phase1_integrity_algorithms  = [try(each.value.tunnel_phase1_integrity_algorithms, null)]
-  tunnel2_phase1_lifetime_seconds      = try(each.value.tunnel_phase1_lifetime_seconds, null)
-  tunnel2_phase2_dh_group_numbers      = [try(each.value.tunnel_phase2_dh_group_numbers, null)]
-  tunnel2_phase2_encryption_algorithms = [try(each.value.tunnel_phase2_encryption_algorithms, null)]
-  tunnel2_phase2_integrity_algorithms  = [try(each.value.tunnel_phase2_integrity_algorithms, null)]
-  tunnel2_phase2_lifetime_seconds      = try(each.value.tunnel_phase2_lifetime_seconds, null)
-
+  tunnel2_ike_versions                    = try(toset(each.value.tunnel2_ike_versions), null)
+  tunnel2_inside_cidr                     = try(each.value.tunnel2_inside_cidr, null)
+  tunnel2_phase1_dh_group_numbers         = [try(each.value.tunnel_phase1_dh_group_numbers, null)]
+  tunnel2_phase1_encryption_algorithms    = [try(each.value.tunnel_phase1_encryption_algorithms, null)]
+  tunnel2_phase1_integrity_algorithms     = [try(each.value.tunnel_phase1_integrity_algorithms, null)]
+  tunnel2_phase1_lifetime_seconds         = try(each.value.tunnel_phase1_lifetime_seconds, null)
+  tunnel2_phase2_dh_group_numbers         = [try(each.value.tunnel_phase2_dh_group_numbers, null)]
+  tunnel2_phase2_encryption_algorithms    = [try(each.value.tunnel_phase2_encryption_algorithms, null)]
+  tunnel2_phase2_integrity_algorithms     = [try(each.value.tunnel_phase2_integrity_algorithms, null)]
+  tunnel2_phase2_lifetime_seconds         = try(each.value.tunnel_phase2_lifetime_seconds, null)
   tunnel2_startup_action                  = try(each.value.tunnel_startup_action, null)
   tunnel2_enable_tunnel_lifecycle_control = try(each.value.tunnel2_enable_tunnel_lifecycle_control, false)
   remote_ipv4_network_cidr                = try(each.value.remote_ipv4_network_cidr, local.core-vpcs[each.value.modernisation_platform_vpc].cidr.subnet_sets["general"].cidr)

--- a/terraform/environments/core-network-services/vpn_attachments.json
+++ b/terraform/environments/core-network-services/vpn_attachments.json
@@ -85,8 +85,8 @@
     "tunnel_phase2_dh_group_numbers": "19",
     "tunnel_phase2_encryption_algorithms": "AES256",
     "tunnel_phase2_integrity_algorithms": "SHA2-256",
-    "tunnel1_ike_versions": "ikev2",
-    "tunnel2_ike_versions": "ikev2"
+    "tunnel1_ike_versions": ["ikev2"],
+    "tunnel2_ike_versions": ["ikev2"]
   },
   "YJB-Juniper-vSRX02-VPN": {
     "bgp_asn": "64523",
@@ -105,7 +105,7 @@
     "tunnel_phase2_dh_group_numbers": "19",
     "tunnel_phase2_encryption_algorithms": "AES256",
     "tunnel_phase2_integrity_algorithms": "SHA2-256",
-    "tunnel1_ike_versions": "ikev2",
-    "tunnel2_ike_versions": "ikev2"
+    "tunnel1_ike_versions": ["ikev2"],
+    "tunnel2_ike_versions": ["ikev2"]
   }
 }

--- a/terraform/environments/core-network-services/vpn_attachments.json
+++ b/terraform/environments/core-network-services/vpn_attachments.json
@@ -84,7 +84,9 @@
     "tunnel_phase1_integrity_algorithms": "SHA2-256",
     "tunnel_phase2_dh_group_numbers": "19",
     "tunnel_phase2_encryption_algorithms": "AES256",
-    "tunnel_phase2_integrity_algorithms": "SHA2-256"
+    "tunnel_phase2_integrity_algorithms": "SHA2-256",
+    "tunnel1_ike_versions": "ikev2",
+    "tunnel2_ike_versions": "ikev2"
   },
   "YJB-Juniper-vSRX02-VPN": {
     "bgp_asn": "64523",
@@ -102,6 +104,8 @@
     "tunnel_phase1_integrity_algorithms": "SHA2-256",
     "tunnel_phase2_dh_group_numbers": "19",
     "tunnel_phase2_encryption_algorithms": "AES256",
-    "tunnel_phase2_integrity_algorithms": "SHA2-256"
+    "tunnel_phase2_integrity_algorithms": "SHA2-256",
+    "tunnel1_ike_versions": "ikev2",
+    "tunnel2_ike_versions": "ikev2"
   }
 }

--- a/terraform/environments/core-network-services/vpn_attachments.json
+++ b/terraform/environments/core-network-services/vpn_attachments.json
@@ -18,6 +18,7 @@
     "dx_gateway_owner_account_id": "",
     "remote_ipv4_network_cidr": "0.0.0.0/0",
     "tunnel1_inside_cidr": "169.254.21.4/30",
+    "tunnel1_ike_versions": ["ikev1", "ikev2"],
     "tunnel2_inside_cidr": "169.254.22.4/30",
     "tunnel_dpd_timeout_action": "restart",
     "tunnel_dpd_timeout_seconds": "45",
@@ -85,8 +86,8 @@
     "tunnel_phase2_dh_group_numbers": "19",
     "tunnel_phase2_encryption_algorithms": "AES256",
     "tunnel_phase2_integrity_algorithms": "SHA2-256",
-    "tunnel1_ike_versions": "ikev2",
-    "tunnel2_ike_versions": "ikev2"
+    "tunnel1_ike_versions": ["ikev2"],
+    "tunnel2_ike_versions": ["ikev2"]
   },
   "YJB-Juniper-vSRX02-VPN": {
     "bgp_asn": "64523",
@@ -105,7 +106,7 @@
     "tunnel_phase2_dh_group_numbers": "19",
     "tunnel_phase2_encryption_algorithms": "AES256",
     "tunnel_phase2_integrity_algorithms": "SHA2-256",
-    "tunnel1_ike_versions": "ikev2",
-    "tunnel2_ike_versions": "ikev2"
+    "tunnel1_ike_versions": ["ikev2"],
+    "tunnel2_ike_versions": ["ikev2"]
   }
 }

--- a/terraform/environments/core-network-services/vpn_attachments.json
+++ b/terraform/environments/core-network-services/vpn_attachments.json
@@ -85,8 +85,8 @@
     "tunnel_phase2_dh_group_numbers": "19",
     "tunnel_phase2_encryption_algorithms": "AES256",
     "tunnel_phase2_integrity_algorithms": "SHA2-256",
-    "tunnel1_ike_versions": ["ikev2"],
-    "tunnel2_ike_versions": ["ikev2"]
+    "tunnel1_ike_versions": "ikev2",
+    "tunnel2_ike_versions": "ikev2"
   },
   "YJB-Juniper-vSRX02-VPN": {
     "bgp_asn": "64523",
@@ -105,7 +105,7 @@
     "tunnel_phase2_dh_group_numbers": "19",
     "tunnel_phase2_encryption_algorithms": "AES256",
     "tunnel_phase2_integrity_algorithms": "SHA2-256",
-    "tunnel1_ike_versions": ["ikev2"],
-    "tunnel2_ike_versions": ["ikev2"]
+    "tunnel1_ike_versions": "ikev2",
+    "tunnel2_ike_versions": "ikev2"
   }
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/9624

## How does this PR fix the problem?

Adds IKE versions input to the vpn resource and specifies `ikev2` for the YJB VPN tunnels.

## How has this been tested?

Local plans and via the checks in this PR.

I've added a condition that checks the if the IKE versions have been set in the vpn configs in `vpn_attachments.json` and if not it will fall back on a default value that specifies BOTH options i.e. `["ikev1", "ikev2"]`. 

The other VPNs show as changes required but they already show as having default config via the console i.e. both ikev1 and ikev2 enabled. This is being triggered I believe as the versions were being ignored as a lifecycle which I've also had to remove as part of this change. 

As best I can tell this won't have any impact on the existing tunnels.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
