### PR TITLE
Update route53-laa.tf

### DIFF
--- a/terraform/environments/core-vpc/route53-laa.tf
+++ b/terraform/environments/core-vpc/route53-laa.tf
@@ -13,5 +13,6 @@ resource "aws_route53_record" "portal_oid" {
   name    = "portal-oid.aws.uat.legalservices.gov.uk"
   records = ["10.206.4.156", "10.206.6.93"]
   type    = "A"
+  ttl     = 300
   zone_id = aws_route53_zone.aws_uat_legalservices_gov_uk[0].zone_id
 }


### PR DESCRIPTION
Add missing TTL value


```
Error: creating Route53 Record: operation error Route 53: ChangeResourceRecordSets, https response error StatusCode: 400, RequestID: e74fc824-e689-47ff-a064-c16c7851cd0b, InvalidInput: Invalid request: Expected exactly one of [AliasTarget, all of [TTL, and ResourceRecords], or TrafficPolicyInstanceId], but found none in Change with [Action=CREATE, Name=portal-oid.aws.uat.legalservices.gov.uk, Type=A, SetIdentifier=null]

  with aws_route53_record.portal_oid[0],
  on route53-laa.tf line 11, in resource "aws_route53_record" "portal_oid":
  11: resource "aws_route53_record" "portal_oid" {
```