### PR TITLE
LAA `portal-tactical` return routes via VPC Peering

### DIFF
--- a/terraform/environments/core-vpc/vpc-peering.tf
+++ b/terraform/environments/core-vpc/vpc-peering.tf
@@ -26,3 +26,18 @@ resource "aws_vpc_peering_connection_accepter" "laa_portal_tactical_accepter" {
     }
   )
 }
+
+locals {
+  peering_routes = {
+    core-vpc-development = toset(["10.206.4.0/24", "10.206.5.0/24", "10.206.6.0/24"])
+    core-vpc-production  = toset([])
+  }
+}
+
+# These route should only exist for the lifetime of the peering
+resource "aws_route" "portal_tactical" {
+  for_each                  = lookup(local.peering_routes, terraform.workspace, toset([]))
+  destination_cidr_block    = each.key
+  route_table_id            = module.vpc["laa-${local.environment}"].private_route_tables.general-private
+  vpc_peering_connection_id = data.aws_vpc_peering_connections.laa_portal_tactical_requestor.ids[0]
+}

--- a/terraform/environments/core-vpc/vpc-peering.tf
+++ b/terraform/environments/core-vpc/vpc-peering.tf
@@ -34,7 +34,7 @@ locals {
   }
 }
 
-# These route should only exist for the lifetime of the peering
+# These routes should only exist for the lifetime of the peering
 resource "aws_route" "portal_tactical" {
   for_each                  = lookup(local.peering_routes, terraform.workspace, toset([]))
   destination_cidr_block    = each.key


### PR DESCRIPTION
## A reference to the issue / Description of it

N/A - See [this Slack thread](https://mojdt.slack.com/archives/C08QWK76VQR/p1747396350459819) for context

## How does this PR fix the problem?

This PR allows us to set up routes on a per-workspace basis to send return traffic to `laa-portal-tactical` over the VPC peering link.

## How has this been tested?

Tested with a local terraform plan against all environments

## Deployment Plan / Instructions

Deploy through CI. This PR will add routes to the `laa-general-private` route table in the `core-vpc-development` account, while also making it easy to amend routes in future.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

@davidkelliott , @vc13837 
