### PR TITLE
Securely mask Slack webhook input in GitHub Actions

### DIFF
--- a/.github/workflows/update-securityhub-slack-secret.yml
+++ b/.github/workflows/update-securityhub-slack-secret.yml
@@ -24,7 +24,10 @@ jobs:
           role-to-assume: "arn:aws:iam::${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_NUMBER }}:role/github-actions-apply"
           role-session-name: githubactionsrolesession
           aws-region: ${{ env.AWS_REGION }}
+      - name: MASK Slack webhook
+        run: |
+          slack_webhook_url=$(cat $GITHUB_EVENT_PATH | jq -r '.inputs.slack_webhook_url' )
+          echo "::add-mask::$slack_webhook_url" 
+           echo "SLACK_WEBHOOK_URL=$slack_webhook_url" >> $GITHUB_ENV
       - name: Run Secret Update Script
-        run: ./scripts/update_securityhub_secret.sh ${{ github.event.inputs.application }} $SLACK_WEBHOOK_URL
-        env:
-          SLACK_WEBHOOK_URL: ${{ github.event.inputs.slack_webhook_url }}
+        run: ./scripts/update_securityhub_secret.sh ${{ github.event.inputs.application }} ${{ env.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
This PR improves the security of our GitHub Actions workflow by ensuring that the `slack_webhook_url` input is masked and never printed in the logs. #10302 