### PR TITLE
route 53 resolver query logging config in eu-west-1

### DIFF
--- a/terraform/environments/core-logging/r53_logs.tf
+++ b/terraform/environments/core-logging/r53_logs.tf
@@ -32,7 +32,7 @@ resource "aws_ram_resource_share" "resolver_query_share" {
 
 resource "aws_ram_resource_association" "resolver_query_share" {
   for_each           = local.resolver_query_log_configs
-  resource_arn       = each.value.arn
+  resource_arn       = each.value
   resource_share_arn = aws_ram_resource_share.resolver_query_share.id
 }
 


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/10489

## How does this PR fix the problem?

Adds a r53 query logging config that is shared to the org in eu-west-1. This should allow AP team to assiociate their VPCs with it. The config points to the same bucket we use for r53 logs in eu-west-2.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
