### PR TITLE
DPR2-1499: Add ecr:ListTagsForResource to CircleCI IAM policy

### DIFF
--- a/terraform/environments/digital-prison-reporting/iam.tf
+++ b/terraform/environments/digital-prison-reporting/iam.tf
@@ -82,6 +82,7 @@ data "aws_iam_policy_document" "circleci_iam_policy" {
       "ecr:DescribeImages",
       "ecr:DescribeRepositories",
       "ecr:ListImages",
+      "ecr:ListTagsForResource",
       "ecr:GetAuthorizationToken",
       "ecr:GetDownloadUrlForLayer",
       "ecr:BatchGetImage",


### PR DESCRIPTION
## A reference to the issue / Description of it

The Digital Prison Reporting circleci pipeline is failing with the error:
```
Error: listing tags for ECR (Elastic Container Registry) Repository (...): operation error ECR: ListTagsForResource, https response error StatusCode: 400, RequestID: b762c838-1ca0-4733-be99-e25b9a8b45f8, api error AccessDeniedException: User: .../circleci_iam_role/circleci-oidc-session is not authorized to perform: ecr:ListTagsForResource on resource: ... because no identity-based policy allows the ecr:ListTagsForResource action
```

See https://app.circleci.com/pipelines/github/ministryofjustice/digital-prison-reporting-domains/3108/workflows/6ee06f2d-1a31-4572-a99f-bb3a4175acee/jobs/10221

## How does this PR fix the problem?

Adds the missing `ecr:ListTagsForResource` permission to the digital prison reporting circleci_iam_policy

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.
The pipeline will be re-applied to verify the fix.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

N/A
