### PR TITLE
Declare outputs of environments module nuke lists

### DIFF
--- a/terraform/environments/outputs.tf
+++ b/terraform/environments/outputs.tf
@@ -1,11 +1,14 @@
 output "environment_nuke_accounts" {
   value = module.environments.environment_nuke_accounts
+  sensitive = true
 }
 
 output "environment_nuke_blocklist_accounts" {
   value = module.environments.environment_nuke_blocklist_accounts
+  sensitive = true
 }
 
 output "environment_rebuild_after_nuke_accounts" {
   value = module.environments.environment_rebuild_after_nuke_accounts
+  sensitive = true
 }

--- a/terraform/environments/outputs.tf
+++ b/terraform/environments/outputs.tf
@@ -1,14 +1,14 @@
 output "environment_nuke_accounts" {
-  value = module.environments.environment_nuke_accounts
+  value     = module.environments.environment_nuke_accounts
   sensitive = true
 }
 
 output "environment_nuke_blocklist_accounts" {
-  value = module.environments.environment_nuke_blocklist_accounts
+  value     = module.environments.environment_nuke_blocklist_accounts
   sensitive = true
 }
 
 output "environment_rebuild_after_nuke_accounts" {
-  value = module.environments.environment_rebuild_after_nuke_accounts
+  value     = module.environments.environment_rebuild_after_nuke_accounts
   sensitive = true
 }

--- a/terraform/environments/outputs.tf
+++ b/terraform/environments/outputs.tf
@@ -1,0 +1,11 @@
+output "environment_nuke_accounts" {
+  value = module.environments.environment_nuke_accounts
+}
+
+output "environment_nuke_blocklist_accounts" {
+  value = module.environments.environment_nuke_blocklist_accounts
+}
+
+output "environment_rebuild_after_nuke_accounts" {
+  value = module.environments.environment_rebuild_after_nuke_accounts
+}


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/10126

## How does this PR fix the problem?

These outputs need to be declared so they can be referenced in a subsequent PR where I'm looking to populate the values in aws secrets manager in the mod platform account.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
