### PR TITLE
Removing SNS Integration Code for VPC Flow Logs Alarms

### DIFF
--- a/terraform/environments/core-vpc/monitoring.tf
+++ b/terraform/environments/core-vpc/monitoring.tf
@@ -86,7 +86,6 @@ resource "aws_cloudwatch_metric_alarm" "accepted_traffic_alarm" {
   threshold_metric_id = "ad1"
   alarm_description   = "Anomaly detection alarm for accepted traffic in VPC '${each.key}'. A sudden spike or drop may indicate a network issue, service outage, or DDoS attempt."
   treat_missing_data  = "notBreaching"
-  alarm_actions       = [aws_sns_topic.vpc_flowlog_alarms.arn]
 
   metric_query {
     id = "m1"
@@ -115,7 +114,6 @@ resource "aws_cloudwatch_metric_alarm" "rejected_connections_alarm" {
   threshold_metric_id = "ad1"
   alarm_description   = "Anomaly detection alarm for rejected connections in VPC '${each.key}'. May indicate unauthorized access attempts, port scanning, or misconfigured security groups."
   treat_missing_data  = "notBreaching"
-  alarm_actions       = [aws_sns_topic.vpc_flowlog_alarms.arn]
 
   metric_query {
     id = "m1"
@@ -144,7 +142,6 @@ resource "aws_cloudwatch_metric_alarm" "ssh_connection_attempts_alarm" {
   threshold_metric_id = "ad1"
   alarm_description   = "Anomaly detection alarm for SSH connection attempts (port 22) in VPC '${each.key}'. Indicates possible brute-force login attempts or unauthorized probing."
   treat_missing_data  = "notBreaching"
-  alarm_actions       = [aws_sns_topic.vpc_flowlog_alarms.arn]
 
   metric_query {
     id = "m1"
@@ -163,80 +160,4 @@ resource "aws_cloudwatch_metric_alarm" "ssh_connection_attempts_alarm" {
     label       = "Sum SSHConnectionAttempts ${each.key} GreaterThanUpperThreshold 1.0"
     return_data = true
   }
-}
-
-# KMS key for SNS topic encryption
-resource "aws_kms_key" "vpc_flowlog_sns_encryption" {
-  description             = "KMS key for VPC Flow Log SNS topic encryption"
-  deletion_window_in_days = 7
-  enable_key_rotation     = true
-
-  policy = jsonencode({
-    Version = "2012-10-17",
-    Statement = [
-      {
-        Sid    = "Enable IAM User Permissions",
-        Effect = "Allow",
-        Principal = {
-          AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
-        },
-        Action   = "kms:*",
-        Resource = "*"
-      },
-      {
-        Sid    = "Allow SNS to use the key",
-        Effect = "Allow",
-        Principal = {
-          Service = "sns.amazonaws.com"
-        },
-        Action = [
-          "kms:Encrypt",
-          "kms:Decrypt",
-          "kms:ReEncrypt*",
-          "kms:GenerateDataKey*",
-          "kms:DescribeKey"
-        ],
-        Resource = "*"
-      },
-      {
-        Sid    = "Allow CloudWatch to use the key",
-        Effect = "Allow",
-        Principal = {
-          Service = "cloudwatch.amazonaws.com"
-        },
-        Action = [
-          "kms:Encrypt",
-          "kms:Decrypt",
-          "kms:ReEncrypt*",
-          "kms:GenerateDataKey*",
-          "kms:DescribeKey"
-        ],
-        Resource = "*"
-      }
-    ]
-  })
-
-  tags = {
-    Name = "vpc-flowlog-sns-encryption-key"
-  }
-}
-
-resource "aws_kms_alias" "vpc_flowlog_sns_topic" {
-  name_prefix   = "alias/vpc-flowlog-sns-encryption"
-  target_key_id = aws_kms_key.vpc_flowlog_sns_encryption.key_id
-}
-
-# SNS topic for VPC Flow Log alarms
-resource "aws_sns_topic" "vpc_flowlog_alarms" {
-  name              = "vpc-flowlog-alarms"
-  kms_master_key_id = aws_kms_key.vpc_flowlog_sns_encryption.arn
-  tags              = local.tags
-}
-
-# linking the sns topics to the pagerduty service
-module "pagerduty_vpc_flowlog_alerts" {
-  depends_on                = [aws_sns_topic.vpc_flowlog_alarms]
-  source                    = "github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration?ref=0179859e6fafc567843cd55c0b05d325d5012dc4" # v2.0.0
-  sns_topics                = [aws_sns_topic.vpc_flowlog_alarms.name]
-  pagerduty_integration_key = local.pagerduty_integration_keys["core_alerts_cloudwatch"]
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/9976 

Removing Code for SNS, as we are giving the alarms about a month for the AWS AI to get used to the LAA VPC traffic and we dont want to be getting alerts, in the slack channel during this period.

The alarms will be  reviewed in about a month, If the team finds the pilot useful, This PR will be reversed, in this [ticket](https://github.com/orgs/ministryofjustice/projects/17/views/1?pane=issue&itemId=113851569&issue=ministryofjustice%7Cmodernisation-platform%7C10239)

## How does this PR fix the problem?

PR

* Removes `alarm_actions` from the following CloudWatch alarms:  
  - `accepted_traffic_alarm`  
  - `rejected_connections_alarm`  
  - `ssh_connection_attempts_alarm`  

* Deletes the KMS key (`aws_kms_key.vpc_flowlog_sns_encryption`) and its alias (`aws_kms_alias.vpc_flowlog_sns_topic`) used for encrypting the SNS topic.

* Removes the SNS topic (`aws_sns_topic.vpc_flowlog_alarms`) that was used for VPC Flow Log alarms.

* Deletes the PagerDuty integration module (`module "pagerduty_vpc_flowlog_alerts"`) that linked the SNS topic to PagerDuty services.)


## How has this been tested?

See tests below

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
