### PR TITLE
Enable Security and Analysis

### DIFF
--- a/terraform/github/modules/repository/main.tf
+++ b/terraform/github/modules/repository/main.tf
@@ -28,19 +28,22 @@ resource "github_repository" "default" {
   visibility                  = var.visibility
   vulnerability_alerts        = true
 
-security_and_analysis {
-  advanced_security {
-    status = "enabled"
+  security_and_analysis {
+    dynamic "advanced_security" {
+      for_each = var.visibility == "public" ? [] : [1]
+      content {
+        status = "enabled"
+      }
+    }
+  
+    secret_scanning {
+      status = "enabled"
+    }
+  
+    secret_scanning_push_protection {
+      status = "enabled"
+    }
   }
-
-  secret_scanning {
-    status = "enabled"
-  }
-
-  secret_scanning_push_protection {
-    status = "enabled"
-  }
-}
 
   template {
     owner      = "ministryofjustice"


### PR DESCRIPTION
This change reintroduces the `dynamic` block for `advanced_security` to avoid GitHub API errors when managing public repositories.

GitHub enforces that `advanced_security` must not be explicitly set for public repos, as it's always enabled by default. Using a `dynamic` block ensures the setting is only applied to private/internal repos, preventing 422 errors during Terraform apply.