### PR TITLE
Update policies.tf to give data-engineer PutObjectTagging permissions

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -458,6 +458,7 @@ data "aws_iam_policy_document" "data_engineering_additional" {
       "s3:PutBucketNotificationConfiguration",
       "s3:GetBucketOwnershipControls",
       "s3:PutObjectAcl",
+      "s3:PutObjectTagging",
       "s3tables:*"
     ]
     resources = ["*"]


### PR DESCRIPTION
## A reference to the issue / Description of it

We have data in a bucket that has object tags on it, but cannot manually move it elsewhere when it gets stuck as the `data-engineer` role has insufficient permissions.

## How does this PR fix the problem?

This adds the s3:PutObjectTagging permission to the data engineering role.

## How has this been tested?

Not tested, as need permissions to check I am then able to move data.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No, just gives data engineers another iam permission.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)
n/a
