### PR TITLE
TM-1365: Adding fallback layer to DSO pagerduty schedule

### DIFF
--- a/terraform/pagerduty/member-services-integrations.tf
+++ b/terraform/pagerduty/member-services-integrations.tf
@@ -1947,6 +1947,18 @@ resource "pagerduty_schedule" "dso" {
   description = "#ask-digital-studio-operations Concierge in-hours rota. Managed in terraform"
   time_zone   = "Europe/London"
 
+  # Incidents will not be created if there is no one on call. Adding a fall back layer to ensure there is always a user on call.
+  layer {
+    name                         = "Fallback layer"
+    start                        = "2025-05-15T06:00:00Z"
+    rotation_virtual_start       = "2025-05-15T06:00:00Z"
+    rotation_turn_length_seconds = 604800
+
+    users = [
+      pagerduty_user.pager_duty_users["modernisation_platform"].id
+    ]
+  }
+
   layer {
     name                         = "Primary Schedule"
     start                        = "2025-05-15T00:00:00Z"


### PR DESCRIPTION
## A reference to the issue / Description of it

Some DSO cloudwatch alerts are being ignored by pagerduty

## How does this PR fix the problem?

Adds a fallback layer to the DSO schedule

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Not tested but mirrors the setup for Mod Platform schedule

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
