### PR TITLE
Adds firewall rules for SES SMTP (tcp 587) access from laa general data subnets test, preprod and prod. 

### DIFF
--- a/terraform/environments/core-network-services/cidr-ranges.tf
+++ b/terraform/environments/core-network-services/cidr-ranges.tf
@@ -85,14 +85,25 @@ locals {
     laa-mp-test-general-private-subnets-b = "10.26.97.0/24"
     laa-mp-test-general-private-subnets-c = "10.26.98.0/24"
 
+    laa-mp-test-general-data-subnets-a = "10.26.100.128/25"
+    laa-mp-test-general-data-subnets-b = "10.26.101.0/25"
+    laa-mp-test-general-data-subnets-c = "10.26.101.128/25"
+
     laa-mp-preproduction-general-private-subnets-a = "10.27.72.0/24"
     laa-mp-preproduction-general-private-subnets-b = "10.27.73.0/24"
     laa-mp-preproduction-general-private-subnets-c = "10.27.74.0/24"
+
+    laa-mp-preproduction-general-data-subnets-a = "10.27.76.128/25"
+    laa-mp-preproduction-general-data-subnets-b = "10.27.77.0/25"
+    laa-mp-preproduction-general-data-subnets-c = "10.27.77.128/25"
 
     laa-mp-production-general-private-subnets-a = "10.27.64.0/24"
     laa-mp-production-general-private-subnets-b = "10.27.65.0/24"
     laa-mp-production-general-private-subnets-c = "10.27.66.0/24"
 
+    laa-mp-production-general-data-subnets-a = "10.27.68.128/25"
+    laa-mp-production-general-data-subnets-b = "10.27.69.0/25"
+    laa-mp-production-general-data-subnets-c = "10.27.69.128/25"
 
     hmpps-preproduction-general-private-subnets = "10.27.0.0/22"
     hmpps-production-general-private-subnets    = "10.27.10.0/22"

--- a/terraform/environments/core-network-services/firewall-rules/development_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/development_rules.json
@@ -695,84 +695,21 @@
   "laa_development_data_a_ses": {
     "action": "PASS",
     "source_ip": "${laa-mp-development-general-data-subnets-a}",
-    "destination_ip": "0.0.0.0/0",
+    "destination_ip": "$AWS_SMTP_EU_WEST_2",
     "destination_port": "587",
     "protocol": "TCP"
   },
   "laa_development_data_b_ses": {
     "action": "PASS",
     "source_ip": "${laa-mp-development-general-data-subnets-b}",
-    "destination_ip": "0.0.0.0/0",
+    "destination_ip": "$AWS_SMTP_EU_WEST_2",
     "destination_port": "587",
     "protocol": "TCP"
   },
   "laa_development_data_c_ses": {
     "action": "PASS",
     "source_ip": "${laa-mp-development-general-data-subnets-c}",
-    "destination_ip": "0.0.0.0/0",
-    "destination_port": "587",
-    "protocol": "TCP"
-  },
-  "laa_test_data_a_ses": {
-    "action": "PASS",
-    "source_ip": "${laa-mp-test-general-data-subnets-a}",
-    "destination_ip": "0.0.0.0/0",
-    "destination_port": "587",
-    "protocol": "TCP"
-  },
-  "laa_test_data_b_ses": {
-    "action": "PASS",
-    "source_ip": "${laa-mp-test-general-data-subnets-b}",
-    "destination_ip": "0.0.0.0/0",
-    "destination_port": "587",
-    "protocol": "TCP"
-  },
-  "laa_test_data_c_ses": {
-    "action": "PASS",
-    "source_ip": "${laa-mp-test-general-data-subnets-c}",
-    "destination_ip": "0.0.0.0/0",
-    "destination_port": "587",
-    "protocol": "TCP"
-  },
-  "laa_preproduction_data_a_ses": {
-    "action": "PASS",
-    "source_ip": "${laa-mp-preproduction-general-data-subnets-a}",
-    "destination_ip": "0.0.0.0/0",
-    "destination_port": "587",
-    "protocol": "TCP"
-  },
-  "laa_preproduction_data_b_ses": {
-    "action": "PASS",
-    "source_ip": "${laa-mp-preproduction-general-data-subnets-b}",
-    "destination_ip": "0.0.0.0/0",
-    "destination_port": "587",
-    "protocol": "TCP"
-  },
-  "laa_preproduction_data_c_ses": {
-    "action": "PASS",
-    "source_ip": "${laa-mp-preproduction-general-data-subnets-c}",
-    "destination_ip": "0.0.0.0/0",
-    "destination_port": "587",
-    "protocol": "TCP"
-  },
-  "laa_production_data_a_ses": {
-    "action": "PASS",
-    "source_ip": "${laa-mp-production-general-data-subnets-a}",
-    "destination_ip": "0.0.0.0/0",
-    "destination_port": "587",
-    "protocol": "TCP"
-  },
-  "laa_production_data_b_ses": {
-    "action": "PASS",
-    "source_ip": "${laa-mp-production-general-data-subnets-b}",
-    "destination_ip": "0.0.0.0/0",
-    "destination_port": "587",
-    "protocol": "TCP"
-  },
-  "laa_production_data_c_ses": {
-    "action": "PASS",
-    "source_ip": "${laa-mp-production-general-data-subnets-c}",
-    "destination_ip": "0.0.0.0/0",
+    "destination_ip": "$AWS_SMTP_EU_WEST_2",
     "destination_port": "587",
     "protocol": "TCP"
   }

--- a/terraform/environments/core-network-services/firewall-rules/development_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/development_rules.json
@@ -712,5 +712,68 @@
     "destination_ip": "0.0.0.0/0",
     "destination_port": "587",
     "protocol": "TCP"
-  }
+  },
+  "laa_test_data_a_ses": {
+    "action": "PASS",
+    "source_ip": "${laa-mp-test-general-data-subnets-a}",
+    "destination_ip": "0.0.0.0/0",
+    "destination_port": "587",
+    "protocol": "TCP"
+  },
+  "laa_test_data_b_ses": {
+    "action": "PASS",
+    "source_ip": "${laa-mp-test-general-data-subnets-b}",
+    "destination_ip": "0.0.0.0/0",
+    "destination_port": "587",
+    "protocol": "TCP"
+  },
+  "laa_test_data_c_ses": {
+    "action": "PASS",
+    "source_ip": "${laa-mp-test-general-data-subnets-c}",
+    "destination_ip": "0.0.0.0/0",
+    "destination_port": "587",
+    "protocol": "TCP"
+  },
+  "laa_preproduction_data_a_ses": {
+    "action": "PASS",
+    "source_ip": "${laa-mp-preproduction-general-data-subnets-a}",
+    "destination_ip": "0.0.0.0/0",
+    "destination_port": "587",
+    "protocol": "TCP"
+  },
+  "laa_preproduction_data_b_ses": {
+    "action": "PASS",
+    "source_ip": "${laa-mp-preproduction-general-data-subnets-b}",
+    "destination_ip": "0.0.0.0/0",
+    "destination_port": "587",
+    "protocol": "TCP"
+  },
+  "laa_preproduction_data_c_ses": {
+    "action": "PASS",
+    "source_ip": "${laa-mp-preproduction-general-data-subnets-c}",
+    "destination_ip": "0.0.0.0/0",
+    "destination_port": "587",
+    "protocol": "TCP"
+  },
+  "laa_production_data_a_ses": {
+    "action": "PASS",
+    "source_ip": "${laa-mp-production-general-data-subnets-a}",
+    "destination_ip": "0.0.0.0/0",
+    "destination_port": "587",
+    "protocol": "TCP"
+  },
+  "laa_production_data_b_ses": {
+    "action": "PASS",
+    "source_ip": "${laa-mp-production-general-data-subnets-b}",
+    "destination_ip": "0.0.0.0/0",
+    "destination_port": "587",
+    "protocol": "TCP"
+  },
+  "laa_production_data_c_ses": {
+    "action": "PASS",
+    "source_ip": "${laa-mp-production-general-data-subnets-c}",
+    "destination_ip": "0.0.0.0/0",
+    "destination_port": "587",
+    "protocol": "TCP"
+  },
 }

