### PR TITLE
Update to v6 aws provider for GitHub

### DIFF
--- a/terraform/github/versions.tf
+++ b/terraform/github/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = "~> 1.0"
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 6.0"
       source  = "hashicorp/aws"
     }
     external = {


### PR DESCRIPTION
## A reference to the issue / Description of it
https://github.com/ministryofjustice/modernisation-platform/issues/10509

## How does this PR fix the problem?
Updates the following TF configs to v6 of the provider:

- `terraform/github` (no changes)

## How has this been tested?
Please describe the tests that you ran and provide instructions to reproduce.

Terraform plan can be seen here (no changes) - https://github.com/ministryofjustice/modernisation-platform/actions/runs/16220612714

## Deployment Plan / Instructions
Will this deployment impact the platform and / or services on it?

no impact expected

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [X] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}