### PR TITLE
Add SQS queue and S3 bucket notification for config logs

### DIFF
--- a/terraform/environments/core-logging/cortex.tf
+++ b/terraform/environments/core-logging/cortex.tf
@@ -107,6 +107,7 @@ data "aws_iam_policy_document" "cortex_user_policy" {
     resources = flatten([
       aws_sqs_queue.mp_cloudtrail_log_queue.arn,
       aws_sqs_queue.mp_modernisation_platform_waf_logs_queue.arn,
+      aws_sqs_queue.mp_config_logs_queue.arn,
       [for key in aws_sqs_queue.logging : key.arn]
     ])
   }
@@ -119,7 +120,9 @@ data "aws_iam_policy_document" "cortex_user_policy" {
         module.s3-bucket-cloudtrail.bucket.arn,
         "${module.s3-bucket-cloudtrail.bucket.arn}/*",
         module.s3-bucket-modernisation-platform-waf-logs.bucket.arn,
-        "${module.s3-bucket-modernisation-platform-waf-logs.bucket.arn}/*"
+        "${module.s3-bucket-modernisation-platform-waf-logs.bucket.arn}/*",
+        module.s3_bucket_config_logs.bucket.arn,
+        "${module.s3_bucket_config_logs.bucket.arn}/*"
       ],
       [for key in aws_s3_bucket.logging : "${key.arn}/*"]
     )

--- a/terraform/environments/core-logging/sqs.tf
+++ b/terraform/environments/core-logging/sqs.tf
@@ -88,3 +88,47 @@ resource "aws_s3_bucket_notification" "modernisation_platform_waf_logs_bucket_no
     events    = ["s3:ObjectCreated:*"]
   }
 }
+
+
+# SQS Queue for modernisation platform logs config (Config Logs) bucket updates for XSIAM
+resource "aws_sqs_queue" "mp_config_logs_queue" {
+  name                       = "mp_config_logs_queue"
+  sqs_managed_sse_enabled    = true
+  delay_seconds              = 0
+  max_message_size           = 262144
+  message_retention_seconds  = 345600
+  visibility_timeout_seconds = 30
+}
+
+resource "aws_sqs_queue_policy" "config_logs_queue_policy" {
+  queue_url = aws_sqs_queue.mp_config_logs_queue.id
+  policy    = data.aws_iam_policy_document.config_logs_queue_policy_document.json
+}
+
+data "aws_iam_policy_document" "config_logs_queue_policy_document" {
+  statement {
+    sid    = "AllowSendMessage"
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["s3.amazonaws.com"]
+    }
+    actions = ["sqs:SendMessage"]
+    resources = [
+      aws_sqs_queue.mp_config_logs_queue.arn
+    ]
+    condition {
+      test     = "ArnEquals"
+      variable = "aws:SourceArn"
+      values   = [module.s3_bucket_config_logs.bucket.arn]
+    }
+  }
+}
+
+resource "aws_s3_bucket_notification" "waf_logs_bucket_notification" {
+  bucket = module.s3_bucket_config_logs.bucket.id
+  queue {
+    queue_arn = aws_sqs_queue.mp_config_logs_queue.arn
+    events    = ["s3:ObjectCreated:*"]
+  }
+}


### PR DESCRIPTION
## A reference to the issue / Description of it

#912 

## How does this PR fix the problem?

This PR introduces a new AWS SQS queue and S3 bucket notification configuration to capture `ObjectCreated` events from the `config-logs` bucket and forward them to the SQS queue. This setup mirrors the existing configuration used for WAF logs.


## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
