### PR TITLE
Issue/9831 - Sets root account usage alarm to route to high priority slack channel

### DIFF
--- a/terraform/environments/bootstrap/secure-baselines/main.tf
+++ b/terraform/environments/bootstrap/secure-baselines/main.tf
@@ -6,7 +6,7 @@ data "aws_kms_key" "cloudtrail_key" {
 
 #trivy:ignore:AVD-AWS-0136
 module "baselines" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=520a8640a5116a098d80d1bd7221c9864c07b31a" # v7.13.6
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=80d7c7ee57e5424707bde43c518f56c9787ad65c" # v7.13.6
   providers = {
     # Default and replication regions
     aws                    = aws.workspace-eu-west-2

--- a/terraform/environments/bootstrap/secure-baselines/main.tf
+++ b/terraform/environments/bootstrap/secure-baselines/main.tf
@@ -6,7 +6,7 @@ data "aws_kms_key" "cloudtrail_key" {
 
 #trivy:ignore:AVD-AWS-0136
 module "baselines" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=73761b029ce904ed09131fa9e8ebbd6d2a6b19b9" # v7.13.5
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=520a8640a5116a098d80d1bd7221c9864c07b31a" # v7.13.6
   providers = {
     # Default and replication regions
     aws                    = aws.workspace-eu-west-2
@@ -79,6 +79,9 @@ module "baselines" {
 
   # Pass in pagerduty integration key for security hub alerts
   pagerduty_integration_key = local.is_core_account ? local.pagerduty_integration_keys["security_hub"] : local.pagerduty_integration_keys["security_hub_members"]
+
+  # PagerDuty Key for High Priority Alarms
+  high_priority_pagerduty_integration_key = local.pagerduty_integration_keys["core_alerts_high_priority_cloudwatch"]
 }
 
 # Keys for pagerduty


### PR DESCRIPTION
## A reference to the issue / Description of it

#9831 

## How does this PR fix the problem?

Updates baselines to 7.13.6 which routes root account usage to high priority alarms channel.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

See sprinkler tests below. @connormaglynn successfully demonstrated alerts via use of root account usage in Sprinkler.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
