### PR TITLE
TM-1218: add DSO pager duty team

### DIFF
--- a/terraform/pagerduty/locals.tf
+++ b/terraform/pagerduty/locals.tf
@@ -48,6 +48,7 @@ locals {
   slack_workspace_id = "T02DYEB3A"
 
   digital_email_suffix = "@digital.justice.gov.uk"
+  justice_email_suffix = "@justice.gov.uk"
 
   existing_users = {
     karen_botsh    = data.pagerduty_user.karen_botsh,

--- a/terraform/pagerduty/member-services-integrations.tf
+++ b/terraform/pagerduty/member-services-integrations.tf
@@ -1851,7 +1851,8 @@ locals {
   dso_digital_justice_team_members = [
     "antony.gowland",
     "dominic.robinson",
-    "robert.sweetman",
+    #"robert.sweetman",
+    #"william.gibbon",
   ]
   dso_justice_team_members = [
     "dave.kent",

--- a/terraform/pagerduty/member-services-integrations.tf
+++ b/terraform/pagerduty/member-services-integrations.tf
@@ -1910,12 +1910,12 @@ locals {
 
 data "pagerduty_user" "dso_digital_justice" {
   for_each = toset(local.dso_digital_justice_team_members)
-  email    = "${each.key}${digital_email_suffix}"
+  email    = "${each.key}${local.digital_email_suffix}"
 }
 
 data "pagerduty_user" "dso_justice" {
   for_each = toset(local.dso_justice_team_members)
-  email    = "${each.key}${justice_email_suffix}"
+  email    = "${each.key}${local.justice_email_suffix}"
 }
 
 resource "pagerduty_team" "dso" {


### PR DESCRIPTION
## A reference to the issue / Description of it

PoC to see if we can use PagerDuty to manage DSO/ProbationHosting/LAAOps concierge rota. Since our current mechanism will break post MS365 migration

## How does this PR fix the problem?

Adds DSO team to PagerDuty as a PoC. Putting this here as the pipeline/terraform is already setup for managing PagerDuty, and related PagerDuty services are created here also.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

It hasn't. However there's similar code for MP which looks like it works.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
