### PR TITLE
rules added to preproduction

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/development_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/development_rules.json
@@ -132,7 +132,7 @@
     "destination_port": "ANY",
     "protocol": "IP"
   },
-   "laa_shared_services_ws_to_mp_laa_development": {
+  "laa_shared_services_ws_to_mp_laa_development": {
     "action": "PASS",
     "source_ip": "${laa-lz-shared-services-nonprod}",
     "destination_ip": "${laa-development}",

--- a/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
@@ -49,10 +49,24 @@
     "protocol": "TCP"
   },
   "laa_shared_services_to_mp_laa_preproduction": {
-    "action": "PASS",
+    "action": "ALERT",
     "source_ip": "${laa-lz-shared-services-nonprod}",
     "destination_ip": "${laa-preproduction}",
     "destination_port": "ANY",
+    "protocol": "TCP"
+  },
+  "laa_shared_services_ws_to_mp_laa_preproduction": {
+    "action": "PASS",
+    "source_ip": "${laa-lz-shared-services-nonprod}",
+    "destination_ip": "${laa-preproduction}",
+    "destination_port": "$LAA_APPSTREAM_TCP",
+    "protocol": "TCP"
+  },
+  "mp_laa_preproduction_to_laa_shared_services_ws": {
+    "action": "PASS",
+    "source_ip": "${laa-preproduction}",
+    "destination_ip": "${laa-lz-shared-services-nonprod}",
+    "destination_port": "$LAA_APPSTREAM_TCP",
     "protocol": "TCP"
   },
   "laa_staging_to_mp_laa_preproduction": {
@@ -665,17 +679,45 @@
     "protocol": "TCP"
   },
   "laa_appstream_to_mp_laa_preproduction": {
-    "action": "PASS",
+    "action": "ALERT",
     "source_ip": "${laa-appstream-vpc}",
     "destination_ip": "${laa-preproduction}",
     "destination_port": "ANY",
     "protocol": "TCP"
   },
   "laa_appstream_additional_to_mp_laa_preproduction": {
-    "action": "PASS",
+    "action": "ALERT",
     "source_ip": "${laa-appstream-vpc_additional}",
     "destination_ip": "${laa-preproduction}",
     "destination_port": "ANY",
+    "protocol": "TCP"
+  },
+  "laa_appstream_ld_to_mp_laa_preproduction": {
+    "action": "PASS",
+    "source_ip": "${laa-appstream-vpc}",
+    "destination_ip": "${laa-preproduction}",
+    "destination_port": "$LAA_APPSTREAM_TCP",
+    "protocol": "TCP"
+  },
+   "laa_appstream_additional_ld_to_mp_laa_preproduction": {
+    "action": "PASS",
+    "source_ip": "${laa-appstream-vpc_additional}",
+    "destination_ip": "${laa-preproduction}",
+    "destination_port": "$LAA_APPSTREAM_TCP",
+    "protocol": "TCP"
+  },
+  "mp_laa_preproduction_to_laa_appstream_ld": {
+    "action": "PASS",
+    "source_ip": "${laa-preproduction}",
+    "destination_ip": "${laa-appstream-vpc}",
+    "destination_port": "$LAA_APPSTREAM_TCP",
+    "protocol": "TCP"
+  },
+   "laa_preproduction_to_mp_laa_appstream_additional_ld": {
+    "action": "PASS",
+    "source_ip": "${laa-preproduction}",
+    "destination_ip": "${laa-appstream-vpc_additional}",
+    "destination_port": "$LAA_APPSTREAM_TCP",
     "protocol": "TCP"
   },
   "youth_justice_networking_to_yjb_preproduction_tcp": {


### PR DESCRIPTION
## A reference to the issue / Description of it

Adding new preproduction rules for laa appstream and shared service cidr range

## How does this PR fix the problem?

New Rules created based off the development rules the any rule is in alert move so will still allow traffic

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
