### PR TITLE
New Account - add alias skip for vcms-test

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/locals.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/locals.tf
@@ -78,6 +78,7 @@ locals {
     "oas-test",
     "portal-development",
     "portal-production",
-    "portal-test"
+    "portal-test",
+    "vcms-test"
   ])
 }


### PR DESCRIPTION
As per new account documentation steps, adding skip alias for vcms-test `Error: creating account alias with name 'vcms-test'`