### PR TITLE
🛂 Give Analytical Platform Engineers Entra ID group access

### DIFF
--- a/environments/analytical-platform-common.json
+++ b/environments/analytical-platform-common.json
@@ -15,6 +15,10 @@
           "github_action_reviewer": "true"
         },
         {
+          "sso_group_name": "azure-aws-sso-analytical-platform-engineers",
+          "level": "platform-engineer-admin"
+        },
+        {
           "sso_group_name": "analytical-platform-airflow",
           "level": "mwaa-user"
         },

--- a/environments/analytical-platform-compute.json
+++ b/environments/analytical-platform-compute.json
@@ -37,6 +37,10 @@
           "github_action_reviewer": "true"
         },
         {
+          "sso_group_name": "azure-aws-sso-analytical-platform-engineers",
+          "level": "platform-engineer-admin"
+        },
+        {
           "sso_group_name": "analytical-platform-engineers",
           "level": "sandbox"
         },
@@ -69,6 +73,10 @@
           "github_action_reviewer": "true"
         },
         {
+          "sso_group_name": "azure-aws-sso-analytical-platform-engineers",
+          "level": "platform-engineer-admin"
+        },
+        {
           "sso_group_name": "analytical-platform-engineers",
           "level": "developer"
         },
@@ -98,6 +106,10 @@
           "sso_group_name": "analytical-platform-engineers",
           "level": "platform-engineer-admin",
           "github_action_reviewer": "true"
+        },
+        {
+          "sso_group_name": "azure-aws-sso-analytical-platform-engineers",
+          "level": "platform-engineer-admin"
         },
         {
           "sso_group_name": "analytical-platform-engineers",

--- a/environments/analytical-platform-data-engineering.json
+++ b/environments/analytical-platform-data-engineering.json
@@ -9,6 +9,10 @@
           "level": "administrator"
         },
         {
+          "sso_group_name": "azure-aws-sso-analytical-platform-engineers",
+          "level": "administrator"
+        },
+        {
           "sso_group_name": "analytical-platform-data-engineering-production-data-engineer",
           "level": "data-engineer"
         },
@@ -27,6 +31,10 @@
       "access": [
         {
           "sso_group_name": "analytical-platform-engineers",
+          "level": "administrator"
+        },
+        {
+          "sso_group_name": "azure-aws-sso-analytical-platform-engineers",
           "level": "administrator"
         },
         {

--- a/environments/analytical-platform-data.json
+++ b/environments/analytical-platform-data.json
@@ -9,6 +9,10 @@
           "level": "administrator"
         },
         {
+          "sso_group_name": "azure-aws-sso-analytical-platform-engineers",
+          "level": "administrator"
+        },
+        {
           "sso_group_name": "analytical-platform-data-development-data-engineer",
           "level": "data-engineer"
         },
@@ -23,6 +27,10 @@
       "access": [
         {
           "sso_group_name": "analytical-platform-engineers",
+          "level": "administrator"
+        },
+        {
+          "sso_group_name": "azure-aws-sso-analytical-platform-engineers",
           "level": "administrator"
         },
         {

--- a/environments/analytical-platform-ingestion.json
+++ b/environments/analytical-platform-ingestion.json
@@ -18,6 +18,10 @@
           "github_action_reviewer": "true"
         },
         {
+          "sso_group_name": "azure-aws-sso-analytical-platform-engineers",
+          "level": "platform-engineer-admin"
+        },
+        {
           "sso_group_name": "analytical-platform-engineers",
           "level": "sandbox"
         },
@@ -36,6 +40,10 @@
           "sso_group_name": "analytical-platform-engineers",
           "level": "platform-engineer-admin",
           "github_action_reviewer": "true"
+        },
+        {
+          "sso_group_name": "azure-aws-sso-analytical-platform-engineers",
+          "level": "platform-engineer-admin"
         },
         {
           "sso_group_name": "analytical-platform-engineers",

--- a/environments/analytical-platform-landing.json
+++ b/environments/analytical-platform-landing.json
@@ -9,6 +9,10 @@
           "level": "administrator"
         },
         {
+          "sso_group_name": "azure-aws-sso-analytical-platform-engineers",
+          "level": "administrator"
+        },
+        {
           "sso_group_name": "data-platform-audit-and-security",
           "level": "security-audit"
         }

--- a/environments/analytical-platform-management.json
+++ b/environments/analytical-platform-management.json
@@ -9,6 +9,10 @@
           "level": "administrator"
         },
         {
+          "sso_group_name": "azure-aws-sso-analytical-platform-engineers",
+          "level": "administrator"
+        },
+        {
           "sso_group_name": "data-platform-audit-and-security",
           "level": "security-audit"
         }

--- a/environments/analytical-platform.json
+++ b/environments/analytical-platform.json
@@ -9,6 +9,10 @@
           "level": "administrator"
         },
         {
+          "sso_group_name": "azure-aws-sso-analytical-platform-engineers",
+          "level": "administrator"
+        },
+        {
           "sso_group_name": "analytical-platform-data-development-data-engineer",
           "level": "data-engineer"
         },
@@ -23,6 +27,10 @@
       "access": [
         {
           "sso_group_name": "analytical-platform-engineers",
+          "level": "administrator"
+        },
+        {
+          "sso_group_name": "azure-aws-sso-analytical-platform-engineers",
           "level": "administrator"
         },
         {


### PR DESCRIPTION
## A reference to the issue / Description of it

Give `azure-aws-sso-analytical-platform-engineers` access to Analytical Platform accounts

## How does this PR fix the problem?

Enables access via Entra ID

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

It hasn't, but following https://user-guide.modernisation-platform.service.justice.gov.uk/concepts/environments/single-sign-on.html#using-entra-id-for-aws-access-management

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No, its additive

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
