### PR TITLE
Adds the production route53 domain for the maat application.

### DIFF
--- a/terraform/environments/core-network-services/route53.tf
+++ b/terraform/environments/core-network-services/route53.tf
@@ -10,6 +10,7 @@ locals {
     delius-jitbit = "jitbit.cr.probation.service.justice.gov.uk",
     equip         = "equip.service.justice.gov.uk",
     laa-apex      = "laa-apex.service.justice.gov.uk",
+    maat          = "means-assessment-administration.service.justice.gov.uk",
     mlra          = "maat-libra-administration-tool.service.justice.gov.uk",
     mojfin        = "laa-finance-data.service.justice.gov.uk",
     ncas          = "neutral-citation-allocation.service.justice.gov.uk",


### PR DESCRIPTION
## A reference to the issue / Description of it

## How does this PR fix the problem?

This adds the new route53 domain for the LAA's MAAT application and it's production migration. The name was proposed by the LAA Crime Apps team and approved by the COAT team via the domains email group.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
