### PR TITLE
Update links to new location of legacy Ops Eng documentation

### DIFF
--- a/source/concepts/networking/dns.html.md.erb
+++ b/source/concepts/networking/dns.html.md.erb
@@ -62,6 +62,6 @@ DNS entries for applications will be created in the relevant zone following the 
 
 Public facing services must have a `service.justice.gov.uk` domain name, excluding exceptional cases.
 
-See the MoJ Technical guidance on [Naming domains](https://user-guide.operations-engineering.service.justice.gov.uk/documentation/services/domain-naming-standard.html) for more information.
+See the MoJ Technical guidance on [Naming domains](https://cloud-optimisation-and-accountability.justice.gov.uk/documentation/operations-engineering-legacy/operations-engineering-user-guide/dns/domain-naming-standard.html) for more information.
 
 For more information on implementing DNS on the Modernisation Platform please see [How to configure DNS](../../user-guide/how-to-configure-dns.html)

--- a/source/user-guide/certificate-import.html.md.erb
+++ b/source/user-guide/certificate-import.html.md.erb
@@ -31,7 +31,7 @@ To request a public certificate under either of the above domains, refer to the 
 
 ## Linux
 
-Refer to [Requesting a new certificate](https://user-guide.operations-engineering.service.justice.gov.uk/documentation/services/sslcertmanage.html).
+Refer to [Requesting a new certificate](https://cloud-optimisation-and-accountability.justice.gov.uk/documentation/operations-engineering-legacy/operations-engineering-user-guide/dns/sslcertmanage.html).
 
 Once you receive the public certificate, you can then import it into your environment by following the instructions in [Getting certificates ready in AWS Certificate Manager](https://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-custom-domains-prerequisites.html).
 

--- a/source/user-guide/how-to-configure-dns.html.md.erb
+++ b/source/user-guide/how-to-configure-dns.html.md.erb
@@ -22,7 +22,7 @@ In order for users to access public facing services with a URL (Uniform Resource
 
 This will enable users to securely access services over HTTPS (Hypertext Transfer Protocol Secure).
 
-There are two main ways to use certificates for DNS on the Modernisation Platform; [ACM](https://aws.amazon.com/certificate-manager/) (Amazon Certificate Manager) public certificates, and [Gandi.net](https://user-guide.operations-engineering.service.justice.gov.uk/documentation/services/sslcertmanage.html) certificates imported into ACM.
+There are two main ways to use certificates for DNS on the Modernisation Platform; [ACM](https://aws.amazon.com/certificate-manager/) (Amazon Certificate Manager) public certificates, and [Gandi.net](https://cloud-optimisation-and-accountability.justice.gov.uk/documentation/operations-engineering-legacy/operations-engineering-user-guide/dns/sslcertmanage.html) certificates imported into ACM.
 
 Unless there is a good reason, ACM public certificates should be used as they are automatically managed and renewed. Gandi.net certificates cost more and require manual renewal.
 


### PR DESCRIPTION
## A reference to the issue / Description of it

PR to update links to Ops Eng guidance that has moved.

## How does this PR fix the problem?

Prevent broken links and ensure guidance can be found.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

N/A

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
