### PR TITLE
DPR2-1499: Add Put and Get BucketNotification permissions to DPR circleci policy

### DIFF
--- a/terraform/environments/digital-prison-reporting/iam.tf
+++ b/terraform/environments/digital-prison-reporting/iam.tf
@@ -155,6 +155,7 @@ data "aws_iam_policy_document" "circleci_iam_policy" {
       "s3:GetBucketLocation",
       "s3:ListBucket",
       "s3:ListAllMyBuckets",
+      "s3:*BucketNotification",
       "s3:*Object*",
       "rds:*",
       "secretsmanager:ListSecrets",


### PR DESCRIPTION

## A reference to the issue / Description of it

The Digital Prison Reporting circleci pipeline is failing with the error:

```
 Error: creating S3 Bucket ... Notification: operation error S3: PutBucketNotificationConfiguration, https response error StatusCode: 403, RequestID: VZSVNG5Q936SPZMN, HostID: ..., api error AccessDenied: User: ...:assumed-role/circleci_iam_role/circleci-oidc-session is not authorized to perform: s3:PutBucketNotification on resource: "..." because no identity-based policy allows the s3:PutBucketNotification action
```

See: https://app.circleci.com/pipelines/github/ministryofjustice/digital-prison-reporting-domains/3113/workflows/145a1467-5c64-4732-9451-d1c3409135fa/jobs/10242

## How does this PR fix the problem?

Adds the missing `s3:PutBucketNotification` permission to the digital prison reporting circleci_iam_policy and also adds `s3:GetBucketNotification` so terraform can read as well as write the notification configuration

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.
The pipeline will be re-applied to verify the fix.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?
No.


## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

N/A
