### PR TITLE
Move Testing-CI access keys secret to the MP account

### DIFF
--- a/terraform/github/testing-ci.tf
+++ b/terraform/github/testing-ci.tf
@@ -181,3 +181,28 @@ data "aws_iam_policy_document" "testing_ci_iam_user_kms_key_policy" {
     }
   }
 }
+
+# Secrets manager policy
+data "aws_iam_policy_document" "testing_ci_iam_user_secrets_manager_policy" {
+  # checkov:skip=CKV_AWS_111: "policy is directly related to the resource"
+  # checkov:skip=CKV_AWS_109: "policy is directly related to the resource"
+  # checkov:skip=CKV_AWS_108: "policy is directly related to the resource"
+  # checkov:skip=CKV_AWS_356: "policy is directly related to the resource"
+  statement {
+    sid    = "AllowModernisationPlatformAccount"
+    effect = "Allow"
+    actions = [
+      "secretsmanager:*"
+    ]
+    resources = [
+      "*"
+    ]
+    principals {
+      type = "AWS"
+      identifiers = [
+        data.aws_caller_identity.modernisation_platform.id
+      ]
+    }
+  }
+}
+


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/10126

## How does this PR fix the problem?

I've moved the testing-ci user access key secret and associated kms key to modernisation-platform account so it can be managed/accessed centrally alongside our other secrets.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
