### PR TITLE
Grant Saj read-only access to yjb prod accounts

### DIFF
--- a/collaborators.json
+++ b/collaborators.json
@@ -1729,6 +1729,20 @@
           "access": "reporting-operations"
         }
       ]
+    },
+    {
+      "username": "sajjad.hai",
+      "github-username": "no-value-supplied",
+      "accounts": [
+        {
+          "account-name": "youth-justice-app-framework-production",
+          "access": "read-only"
+        },
+        {
+          "account-name": "youth-justice-networking-production",
+          "access": "read-only"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

Request via email to allow Sajjad Hai access to the production accounts to see Security Hub warnings.

## How does this PR fix the problem?

Grants access as required.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
