### PR TITLE
Disable S3 ACLs to Support Cross-Account Uploads

### DIFF
--- a/terraform/environments/core-shared-services/s3.tf
+++ b/terraform/environments/core-shared-services/s3.tf
@@ -9,7 +9,7 @@ module "s3-bucket" {
   replication_enabled = false
   versioning_enabled  = true
   force_destroy       = false
-  ownership_controls  = "BucketOwnerPreferred"
+  ownership_controls  = "BucketOwnerEnforced"
   lifecycle_rule = [
     {
       id      = "main"


### PR DESCRIPTION
## A reference to the issue / Description of it

When users from different AWS accounts or roles upload objects to the S3 bucket, those objects retain ownership and permissions scoped to the uploader's identity. This leads to access failures when other roles or services try to read or manage these objects. #9970 

## How does this PR fix the problem?

By disabling ACLs:

1. All uploaded objects are automatically owned by the bucket owner.
2. Ensures consistent permissions and access behavior across accounts.
3. Aligns with AWS best practices for secure and simplified S3 access management.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
