### PR TITLE
🔧 Fix Environment Creation Process Not Being Able to Create a CloudTrail

### DIFF
--- a/terraform/environments/core-logging/s3_logging.tf
+++ b/terraform/environments/core-logging/s3_logging.tf
@@ -190,9 +190,9 @@ module "s3-bucket-cloudtrail" {
 
 data "aws_iam_policy_document" "cloudtrail_bucket_policy" {
   statement {
-    sid       = "AllowCloudTrailPutObjectWithinOrg"
+    sid       = "AllowCloudTrailPutObjectAndGetBucketACLWithinOrg"
     effect    = "Allow"
-    actions   = ["s3:PutObject"]
+    actions   = ["s3:PutObject", "s3:GetBucketAcl"]
     resources = ["${module.s3-bucket-cloudtrail.bucket.arn}/*"]
     principals {
       type        = "Service"


### PR DESCRIPTION
## A reference to the issue / Description of it

- The environment creation process isn't working due to Bucket lacking the right permissions for CloudTrail to create Trail

## How does this PR fix the problem?

- The assumption here is that it's missing the action to GetACLs, as this is the only other action defined in [AWS Docs For CloudTrail](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-set-bucket-policy-for-multiple-accounts.html)

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

- Testing live 💣 🧪 

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

- No, adds additional permisions so no impact

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

NA
