### PR TITLE
Adds outgoing port 22 from laa public subnets.

### DIFF
--- a/terraform/environments/core-network-services/cidr-ranges.tf
+++ b/terraform/environments/core-network-services/cidr-ranges.tf
@@ -77,6 +77,20 @@ locals {
     laa-appstream-vpc              = "10.200.32.0/19"
     laa-appstream-vpc_additional   = "10.200.68.0/22"
 
+    # laa modernisation-platform ranges
+    laa-mp-development-public-subnets-a   = "10.26.59.0/25"
+    laa-mp-development-public-subnets-b   = "10.26.59.128/25"
+    laa-mp-development-public-subnets-c   = "10.26.60.0/25"
+
+    laa-mp-preproduction-public-subnets-a = "10.27.75.0/25"
+    laa-mp-preproduction-public-subnets-b = "10.27.75.128/25"
+    laa-mp-preproduction-public-subnets-c = "10.27.76.0/25"
+ 
+    laa-mp-production-public-subnets-a    = "10.27.67.0/25"
+    laa-mp-production-public-subnets-b    = "10.27.67.128/25"
+    laa-mp-production-public-subnets-c    = "10.27.68.0/25"
+
+
     hmpps-preproduction-general-private-subnets = "10.27.0.0/22"
     hmpps-production-general-private-subnets    = "10.27.10.0/22"
 

--- a/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
@@ -670,5 +670,26 @@
     "destination_ip": "${youth-justice-networking-production}",
     "destination_port": "$YJB_TCP",
     "protocol": "TCP"
+  },
+  "laa_preproduction_to_internet_ssh-a": {
+    "action": "PASS",
+    "source_ip": "${laa-mp-preproduction-public-subnets-a}",
+    "destination_ip": "0.0.0.0/0",
+    "destination_port": "22",
+    "protocol": "TCP"
+  },
+  "laa_preproduction_to_internet_ssh-b": {
+    "action": "PASS",
+    "source_ip": "${laa-mp-preproduction-public-subnets-b}",
+    "destination_ip": "0.0.0.0/0",
+    "destination_port": "22",
+    "protocol": "TCP"
+  },
+  "laa_preproduction_to_internet_ssh-c": {
+    "action": "PASS",
+    "source_ip": "${laa-mp-preproduction-public-subnets-c}",
+    "destination_ip": "0.0.0.0/0",
+    "destination_port": "22",
+    "protocol": "TCP"
   }
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

This adds outgoing on tcp 22 from laa public subnets to support the implementation of sftp integration across various laa MP accounts.

## How does this PR fix the problem?

{Please write here}

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
