### PR TITLE
Remove any rule for laa preproduction

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
@@ -55,13 +55,6 @@
     "destination_port": "ANY",
     "protocol": "TCP"
   },
-  "laa_staging_to_mp_laa_preproduction": {
-    "action": "ALERT",
-    "source_ip": "${laa-lz-staging}",
-    "destination_ip": "${laa-preproduction}",
-    "destination_port": "ANY",
-    "protocol": "TCP"
-  },
   "laa_preproduction_to_mp_laa_preproduction_ccms": {
     "action": "PASS",
     "source_ip": "${laa-lz-staging}",


### PR DESCRIPTION
## A reference to the issue / Description of it

After monitoring for a week and adding in extra rules for reverse lookup it is now time to remove the any rule for laa preproduction

## How does this PR fix the problem?

Remove laa any rule

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