--- a/terraform/environments/core-network-services/firewall-rules/development_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/development_rules.json
@@ -775,5 +775,5 @@
     "destination_ip": "0.0.0.0/0",
     "destination_port": "587",
     "protocol": "TCP"
-  },
+  }
 }

--- a/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
@@ -712,5 +712,26 @@
     "destination_ip": "13.17.132.44",
     "destination_port": "22",
     "protocol": "TCP"
+  },
+  "laa_preproduction_data_a_ses": {
+    "action": "PASS",
+    "source_ip": "${laa-mp-preproduction-general-data-subnets-a}",
+    "destination_ip": "$AWS_SMTP_EU_WEST_2",
+    "destination_port": "587",
+    "protocol": "TCP"
+  },
+  "laa_preproduction_data_b_ses": {
+    "action": "PASS",
+    "source_ip": "${laa-mp-preproduction-general-data-subnets-b}",
+    "destination_ip": "$AWS_SMTP_EU_WEST_2",
+    "destination_port": "587",
+    "protocol": "TCP"
+  },
+  "laa_preproduction_data_c_ses": {
+    "action": "PASS",
+    "source_ip": "${laa-mp-preproduction-general-data-subnets-c}",
+    "destination_ip": "$AWS_SMTP_EU_WEST_2",
+    "destination_port": "587",
+    "protocol": "TCP"
   }
 }

