### PR TITLE
Add GitHub OIDC Role for Security Hub Insight Creation and Summary Access for core accounts 

### DIFF
--- a/.github/workflows/securityhub-findings-notification.yml
+++ b/.github/workflows/securityhub-findings-notification.yml
@@ -40,7 +40,7 @@ jobs:
           MATRIX_JSON=$(echo $ENVIRONMENT_MANAGEMENT | jq -c '[.account_ids | to_entries[] | {name: .key, id: .value}]')
           echo "matrix=$MATRIX_JSON" >> $GITHUB_OUTPUT
   process-security-findings:
-    name: Process Security Findings - ${{ matrix.account.name }}
+    name: ${{ matrix.account.name }}
     runs-on: ubuntu-latest
     needs: [fetch-secrets, generate-account-matrix]
     strategy:

--- a/.github/workflows/securityhub-findings-notification.yml
+++ b/.github/workflows/securityhub-findings-notification.yml
@@ -88,12 +88,15 @@ jobs:
             echo "No webhook found for this channel. Skipping."
             exit 0
           fi
+          ACCOUNT_NUMBER=${{ matrix.account.id }}
+          echo "::add-mask::$ACCOUNT_NUMBER"
+          echo ACCOUNT_NUMBER=$ACCOUNT_NUMBER >> $GITHUB_ENV
           echo "webhook_url=$WEBHOOK" >> $GITHUB_OUTPUT
       - name: Configure AWS Credentials
         if: steps.fetch-webhook-url.outputs.webhook_url != ''
         uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
         with:
-          role-to-assume: "arn:aws:iam::${{ matrix.account.id }}:role/github-actions-securityhub-insights"
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions-securityhub-insights"
           role-session-name: githubactionsrolesession
           aws-region: ${{ env.AWS_REGION }}
       - name: Analyze Security Hub Findings
@@ -109,7 +112,7 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ steps.fetch-webhook-url.outputs.webhook_url }}
           ACCOUNT_NAME: ${{ matrix.account.name }}
-          ACCOUNT_NUMBER: ${{ matrix.account.id }}
+          ACCOUNT_NUMBER: ${{ env.ACCOUNT_NUMBER }}
         run: |
           MESSAGE="*Security Hub Severity Summary - $ACCOUNT_NAME ($ACCOUNT_NUMBER)*\n\`\`\`\n${{ steps.analyze-findings.outputs.output }}\n\`\`\`"
           curl -X POST -H 'Content-type: application/json' --data "{\"text\": \"$MESSAGE\"}" "$SLACK_WEBHOOK_URL"

--- a/scripts/extract-securityhub-severity-summary.sh
+++ b/scripts/extract-securityhub-severity-summary.sh
@@ -11,7 +11,7 @@ create_or_get_insight() {
         --query "Insights[?Name=='$INSIGHT_NAME'].InsightArn" \
         --output text)
     if [ -z "$INSIGHT_ARN" ]; then
-        echo "Creating new Security Hub insight..."
+        #Creating new Security Hub insight...
         INSIGHT_ARN=$(aws securityhub create-insight --region "$REGION" \
             --name "$INSIGHT_NAME" \
             --filters '{"RecordState": [{"Value": "ACTIVE", "Comparison": "EQUALS"}]}' \

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -954,6 +954,16 @@ module "securityhub_insights_oidc_role" {
   tags                = { "Name" = format("%s-oidc-securityhub-insights", terraform.workspace) }
 }
 
+module "securityhub_insights_oidc_role_core" {
+  count                  = startswith(terraform.workspace, "core") && terraform.workspace != "core-shared-services-production" ? 1 : 0
+  source                 = "github.com/ministryofjustice/modernisation-platform-github-oidc-provider?ref=82f546bd5f002674138a2ccdade7d7618c6758b3" # v3.0.0
+  github_repositories    = ["ministryofjustice/modernisation-platform:ref:refs/heads/main"]
+  role_name              = "github-actions-securityhub-insights"
+  additional_permissions = data.aws_iam_policy_document.securityhub_insights_oidc_policy.json
+  tags_common            = { "Name" = format("%s-oidc-securityhub-insights", terraform.workspace) }
+  tags_prefix            = ""
+}
+
 data "aws_iam_policy_document" "securityhub_insights_oidc_policy" {
   # checkov:skip=CKV_AWS_111 "Required wildcard resource due to AWS Security Hub API limitations"
   # checkov:skip=CKV_AWS_356 "Wildcard resource necessary because specific ARNs not supported for these actions"


### PR DESCRIPTION
This PR introduces a new IAM role for GitHub OIDC authentication that grants permissions to create Security Hub insights and retrieve their summaries for core accounts except on `core-shared-services`