### PR TITLE
Fix ECR repository policy errors for soa-admin and soa-managed

### DIFF
--- a/terraform/environments/core-shared-services/ecr_repos.tf
+++ b/terraform/environments/core-shared-services/ecr_repos.tf
@@ -1342,15 +1342,15 @@ module "soa_admin_ecr_repo" {
 
   push_principals = [
     "arn:aws:iam::${local.environment_management.account_ids["laa-ccms-soa-development"]}:role/modernisation-platform-oidc-cicd",
-    local.environment_management.account_ids["laa-ccms-soa-development"]
+    "arn:aws:iam::${local.environment_management.account_ids["laa-ccms-soa-development"]}:root"
   ]
 
   pull_principals = [
     "arn:aws:iam::${local.environment_management.account_ids["laa-ccms-soa-development"]}:role/modernisation-platform-oidc-cicd",
-    local.environment_management.account_ids["laa-ccms-soa-development"],
-    local.environment_management.account_ids["laa-ccms-soa-test"],
-    local.environment_management.account_ids["laa-ccms-soa-preproduction"],
-    local.environment_management.account_ids["laa-ccms-soa-production"]
+    "arn:aws:iam::${local.environment_management.account_ids["laa-ccms-soa-development"]}:root",
+    "arn:aws:iam::${local.environment_management.account_ids["laa-ccms-soa-test"]}:root",
+    "arn:aws:iam::${local.environment_management.account_ids["laa-ccms-soa-preproduction"]}:root",
+    "arn:aws:iam::${local.environment_management.account_ids["laa-ccms-soa-production"]}:root"
   ]
   tags_common = local.tags
 }
@@ -1362,15 +1362,15 @@ module "soa_managed_ecr_repo" {
 
   push_principals = [
     "arn:aws:iam::${local.environment_management.account_ids["laa-ccms-soa-development"]}:role/modernisation-platform-oidc-cicd",
-    local.environment_management.account_ids["laa-ccms-soa-development"]
+    "arn:aws:iam::${local.environment_management.account_ids["laa-ccms-soa-development"]}:root"
   ]
 
   pull_principals = [
     "arn:aws:iam::${local.environment_management.account_ids["laa-ccms-soa-development"]}:role/modernisation-platform-oidc-cicd",
-    local.environment_management.account_ids["laa-ccms-soa-development"],
-    local.environment_management.account_ids["laa-ccms-soa-test"],
-    local.environment_management.account_ids["laa-ccms-soa-preproduction"],
-    local.environment_management.account_ids["laa-ccms-soa-production"]
+    "arn:aws:iam::${local.environment_management.account_ids["laa-ccms-soa-development"]}:root",
+    "arn:aws:iam::${local.environment_management.account_ids["laa-ccms-soa-test"]}:root",
+    "arn:aws:iam::${local.environment_management.account_ids["laa-ccms-soa-preproduction"]}:root",
+    "arn:aws:iam::${local.environment_management.account_ids["laa-ccms-soa-production"]}:root"
   ]
   tags_common = local.tags
 }


### PR DESCRIPTION
This PR updates the `push_principals` and `pull_principals` values for the `soa_admin_ecr_repo` and `soa_managed_ecr_repo` modules to fix the following error:

> InvalidParameterException: Invalid parameter at 'PolicyText' failed to satisfy constraint: 'Principal not found'

