### PR TITLE
Add Rekognition permission to memberinfrastructureaccess role for hmpps-esupervision

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -271,6 +271,20 @@ data "aws_iam_policy_document" "member-access" {
       values   = ["guardduty.amazonaws.com"]
     }
   }
+  # Only grant Rekognition permissions for e-supervision application
+  statement {
+    effect    = "Allow"
+    actions   = ["rekognition:*"]
+    resources = ["*"]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalAccount"
+      values = [
+        local.environment_management.account_ids["hmpps-esupervision-development"],
+        local.environment_management.account_ids["hmpps-esupervision-production"]
+      ]
+    }
+  }
   statement {
     effect = "Deny"
     actions = [


### PR DESCRIPTION
## A reference to the issue / Description of it

#10731 
## How does this PR fix the problem?

This PR adds Rekognition permissions only to the specified development and production accounts for hmpps-esupervision so only those accounts have access, ensuring other member accounts can't deploy Rekognition resources.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
