### PR TITLE
Automate Export of Route 53 Records from All Accounts to S3

### DIFF
--- a/.github/workflows/export-route53-records.yml
+++ b/.github/workflows/export-route53-records.yml
@@ -1,0 +1,41 @@
+name: Export Route 53 DNS Records to S3
+on: 
+  schedule:
+     # trigger every weekday at 06:30am
+    - cron: '30 6 * * *'
+  workflow_dispatch:
+env:
+  AWS_REGION: "eu-west-2"
+permissions:
+  id-token: write # This is required for requesting the JWT
+  contents: read # This is required for actions/checkout
+
+jobs:
+  fetch-secrets:
+    uses: ministryofjustice/modernisation-platform-github-actions/.github/workflows/aws-secrets-management.yml@c46848c0f17b1550dcf8ecffa0cdad8f0fc858ef # v3.2.3
+    secrets:
+      MODERNISATION_PLATFORM_ACCOUNT_NUMBER: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_NUMBER }}
+      PASSPHRASE: ${{ secrets.PASSPHRASE }}
+  export-route53-records:
+    runs-on: ubuntu-latest
+    needs: fetch-secrets
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Decrypt Secrets
+        uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@c46848c0f17b1550dcf8ecffa0cdad8f0fc858ef # v3.2.3
+        with:
+          environment_management: ${{ needs.fetch-secrets.outputs.environment_management }}
+          PASSPHRASE: ${{ secrets.PASSPHRASE }}
+      - name: Set Account Number
+        run: |
+          ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< $ENVIRONMENT_MANAGEMENT)
+          echo "::add-mask::$ACCOUNT_NUMBER"
+          echo ACCOUNT_NUMBER=$ACCOUNT_NUMBER >> $GITHUB_ENV
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions-apply"
+          role-session-name: githubactionsrolesession
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Run Route 53 Inventory Script
+        run: bash ./scripts/internal/export-route53-records.sh

--- a/scripts/internal/export-route53-records.sh
+++ b/scripts/internal/export-route53-records.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+set -euo pipefail
+
+# AWS credentials for the MP account
+ROOT_AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
+ROOT_AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
+ROOT_AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN
+
+# S3 config
+S3_BUCKET="modernisation-member-information"
+S3_KEY="route53-inventory/route53-records.json"
+
+# Temporary file for final JSON output
+OUTPUT_FILE=$(mktemp)
+echo "[]" > "$OUTPUT_FILE"
+
+# Function to assume role
+getAssumeRoleCreds() {
+    local account_id=$1
+    aws sts assume-role \
+        --role-arn "arn:aws:iam::${account_id}:role/ModernisationPlatformAccess" \
+        --role-session-name "route53-fetch-session" \
+        --output json > credentials.json
+
+    export AWS_ACCESS_KEY_ID=$(jq -r '.Credentials.AccessKeyId' credentials.json)
+    export AWS_SECRET_ACCESS_KEY=$(jq -r '.Credentials.SecretAccessKey' credentials.json)
+    export AWS_SESSION_TOKEN=$(jq -r '.Credentials.SessionToken' credentials.json)
+}
+
+# Iterate over accounts from ENVIRONMENT_MANAGEMENT
+for account_id in $(jq -r '.account_ids | to_entries[] | "\(.value)"' <<< $ENVIRONMENT_MANAGEMENT); do
+    account_name=$(jq -r ".account_ids | to_entries[] | select(.value==\"$account_id\").key" <<< $ENVIRONMENT_MANAGEMENT)
+
+    echo "Assuming role into $account_name"
+    getAssumeRoleCreds "$account_id"
+
+    zones=$(aws route53 list-hosted-zones --query 'HostedZones' --output json)
+    zone_count=$(echo "$zones" | jq 'length')
+
+    if [[ "$zone_count" -eq 0 ]]; then
+        echo "No hosted zones found in $account_name, skipping."
+
+        # Reset credentials
+        export AWS_ACCESS_KEY_ID=$ROOT_AWS_ACCESS_KEY_ID
+        export AWS_SECRET_ACCESS_KEY=$ROOT_AWS_SECRET_ACCESS_KEY
+        export AWS_SESSION_TOKEN=$ROOT_AWS_SESSION_TOKEN
+        rm -f credentials.json
+        continue
+    fi
+
+    for row in $(echo "$zones" | jq -r '.[] | @base64'); do
+        _jq() { echo "$row" | base64 --decode | jq -r "$1"; }
+
+        zone_id=$(_jq '.Id' | cut -d'/' -f3)
+        zone_name=$(_jq '.Name')
+
+        echo "Fetching records for zone: $zone_name"
+        records=$(aws route53 list-resource-record-sets \
+            --hosted-zone-id "$zone_id" --output json)
+
+        zone_data=$(jq -n \
+            --arg account_id "$account_id" \
+            --arg account_name "$account_name" \
+            --arg zone_id "$zone_id" \
+            --arg zone_name "$zone_name" \
+            --argjson records "$records" \
+            '{
+                account_id: $account_id,
+                account_name: $account_name,
+                zone_id: $zone_id,
+                zone_name: $zone_name,
+                records: $records.ResourceRecordSets
+            }')
+
+        jq --argjson zone "$zone_data" '. += [$zone]' "$OUTPUT_FILE" > tmp.$$.json && mv tmp.$$.json "$OUTPUT_FILE"
+    done
+
+    # Reset to root credentials
+    export AWS_ACCESS_KEY_ID=$ROOT_AWS_ACCESS_KEY_ID
+    export AWS_SECRET_ACCESS_KEY=$ROOT_AWS_SECRET_ACCESS_KEY
+    export AWS_SESSION_TOKEN=$ROOT_AWS_SESSION_TOKEN
+    rm -f credentials.json
+
+    echo "Completed $account_name"
+done
+
+# Upload final result to S3
+echo "Uploading to S3"
+aws s3 cp "$OUTPUT_FILE" "s3://${S3_BUCKET}/${S3_KEY}"
+echo "Upload successful."
+
+rm -f "$OUTPUT_FILE"


### PR DESCRIPTION
This PR enables the automated collection of all DNS records from Route 53 hosted zones across multiple AWS accounts. The aggregated records are stored as a single JSON file in a centralized S3 bucket for auditing or monitoring 
[#issue](https://github.com/ministryofjustice/modernisation-platform-security/issues/54)