### PR TITLE
Additional permissions for read_firewall policy in core-network-services.

### DIFF
--- a/terraform/environments/core-network-services/iam.tf
+++ b/terraform/environments/core-network-services/iam.tf
@@ -224,15 +224,22 @@ resource "aws_iam_role_policy" "read_firewall" {
         "Action" : [
           "logs:DescribeLogGroups",
           "logs:DescribeLogStreams",
+          "logs:DescribeQueries",
+          "logs:FilterLogEvents",
           "logs:GetLogEvents",
-          "logs:FilterLogEvents"
+          "logs:GetLogGroupFields",
+          "logs:GetLogRecord",
+          "logs:GetQueryResults",
+          "logs:StartQuery",
+          "logs:StopQuery"
         ],
         "Resource" : [
           "arn:aws:logs:*:*:log-group::log-stream:",
           "arn:aws:logs:*:*:log-group:fw-*:log-stream:*",
           "arn:aws:logs:*:*:log-group:*-vpc-flow-logs-*:log-stream:*",
           "arn:aws:logs:*:*:log-group:external-inspection-flow-logs:log-stream:*",
-          "arn:aws:logs:*:*:log-group:tgw-*:log-stream:*"
+          "arn:aws:logs:*:*:log-group:tgw-*:log-stream:*",
+          "arn:aws:logs:*:*:log-group:NEC*:log-stream:*"
         ],
       },
       {


### PR DESCRIPTION
Adds logs permissions to resolve FilterLogEvents not implicitly granting permissions that changed in 2023. Also added NEC logs to the policy. Required by the CCMS Ops team to read both TGW and NEC vpc related flow logs.

## A reference to the issue / Description of it

{Please write here}

## How does this PR fix the problem?

{Please write here}

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
