### PR TITLE
Add `SSO Plan` Step for Modified JSON Files Only (Pre-review Before Apply)

### DIFF
--- a/.github/workflows/new-environment.yml
+++ b/.github/workflows/new-environment.yml
@@ -347,6 +347,51 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ env.SLACK_WEBHOOK_URL }}
         if: ${{ failure() }}
+  single-sign-on-plan:
+    runs-on: ubuntu-latest
+    if: github.event.ref != 'refs/heads/main' || github.event_name != 'workflow_dispatch'
+    needs: fetch-secrets
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          fetch-depth: 0
+      - name: Decrypt Secrets
+        uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@3cd73da46642bf52bb4045d8abf05e1d96fc4a53 # v2.0.0
+        with:
+          environment_management: ${{ needs.fetch-secrets.outputs.environment_management }}
+          PASSPHRASE: ${{ secrets.PASSPHRASE }}
+      - name: Set Account Number
+        run: |
+          ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< $ENVIRONMENT_MANAGEMENT)
+          echo "::add-mask::$ACCOUNT_NUMBER"
+          echo ACCOUNT_NUMBER=$ACCOUNT_NUMBER >> $GITHUB_ENV
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@f24d7193d98baebaeacc7e2227925dd47cc267f5 # v4.2.0
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions-plan"
+          role-session-name: githubactionsrolesession
+          aws-region: ${{ env.AWS_REGION }}
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+        with:
+          terraform_version: "~1"
+          terraform_wrapper: false
+      - name: get new account(s)
+        id: new_account
+        run: |
+          files=$(git diff --name-only --diff-filter=M @^ -- 'environments/*.json' | uniq | sed 's#environments/##' | sed 's/\.json$//' | tr '\n' ',' | awk '{$1=$1};1')
+          echo "files=$files" >> $GITHUB_OUTPUT
+      - name: Run single sign on
+        run: |
+          IFS=',' read -r -a accounts <<< "${{ steps.new_account.outputs.files }}"
+          if [[ ${#accounts[@]} -gt 0 ]]; then
+            for i in "${accounts[@]}"; do
+              echo "[+] Running single sign on baseline for account ${i}"
+              bash scripts/terraform-init.sh terraform/environments/bootstrap/single-sign-on
+              bash scripts/setup-baseline.sh terraform/environments/bootstrap/single-sign-on "${i}" plan
+            done
+          else
+            echo "[+] There were no AWS member accounts to process"
+          fi
   single-sign-on:
     runs-on: ubuntu-latest
     if: github.event.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'

--- a/terraform/modernisation-platform-account/iam.tf
+++ b/terraform/modernisation-platform-account/iam.tf
@@ -226,6 +226,7 @@ data "aws_iam_policy_document" "oidc_assume_plan_role_member" {
     ]
     resources = [
       "arn:aws:iam::*:role/ModernisationPlatformAccess",
+      "arn:aws:iam::${local.environment_management.aws_organizations_root_account_id}:role/ModernisationPlatformSSOAdministrator"
     ]
     condition {
       test     = "ForAnyValue:StringLike"


### PR DESCRIPTION
## A reference to the issue / Description of it

This PR introduces a new step in the `New environment` workflow to enable a `plan` phase for the single sign-on process. The new step is designed to run only when `.json` files under the `environments/` directory are modified (not for new files). It allows users to pre-review the changes that would be applied to the SSO configuration, without making actual changes to the infrastructure. #9381 

## How does this PR fix the problem?

Previously, there was no visibility into potential SSO changes before applying them. This led to reduced confidence and potential misconfigurations. With this plan step:

- The workflow filters only modified JSON files.
- SSO plans are executed per modified account file, allowing a targeted review of changes.
- It does not run on main branch or when triggered manually via workflow_dispatch, ensuring it behaves safely in CI workflows only.

## How has this been tested?

Yes, the workflow has been tested successfully.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
