### PR TITLE
Flip static route cidrs for YJAF VPN

### DIFF
--- a/terraform/environments/core-network-services/locals.tf
+++ b/terraform/environments/core-network-services/locals.tf
@@ -130,9 +130,9 @@ locals {
 
   parole_board_vpn_static_routes = ["10.50.0.0/16"]
 
-  yjb_vpn_static_route_srx01 = ["10.20.224.0/22"]
+  yjb_vpn_static_route_srx01 = ["10.20.228.0/22"]
 
-  yjb_vpn_static_route_srx02 = ["10.20.228.0/22"]
+  yjb_vpn_static_route_srx02 = ["10.20.224.0/22"]
 
 
   core-vpcs = {


### PR DESCRIPTION
## A reference to the issue / Description of it

Steve Hobden has asked for the routes to be flipped to match his configuration.
https://github.com/ministryofjustice/modernisation-platform/issues/9624

## How does this PR fix the problem?

Routes have been flipped around accordingly.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
