### PR TITLE
Update devcontainer-lock.json

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,9 +1,9 @@
 {
   "features": {
     "ghcr.io/ministryofjustice/devcontainer-feature/aws:1": {
-      "version": "1.0.1",
-      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/aws@sha256:53233b394572638b1853a96a5e9d2adc3bae459eb2038a77584330282c82bf40",
-      "integrity": "sha256:53233b394572638b1853a96a5e9d2adc3bae459eb2038a77584330282c82bf40"
+      "version": "1.1.0",
+      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/aws@sha256:64240f48a66e28fc065d58d2c3aa75319106ec4293b0a0736402290317b256d5",
+      "integrity": "sha256:64240f48a66e28fc065d58d2c3aa75319106ec4293b0a0736402290317b256d5"
     },
     "ghcr.io/ministryofjustice/devcontainer-feature/kubernetes:1": {
       "version": "1.0.2",


### PR DESCRIPTION
## A reference to the issue / Description of it

* Bumps AWS feature

## How does this PR fix the problem?

Without this bump the dev container will not build

## How has this been tested?

Tested successfully with this manifest in the analytical-platform repository via #[7746](https://github.com/ministryofjustice/analytical-platform/pull/7746)

## Deployment Plan / Instructions

N/A - only relevant to dev container users

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
