### PR TITLE
instance management getrolecredentials

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -930,6 +930,7 @@ data "aws_iam_policy_document" "instance-access-document" {
       "rhelkb:GetRhelURL",
       "s3:PutObject",
       "ssm-guiconnect:*",
+      "sso:GetRoleCredentials",
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
## A reference to the issue / Description of it

instance-management user gets the below error when trying aws sts get-caller-identity --profile  nomis-test 
An error occurred (ForbiddenException) when calling the GetRoleCredentials operation: No access

## How does this PR fix the problem?

should give necessary permissions

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
