### PR TITLE
Fix cross-account S3 upload failure by adding `kms:Decrypt` permission

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -1575,6 +1575,7 @@ data "aws_iam_policy_document" "s3_upload_policy_document" {
     sid    = "AllowS3UploadKms"
     effect = "Allow"
     actions = [
+      "kms:Decrypt",
       "kms:Encrypt",
       "kms:GenerateDataKey*",
       "kms:ReEncrypt*",


### PR DESCRIPTION
Uploading files to the S3 bucket using the AWS Console was failing with an `Access Denied` error when using a CMK from another account. This PR adds the `kms:Decrypt` permission to the IAM role used for uploading objects to S3 with a cross-account customer managed KMS key. #9970 