### PR TITLE
DPR2-849: Add lakeformation:RevokePermissions to reporting circleci role

### DIFF
--- a/terraform/environments/digital-prison-reporting/iam.tf
+++ b/terraform/environments/digital-prison-reporting/iam.tf
@@ -263,7 +263,8 @@ data "aws_iam_policy_document" "circleci_iam_policy" {
       "scheduler:GetSchedule",
       "scheduler:ListSchedules",
       "scheduler:TagResource",
-      "scheduler:UntagResource"
+      "scheduler:UntagResource",
+      "lakeformation:RevokePermissions"
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
## A reference to the issue / Description of it

The Digital Prisons Reporting circleci is failing with the error:
```
│ Error: unable to revoke LakeFormation Permissions (input: &{[DESCRIBE GRANT_WITH_LF_TAG_EXPRESSION ASSOCIATE] 0xc00289dbc0 0xc002315310 <nil> <nil> [DESCRIBE DROP GRANT_WITH_LF_TAG_EXPRESSION ALTER ASSOCIATE] {}}): unable to revoke Lake Formation Permissions: operation error LakeFormation: RevokePermissions, https response error StatusCode: 400, RequestID: 5ed4958a-49b6-4813-846f-a936f38ae1c6, InvalidInputException: No permissions revoked. Revoking Tag permissions on Tags that grantee does not have permissions on.
```

## How does this PR fix the problem?

This PR adds the required `lakeformation:RevokePermissions` action to the role.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

This fails on pipelines:
https://github.com/ministryofjustice/modernisation-platform-environments/actions/runs/14910292936/job/41882776041

https://github.com/ministryofjustice/modernisation-platform-environments/actions/runs/14910104063/job/41882386600?pr=10522

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No. There will be no impact.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (Not needed)

## Additional comments (if any)

N/A
