### PR TITLE
Standardised CloudWatch metric filter/alarms to use VPCFlowLogs namespace

### DIFF
--- a/terraform/environments/core-vpc/monitoring.tf
+++ b/terraform/environments/core-vpc/monitoring.tf
@@ -57,7 +57,7 @@ resource "aws_cloudwatch_log_metric_filter" "rejected_connections" {
 
   metric_transformation {
     name          = "RejectedConnections"
-    namespace     = "VPCFlowMetrics"
+    namespace     = "VPCFlowLogs"
     value         = "1"
     default_value = "0"
   }
@@ -71,7 +71,7 @@ resource "aws_cloudwatch_log_metric_filter" "ssh_connection_attempts" {
 
   metric_transformation {
     name      = "SSHConnectionAttempts"
-    namespace = "VPCFlowMetrics"
+    namespace = "VPCFlowLogs"
     value     = "1"
   }
 }
@@ -119,7 +119,7 @@ resource "aws_cloudwatch_metric_alarm" "rejected_connections_alarm" {
     id = "m1"
     metric {
       metric_name = "RejectedConnections"
-      namespace   = "VPCFlowMetrics"
+      namespace   = "VPCFlowLogs"
       period      = 300
       stat        = "Sum"
     }
@@ -147,7 +147,7 @@ resource "aws_cloudwatch_metric_alarm" "ssh_connection_attempts_alarm" {
     id = "m1"
     metric {
       metric_name = "SSHConnectionAttempts"
-      namespace   = "VPCFlowMetrics"
+      namespace   = "VPCFlowLogs"
       period      = 300
       stat        = "Sum"
     }


### PR DESCRIPTION
## A reference to the issue / Description of it

[#9976](https://github.com/ministryofjustice/modernisation-platform/issues/9976)

## How does this PR fix the problem?

PR  standardises CloudWatch metric filter/alarms to use VPCFlowLogs namespace

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

See tests below

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
