### PR TITLE
To resolve trivvy errors a release was amended

### DIFF
--- a/terraform/environments/core-shared-services/ad-fixngo.tf
+++ b/terraform/environments/core-shared-services/ad-fixngo.tf
@@ -1239,7 +1239,7 @@ resource "aws_ssm_parameter" "ad_fixngo" {
 
 #trivy:ignore:AVD-AWS-0345: Required for SSM patching module to access S3 buckets
 module "ad_fixngo_ssm_patching" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-ssm-patching.git?ref=aeb25bbec66ae3575d9435841792c333f46fe614" # v4.0.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-ssm-patching.git?ref=3659b4c4d37d5d71bca0ae9f2760cf3541e8d291" # v4.0.1
   providers = {
     aws.bucket-replication = aws
   }


### PR DESCRIPTION
## A reference to the issue / Description of it

See https://dsdmoj.atlassian.net/browse/TM-1282

## How does this PR fix the problem?

Check https://dsdmoj.atlassian.net/browse/TM-1282

## Deployment Plan / Instructions

Simply apply the release

## Additional comments (if any)
The modernisation platform-terraform-ssm-patachig was amended to put in the new release that stops it using the s3.* part of the routine. This was updated to amend this and the change made in here.
