### PR TITLE
TM-1218: add dso pagerduty restriction

### DIFF
--- a/terraform/pagerduty/member-services-integrations.tf
+++ b/terraform/pagerduty/member-services-integrations.tf
@@ -1937,6 +1937,13 @@ resource "pagerduty_schedule" "dso" {
     users                        = [for user in data.pagerduty_user.dso : user.id]
   }
 
+  restriction {
+    type              = "weekly_restriction"
+    start_day_of_week = 1
+    start_time_of_day = "08:00:00"
+    duration_seconds  = 374400 # to Fri 16:00
+  }
+
   teams = [pagerduty_team.dso.id]
 }
 

--- a/terraform/pagerduty/member-services-integrations.tf
+++ b/terraform/pagerduty/member-services-integrations.tf
@@ -1850,12 +1850,13 @@ locals {
   # add users to this list once they've signed into PagerDuty via SSO for first time
   # avoid putting full email as public repo
   dso_team_members = {
-    #"antony.gowland" = local.digital_email_suffix
-    "dominic.robinson" = local.digital_email_suffix
+    "robertsweetman"   = "pm.me"
     "dave.kent"        = local.justice_email_suffix
-    #"robert.sweetman"
-    #"william.gibbon"
+    "william.gibbon"   = local.digital_email_suffix
+    "antony.gowland"   = local.digital_email_suffix
+    "dominic.robinson" = local.digital_email_suffix
   }
+  dso_schedule_rotation_days = 3 # e.g. rotate each user after 3 days
 
   services = {
     corporate-staff-rostering-preproduction = { slack_channel_id = "C0617EZEVNZ" } # corporate_staff_rostering_alarms
@@ -1931,17 +1932,46 @@ resource "pagerduty_schedule" "dso" {
 
   layer {
     name                         = "Primary Schedule"
-    start                        = "2025-05-12T07:00:00Z"
-    rotation_virtual_start       = "2025-05-12T07:00:00Z"
+    start                        = "2025-05-15T00:00:00Z"
+    rotation_virtual_start       = "2025-05-15T00:00:00Z"
     rotation_turn_length_seconds = 86400
-    users                        = [for user in data.pagerduty_user.dso : user.id]
+
+    users = flatten([
+      for user in data.pagerduty_user.dso : [
+        for days in range(local.dso_schedule_rotation_days) : user.id
+      ]
+    ])
+
     restriction {
       type              = "weekly_restriction"
       start_day_of_week = 1
       start_time_of_day = "08:00:00"
-      duration_seconds  = 374400 # to Fri 16:00
+      duration_seconds  = 28800
     }
-
+    restriction {
+      type              = "weekly_restriction"
+      start_day_of_week = 2
+      start_time_of_day = "08:00:00"
+      duration_seconds  = 28800
+    }
+    restriction {
+      type              = "weekly_restriction"
+      start_day_of_week = 3
+      start_time_of_day = "08:00:00"
+      duration_seconds  = 28800
+    }
+    restriction {
+      type              = "weekly_restriction"
+      start_day_of_week = 4
+      start_time_of_day = "08:00:00"
+      duration_seconds  = 28800
+    }
+    restriction {
+      type              = "weekly_restriction"
+      start_day_of_week = 5
+      start_time_of_day = "08:00:00"
+      duration_seconds  = 28800
+    }
   }
 
   teams = [pagerduty_team.dso.id]

--- a/terraform/pagerduty/member-services-integrations.tf
+++ b/terraform/pagerduty/member-services-integrations.tf
@@ -1850,7 +1850,7 @@ locals {
   # add users to this list once they've signed into PagerDuty via SSO for first time
   # avoid putting full email as public repo
   dso_team_members = {
-    "robertsweetman"   = "pm.me"
+    "robertsweetman"   = "@pm.me"
     "dave.kent"        = local.justice_email_suffix
     "william.gibbon"   = local.digital_email_suffix
     "antony.gowland"   = local.digital_email_suffix

--- a/terraform/pagerduty/member-services-integrations.tf
+++ b/terraform/pagerduty/member-services-integrations.tf
@@ -1935,13 +1935,13 @@ resource "pagerduty_schedule" "dso" {
     rotation_virtual_start       = "2025-05-12T07:00:00Z"
     rotation_turn_length_seconds = 86400
     users                        = [for user in data.pagerduty_user.dso : user.id]
-  }
+    restriction {
+      type              = "weekly_restriction"
+      start_day_of_week = 1
+      start_time_of_day = "08:00:00"
+      duration_seconds  = 374400 # to Fri 16:00
+    }
 
-  restriction {
-    type              = "weekly_restriction"
-    start_day_of_week = 1
-    start_time_of_day = "08:00:00"
-    duration_seconds  = 374400 # to Fri 16:00
   }
 
   teams = [pagerduty_team.dso.id]


### PR DESCRIPTION
## A reference to the issue / Description of it

PoC for using PagerDuty to manage DSO concierge rotas.

## How does this PR fix the problem?

Adds a restriction for the weekend. Allows manual overrides to be made.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

By messing about in PagerDuty UI and getting terraform to match

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
