### PR TITLE
Adds GetObjectVersion permissions to the laa shared bucket.

### DIFF
--- a/terraform/environments/core-shared-services/s3-laa-shared.tf
+++ b/terraform/environments/core-shared-services/s3-laa-shared.tf
@@ -78,6 +78,7 @@ data "aws_iam_policy_document" "laa_shared_bucket_policy" {
       "s3:DeleteObject",
       "s3:GetObject",
       "s3:GetObjectTagging",
+      "s3:GetObjectVersion",
       "s3:ListBucket",
       "s3:PutObject",
       "s3:PutObjectTagging",


### PR DESCRIPTION
## A reference to the issue / Description of it

{Please write here}

## How does this PR fix the problem?

As per the title. The LAA FTP Lambdas need this permission to read the ftp client python file.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
