### PR TITLE
🔧 Fix S3 Bucket Policy By Adding an Applicable Resoruce For The Actions

### DIFF
--- a/terraform/environments/core-logging/s3_logging.tf
+++ b/terraform/environments/core-logging/s3_logging.tf
@@ -193,7 +193,7 @@ data "aws_iam_policy_document" "cloudtrail_bucket_policy" {
     sid       = "AllowCloudTrailPutObjectAndGetBucketACLWithinOrg"
     effect    = "Allow"
     actions   = ["s3:PutObject", "s3:GetBucketAcl"]
-    resources = ["${module.s3-bucket-cloudtrail.bucket.arn}/*", "${module.s3-bucket-cloudtrail.bucket.arn}"]
+    resources = ["${module.s3-bucket-cloudtrail.bucket.arn}/*", module.s3-bucket-cloudtrail.bucket.arn]
     principals {
       type        = "Service"
       identifiers = ["cloudtrail.amazonaws.com"]


### PR DESCRIPTION
## A reference to the issue / Description of it

- Fixes #10761 
- Bucket policy is invalid, I believe because the GetACL is applicable to the bucket and not it's objects, and currently the policy only targets the objets

```
Error: putting S3 Bucket (modernisation-platform-logs-cloudtrail) Policy: operation error S3: PutBucketPolicy, https response error StatusCode: 400, RequestID: TGDKFQTGDPDSCWBA, HostID: 1GVeRkLg0Vqj32oIgFWYQi7EuPbb+UOT1ZlH7BAD8oXeVJQxDvdklekzz3n14EDl1ks5luJ4d34OejAOMYVm4KGpITP4ZhgtsxAXJNdLbL4=, api error MalformedPolicy: Action does not apply to any resource(s) in statement
```

## How does this PR fix the problem?

- Added an extra resource to the policy to target, in hopes that's enough for the policy to apply correctly

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

- Straight to live 🚀 

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

- No, fixing forwards 🍾 

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

NA
