### PR TITLE
PagerDuty integration for Performance Hub

### DIFF
--- a/terraform/pagerduty/aws.tf
+++ b/terraform/pagerduty/aws.tf
@@ -62,14 +62,16 @@ resource "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {
     laa_apex_nonprod_alarms              = pagerduty_service_integration.apex_non_prod.integration_key
     laa_apex_prod_alarms                 = pagerduty_service_integration.apex_prod.integration_key
     electronic_monitoring_data_alarms    = pagerduty_service_integration.electronic_monitoring_data_cloudwatch.integration_key
-    # delius_mis_non_prod                     = pagerduty_event_orchestration_integration.delius_mis_non_prod_integration.parameters[0].routing_key
-    delius_mis_nonprod_alarms = pagerduty_service_integration.delius_mis_non_prod.integration_key
-    delius_mis_prod_alarms    = pagerduty_service_integration.delius_mis_prod.integration_key
-    laa_edw_nonprod_alarms    = pagerduty_service_integration.edw_non_prod.integration_key
-    laa_edw_prod_alarms       = pagerduty_service_integration.edw_prod.integration_key
-    cdpt-ifs-alarms           = pagerduty_service_integration.cdpt_ifs_cloudwatch.integration_key
-    sprinkler_development     = pagerduty_event_orchestration_integration.sprinkler_development_integration.parameters[0].routing_key
-    laa_cis_nonprod_alarms    = pagerduty_service_integration.cis_non_prod.integration_key
+    # delius_mis_non_prod                = pagerduty_event_orchestration_integration.delius_mis_non_prod_integration.parameters[0].routing_key
+    delius_mis_nonprod_alarms            = pagerduty_service_integration.delius_mis_non_prod.integration_key
+    delius_mis_prod_alarms               = pagerduty_service_integration.delius_mis_prod.integration_key
+    laa_edw_nonprod_alarms               = pagerduty_service_integration.edw_non_prod.integration_key
+    laa_edw_prod_alarms                  = pagerduty_service_integration.edw_prod.integration_key
+    cdpt-ifs-alarms                      = pagerduty_service_integration.cdpt_ifs_cloudwatch.integration_key
+    sprinkler_development                = pagerduty_event_orchestration_integration.sprinkler_development_integration.parameters[0].routing_key
+    laa_cis_nonprod_alarms               = pagerduty_service_integration.cis_non_prod.integration_key
+    performance_hub_nonprod_alarms       = pagerduty_service_integration.performance_hub_non_prod.integration_key
+    performance_hub_prod_alarms          = pagerduty_service_integration.performance_hub_prod.integration_key
     },
     {
       for key, integration in pagerduty_service_integration.integrations : key => integration.integration_key

--- a/terraform/pagerduty/member-services-integrations.tf
+++ b/terraform/pagerduty/member-services-integrations.tf
@@ -2333,3 +2333,95 @@ resource "pagerduty_slack_connection" "cis_non_prod" {
 }
 
 # # Slack channel: #mp-laa-alerts-cis-nonprod
+
+# Performance Hub --------------
+resource "pagerduty_service" "performance_hub_non_prod" {
+  name                    = "Performance Hub non-production alarms"
+  description             = "Performance Hub non-production (dev, preprod) alarms"
+  auto_resolve_timeout    = 345600
+  acknowledgement_timeout = "null"
+  escalation_policy       = pagerduty_escalation_policy.member_policy.id
+  alert_creation          = "create_alerts_and_incidents"
+}
+
+resource "pagerduty_service_integration" "performance_hub_non_prod" {
+  name    = data.pagerduty_vendor.cloudwatch.name
+  service = pagerduty_service.performance_hub_non_prod.id
+  vendor  = data.pagerduty_vendor.cloudwatch.id
+}
+
+resource "pagerduty_slack_connection" "performance_hub_non_prod" {
+  source_id = pagerduty_service.performance_hub_non_prod.id
+  source_type = "service_reference"
+  workspace_id = local.slack_workspace_id
+  # performance-hub-dev channel
+  channel_id = "C010UJ48GEM" 
+  notification_type = "responder"
+  config {
+    events = [
+      "incident.triggered",
+      "incident.acknowledged",
+      "incident.escalated",
+      "incident.resolved",
+      "incident.reassigned",
+      "incident.annotated",
+      "incident.unacknowledged",
+      "incident.delegated",
+      "incident.priority_updated",
+      "incident.responder.added",
+      "incident.responder.replied",
+      "incident.action_invocation.created",
+      "incident.action_invocation.terminated",
+      "incident.action_invocation.updated",
+      "incident.status_update_published",
+      "incident.reopened"
+    ]
+    priorities = ["*"]
+  }
+}
+
+resource "pagerduty_service" "performance_hub_prod" {
+  name                    = "Performance Hub production alarms"
+  description             = "Performance Hub production alarms"
+  auto_resolve_timeout    = 345600
+  acknowledgement_timeout = "null"
+  escalation_policy       = pagerduty_escalation_policy.member_policy.id
+  alert_creation          = "create_alerts_and_incidents"
+}
+
+resource "pagerduty_service_integration" "performance_hub_prod" {
+  name    = data.pagerduty_vendor.cloudwatch.name
+  service = pagerduty_service.performance_hub_prod.id
+  vendor  = data.pagerduty_vendor.cloudwatch.id
+}
+
+resource "pagerduty_slack_connection" "performance_hub_prod" {
+  source_id = pagerduty_service.performance_hub_prod.id
+  source_type = "service_reference"
+  workspace_id = local.slack_workspace_id
+  # performance-hub-dev channel
+  channel_id = "C010UJ48GEM" 
+  notification_type = "responder"
+  config {
+    events = [
+      "incident.triggered",
+      "incident.acknowledged",
+      "incident.escalated",
+      "incident.resolved",
+      "incident.reassigned",
+      "incident.annotated",
+      "incident.unacknowledged",
+      "incident.delegated",
+      "incident.priority_updated",
+      "incident.responder.added",
+      "incident.responder.replied",
+      "incident.action_invocation.created",
+      "incident.action_invocation.terminated",
+      "incident.action_invocation.updated",
+      "incident.status_update_published",
+      "incident.reopened"
+    ]
+    priorities = ["*"]
+  }
+}
+# End Performance Hub ----------


### PR DESCRIPTION
## A reference to the issue / Description of it

As part of our app migration to dotnet core, we'd like to move away from our current error notification using GOV.UK Notify.

## How does this PR fix the problem?

Add a new PagerDuty integration

## How has this been tested?

As yet untested

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No
