### PR TITLE
Add ec2:AttachVolume permissions

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -206,6 +206,7 @@ data "aws_iam_policy_document" "developer_additional" {
       "ds-data:Describe*",
       "ds-data:List*",
       "ds-data:Search*",
+      "ec2:AttachVolume",
       "ec2:St*",
       "ec2:RebootInstances",
       "ec2:Modify*",


### PR DESCRIPTION
As per slack request https://mojdt.slack.com/archives/C01A7QK5VM1/p1747396751048869 this PR adds the `ec2:AttachVolume` to the developer permissions. 