### PR TITLE
🛂 Firewall rules for CICA Tariff Test

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/sets.json
+++ b/terraform/environments/core-network-services/firewall-rules/sets.json
@@ -19,6 +19,12 @@
       "${cica-aws-dev-data-a}",
       "${cica-aws-dev-data-b}"
     ],
+    "CICA_AWS_UAT": [
+      "${cica-aws-uat-a}",
+      "${cica-aws-uat-b}",
+      "${cica-aws-uat-data-a}",
+      "${cica-aws-uat-data-b}"
+    ],
     "CICA_AWS_PROD": [
       "${cica-aws-prod-a}",
       "${cica-aws-prod-b}",

--- a/terraform/environments/core-network-services/firewall-rules/test_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/test_rules.json
@@ -418,5 +418,54 @@
     "destination_ip": "$AWS_SMTP_EU_WEST_2",
     "destination_port": "587",
     "protocol": "TCP"
+  },
+    "cica_aws_uat_to_cica_tariff_test": {
+    "action": "PASS",
+    "source_ip": "$CICA_AWS_UAT",
+    "destination_ip": "${cica-test}",
+    "destination_port": "$TARIFF_TCP",
+    "protocol": "TCP"
+  },
+  "cica_tariff_test_to_cica_aws_uat": {
+    "action": "PASS",
+    "source_ip": "${cica-test}",
+    "destination_ip": "$CICA_AWS_UAT",
+    "destination_port": "ANY",
+    "protocol": "TCP"
+  },
+  "cica_tariff_test_to_cica_aws_uat_icmp": {
+    "action": "PASS",
+    "source_ip": "${cica-test}",
+    "destination_ip": "$CICA_AWS_UAT",
+    "destination_port": "ANY",
+    "protocol": "ICMP"
+  },
+  "cica_devices_to_cica_tariff_test": {
+    "action": "PASS",
+    "source_ip": "${cica-end-user-devices}",
+    "destination_ip": "${cica-test}",
+    "destination_port": "$TARIFF_TCP",
+    "protocol": "TCP"
+  },
+  "cica_ras_to_cica_tariff_test": {
+    "action": "PASS",
+    "source_ip": "${cica-ras-nat}",
+    "destination_ip": "${cica-test}",
+    "destination_port": "$TARIFF_TCP",
+    "protocol": "TCP"
+  },
+  "cica_tariff_test_to_cica_devices": {
+    "action": "PASS",
+    "source_ip": "${cica-test}",
+    "destination_ip": "${cica-end-user-devices}",
+    "destination_port": "ANY",
+    "protocol": "TCP"
+  },
+  "cica_tariff_test_to_cica_ras_nat": {
+    "action": "PASS",
+    "source_ip": "${cica-test}",
+    "destination_ip": "${cica-ras-nat}",
+    "destination_port": "ANY",
+    "protocol": "TCP"
   }
 }


### PR DESCRIPTION
Firewall rules to allow traffic between Tariff Test and CICA UAT and user access.

## A reference to the issue / Description of it

Firewall rules to allow traffic between Tariff Test and CICA UAT and user access.

## How does this PR fix the problem?

Updates firewall to have rules that will allow access for CICA devices and CICA AWS UAT to Tariff Test 

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Followed same format as already in place for development Tariff.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
