### PR TITLE
Adding quicksite to yjaf

### DIFF
--- a/environments/youth-justice-app-framework.json
+++ b/environments/youth-justice-app-framework.json
@@ -7,6 +7,10 @@
         {
           "sso_group_name": "modernisation-platform-engineers",
           "level": "sandbox"
+        },
+        {
+          "sso_group_name": "modernisation-platform-engineers",
+          "level": "quicksight-admin"
         }
       ],
       "nuke": "exclude",


### PR DESCRIPTION
## A reference to the issue / Description of it

as part of a user request:
've just tried to create an Enterprise Quicksight subscription in account youth-justice-app-framework-development  using authentication method "Use IAM federated identities & QuickSight-managed users" and got error  "Signup request failed because the IAM user does not have ds:CreateIdentityPoolDirectory permission."
Can this permission be provided to the sandbox role? Or should I be using another role?
Quicksight is needed so that we can do a lift-and-shift of our current Quicksite setup.

## How does this PR fix the problem?

adding quicksite role to users environment

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
