### PR TITLE
Add crowdstrike component to ccms-ebs and laa-portal-tactical accounts

### DIFF
--- a/environments/ccms-ebs.json
+++ b/environments/ccms-ebs.json
@@ -1,5 +1,10 @@
 {
   "account-type": "member",
+  "components": [
+    {
+      "name": "crowdstrike"
+    }
+  ],
   "environments": [
     {
       "name": "development",

--- a/environments/laa-portal-tactical.json
+++ b/environments/laa-portal-tactical.json
@@ -1,5 +1,10 @@
 {
   "account-type": "member",
+  "components": [
+    {
+      "name": "crowdstrike"
+    }
+  ],
   "isolated-network": "true",
   "environments": [
     {


### PR DESCRIPTION
## A reference to the issue / Description of it

## How does this PR fix the problem?

Creates a component for CrowdStrike resources to be deployed to the referenced accounts, without impacting existing Terraform code.

## How has this been tested?

Tested through CI pipeline checks

## Deployment Plan / Instructions

Deploy as per our runbook guidance [here](https://user-guide.modernisation-platform.service.justice.gov.uk/runbooks/creating-components-for-member-applications.html#creating-components-for-member-applications).

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
