### PR TITLE
Fix AWS Config ListBucket access

### DIFF
--- a/terraform/environments/core-logging/config_logging.tf
+++ b/terraform/environments/core-logging/config_logging.tf
@@ -199,5 +199,21 @@ data "aws_iam_policy_document" "config_bucket_policy" {
     actions   = ["s3:GetBucketAcl"]
     resources = [module.s3_bucket_config_logs.bucket.arn]
   }
+
+  statement {
+    sid    = "AllowAWSConfigListObject"
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+    actions = ["s3:ListBucket"]
+    resources = [module.s3_bucket_config_logs.bucket.arn]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalOrgID"
+      values   = [data.aws_organizations_organization.moj_root_account.id]
+    }
+  }
 }
 


### PR DESCRIPTION
## A reference to the issue / Description of it

[#issue](https://moj-digital-tools.pagerduty.com/incidents/Q2NH10Y73XU9F3?utm_campaign=channel&utm_source=slack)

## How does this PR fix the problem?

This PR updates the S3 bucket policy on `modernisation-platform-logs-config` to allow AWS Config to perform `s3:ListBucket`

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
