### PR TITLE
Remove VPC peering deny

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -270,7 +270,6 @@ data "aws_iam_policy_document" "member-access" {
   statement {
     effect = "Deny"
     actions = [
-      "ec2:CreateVpcPeeringConnection",
       "iam:AddUserToGroup",
       "iam:AttachGroupPolicy",
       "iam:CreateAccountAlias",


### PR DESCRIPTION


## A reference to the issue / Description of it

We need to peer a custom LAA VPC with our existing VPCs, currently this is prevented with an explicit deny.



## How does this PR fix the problem?

Removing this to allow it.  2nd PR here https://github.com/ministryofjustice/modernisation-platform-environments/pull/10612 to add this to the plan evaluator.


## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
