### PR TITLE
Fix S3 cross-account upload error by updating permissions and ACL usage

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -1559,6 +1559,7 @@ data "aws_iam_policy_document" "s3_upload_policy_document" {
     effect = "Allow"
     actions = [
       "s3:GetObject",
+      "s3:GetBucketOwnershipControls",
       "s3:ListBucket",
       "s3:ListBucketVersions",
       "s3:PutObject"


### PR DESCRIPTION
This PR resolves the issue encountered during cross-account S3 object uploads where the target bucket requires either no ACL or the `bucket-owner-full-control` canned ACL. The source object was previously carrying ACLs that conflicted with the target bucket’s ownership controls. #9970 