### PR TITLE
Use modernisation platform account ID for role assumption

### DIFF
--- a/.github/workflows/monitor-ecs-eks-amis.yml
+++ b/.github/workflows/monitor-ecs-eks-amis.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Set Account Number
         run: |
-          ACCOUNT_NUMBER=$(jq -r -e '.aws_organizations_root_account_id' <<< $ENVIRONMENT_MANAGEMENT)
+          ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< $ENVIRONMENT_MANAGEMENT)
           echo "::add-mask::$ACCOUNT_NUMBER"
           echo ACCOUNT_NUMBER=$ACCOUNT_NUMBER >> $GITHUB_ENV
 


### PR DESCRIPTION
## A reference to the issue / Description of it

This PR updates the GitHub Actions workflow to use the `modernisation_platform_account_id` instead of the AWS Organizations `root_account_id` when assuming IAM roles.

## How does this PR fix the problem?

Previously, the workflow attempted to assume a role using the root account ID, which is not the correct target. This change ensures the `github-actions-apply` role is assumed in the correct (Modernisation Platform) account.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
