### PR TITLE
Add VPC peering acceptor for LAA tactical portal

### DIFF
--- a/terraform/environments/core-vpc/locals.tf
+++ b/terraform/environments/core-vpc/locals.tf
@@ -6,6 +6,7 @@ data "aws_organizations_organization" "root_account" {}
 
 locals {
   application_name           = "core-vpc"
+  environment                = trimprefix(terraform.workspace, "${local.application_name}-")
   environment_management     = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
   pagerduty_integration_keys = jsondecode(data.aws_secretsmanager_secret_version.pagerduty_integration_keys.secret_string)
 

--- a/terraform/environments/core-vpc/vpc-peering.tf
+++ b/terraform/environments/core-vpc/vpc-peering.tf
@@ -1,0 +1,28 @@
+# laa-portal-tactical
+data "aws_vpc_peering_connections" "laa_portal_tactical_requestor" {
+  filter {
+    name   = "accepter-vpc-info.vpc-id"
+    values = [module.vpc["laa-${local.environment}"].vpc_id]
+  }
+  filter {
+    name = "requester-vpc-info.owner-id"
+    values = [
+      local.environment_management.account_ids["laa-portal-tactical-development"],
+      local.environment_management.account_ids["laa-portal-tactical-production"]
+    ]
+  }
+}
+
+resource "aws_vpc_peering_connection_accepter" "laa_portal_tactical_accepter" {
+  count                     = length(data.aws_vpc_peering_connections.laa_portal_tactical_requestor.ids) == 1 ? 1 : 0
+  vpc_peering_connection_id = data.aws_vpc_peering_connections.laa_portal_tactical_requestor.ids[0]
+  auto_accept               = true
+
+  tags = merge(
+    local.tags,
+    {
+      Side      = "Accepter",
+      Requester = "LAA Tactical Portal ${local.environment}"
+    }
+  )
+}


### PR DESCRIPTION


## A reference to the issue / Description of it

We need to peer the laa-development VPC with the laa-portal-tactical VPC.

## How does this PR fix the problem?

This adds a peering acceptor for LAA tactical portal account.

Using aws_vpc_peering_connections so that the data source doesn't fail if there isn't a connection and we can use a count for the acceptor.

## How has this been tested?

TF plans locally

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
