### PR TITLE
Add GitHub workflow and script to update Securityhub Slack webhooks secret

### DIFF
--- a/.github/workflows/update-securityhub-slack-secret.yml
+++ b/.github/workflows/update-securityhub-slack-secret.yml
@@ -1,0 +1,26 @@
+name: Update Securityhub Slack Secret
+on:
+  workflow_dispatch:
+    inputs:
+      application:
+        description: "Application name (eg: sprinkler)"
+        required: true
+      slack_webhook_url:
+        description: "Slack webhook URL"
+        required: true
+jobs:
+  update-secret:
+    runs-on: ubuntu-latest
+    needs: fetch-secrets
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
+        with:
+          role-to-assume: "arn:aws:iam::${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_NUMBER }}:role/github-actions-apply"
+          role-session-name: githubactionsrolesession
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Run Secret Update Script
+        run: ./scripts/update_securityhub_secret.sh ${{ github.event.inputs.application }} $SLACK_WEBHOOK_URL
+        env:
+          SLACK_WEBHOOK_URL: ${{ github.event.inputs.slack_webhook_url }}

--- a/scripts/update_securityhub_secret.sh
+++ b/scripts/update_securityhub_secret.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set +x
+
+APP_NAME=$1
+NEW_URL=$2
+SECRET_NAME="securityhub_slack_webhooks"
+REGION="eu-west-2"
+JSON_FILE="./environments/${APP_NAME}.json"
+
+if [[ ! -f "$JSON_FILE" ]]; then
+  echo "File $JSON_FILE not found."
+  exit 1
+fi
+
+# Extract slack-channel tag
+SLACK_CHANNEL=$(jq -r '.tags["securityhub-slack-channel"] // empty' "$JSON_FILE")
+if [[ -z "$SLACK_CHANNEL" ]]; then
+  echo "No tag 'slack-channel' in ${APP_NAME}.json."
+  exit 0
+fi
+
+# Get current secret
+SECRET_JSON=$(aws secretsmanager get-secret-value --secret-id "$SECRET_NAME" --region "$REGION" --query SecretString --output text)
+
+# Check if the key exists in secret
+EXISTING_VALUE=$(echo "$SECRET_JSON" | jq -r --arg key "$SLACK_CHANNEL" '.[$key] // empty')
+
+# Update or add the key-value pair
+UPDATED_JSON=$(echo "$SECRET_JSON" | jq --arg k "$SLACK_CHANNEL" --arg v "$NEW_URL" '.[$k] = $v')
+
+# Put updated secret back
+aws secretsmanager update-secret --secret-id "$SECRET_NAME" --region "$REGION" --secret-string "$UPDATED_JSON" > /dev/null
+
+if [[ -n "$EXISTING_VALUE" ]]; then
+  echo "Slack channel '$SLACK_CHANNEL' webhook updated in secret."
+else
+  echo "Slack channel '$SLACK_CHANNEL' webhook added to secret."
+fi


### PR DESCRIPTION
## A reference to the issue / Description of it

#10302 

## How does this PR fix the problem?

This PR introduces a GitHub Actions workflow and accompanying bash script that allows members to update Slack webhook URLs stored in AWS Secrets Manager. 

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
