### PR TITLE
TM-1218: add DSO pagerduty escalation policy

### DIFF
--- a/terraform/pagerduty/member-services-integrations.tf
+++ b/terraform/pagerduty/member-services-integrations.tf
@@ -1940,6 +1940,19 @@ resource "pagerduty_schedule" "dso" {
   teams = [pagerduty_team.dso.id]
 }
 
+resource "pagerduty_escalation_policy" "dso" {
+  name  = "Digital Studio Operations Escalation Policy"
+  teams = [pagerduty_team.dso.id]
+
+  rule {
+    escalation_delay_in_minutes = 120  # since no on-call and primary notification is via slack integration
+    target {
+      type = "schedule_reference"
+      id   = pagerduty_schedule.dso.id
+    }
+  }
+}
+
 resource "pagerduty_service" "services" {
   for_each = local.services
 
@@ -1947,10 +1960,10 @@ resource "pagerduty_service" "services" {
   description             = "${each.key}-alarms"
   auto_resolve_timeout    = "null"
   acknowledgement_timeout = "null"
-  escalation_policy       = pagerduty_escalation_policy.member_policy.id
+  escalation_policy       = pagerduty_escalation_policy.dso.id
   alert_creation          = "create_alerts_and_incidents"
-
 }
+
 resource "pagerduty_service_integration" "integrations" {
   for_each = pagerduty_service.services
 


### PR DESCRIPTION
## A reference to the issue / Description of it

PoC to see if we can use PagerDuty to manage DSO/ProbationHosting/LAAOps concierge rota. Since our current mechanism will break post MS365 migration

## How does this PR fix the problem?

Adds a DSO escalation policy so DSO services are allocated to correct team + to enable notifications

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

It hasn't. However there's similar code for MP which looks like it works.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
