### PR TITLE
remove production ICMP rule

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/production_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/production_rules.json
@@ -237,13 +237,6 @@
     "destination_port": "ANY",
     "protocol": "TCP"
   },
-  "cp_to_mp_hmpps_production_icmp": {
-    "action": "PASS",
-    "source_ip": "${cloud-platform}",
-    "destination_ip": "${hmpps-production}",
-    "destination_port": "ANY",
-    "protocol": "ICMP"
-  },
   "hmpps_production_to_delius_eng_prod_oracledb": {
     "action": "PASS",
     "source_ip": "${hmpps-production}",


### PR DESCRIPTION
## A reference to the issue / Description of it

after Looking through a list of rules i have identified one rule that can be removed which is an icmp rule that allow ping to be done from cloud platform to hampps production that was for testing reasons.

## How does this PR fix the problem?

removed the ICMP rule

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
