### PR TITLE
add daily trigger to ip usage lambda

### DIFF
--- a/terraform/environments/core-logging/ip_utilisation.tf
+++ b/terraform/environments/core-logging/ip_utilisation.tf
@@ -108,7 +108,7 @@ resource "aws_lambda_function" "ip_usage" {
 resource "aws_cloudwatch_event_rule" "ip_usage_schedule" {
   name                = "ip-usage-schedule"
   description         = "Trigger IP Usage Lambda every 1 day"
-  schedule_expression = "rate(1 day)"
+  schedule_expression = "cron(0 10 * * ? *)" # run daily at 10:00 UTC
 }
 
 resource "aws_cloudwatch_event_target" "ip_usage_lambda_target" {

--- a/terraform/environments/core-logging/ip_utilisation.tf
+++ b/terraform/environments/core-logging/ip_utilisation.tf
@@ -105,8 +105,26 @@ resource "aws_lambda_function" "ip_usage" {
     }
   }
 }
+resource "aws_cloudwatch_event_rule" "ip_usage_schedule" {
+  name                = "ip-usage-schedule"
+  description         = "Trigger IP Usage Lambda every 1 day"
+  schedule_expression = "rate(1 day)"
+}
 
-# KMS key for Lambda encryption
+resource "aws_cloudwatch_event_target" "ip_usage_lambda_target" {
+  rule      = aws_cloudwatch_event_rule.ip_usage_schedule.name
+  target_id = "ip-usage-lambda"
+  arn       = aws_lambda_function.ip_usage.arn
+}
+
+resource "aws_lambda_permission" "allow_cloudwatch_to_invoke" {
+  statement_id  = "AllowExecutionFromCloudWatch"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.ip_usage.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.ip_usage_schedule.arn
+}
+
 resource "aws_kms_key" "ip_usage" {
   description             = "KMS key for IP Usage Lambda encryption"
   deletion_window_in_days = 7
@@ -144,13 +162,11 @@ resource "aws_kms_key" "ip_usage" {
   }
 }
 
-# KMS Alias for the key
 resource "aws_kms_alias" "ip_usage" {
   name          = "alias/ip-usage-lambda"
   target_key_id = aws_kms_key.ip_usage.key_id
 }
 
-# Add KMS permissions to Lambda execution role
 data "aws_iam_policy_document" "ip_usage_kms" {
   statement {
     effect = "Allow"


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/8334

## How does this PR fix the problem?

This change adds a daily trigger to the ip usage lambda so that metrics are refreshes on a daily basis and we can subsequently set up alerting based on fresh data.

It could be ran more frequently but as the figures are unlikely to change that quickly I don't feel we need real-time monitoring of this.


## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [X] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
