### PR TITLE
Update to v6 aws provider for core-sandbox

### DIFF
--- a/terraform/environments/core-sandbox/versions.tf
+++ b/terraform/environments/core-sandbox/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 6.0"
       source  = "hashicorp/aws"
     }
   }


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/10509

## How does this PR fix the problem?

Updates the following TF configs to v6 of the provider:

- `terraform/environments/core-sandbox/`

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

local plan ran, no difference between v5 and v6 provider version 

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
