### PR TITLE
detach volume permission added to developer role

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -207,6 +207,7 @@ data "aws_iam_policy_document" "developer_additional" {
       "ds-data:List*",
       "ds-data:Search*",
       "ec2:AttachVolume",
+      "ec2:DetachVolume",
       "ec2:St*",
       "ec2:RebootInstances",
       "ec2:Modify*",


### PR DESCRIPTION
## A reference to the issue / Description of it

Need to be able to manually detach volumes for OS upgrades otherwise subsequent tf plans get confused

## How does this PR fix the problem?

Allow devs to detach temporarily added volumes before running tf plan

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

fixes the permissions error message 

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
