### PR TITLE
TM-1319: remove-az-uks-fixngo-network-ranges

### DIFF
--- a/terraform/environments/core-network-services/cidr-ranges.tf
+++ b/terraform/environments/core-network-services/cidr-ranges.tf
@@ -41,15 +41,10 @@ locals {
 
     # hmpps azure cidr ranges
     noms-live-vnet            = "10.40.0.0/18"
-    noms-live-dr-vnet         = "10.40.64.0/18"
     noms-mgmt-live-vnet       = "10.40.128.0/20"
-    noms-mgmt-live-dr-vnet    = "10.40.144.0/20"
     noms-transit-live-vnet    = "10.40.160.0/20"
-    noms-transit-live-dr-vnet = "10.40.176.0/20"
     noms-test-vnet            = "10.101.0.0/16"
     noms-mgmt-vnet            = "10.102.0.0/16"
-    noms-test-dr-vnet         = "10.111.0.0/16"
-    noms-mgmt-dr-vnet         = "10.112.0.0/16"
     moj-smtp-relay1           = "10.180.104.100/32"
     moj-smtp-relay2           = "10.180.105.100/32"
 


### PR DESCRIPTION
## A reference to the issue / Description of it

Remove the IP ranges from the cidr-ranges.tf related to the decommissioned Azure FixnGo UK South (DR) network.

## How does this PR fix the problem?

Removes ranges no longer used

## How has this been tested?

Network rules have already been updated accordingly in DSO manage accounts.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

None, no active resources are left in UK South

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

https://dsdmoj.atlassian.net/browse/TM-1319 
