### PR TITLE
🛂 Add Network Monitor permissions to Platform Engineer Admin role

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -601,7 +601,6 @@ data "aws_iam_policy_document" "platform_engineer_additional_additional" {
       "dbqms:*",
       "discovery:*",
       "detective:*",
-      "graph:*",
       "dlm:*",
       "dms:*",
       "drs:*",
@@ -634,6 +633,7 @@ data "aws_iam_policy_document" "platform_engineer_additional_additional" {
       "mgn:*",
       "migrationhub-strategy:*",
       "networkflowmonitor:*",
+      "networkmonitor:*"
       "oam:*",
       "organizations:DescribeOrganization",
       "quicksight:*",


### PR DESCRIPTION
## A reference to the issue / Description of it

I want to view CloudWatch Flow Monitor

## How does this PR fix the problem?

Gives access to Platform Engineer Admin role

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

It hasn't been tested, but its additive

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

I've removed `graph` because it doesn't exist