### PR TITLE
Remove GH secrets for MPE repo

### DIFF
--- a/terraform/environments/secrets.tf
+++ b/terraform/environments/secrets.tf
@@ -145,7 +145,7 @@ locals {
 
 # Store environment management secret in Github secrets
 resource "github_actions_secret" "environment_management" {
-  for_each = toset(["modernisation-platform-environments", "modernisation-platform", "modernisation-platform-ami-builds", "modernisation-platform-configuration-management", "modernisation-platform-security"])
+  for_each = toset(["modernisation-platform", "modernisation-platform-ami-builds", "modernisation-platform-configuration-management", "modernisation-platform-security"])
   # checkov:skip=CKV_SECRET_6: "secret_name is not a secret"
   secret_name = "MODERNISATION_PLATFORM_ENVIRONMENTS"
   repository  = each.key
@@ -153,26 +153,4 @@ resource "github_actions_secret" "environment_management" {
     local.environment_management,
     { account_ids : module.environments.environment_account_ids }
   ))
-}
-
-resource "github_actions_secret" "autonuke_blocklist" {
-  # checkov:skip=CKV_SECRET_6: "secret_name is not a secret"
-  secret_name     = "MODERNISATION_PLATFORM_AUTONUKE_BLOCKLIST"
-  repository      = "modernisation-platform-environments"
-  plaintext_value = jsonencode(module.environments.environment_nuke_blocklist_accounts)
-}
-
-resource "github_actions_secret" "autonuke_rebuild" {
-  # checkov:skip=CKV_SECRET_6: "secret_name is not a secret"
-  secret_name     = "MODERNISATION_PLATFORM_AUTONUKE_REBUILD"
-  repository      = "modernisation-platform-environments"
-  plaintext_value = jsonencode(concat(module.environments.environment_rebuild_after_nuke_accounts, ["cooker-development"]))
-}
-
-resource "github_actions_secret" "autonuke" {
-  # checkov:skip=CKV_SECRET_6: "secret_name is not a secret"
-  secret_name = "MODERNISATION_PLATFORM_AUTONUKE"
-  repository  = "modernisation-platform-environments"
-  # testing-test, cooker-development, and example-development are internal test account which are not sandpits but require nuking.
-  plaintext_value = jsonencode(concat(module.environments.environment_nuke_accounts, ["testing-test"]))
 }

--- a/terraform/github/repositories.tf
+++ b/terraform/github/repositories.tf
@@ -326,13 +326,8 @@ module "modernisation-platform-environments" {
   required_checks = ["run-opa-policy-tests"]
   secrets = {
     # Terraform GitHub token for the CI/CD user
-    MODERNISATION_PLATFORM_CI_USER_ENVIRONMENTS_REPO_PAT = data.aws_secretsmanager_secret_version.github_ci_user_environments_repo_pat_token.secret_string
-    MODERNISATION_PLATFORM_ACCOUNT_ID                    = local.modernisation_platform_account
-    SLACK_WEBHOOK_URL                                    = data.aws_secretsmanager_secret_version.slack_webhook_url.secret_string
-    TERRAFORM_GITHUB_TOKEN                               = data.aws_secretsmanager_secret_version.github_ci_user_token.secret_string
-    PASSPHRASE                                           = local.decrypt_passphrase
-    TESTING_AWS_ACCESS_KEY_ID                            = local.testing_ci_iam_user_keys.AWS_ACCESS_KEY_ID
-    TESTING_AWS_SECRET_ACCESS_KEY                        = local.testing_ci_iam_user_keys.AWS_SECRET_ACCESS_KEY
+    MODERNISATION_PLATFORM_ACCOUNT_ID = local.modernisation_platform_account
+    PASSPHRASE                        = local.decrypt_passphrase
   }
   restrict_dismissals    = true
   dismissal_restrictions = ["ministryofjustice/modernisation-platform"]


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/10126

## How does this PR fix the problem?

Removes GitHub secrets from the Mod Platform Environments repo now that all the workflows have been updated to pull their secrets from AWS using the centralised github action.

A couple of GH secrets remain (`MODERNISATION_PLATFORM_ACCOUNT_ID` and `PASSPHRASE`) which are still required to call the secrets github action.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Tested in each of the other workflows that have already been migrated (see ticket for details).

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
