### PR TITLE
maat - adds instance-management role use for crime-apps team.

### DIFF
--- a/environments/maat.json
+++ b/environments/maat.json
@@ -15,6 +15,10 @@
           "github_action_reviewer": "true"
         },
         {
+          "sso_group_name": "laa-crime-apps-team",
+          "level": "instance-management"
+        },
+        {
           "sso_group_name": "laa-sre-admins",
           "level": "sandbox"
         }
@@ -33,6 +37,10 @@
           "sso_group_name": "laa-crime-apps-team",
           "level": "developer",
           "github_action_reviewer": "true"
+        },
+        {
+          "sso_group_name": "laa-crime-apps-team",
+          "level": "instance-management"
         },
         {
           "sso_group_name": "laa-sre-admins",
@@ -54,6 +62,10 @@
           "github_action_reviewer": "true"
         },
         {
+          "sso_group_name": "laa-crime-apps-team",
+          "level": "instance-management"
+        },
+        {
           "sso_group_name": "laa-sre-admins",
           "level": "developer"
         }
@@ -71,6 +83,10 @@
           "sso_group_name": "laa-crime-apps-team",
           "level": "developer",
           "github_action_reviewer": "true"
+        },
+        {
+          "sso_group_name": "laa-crime-apps-team",
+          "level": "instance-management"
         },
         {
           "sso_group_name": "laa-sre-admins",


### PR DESCRIPTION
This adds instance-management role to the maat application to give crime-apps devs the ability to manage their ecs tasks and task versions. This will save MP team having to use Administrator access to undertake this work when it's needed.

## A reference to the issue / Description of it

{Please write here}

## How does this PR fix the problem?

{Please write here}

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
