### PR TITLE
Update workflow to use testing branch

### DIFF
--- a/.github/workflows/new-member-environment-files.yml
+++ b/.github/workflows/new-member-environment-files.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Commit changes to GitHub
         run: bash ./core-repo/scripts/git-setup.sh ./modernisation-platform-environments
       - name: Commit and Create PR with Signed Commit
-        uses: ministryofjustice/modernisation-platform-github-actions/signed-commit@f2a9793a84f2049008a70b9ef3987ce5d623c613 # Testing Update
+        uses: ministryofjustice/modernisation-platform-github-actions/signed-commit@fixup/github-token-1 # switch to branch for testing
         with:
           github_token: ${{ secrets.TERRAFORM_GITHUB_TOKEN }} # use this token as writing to a different repo
           remote_repository: "ministryofjustice/modernisation-platform-environments"


### PR DESCRIPTION
This PR updates the workflow to use a branch in the github-action repo that I'm currently using for testing - should help cutdown on the some PR requests while I iron things out..