### PR TITLE
Add secret to store Slack channel webhook URLs for Security Hub notifications

### DIFF
--- a/environments/core-logging.json
+++ b/environments/core-logging.json
@@ -10,6 +10,7 @@
     "application": "modernisation-platform",
     "business-unit": "Platforms",
     "infrastructure-support": "modernisation-platform@digital.justice.gov.uk",
+    "securityhub_slack_channel": "modernisation-platform",
     "owner": "Modernisation Platform: modernisation-platform@digital.justice.gov.uk",
     "critical-national-infrastructure": false
   },

--- a/environments/core-logging.json
+++ b/environments/core-logging.json
@@ -10,7 +10,7 @@
     "application": "modernisation-platform",
     "business-unit": "Platforms",
     "infrastructure-support": "modernisation-platform@digital.justice.gov.uk",
-    "securityhub_slack_channel": "modernisation-platform",
+    "securityhub-slack-channel": "modernisation-platform",
     "owner": "Modernisation Platform: modernisation-platform@digital.justice.gov.uk",
     "critical-national-infrastructure": false
   },

--- a/environments/core-network-services.json
+++ b/environments/core-network-services.json
@@ -10,6 +10,7 @@
     "application": "modernisation-platform",
     "business-unit": "Platforms",
     "infrastructure-support": "modernisation-platform@digital.justice.gov.uk",
+    "securityhub_slack_channel": "modernisation-platform",
     "owner": "Modernisation Platform: modernisation-platform@digital.justice.gov.uk",
     "critical-national-infrastructure": false
   },

--- a/environments/core-network-services.json
+++ b/environments/core-network-services.json
@@ -10,7 +10,7 @@
     "application": "modernisation-platform",
     "business-unit": "Platforms",
     "infrastructure-support": "modernisation-platform@digital.justice.gov.uk",
-    "securityhub_slack_channel": "modernisation-platform",
+    "securityhub-slack-channel": "modernisation-platform",
     "owner": "Modernisation Platform: modernisation-platform@digital.justice.gov.uk",
     "critical-national-infrastructure": false
   },

--- a/environments/core-sandbox.json
+++ b/environments/core-sandbox.json
@@ -10,6 +10,7 @@
     "application": "core-sandbox",
     "business-unit": "Platforms",
     "infrastructure-support": "modernisation-platform@digital.justice.gov.uk",
+    "securityhub_slack_channel": "modernisation-platform",
     "owner": "Modernisation Platform: modernisation-platform@digital.justice.gov.uk",
     "critical-national-infrastructure": false
   },

--- a/environments/core-sandbox.json
+++ b/environments/core-sandbox.json
@@ -10,7 +10,7 @@
     "application": "core-sandbox",
     "business-unit": "Platforms",
     "infrastructure-support": "modernisation-platform@digital.justice.gov.uk",
-    "securityhub_slack_channel": "modernisation-platform",
+    "securityhub-slack-channel": "modernisation-platform",
     "owner": "Modernisation Platform: modernisation-platform@digital.justice.gov.uk",
     "critical-national-infrastructure": false
   },

--- a/environments/core-security.json
+++ b/environments/core-security.json
@@ -10,6 +10,7 @@
     "application": "modernisation-platform",
     "business-unit": "Platforms",
     "infrastructure-support": "modernisation-platform@digital.justice.gov.uk",
+    "securityhub_slack_channel": "modernisation-platform",
     "owner": "Modernisation Platform: modernisation-platform@digital.justice.gov.uk",
     "critical-national-infrastructure": false
   },

--- a/environments/core-security.json
+++ b/environments/core-security.json
@@ -10,7 +10,7 @@
     "application": "modernisation-platform",
     "business-unit": "Platforms",
     "infrastructure-support": "modernisation-platform@digital.justice.gov.uk",
-    "securityhub_slack_channel": "modernisation-platform",
+    "securityhub-slack-channel": "modernisation-platform",
     "owner": "Modernisation Platform: modernisation-platform@digital.justice.gov.uk",
     "critical-national-infrastructure": false
   },

--- a/environments/core-shared-services.json
+++ b/environments/core-shared-services.json
@@ -15,6 +15,7 @@
     "application": "modernisation-platform",
     "business-unit": "Platforms",
     "infrastructure-support": "modernisation-platform@digital.justice.gov.uk",
+    "securityhub_slack_channel": "modernisation-platform",
     "owner": "Modernisation Platform: modernisation-platform@digital.justice.gov.uk",
     "critical-national-infrastructure": false
   },

--- a/environments/core-shared-services.json
+++ b/environments/core-shared-services.json
@@ -15,7 +15,7 @@
     "application": "modernisation-platform",
     "business-unit": "Platforms",
     "infrastructure-support": "modernisation-platform@digital.justice.gov.uk",
-    "securityhub_slack_channel": "modernisation-platform",
+    "securityhub-slack-channel": "modernisation-platform",
     "owner": "Modernisation Platform: modernisation-platform@digital.justice.gov.uk",
     "critical-national-infrastructure": false
   },

--- a/environments/core-vpc.json
+++ b/environments/core-vpc.json
@@ -26,6 +26,7 @@
     "application": "modernisation-platform",
     "business-unit": "Platforms",
     "infrastructure-support": "modernisation-platform@digital.justice.gov.uk",
+    "securityhub_slack_channel": "modernisation-platform",
     "owner": "Modernisation Platform: modernisation-platform@digital.justice.gov.uk",
     "critical-national-infrastructure": false
   },

--- a/environments/core-vpc.json
+++ b/environments/core-vpc.json
@@ -26,7 +26,7 @@
     "application": "modernisation-platform",
     "business-unit": "Platforms",
     "infrastructure-support": "modernisation-platform@digital.justice.gov.uk",
-    "securityhub_slack_channel": "modernisation-platform",
+    "securityhub-slack-channel": "modernisation-platform",
     "owner": "Modernisation Platform: modernisation-platform@digital.justice.gov.uk",
     "critical-national-infrastructure": false
   },

--- a/terraform/modernisation-platform-account/secrets.tf
+++ b/terraform/modernisation-platform-account/secrets.tf
@@ -200,6 +200,17 @@ resource "aws_secretsmanager_secret" "slack_webhooks" {
   }
 }
 
+resource "aws_secretsmanager_secret" "securityhub_slack_webhooks" {
+  # checkov:skip=CKV2_AWS_57:Auto rotation not possible
+  name        = "securityhub_slack_webhooks"
+  description = "Stores Slack channel webhook URLs for sending Security Hub findings notifications"
+  kms_key_id  = aws_kms_key.secrets_key_multi_region.id
+  tags        = local.tags
+  replica {
+    region = local.replica_region
+  }
+}
+
 resource "aws_secretsmanager_secret" "secrets-fetch-decrypt-passphrase" {
   # checkov:skip=CKV2_AWS_57:Auto rotation not possible
   name        = "secrets-fetch-decrypt-passphrase"


### PR DESCRIPTION
## A reference to the issue / Description of it

This PR introduces a new secret named `securityhub-slack-channel` which stores Slack channel names as keys and their corresponding webhook URLs as values in a key-value JSON format. #10041 

## How does this PR fix the problem?

Currently, there is no centralised way to manage Slack webhook URLs for Security Hub notifications. By storing all Slack channel webhook URLs in a dedicated secret (securityhub-slack-webhooks), the system can easily retrieve and send summary reports to the correct Slack channels. This improves operational efficiency and ensures timely alerting of security findings.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
