### PR TITLE
Adds default tags to member-bootstrap provider

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/providers.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/providers.tf
@@ -4,6 +4,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
@@ -22,16 +23,19 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
   alias = "modernisation-platform-environments-us-east-1"
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
   alias  = "modernisation-platform"
   region = "eu-west-2"
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for the Modernisation Platform for us-east-1, to do things like License Manager grants
 provider "aws" {
   alias  = "modernisation-platform-us-east-1"
   region = "us-east-1"
+  default_tags { tags = local.tags }
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

#10313
## How does this PR fix the problem?

 Ensures that all AWS resources created or managed by your Terraform code are consistently tagged, without needing to manually add tags to each individual resource.
 
## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
