### PR TITLE
Add GitHub OIDC Role for Security Hub Insight Creation and Summary Access

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -954,6 +954,8 @@ module "securityhub_insights_oidc_role" {
 }
 
 data "aws_iam_policy_document" "securityhub_insights_oidc_policy" {
+  # checkov:skip=CKV_AWS_111 "Required wildcard resource due to AWS Security Hub API limitations"
+  # checkov:skip=CKV_AWS_356 "Wildcard resource necessary because specific ARNs not supported for these actions"
   statement {
     sid    = "AllowSecurityHubInsightActions"
     effect = "Allow"


### PR DESCRIPTION
## A reference to the issue / Description of it

This PR introduces a new IAM role for GitHub OIDC authentication that grants permissions to create Security Hub insights and retrieve their summaries. #10041 

## How does this PR fix the problem?

This enables workflows authenticated via GitHub Actions to programmatically create Security Hub insights, fetch insight summaries, and send the summary to individual member Slack channels.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
