### PR TITLE
🔐 Harden Bucket Policy for Central CloudTrail Logging

### DIFF
--- a/terraform/environments/core-logging/s3_logging.tf
+++ b/terraform/environments/core-logging/s3_logging.tf
@@ -263,7 +263,7 @@ data "aws_iam_policy_document" "cloudtrail_bucket_policy" {
     }
   }
   statement {
-    sid       = "DenyUnencryptedData"
+    sid       = "AllowCloudTrailWriteWithOrgAndACL"
     effect    = "Allow"
     actions   = ["s3:PutObject"]
     resources = ["${module.s3-bucket-cloudtrail.bucket.arn}/*"]
@@ -275,6 +275,11 @@ data "aws_iam_policy_document" "cloudtrail_bucket_policy" {
       test     = "StringEquals"
       variable = "s3:x-amz-acl"
       values   = ["bucket-owner-full-control"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceOrgID"
+      values   = [data.aws_organizations_organization.moj_root_account.id]
     }
   }
   statement {
@@ -757,3 +762,4 @@ resource "aws_iam_role_policy" "cwl_to_firehose_policy" {
     }]
   })
 }
+


### PR DESCRIPTION
## A reference to the issue / Description of it

- In relation to #10511 
- To restrict objects being put into this bucket to only our AWS organisation.

## How does this PR fix the problem?

- Adds a condition to allow the action `s3:PutObject` to enforce that the `aws:sourceOrgId` is the MoJ Organisation.

## How has this been tested?

- This policy already exists for the config logging bucket

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

- It shouldn't impact the logging of CloudTrail events, but I will test that everything operates as normal after deployment and rollback if there's any issues.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

- I'll be making more changes in this area to better standardise the policy and remove some redundancy, but I thought I'd go for one small change at a time 🤏 
