### PR TITLE
Update Terraform-Docs to use signed-commits

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         ref: ${{ github.event.pull_request.head.ref }}
 
@@ -27,4 +27,12 @@ jobs:
         find-dir: terraform/modules
         output-file: README.md
         output-method: inject
-        git-push: "true"
+        git-push: "false"
+
+    - name: Fix Git permissions
+      run: sudo chown -R $(whoami) .git/
+
+    - name: Run Signed Commit Action
+      uses: ministryofjustice/modernisation-platform-github-actions/signed-commit@ee0701cae8ac3179d7989aca0bfabe99262a8083 # v3.2.0
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR updates the `terraform-doc` action to use the `signed-commit` workflow rather than the built-in `git-push` command which is unsigned as per ticket https://github.com/ministryofjustice/modernisation-platform/issues/9858