--- a/terraform/environments/core-network-services/firewall-rules/production_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/production_rules.json
@@ -649,5 +649,26 @@
     "destination_ip": "${youth-justice-networking-production}",
     "destination_port": "$YJB_TCP",
     "protocol": "TCP"
+  },
+  "laa_production_data_a_ses": {
+    "action": "PASS",
+    "source_ip": "${laa-mp-production-general-data-subnets-a}",
+    "destination_ip": "$AWS_SMTP_EU_WEST_2",
+    "destination_port": "587",
+    "protocol": "TCP"
+  },
+  "laa_production_data_b_ses": {
+    "action": "PASS",
+    "source_ip": "${laa-mp-production-general-data-subnets-b}",
+    "destination_ip": "$AWS_SMTP_EU_WEST_2",
+    "destination_port": "587",
+    "protocol": "TCP"
+  },
+  "laa_production_data_c_ses": {
+    "action": "PASS",
+    "source_ip": "${laa-mp-production-general-data-subnets-c}",
+    "destination_ip": "$AWS_SMTP_EU_WEST_2",
+    "destination_port": "587",
+    "protocol": "TCP"
   }
 }

--- a/terraform/environments/core-network-services/firewall-rules/sets.json
+++ b/terraform/environments/core-network-services/firewall-rules/sets.json
@@ -1,6 +1,7 @@
 {
   "IP_SETS": {
     "IP_SET_EXAMPLE": ["1.1.1.1/32", "1.0.0.1/32"],
+    "AWS_SMTP_EU_WEST_2": ["3.11.252.235", "35.178.252.162", "35.177.173.199"],
     "AD_HMPP_DCS": ["${ad-hmpp-dc-a}", "${ad-hmpp-dc-b}"],
     "AD_HMPP_RD_LICENSING": ["${ad-hmpp-rdlic}"],
     "AD_AZURE_DCS": ["${ad-azure-dc-a}", "${ad-azure-dc-b}"],

--- a/terraform/environments/core-network-services/firewall-rules/test_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/test_rules.json
@@ -390,5 +390,26 @@
     "destination_ip": "${laa-test}",
     "destination_port": "ANY",
     "protocol": "IP"
+  },
+  "laa_test_data_a_ses": {
+    "action": "PASS",
+    "source_ip": "${laa-mp-test-general-data-subnets-a}",
+    "destination_ip": "$AWS_SMTP_EU_WEST_2",
+    "destination_port": "587",
+    "protocol": "TCP"
+  },
+  "laa_test_data_b_ses": {
+    "action": "PASS",
+    "source_ip": "${laa-mp-test-general-data-subnets-b}",
+    "destination_ip": "$AWS_SMTP_EU_WEST_2",
+    "destination_port": "587",
+    "protocol": "TCP"
+  },
+  "laa_test_data_c_ses": {
+    "action": "PASS",
+    "source_ip": "${laa-mp-test-general-data-subnets-c}",
+    "destination_ip": "$AWS_SMTP_EU_WEST_2",
+    "destination_port": "587",
+    "protocol": "TCP"
   }
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

Adds firewall rules for SES SMTP (tcp 587) access from laa general data subnets test, preprod and prod. 
Create a new IP list for the current public IP endpoints for SES SMTP in eu-west-2.

## How does this PR fix the problem?

These are required by LAA to access SES SMTP endpoints from MAATDB.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Tested in development.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
