### PR TITLE
Adjust Anomaly Detection Band to 3 in CloudWatch Alarms

### DIFF
--- a/terraform/environments/core-vpc/monitoring.tf
+++ b/terraform/environments/core-vpc/monitoring.tf
@@ -101,7 +101,7 @@ resource "aws_cloudwatch_metric_alarm" "accepted_traffic_alarm" {
 
   metric_query {
     id          = "ad1"
-    expression  = "ANOMALY_DETECTION_BAND(m1, 2)"
+    expression  = "ANOMALY_DETECTION_BAND(m1, 3)"
     label       = "Sum AcceptedTrafficCount ${each.key} GreaterThanUpperThreshold 1.0"
     return_data = true
   }
@@ -130,7 +130,7 @@ resource "aws_cloudwatch_metric_alarm" "rejected_connections_alarm" {
 
   metric_query {
     id          = "ad1"
-    expression  = "ANOMALY_DETECTION_BAND(m1, 2)"
+    expression  = "ANOMALY_DETECTION_BAND(m1, 3)"
     label       = "Sum RejectedConnections ${each.key} GreaterThanUpperThreshold 1.0"
     return_data = true
   }
@@ -159,7 +159,7 @@ resource "aws_cloudwatch_metric_alarm" "ssh_connection_attempts_alarm" {
 
   metric_query {
     id          = "ad1"
-    expression  = "ANOMALY_DETECTION_BAND(m1, 2)"
+    expression  = "ANOMALY_DETECTION_BAND(m1, 3)"
     label       = "Sum SSHConnectionAttempts ${each.key} GreaterThanUpperThreshold 1.0"
     return_data = true
   }


### PR DESCRIPTION
## A reference to the issue / Description of it

[#9976](https://github.com/ministryofjustice/modernisation-platform/issues/9976)

Currently standard deviation of 2 is constantly being breached. Reducing sensitivity to get less false positives.

## How does this PR fix the problem?

PR increases SD to 3

## How has this been tested?

Please see below

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
