### PR TITLE
Add mpe repo to sprinkler gh actions OIDC role

### DIFF
--- a/terraform/environments/sprinkler/iam.tf
+++ b/terraform/environments/sprinkler/iam.tf
@@ -4,7 +4,7 @@ module "github-oidc" {
   source                      = "github.com/ministryofjustice/modernisation-platform-github-oidc-provider?ref=84a83751b5289f363a728eb181470b59fc5e2899" # v3.0.1
   additional_permissions      = data.aws_iam_policy_document.oidc_deny_specific_actions.json
   additional_managed_policies = ["arn:aws:iam::aws:policy/AdministratorAccess"]
-  github_repositories         = ["ministryofjustice/modernisation-platform:*"]
+  github_repositories         = ["ministryofjustice/modernisation-platform:*", "ministryofjustice/modernisation-platform-environments:*"]
   tags_common                 = { "Name" = format("%s-oidc", terraform.workspace) }
   tags_prefix                 = ""
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

I'm running some testing for https://github.com/ministryofjustice/modernisation-platform/issues/9882

## How does this PR fix the problem?

This PR adds the `modernisation-platform-environments` repo to the sprinkler github actions OIDC role, so that the pipeline no longer fails e.g.
https://github.com/ministryofjustice/modernisation-platform-environments/actions/runs/15055734744/job/42321478706#step:6:27

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
