### PR TITLE
Add `ssm-guiconnect:*` back to instance mgmt policy

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -1165,6 +1165,7 @@ data "aws_iam_policy_document" "instance-management-document" {
       "secretsmanager:GetSecretValue",
       "secretsmanager:ListSecret*",
       "ssm:*",
+      "ssm-guiconnect:*",
       "sso:ListDirectoryAssociations",
       "support:*"
     ]


### PR DESCRIPTION
## A reference to the issue / Description of it

https://mojdt.slack.com/archives/C01A7QK5VM1/p1747655966000939

## How does this PR fix the problem?

Adds `ssm-guiconnect:*` back to instance mgmt policy

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
