### PR TITLE
Adds tcp 587 outbound for SES public endpoint access from MAATDB RDS.

### DIFF
--- a/terraform/environments/core-network-services/cidr-ranges.tf
+++ b/terraform/environments/core-network-services/cidr-ranges.tf
@@ -77,6 +77,10 @@ locals {
     laa-mp-development-general-private-subnets-b = "10.26.57.0/24"
     laa-mp-development-general-private-subnets-c = "10.26.58.0/24"
 
+    laa-mp-development-general-data-subnets-a = "10.26.60.128/25"
+    laa-mp-development-general-data-subnets-b = "10.26.61.0/25"
+    laa-mp-development-general-data-subnets-c = "10.26.61.128/25"
+
     laa-mp-test-general-private-subnets-a = "10.26.96.0/24"
     laa-mp-test-general-private-subnets-b = "10.26.97.0/24"
     laa-mp-test-general-private-subnets-c = "10.26.98.0/24"

--- a/terraform/environments/core-network-services/firewall-rules/development_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/development_rules.json
@@ -712,5 +712,5 @@
     "destination_ip": "0.0.0.0/0",
     "destination_port": "587",
     "protocol": "TCP"
-  },
+  }
 }

--- a/terraform/environments/core-network-services/firewall-rules/development_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/development_rules.json
@@ -691,5 +691,26 @@
     "destination_ip": "${laa-development}",
     "destination_port": "ANY",
     "protocol": "IP"
-  }
+  },
+  "laa_development_data_a_ses": {
+    "action": "PASS",
+    "source_ip": "${laa-mp-development-general-data-subnets-a}",
+    "destination_ip": "0.0.0.0/0",
+    "destination_port": "587",
+    "protocol": "TCP"
+  },
+  "laa_development_data_b_ses": {
+    "action": "PASS",
+    "source_ip": "${laa-mp-development-general-data-subnets-b}",
+    "destination_ip": "0.0.0.0/0",
+    "destination_port": "587",
+    "protocol": "TCP"
+  },
+  "laa_development_data_c_ses": {
+    "action": "PASS",
+    "source_ip": "${laa-mp-development-general-data-subnets-c}",
+    "destination_ip": "0.0.0.0/0",
+    "destination_port": "587",
+    "protocol": "TCP"
+  },
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

As per above title, this adds outbound access to SES public endpoint via tcp 587. This is required to allow MAATDB RDS to connect to the SES SMTP endpoint. Note that the general-data subnets already have NACL rules for general outbound access via this port.

This is initially for testing and if successful a follow-up PR will add it for the other LAA VPCs.

## How does this PR fix the problem?

{Please write here}

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
