### PR TITLE
update doc to include purpose of secrets

### DIFF
--- a/source/runbooks/rotating-secrets.html.md.erb
+++ b/source/runbooks/rotating-secrets.html.md.erb
@@ -76,28 +76,37 @@ This runbook describes the process for rotating the **slack_webhook_url** secret
 ### AWS SSO Entra ID
 
 1. **Log into the Azure Portal**
-   - Navigate to [Azure Portal](https://portal.azure.com).
-   - Use your `justice.gov.uk` credentials to sign in.
+    - Navigate to [Azure Portal](https://portal.azure.com).
+    - Use your `justice.gov.uk` credentials to sign in.
+
 2. **Locate the Application or Service**
-   - Go to **Microsoft Entra ID** > **App registrations**.
-   - Search for the `justicedigital-panda-awsidentitycenter` application.
+    - Go to **Microsoft Entra ID** > **App registrations**.
+    - Search for the relevant application, such as `justicedigital-panda-awsidentitycenter`.
+
 3. **Access Certificates & Secrets**
-   - Click on the application.
-   - In the left-hand menu, select **Certificates & secrets**.
+    - Click on the application.
+    - In the left-hand menu, select **Certificates & secrets**.
+
 4. **Add a New Secret**
-   - Under **Client secrets**, click **+ New client secret**.
-   - Enter a description and select the expiration period (e.g., 6 months).
-   - Click **Add** and copy the generated secret value immediately.
+    - Under **Client secrets**, click **+ New client secret**.
+    - Enter a description and select the expiration period (e.g., 6 months).
+    - Click **Add** and copy the generated secret value immediately.
+
 5. **Update AWS Secrets Manager**
-   - Navigate to [AWS Secrets Manager](https://eu-west-2.console.aws.amazon.com/secretsmanager/home?region=eu-west-2).
-   - Locate the secret named `azure_entraid_oidc`.
-   - Click **Retrieve secret value** to view the current configuration.
-   - Click **Edit**, replace the old secret value with the newly generated client secret, and click **Save**.
+    - Update the following secrets as appropriate:
+        - **`azure_entraid_oidc`** – Enables users to log into AWS with their justice.gov.uk accounts via federated authentication from Azure Entra ID using OIDC.
+        - **`entra_id_aws_connectivity_details`** – Used by the Azure SCIM Lambda to securely authenticate and interact with Azure Entra ID APIs for automated user and group provisioning between Azure and AWS.
+    - Navigate to the [AWS Secrets Manager](https://eu-west-2.console.aws.amazon.com/secretsmanager/home?region=eu-west-2).
+    - Locate the relevant secret (e.g., `azure_entraid_oidc` or `entra_id_aws_connectivity_details`).
+    - Click **Retrieve secret value** to view the current configuration.
+    - Click **Edit**, replace the old secret value with the newly generated client secret, and click **Save**.
+
 6. **Verify Functionality**
-   - Test the application or service to confirm that it works with the new secret.
+    - Test the application or service to confirm that it works with the new secret.
+
 7. **Remove the Old Secret**
-   - Once the new secret is fully functional, delete the old one to prevent misuse.
-   - Click the **Delete** icon next to the old secret.
+    - Once the new secret is fully functional, delete the old one to prevent misuse.
+    - Click the **Delete** icon next to the old secret.
 
 ### Cortex Xsiam User Account Access Key
 


### PR DESCRIPTION
## A reference to the issue / Description of it

#10003 
## How does this PR fix the problem?

All necessary Azure Entra ID credentials for AWS SSO and SCIM integrations are managed using the azure_entraid_oidc and entra_id_aws_connectivity_details secrets. This documentation makes it clear their purpose and eiminates confusion about it's use and makes secret rotation more straightforward. A third secret was adding to the confusion, but have raised a PR to remove it as can be seen here: https://github.com/ministryofjustice/aws-root-account/pull/1232

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
