### PR TITLE
Propagate NEC VPN routes and update read-log-records role permissions

### DIFF
--- a/terraform/environments/core-network-services/iam.tf
+++ b/terraform/environments/core-network-services/iam.tf
@@ -201,7 +201,11 @@ resource "aws_iam_role_policy" "read_dns" {
           "ec2:DescribeNetworkAcls",
           "ec2:DescribeSecurityGroups",
           "ec2:DescribeAddresses", # Elastic IPs
-          "ec2:DescribeNetworkInterfaces"
+          "ec2:DescribeNetworkInterfaces",
+          "ec2:GetTransitGatewayRouteTablePropagations",
+          "ec2:GetTransitGatewayRouteTableAssociations",
+          "ec2:GetTransitGatewayPrefixListReferences",
+          "ec2:SearchTransitGatewayRoutes"
         ],
         "Resource" : "*"
       }

--- a/terraform/environments/core-network-services/locals.tf
+++ b/terraform/environments/core-network-services/locals.tf
@@ -60,6 +60,8 @@ locals {
 
   noms_vpn_attachment_ids = toset([for k in aws_vpn_connection.this : k.transit_gateway_attachment_id if(length(regexall("(?:NOMS)", k.tags.Name)) > 0)])
 
+  nec_vpn_attachment_ids = toset([for k in aws_vpn_connection.this : k.transit_gateway_attachment_id if(length(regexall("(?:NEC)", k.tags.Name)) > 0)])
+
   azure_static_routes = [
     "10.0.0.0/11",
     "10.64.0.0/11",

--- a/terraform/environments/core-network-services/vpn.tf
+++ b/terraform/environments/core-network-services/vpn.tf
@@ -99,6 +99,12 @@ resource "aws_ec2_transit_gateway_route_table_propagation" "propagate_noms_route
   transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.external_inspection_out.id
 }
 
+resource "aws_ec2_transit_gateway_route_table_propagation" "propagate_nec_routes_to_firewall" {
+  for_each                       = local.nec_vpn_attachment_ids
+  transit_gateway_attachment_id  = each.key
+  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.external_inspection_out.id
+}
+
 resource "aws_ec2_transit_gateway_route" "parole_board_routes" {
   for_each                       = toset(local.parole_board_vpn_static_routes)
   destination_cidr_block         = each.key


### PR DESCRIPTION
## A reference to the issue / Description of it

Requested via slack: https://mojdt.slack.com/archives/C01A7QK5VM1/p1752053558159089

## How does this PR fix the problem?

Propagates NEC VPN routes to tgw rtb and adds permissions to read tgw/networking via the `read-log-records` role.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
