### PR TITLE
Appstream and shared service firewall rules

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/development_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/development_rules.json
@@ -126,12 +126,27 @@
     "protocol": "TCP"
   },
   "laa_shared_services_to_mp_laa_development": {
-    "action": "PASS",
+    "action": "ALERT",
     "source_ip": "${laa-lz-shared-services-nonprod}",
     "destination_ip": "${laa-development}",
     "destination_port": "ANY",
     "protocol": "IP"
   },
+   "laa_shared_services_ws_to_mp_laa_development": {
+    "action": "PASS",
+    "source_ip": "${laa-lz-shared-services-nonprod}",
+    "destination_ip": "${laa-development}",
+    "destination_port": "$LAA_APPSTREAM_TCP",
+    "protocol": "TCP"
+  },
+  "mp_laa_development_to_laa_shared_services_ws": {
+    "action": "PASS",
+    "source_ip": "${laa-development}",
+    "destination_ip": "${laa-lz-shared-services-nonprod}",
+    "destination_port": "$LAA_APPSTREAM_TCP",
+    "protocol": "TCP"
+  },
+
   "analytical_platform_to_mp_laa_development_oracledb": {
     "action": "PASS",
     "source_ip": "${analytical-platform-airflow-dev}",
@@ -263,6 +278,34 @@
     "source_ip": "${laa-appstream-vpc_additional}",
     "destination_ip": "${laa-development}",
     "destination_port": "ANY",
+    "protocol": "TCP"
+  },
+  "laa_appstream_ld_to_mp_laa_development": {
+    "action": "PASS",
+    "source_ip": "${laa-appstream-vpc}",
+    "destination_ip": "${laa-development}",
+    "destination_port": "$LAA_APPSTREAM_TCP",
+    "protocol": "TCP"
+  },
+   "laa_appstream_additional_ld_to_mp_laa_development": {
+    "action": "PASS",
+    "source_ip": "${laa-appstream-vpc_additional}",
+    "destination_ip": "${laa-development}",
+    "destination_port": "$LAA_APPSTREAM_TCP",
+    "protocol": "TCP"
+  },
+  "mp_laa_development_to_laa_appstream_ld": {
+    "action": "PASS",
+    "source_ip": "${laa-development}",
+    "destination_ip": "${laa-appstream-vpc}",
+    "destination_port": "$LAA_APPSTREAM_TCP",
+    "protocol": "TCP"
+  },
+   "laa_development_to_mp_laa_appstream_additional_ld": {
+    "action": "PASS",
+    "source_ip": "${laa-development}",
+    "destination_ip": "${laa-appstream-vpc_additional}",
+    "destination_port": "$LAA_APPSTREAM_TCP",
     "protocol": "TCP"
   },
   "cp_to_mp_platforms_development_icmp": {


### PR DESCRIPTION
## A reference to the issue / Description of it

New rules created for appstream vpc in dev and shared services for LAA development as per 
[Laa Appstream/workspace mp firewall rules](https://github.com/ministryofjustice/modernisation-platform/issues/10341)
#10341

## How does this PR fix the problem?

new rules adde to restrict traffic down to the new ports set created and any rule has been put into alert mode

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
