### PR TITLE
Feaat/add soa r53 zone

### DIFF
--- a/terraform/environments/core-network-services/route53.tf
+++ b/terraform/environments/core-network-services/route53.tf
@@ -15,7 +15,7 @@ locals {
     mojfin        = "laa-finance-data.service.justice.gov.uk",
     ncas          = "neutral-citation-allocation.service.justice.gov.uk",
     pra-register  = "parental-responsibility-agreement.service.justice.gov.uk",
-    soa           = "ccms-soa.service.justice.gov.uk"
+    soa           = "laa-ccms-soa.service.justice.gov.uk"
     tipstaff      = "tipstaff.service.justice.gov.uk",
     tribunals     = "tribunals.gov.uk",
     wardship      = "wardship-agreements-register.service.justice.gov.uk"

--- a/terraform/environments/core-network-services/route53.tf
+++ b/terraform/environments/core-network-services/route53.tf
@@ -15,6 +15,7 @@ locals {
     mojfin        = "laa-finance-data.service.justice.gov.uk",
     ncas          = "neutral-citation-allocation.service.justice.gov.uk",
     pra-register  = "parental-responsibility-agreement.service.justice.gov.uk",
+    soa           = "ccms-soa.service.justice.gov.uk"
     tipstaff      = "tipstaff.service.justice.gov.uk",
     tribunals     = "tribunals.gov.uk",
     wardship      = "wardship-agreements-register.service.justice.gov.uk"


### PR DESCRIPTION
## A reference to the issue / Description of it

Adds new *INTERNAL* DNS zone `laa-ccms-soa.service.justice.gov.uk`

## How does this PR fix the problem?

Currently this application has no DNS zone and one is needed

## How has this been tested?

New resources, cannot test

{Please write here}

## Deployment Plan / Instructions

Deploy zone then deploy records from `modernisation-platform-environment`. Starting in dev and promoting to higher envs

