### PR TITLE
change to uncompress firehose logs

### DIFF
--- a/terraform/environments/core-logging/s3_logging.tf
+++ b/terraform/environments/core-logging/s3_logging.tf
@@ -610,7 +610,7 @@ resource "aws_kinesis_firehose_delivery_stream" "waf_logs_to_s3" {
     bucket_arn         = module.s3-bucket-modernisation-platform-waf-logs.bucket.arn
     buffering_size     = 5
     buffering_interval = 300
-    compression_format = "GZIP"
+    compression_format = "UNCOMPRESSED"
     kms_key_arn        = aws_kms_key.s3_modernisation_platform_waf_logs.arn
   }
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

[#10271](https://github.com/ministryofjustice/modernisation-platform/issues/10271)

This PR updates the Kinesis Firehose configuration to set `compression_format = "UNCOMPRESSED"` for the `waf-logs-to-s3` delivery stream. Previously, the logs were being written to S3 in GZIP format, which caused Cortex XSIAM to ingest unreadable binary data when `Log Format = RAW` was selected. By disabling compression, the logs are now written as plain text JSON, enabling proper ingestion and parsing in XSIAM.

## How does this PR fix the problem?

PR disables compression

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
