### PR TITLE
Update DE policy

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -427,6 +427,7 @@ data "aws_iam_policy_document" "data_engineering_additional" {
       "glue:DeleteDatabase",
       "glue:DeletePartition",
       "glue:DeleteTable",
+      "glue:Describe*",
       "glue:*JobRun",
       "glue:RunStatement",
       "glue:UpdateDatabase",


### PR DESCRIPTION
## A reference to the issue / Description of it

I am trying to create, list glue connections and zero etl jobs. I can't see them with my DE role as I don't have `glue:DescribeInboundIntegrations` permission.

## How does this PR fix the problem?

Adds `glue:Describe*` permissions: https://docs.aws.amazon.com/service-authorization/latest/reference/list_awsglue.html.
## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

n/a

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

n/a

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)
