### PR TITLE
Create legalservices hosted zone

### DIFF
--- a/terraform/environments/core-network-services/route53.tf
+++ b/terraform/environments/core-network-services/route53.tf
@@ -18,6 +18,7 @@ locals {
     tipstaff      = "tipstaff.service.justice.gov.uk",
     tribunals     = "tribunals.gov.uk",
     wardship      = "wardship-agreements-register.service.justice.gov.uk"
+    legalservices = "legalservices.gov.uk"
   }
 
   private-application-zones = {


### PR DESCRIPTION
## A reference to the issue / Description of it

The LAA production account is disabled but the DNS is still active, we need to migrate this from LAA Production to MP.

## How does this PR fix the problem?

Initial creation of legalservices hosted zone.  Next steps are to recreate the existing records in code, then change the NS records to point to this zone.

## How has this been tested?

Adding to an existing tested process

## Deployment Plan / Instructions

No impact until NS records point here

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
