### PR TITLE
Remove collaborator accounts for Lis and Adrian

### DIFF
--- a/collaborators.json
+++ b/collaborators.json
@@ -1639,26 +1639,6 @@
       ]
     },
     {
-      "username": "adrian.watson",
-      "github-username": "no-value-supplied",
-      "accounts": [
-        {
-          "account-name": "long-term-storage-production",
-          "access": "civica-role"
-        }
-      ]
-    },
-    {
-      "username": "lis.croxen",
-      "github-username": "no-value-supplied",
-      "accounts": [
-        {
-          "account-name": "long-term-storage-production",
-          "access": "civica-role"
-        }
-      ]
-    },
-    {
       "username": "lokesh.manjegowd",
       "github-username": "no-value-supplied",
       "accounts": [


### PR DESCRIPTION
This PR removes the user accounts for Lis and Adrian as per instructions from Nick.