### PR TITLE
update new-member-environmnets-files workflow to use signed commits

### DIFF
--- a/.github/workflows/new-member-environment-files.yml
+++ b/.github/workflows/new-member-environment-files.yml
@@ -36,10 +36,10 @@ jobs:
           slack_webhook_url: ${{ needs.fetch-secrets.outputs.slack_webhook_url }}
           terraform_github_token: ${{ needs.fetch-secrets.outputs.terraform_github_token }}
           PASSPHRASE: ${{ secrets.PASSPHRASE }}
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           path: core-repo
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: ministryofjustice/modernisation-platform-environments
           path: modernisation-platform-environments
@@ -50,12 +50,14 @@ jobs:
         run: bash ./core-repo/scripts/provision-member-directories.sh
       - name: Commit changes to GitHub
         run: bash ./core-repo/scripts/git-setup.sh ./modernisation-platform-environments
-      - run: bash ./core-repo/scripts/git-commit.sh . ./modernisation-platform-environments
-        env:  
-          TERRAFORM_GITHUB_TOKEN: ${{ env.TERRAFORM_GITHUB_TOKEN }} # use this token as writing to a different repo
-      - run: bash ./core-repo/scripts/git-pull-request.sh terraform/environments ./modernisation-platform-environments
-        env:
-          TERRAFORM_GITHUB_TOKEN: ${{ env.TERRAFORM_GITHUB_TOKEN }}
+      - name: Commit and Create PR with Signed Commit
+        uses: ministryofjustice/modernisation-platform-github-actions/signed-commit@c46848c0f17b1550dcf8ecffa0cdad8f0fc858ef # v3.2.3
+        with:
+          github_token: ${{ secrets.TERRAFORM_GITHUB_TOKEN }} # use this token as writing to a different repo
+          remote_repository: "ministryofjustice/modernisation-platform-environments"
+          remote_repository_path: "./modernisation-platform-environments"
+          pr_title: "New files for terraform/environments"
+          pr_body: "> This PR was automatically created via a GitHub action workflow 🤖"
       - name: Slack failure notification
         uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
         with:


### PR DESCRIPTION
As per issue https://github.com/ministryofjustice/modernisation-platform/issues/9700 this PR updates the `new-member-environments-files` workflow to use the signed-commits GitHub action.