### PR TITLE
Add KMS encryption for SNS topic and PagerDuty integration for alarms

### DIFF
--- a/terraform/environments/core-vpc/monitoring.tf
+++ b/terraform/environments/core-vpc/monitoring.tf
@@ -86,6 +86,7 @@ resource "aws_cloudwatch_metric_alarm" "accepted_traffic_alarm" {
   threshold_metric_id = "ad1"
   alarm_description   = "Anomaly detection alarm for accepted traffic in VPC '${each.key}'. A sudden spike or drop may indicate a network issue, service outage, or DDoS attempt."
   treat_missing_data  = "notBreaching"
+  alarm_actions       = [aws_sns_topic.vpc_flowlog_alarms.arn]
 
   metric_query {
     id = "m1"
@@ -142,6 +143,7 @@ resource "aws_cloudwatch_metric_alarm" "ssh_connection_attempts_alarm" {
   threshold_metric_id = "ad1"
   alarm_description   = "Anomaly detection alarm for SSH connection attempts (port 22) in VPC '${each.key}'. Indicates possible brute-force login attempts or unauthorized probing."
   treat_missing_data  = "notBreaching"
+  alarm_actions       = [aws_sns_topic.vpc_flowlog_alarms.arn]
 
   metric_query {
     id = "m1"
@@ -160,4 +162,79 @@ resource "aws_cloudwatch_metric_alarm" "ssh_connection_attempts_alarm" {
     label       = "Sum SSHConnectionAttempts ${each.key} GreaterThanUpperThreshold 1.0"
     return_data = true
   }
+}
+# KMS key for SNS topic encryption
+resource "aws_kms_key" "vpc_flowlog_sns_encryption" {
+  description             = "KMS key for VPC Flow Log SNS topic encryption"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Sid    = "Enable IAM User Permissions",
+        Effect = "Allow",
+        Principal = {
+          AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+        },
+        Action   = "kms:*",
+        Resource = "*"
+      },
+      {
+        Sid    = "Allow SNS to use the key",
+        Effect = "Allow",
+        Principal = {
+          Service = "sns.amazonaws.com"
+        },
+        Action = [
+          "kms:Encrypt",
+          "kms:Decrypt",
+          "kms:ReEncrypt*",
+          "kms:GenerateDataKey*",
+          "kms:DescribeKey"
+        ],
+        Resource = "*"
+      },
+      {
+        Sid    = "Allow CloudWatch to use the key",
+        Effect = "Allow",
+        Principal = {
+          Service = "cloudwatch.amazonaws.com"
+        },
+        Action = [
+          "kms:Encrypt",
+          "kms:Decrypt",
+          "kms:ReEncrypt*",
+          "kms:GenerateDataKey*",
+          "kms:DescribeKey"
+        ],
+        Resource = "*"
+      }
+    ]
+  })
+
+  tags = {
+    Name = "vpc-flowlog-sns-encryption-key"
+  }
+}
+
+resource "aws_kms_alias" "vpc_flowlog_sns_topic" {
+  name_prefix   = "alias/vpc-flowlog-sns-encryption"
+  target_key_id = aws_kms_key.vpc_flowlog_sns_encryption.key_id
+}
+
+# SNS topic for VPC Flow Log alarms
+resource "aws_sns_topic" "vpc_flowlog_alarms" {
+  name              = "vpc-flowlog-alarms"
+  kms_master_key_id = aws_kms_key.vpc_flowlog_sns_encryption.arn
+  tags              = local.tags
+}
+
+# linking the sns topics to the pagerduty service
+module "pagerduty_vpc_flowlog_alerts" {
+  depends_on                = [aws_sns_topic.vpc_flowlog_alarms]
+  source                    = "github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration?ref=0179859e6fafc567843cd55c0b05d325d5012dc4" # v2.0.0
+  sns_topics                = [aws_sns_topic.vpc_flowlog_alarms.name]
+  pagerduty_integration_key = local.pagerduty_integration_keys["core_alerts_cloudwatch"]
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

#10239 
## How does this PR fix the problem?

 PR adds encryption to the SNS topic for VPC Flow Log alarms using a new KMS key and integrates PagerDuty for alerting.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
