### PR TITLE
Update sso and pagerduty codebase to v6 AWS provider

### DIFF
--- a/.github/workflows/reusable_terraform_plan_apply.yml
+++ b/.github/workflows/reusable_terraform_plan_apply.yml
@@ -125,6 +125,8 @@ jobs:
       - name: Run Terraform Plan
         if: github.event.ref != 'refs/heads/main'
         id: show
+        env:
+          TF_LOG: DEBUG
         run: |
           bash scripts/terraform-plan.sh ${{ inputs.working-directory }}
 

--- a/.github/workflows/reusable_terraform_plan_apply.yml
+++ b/.github/workflows/reusable_terraform_plan_apply.yml
@@ -125,8 +125,6 @@ jobs:
       - name: Run Terraform Plan
         if: github.event.ref != 'refs/heads/main'
         id: show
-        env:
-          TF_LOG: DEBUG
         run: |
           bash scripts/terraform-plan.sh ${{ inputs.working-directory }}
 

--- a/terraform/pagerduty/versions.tf
+++ b/terraform/pagerduty/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
     pagerduty = {
       source  = "pagerduty/pagerduty"

--- a/terraform/single-sign-on/versions.tf
+++ b/terraform/single-sign-on/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 6.0"
       source  = "hashicorp/aws"
     }
   }


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/10509

## How does this PR fix the problem?

Updates the following TF configs to v6 of the provider:

- `terraform/single-sign-on` (additional attribute `region` added to ` data.aws_ssoadmin_instances.default`)
- `terraform/pagerduty` (no changes)

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
