### PR TITLE
Private hosted zone and record for `laa-development`

### DIFF
--- a/terraform/environments/core-vpc/route53-laa.tf
+++ b/terraform/environments/core-vpc/route53-laa.tf
@@ -1,0 +1,17 @@
+resource "aws_route53_zone" "aws_uat_legalservices_gov_uk" {
+  count = terraform.workspace == "core-vpc-development" ? 1 : 0
+  name = "aws.uat.legalservices.gov.uk"
+
+  vpc {
+    vpc_id = module.vpc["laa-${local.environment}"].vpc_id
+  }
+  tags = local.tags
+}
+
+resource "aws_route53_record" "portal_oid" {
+  count = terraform.workspace == "core-vpc-development" ? 1 : 0
+  name    = "portal-oid.aws.uat.legalservices.gov.uk"
+  records = ["10.206.4.156", "10.206.6.93"]
+  type    = "A"
+  zone_id = aws_route53_zone.aws_uat_legalservices_gov_uk[0].zone_id
+}


### PR DESCRIPTION
## A reference to the issue / Description of it

N/A - See [this Slack thread](https://mojdt.slack.com/archives/C08QWK76VQR/p1747396350459819) for context

## How does this PR fix the problem?

Adds a private hosted zone and record to ensure hosts correctly resolve the private address in the portal-tactical account

## How has this been tested?

Tested through local terraform plan

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
