### PR TITLE
Temporarily redirect Security Hub alerts for core accounts to Members channel

### DIFF
--- a/terraform/environments/bootstrap/secure-baselines/main.tf
+++ b/terraform/environments/bootstrap/secure-baselines/main.tf
@@ -78,7 +78,7 @@ module "baselines" {
   enable_securityhub_alerts = true
 
   # Pass in pagerduty integration key for security hub alerts
-  pagerduty_integration_key = local.is_core_account ? local.pagerduty_integration_keys["security_hub"] : local.pagerduty_integration_keys["security_hub_members"]
+  pagerduty_integration_key = local.pagerduty_integration_keys["security_hub_members"]
 
   # PagerDuty Key for High Priority Alarms
   high_priority_pagerduty_integration_key = local.pagerduty_integration_keys["core_alerts_high_priority_cloudwatch"]


### PR DESCRIPTION
## A reference to the issue / Description of it

This PR updates the `pagerduty_integration_key` logic for core accounts to redirect Security Hub alerts to the shared channel `modernisation-platform-members-security-hub-alerts`.  #10041 

## How does this PR fix the problem?

We are transitioning to a summary-based approach for reporting Security Hub findings. Receiving individual alerts through Slack has created noise and reduced signal clarity. The goal is to reduce alert fatigue and focus on aggregated insights.


## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
