### PR TITLE
Add Slack Notification Workflow for SecurityHub Severity Summaries

### DIFF
--- a/.github/workflows/securityhub-findings-notification.yml
+++ b/.github/workflows/securityhub-findings-notification.yml
@@ -1,0 +1,115 @@
+name: Notify Slack with SecurityHub Findings Summary
+
+on:
+  schedule:
+    # trigger every weekday at 08:30am
+    - cron: '30 8 * * 1-5'
+  workflow_dispatch:
+
+env:
+  AWS_REGION: "eu-west-2"
+
+permissions:
+  id-token: write # This is required for requesting the JWT
+  contents: read # This is required for actions/checkout
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  fetch-secrets:
+    uses: ministryofjustice/modernisation-platform-github-actions/.github/workflows/aws-secrets-management.yml@c46848c0f17b1550dcf8ecffa0cdad8f0fc858ef # v3.2.3
+    secrets:
+        MODERNISATION_PLATFORM_ACCOUNT_NUMBER: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_NUMBER }}
+        PASSPHRASE: ${{ secrets.PASSPHRASE }}
+  generate-account-matrix:
+    runs-on: ubuntu-latest
+    needs: fetch-secrets
+    outputs:
+      matrix: ${{ steps.generate-account-matrix.outputs.matrix }}
+    steps:
+      - name: Decrypt Secrets
+        uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@5335a4d366f91f5c860cb1c53e71e5e2454755a5 # v3.2.2
+        with:
+          environment_management: ${{ needs.fetch-secrets.outputs.environment_management }}
+          PASSPHRASE: ${{ secrets.PASSPHRASE }}
+      - name: Generate Account Matrix from Secret
+        id: generate-account-matrix
+        run: |
+          MATRIX_JSON=$(echo $ENVIRONMENT_MANAGEMENT | jq -c '[.account_ids | to_entries[] | {name: .key, id: .value}]')
+          echo "matrix=$MATRIX_JSON" >> $GITHUB_OUTPUT
+  process-security-findings:
+    name: Process Security Findings - ${{ matrix.account.name }}
+    runs-on: ubuntu-latest
+    needs: [fetch-secrets, generate-account-matrix]
+    strategy:
+      matrix:
+        account: ${{ fromJson(needs.generate-account-matrix.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Decrypt Secrets
+        uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@5335a4d366f91f5c860cb1c53e71e5e2454755a5 # v3.2.2
+        with:
+          environment_management: ${{ needs.fetch-secrets.outputs.environment_management }}
+          securityhub_slack_webhooks: ${{ needs.fetch-secrets.outputs.securityhub_slack_webhooks }}
+          PASSPHRASE: ${{ secrets.PASSPHRASE }}
+      - name: Determine Environment Config File
+        id: derive-json-filename
+        run: |
+          FILENAME=$(echo "${{ matrix.account.name }}" | sed 's/-[^-]*$//').json
+          echo "JSON filename: $FILENAME"
+          echo "json_filename=$FILENAME" >> $GITHUB_OUTPUT
+      - name: Check Slack Channel Configuration
+        id: verify-slack-config
+        run: |
+          FILE_PATH="environments/${{ steps.derive-json-filename.outputs.json_filename }}"
+          if [ -f "$FILE_PATH" ]; then
+            if jq -e '.tags | has("securityhub-slack-channel")' "$FILE_PATH" > /dev/null; then
+              echo "Slack channel configured in environment tags"
+              CHANNEL=$(jq -r '.tags["securityhub-slack-channel"]' "$FILE_PATH")
+              echo "channel_exists=true" >> $GITHUB_OUTPUT
+              echo "channel_name=$CHANNEL" >> $GITHUB_OUTPUT
+            else
+              echo "No Slack channel configured in environment tags"
+              echo "channel_exists=false" >> $GITHUB_OUTPUT
+            fi
+          else
+            echo "Environment config file $FILE_PATH not found"
+            echo "channel_exists=false" >> $GITHUB_OUTPUT
+          fi
+      - name: Retrieve Slack Webhook URL
+        id: fetch-webhook-url
+        if: steps.verify-slack-config.outputs.channel_exists == 'true'
+        run: |
+          echo "Using channel name: ${{ steps.verify-slack-config.outputs.channel_name }}"
+          WEBHOOK=$(echo $SECURITYHUB_SLACK_WEBHOOKS | jq -r '.["${{ steps.verify-slack-config.outputs.channel_name }}"]')
+          if [ "$WEBHOOK" = "null" ] || [ -z "$WEBHOOK" ]; then
+            echo "No webhook found for this channel. Skipping."
+            exit 0
+          fi
+          echo "webhook_url=$WEBHOOK" >> $GITHUB_OUTPUT
+      - name: Configure AWS Credentials
+        if: steps.fetch-webhook-url.outputs.webhook_url != ''
+        uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
+        with:
+          role-to-assume: "arn:aws:iam::${{ matrix.account.id }}:role/github-actions-securityhub-insights"
+          role-session-name: githubactionsrolesession
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Analyze Security Hub Findings
+        id: analyze-findings
+        if: steps.fetch-webhook-url.outputs.webhook_url != ''
+        run: |
+          OUTPUT=$(bash ./scripts/extract-securityhub-severity-summary.sh)
+          echo "output<<EOF" >> $GITHUB_OUTPUT
+          echo "$OUTPUT" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+      - name: Send severity summary to Slack
+        if: steps.fetch-webhook-url.outputs.webhook_url != ''
+        env:
+          SLACK_WEBHOOK_URL: ${{ steps.fetch-webhook-url.outputs.webhook_url }}
+          ACCOUNT_NAME: ${{ matrix.account.name }}
+          ACCOUNT_NUMBER: ${{ matrix.account.id }}
+        run: |
+          MESSAGE="*Security Hub Severity Summary - $ACCOUNT_NAME ($ACCOUNT_NUMBER)*\n\`\`\`\n${{ steps.analyze-findings.outputs.output }}\n\`\`\`"
+          curl -X POST -H 'Content-type: application/json' --data "{\"text\": \"$MESSAGE\"}" "$SLACK_WEBHOOK_URL"

--- a/scripts/extract-securityhub-severity-summary.sh
+++ b/scripts/extract-securityhub-severity-summary.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+REGION="eu-west-2"
+INSIGHT_NAME="FindingCountsBySeverity"
+
+# Function to create insight if it doesn't exist
+create_or_get_insight() {
+    
+    # Check if insight already exists
+    INSIGHT_ARN=$(aws securityhub get-insights --region "$REGION" \
+        --query "Insights[?Name=='$INSIGHT_NAME'].InsightArn" \
+        --output text)
+    if [ -z "$INSIGHT_ARN" ]; then
+        echo "Creating new Security Hub insight..."
+        INSIGHT_ARN=$(aws securityhub create-insight --region "$REGION" \
+            --name "$INSIGHT_NAME" \
+            --filters '{"RecordState": [{"Value": "ACTIVE", "Comparison": "EQUALS"}]}' \
+            --group-by-attribute "SeverityLabel" \
+            --query "InsightArn" \
+            --output text)
+    fi
+    get_severity_counts "$INSIGHT_ARN"
+    
+}
+
+# Function to get severity counts
+get_severity_counts() {
+    local insight_arn=$1
+    # Fetching current severity counts
+    aws securityhub get-insight-results \
+        --region "$REGION" \
+        --insight-arn "$insight_arn" \
+        --query "InsightResults.ResultValues" \
+        --output json | jq -r ' map({(.GroupByAttributeValue): .Count}) | add as $all | ["CRITICAL","HIGH","MEDIUM","LOW"][] as $sev | "\($sev): \($all[$sev] // 0)"'
+}
+
+# Checking/creating Security Hub insight in $REGION
+create_or_get_insight


### PR DESCRIPTION
## A reference to the issue / Description of it

This PR introduces a GitHub Actions workflow that sends AWS SecurityHub findings (CRITICAL, HIGH, MEDIUM, LOW) to designated Slack channels per account environment. #10041 

## How does this PR fix the problem?

Previously, SecurityHub findings were not being communicated to relevant stakeholders automatically. This workflow ensures that each environment sends its own summarized severity findings directly to its respective Slack channel (if defined), improving visibility, response time, and accountability.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
