### PR TITLE
🛂 Add Network Monitor permissions to Member Infrastructure Access role

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -163,6 +163,8 @@ data "aws_iam_policy_document" "member-access" {
       "lakeformation:*",
       "lambda:*",
       "logs:*",
+      "networkflowmonitor:*",
+      "networkmonitor:*",
       "organizations:Describe*",
       "organizations:List*",
       "oam:*",


### PR DESCRIPTION
## A reference to the issue / Description of it

Follows:

- https://github.com/ministryofjustice/modernisation-platform/pull/10477
- https://github.com/ministryofjustice/modernisation-platform/pull/10483

## How does this PR fix the problem?

Enables same permissions for CI/CD role

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Tested via linked pull requests

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No, its additive

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
