### PR TITLE
🧪  Testing new version of signed-commit

### DIFF
--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -49,7 +49,7 @@ jobs:
           REPORT_OUTPUT_FOLDER: none
           
       - name: Commit and Create PR with Signed Commit if Changes are Found
-        uses: ministryofjustice/modernisation-platform-github-actions/signed-commit@3cd73da46642bf52bb4045d8abf05e1d96fc4a53 # v3.1.0
+        uses: ministryofjustice/modernisation-platform-github-actions/signed-commit@ee0701cae8ac3179d7989aca0bfabe99262a8083 # slurpfile testing
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           pr_title: "GitHub Actions Code Formatter workflow"


### PR DESCRIPTION
The sign-commit step is currently failing on this workflow with an of `Argument list too long` This PR updates the action to a version that uses `slurpfile` rather than `argjson` to see if this resolves the issue. 

details of the signed-commit update can be found here https://github.com/ministryofjustice/modernisation-platform-github-actions/pull/59