### PR TITLE
chore: add github auth for laa-ccms-soa docker builds

### DIFF
--- a/environments/laa-ccms-soa.json
+++ b/environments/laa-ccms-soa.json
@@ -75,6 +75,6 @@
     "owner": "ApplicationOperations@justice.gov.uk",
     "critical-national-infrastructure": false
   },
-  "github-oidc-team-repositories": [""],
+  "github-oidc-team-repositories": ["laa-ccms-soa-docker"],
   "go-live-date": ""
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

Adds OIDC auth between MP env `laa-ccms-soa` and container image build repo `laa-ccms-soa-docker`

## How does this PR fix the problem?

Currently no auth exists

## How has this been tested?

No infra currently exists to test
