### PR TITLE
Add AWS_REGION env and OIDC permissions to GitHub Actions workflow

### DIFF
--- a/.github/workflows/update-securityhub-slack-secret.yml
+++ b/.github/workflows/update-securityhub-slack-secret.yml
@@ -8,6 +8,11 @@ on:
       slack_webhook_url:
         description: "Slack webhook URL"
         required: true
+env:
+  AWS_REGION: "eu-west-2"
+permissions:
+  id-token: write # This is required for requesting the JWT
+  contents: read # This is required for actions/checkout
 jobs:
   update-secret:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Added `AWS_REGION` env and OIDC permissions (id-token: write, contents: read) to the workflow.