### PR TITLE
Add IP usage alerts SNS topic to chatbot config 

### DIFF
--- a/terraform/environments/core-logging/cortex_alarms.tf
+++ b/terraform/environments/core-logging/cortex_alarms.tf
@@ -135,7 +135,10 @@ module "mp-sqs-sns-chatbot" {
   for_each         = { for topic in local.cortex_topic_names : topic.name => topic }
   source           = "github.com/ministryofjustice/modernisation-platform-terraform-aws-chatbot?ref=73280f80ce8a4557cec3a76ee56eb913452ca9aa" // v2.0.0
   slack_channel_id = each.value.channel_id
-  sns_topic_arns   = [aws_sns_topic.cortex_sqs_sns_topic[each.key].arn]
+  sns_topic_arns = each.key == "modplatform" ? [
+    aws_sns_topic.cortex_sqs_sns_topic[each.key].arn,
+    aws_sns_topic.ip_usage_alerts.arn
+  ] : [aws_sns_topic.cortex_sqs_sns_topic[each.key].arn]
   tags             = merge(local.tags, try(each.value.tags, {}))
   application_name = "${each.value.name}-sqs-alarm-chatbot"
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/8436

## How does this PR fix the problem?

I tried to create a chatbot config so that we could receive alerts to the low priority alerts slack channel when the ip usage sns topic was in alarm. However a config had already been established for the `core-logging` account when the cortex alarms were configured.

This adds a condition so that the IP usage alerts SNS topic is added to the `modplatform` chatbot config.


## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
