### PR TITLE
Remove Hosted Zone Names from Workflow Log Messages

### DIFF
--- a/scripts/internal/export-route53-records.sh
+++ b/scripts/internal/export-route53-records.sh
@@ -54,7 +54,7 @@ for account_id in $(jq -r '.account_ids | to_entries[] | "\(.value)"' <<< $ENVIR
         zone_id=$(_jq '.Id' | cut -d'/' -f3)
         zone_name=$(_jq '.Name')
 
-        echo "Fetching records for zone: $zone_name"
+        echo "Fetching records for zone"
         records=$(aws route53 list-resource-record-sets \
             --hosted-zone-id "$zone_id" --output json)
 


### PR DESCRIPTION
This PR updates workflow log messages to avoid printing Route 53 hosted zone names. The original logs included domain-level information, which can be sensitive when stored or displayed publicly.