### PR TITLE
DMET-prisons-356: adding RAM permissions for lake formation work

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -456,7 +456,31 @@ data "aws_iam_policy_document" "data_engineering_additional" {
       "s3:PutBucketNotificationConfiguration",
       "s3:GetBucketOwnershipControls",
       "s3:PutObjectAcl",
-      "s3tables:*"
+      "s3tables:*",
+      "ram:AcceptResourceShareInvitation",
+      "ram:AssociateResourceShare",
+      "ram:AssociateResourceSharePermission",
+      "ram:CreateResourceShare",
+      "ram:DeleteResourceShare",
+      "ram:DisassociateResourceShare",
+      "ram:DisassociateResourceSharePermission",
+      "ram:EnableSharingWithAwsOrganization",
+      "ram:GetPermission",
+      "ram:GetResourcePolicies",
+      "ram:GetResourceShareAssociations",
+      "ram:GetResourceShareInvitations",
+      "ram:GetResourceShares",
+      "ram:ListPendingInvitationResources",
+      "ram:ListPermissionVersions",
+      "ram:ListPermissions",
+      "ram:ListPrincipals",
+      "ram:ListResourceSharePermissions",
+      "ram:ListResourceTypes",
+      "ram:ListResources",
+      "ram:RejectResourceShareInvitation",
+      "ram:TagResource",
+      "ram:UntagResource",
+      "ram:UpdateResourceShare"
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
## A reference to the issue / Description of it

Raised as a feature request [here](https://github.com/ministryofjustice/analytical-platform/issues/7807).  The work is mentioned in our own ticket [here](https://github.com/moj-analytical-services/dmet-prisons/issues/356).

We want to be able to set up RAM shares via the console using the DE role in order to be able to then implement the shares using Terraform.

## How does this PR fix the problem?

This is set out in the [feature request](https://github.com/ministryofjustice/analytical-platform/issues/7807).  

```
The team do not have extensive experience in Terraform and without being able to set everything up through the console we are spending a lot of time 'throwing code at the wall' - whereas the AWS console works us through the process of setting up these permissions. We will be able to document an end-to-end process for others to benefit from this.
```

## How has this been tested?

The changes provide additional permissions only.

## Deployment Plan / Instructions

This deployment will affect SSO roles only - it will not directly impact any platforms/services.

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [ ] All checks have passed [waiting]

**Not applicable:**
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

