### PR TITLE
Adding decrypt secrets passphrase to MPE repo

### DIFF
--- a/terraform/github/repositories.tf
+++ b/terraform/github/repositories.tf
@@ -330,6 +330,8 @@ module "modernisation-platform-environments" {
     MODERNISATION_PLATFORM_ACCOUNT_ID                    = local.modernisation_platform_account
     SLACK_WEBHOOK_URL                                    = data.aws_secretsmanager_secret_version.slack_webhook_url.secret_string
     TERRAFORM_GITHUB_TOKEN                               = data.aws_secretsmanager_secret_version.github_ci_user_token.secret_string
+    PASSPHRASE                                           = local.decrypt_passphrase
+    MODERNISATION_PLATFORM_ACCOUNT_NUMBER                = local.modernisation_platform_account
     TESTING_AWS_ACCESS_KEY_ID                            = local.testing_ci_iam_user_keys.AWS_ACCESS_KEY_ID
     TESTING_AWS_SECRET_ACCESS_KEY                        = local.testing_ci_iam_user_keys.AWS_SECRET_ACCESS_KEY
   }


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/10126

## How does this PR fix the problem?

I need to add the decrypt secrets passphrase so that I can transition the MPE repo to using the decrypt secrets workflow 

In a subsequent PR I will need to remove the other secrets once all the member workflows have been migrated to using the decrypt secrets workflow and work independantly of GH secrets.
 
## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
