### PR TITLE
remove overly permissive rules

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/development_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/development_rules.json
@@ -48,13 +48,6 @@
     "destination_port": "5432",
     "protocol": "TCP"
   },
-  "laa_development_to_mp_laa_development": {
-    "action": "ALERT",
-    "source_ip": "${laa-lz-development}",
-    "destination_ip": "${laa-development}",
-    "destination_port": "ANY",
-    "protocol": "IP"
-  },
   "laa_development_to_mp_laa_development_ccms": {
     "action": "PASS",
     "source_ip": "${laa-lz-development}",

--- a/terraform/environments/core-network-services/firewall-rules/test_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/test_rules.json
@@ -146,13 +146,6 @@
     "destination_port": "53",
     "protocol": "UDP"
   },
-  "laa_uat_to_mp_laa_test": {
-    "action": "ALERT",
-    "source_ip": "${laa-lz-uat}",
-    "destination_ip": "${laa-test}",
-    "destination_port": "ANY",
-    "protocol": "IP"
-  },
   "laa_test_to_mp_laa_test_ccms": {
     "action": "PASS",
     "source_ip": "${laa-lz-uat}",


### PR DESCRIPTION
## A reference to the issue / Description of it

as part of the security update for wire wall rules we need to remove any fire wall rule that uses the any port and not useing a port set this first PR will cover dev and test on LAA

## How does this PR fix the problem?

two any rules removed one from dev and one from test

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
