### PR TITLE
Update mp account code to v6 aws TF provider

### DIFF
--- a/terraform/modernisation-platform-account/baselines.tf
+++ b/terraform/modernisation-platform-account/baselines.tf
@@ -18,7 +18,7 @@ locals {
 # Secure baselines (GuardDuty, Config, SecurityHub, etc)
 #trivy:ignore:AVD-AWS-0136 trivy:ignore:AVD-AWS-0132
 module "baselines-modernisation-platform" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=9d3bd4e8e11173deb72b06e401b0e0bdd22b348e" # v8.1.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=50f85fbf13e9c6538b2b0e5542533d2f8393454c" # v8.1.1
   providers = {
     # Default and replication regions
     aws                    = aws.modernisation-platform-eu-west-2

--- a/terraform/modernisation-platform-account/baselines.tf
+++ b/terraform/modernisation-platform-account/baselines.tf
@@ -18,7 +18,7 @@ locals {
 # Secure baselines (GuardDuty, Config, SecurityHub, etc)
 #trivy:ignore:AVD-AWS-0136 trivy:ignore:AVD-AWS-0132
 module "baselines-modernisation-platform" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=11d10dd31e16f3cfada4048d65d1a4f22983b40a" # v8.0.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=9d3bd4e8e11173deb72b06e401b0e0bdd22b348e" # v8.1.0
   providers = {
     # Default and replication regions
     aws                    = aws.modernisation-platform-eu-west-2

--- a/terraform/modernisation-platform-account/baselines.tf
+++ b/terraform/modernisation-platform-account/baselines.tf
@@ -18,7 +18,7 @@ locals {
 # Secure baselines (GuardDuty, Config, SecurityHub, etc)
 #trivy:ignore:AVD-AWS-0136 trivy:ignore:AVD-AWS-0132
 module "baselines-modernisation-platform" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=8b89686fdff114f745b38f530aa27c390fa8909b" # v7.14.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=11d10dd31e16f3cfada4048d65d1a4f22983b40a" # v8.0.0
   providers = {
     # Default and replication regions
     aws                    = aws.modernisation-platform-eu-west-2

--- a/terraform/modernisation-platform-account/iam.tf
+++ b/terraform/modernisation-platform-account/iam.tf
@@ -14,7 +14,7 @@ module "collaborators_group" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   #checkov:skip=CKV_TF_2:Module registry does not support tags
   source  = "terraform-aws-modules/iam/aws//modules/iam-group-with-policies"
-  version = ">= 5.0"
+  version = "~> 5.0"
   name    = "collaborators"
 
   group_users = [for user in module.collaborators : user.username]

--- a/terraform/modernisation-platform-account/iam.tf
+++ b/terraform/modernisation-platform-account/iam.tf
@@ -14,7 +14,7 @@ module "collaborators_group" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   #checkov:skip=CKV_TF_2:Module registry does not support tags
   source  = "terraform-aws-modules/iam/aws//modules/iam-group-with-policies"
-  version = "~> 5.0"
+  version = ">= 5.0"
   name    = "collaborators"
 
   group_users = [for user in module.collaborators : user.username]

--- a/terraform/modernisation-platform-account/iam.tf
+++ b/terraform/modernisation-platform-account/iam.tf
@@ -1,7 +1,7 @@
 #tfsec:ignore:aws-iam-no-policy-wildcards
 #tfsec:ignore:aws-iam-enforce-mfa
 module "iam" {
-  source        = "github.com/ministryofjustice/modernisation-platform-terraform-iam-superadmins?ref=a972f65af06fbdf48fdd9183ac5396c3906f5034" # v2.1.0
+  source        = "github.com/ministryofjustice/modernisation-platform-terraform-iam-superadmins?ref=83b376fb80315304f0a09287ff0ec9a358901591" # v3.0.0
   account_alias = "moj-modernisation-platform"
 }
 
@@ -198,7 +198,7 @@ resource "aws_iam_role_policy_attachment" "modernisation_account_limited_read" {
 # OIDC Provider for GitHub Actions Plan
 #trivy:ignore:AVD-AWS-0345: Required for GitHub Actions to access Terraform state in S3
 module "github_actions_plan_role" {
-  source              = "github.com/ministryofjustice/modernisation-platform-github-oidc-role?ref=62b8a16c73d8e4422cd81923e46948e8f4b5cf48" # v3.2.0
+  source              = "github.com/ministryofjustice/modernisation-platform-github-oidc-role?ref=b40748ec162b446f8f8d282f767a85b6501fd192" # v4.0.0
   github_repositories = ["ministryofjustice/modernisation-platform", "ministryofjustice/modernisation-platform-ami-builds", "ministryofjustice/modernisation-platform-security"]
   role_name           = "github-actions-plan"
   policy_jsons        = [data.aws_iam_policy_document.oidc_assume_plan_role_member.json]
@@ -258,7 +258,7 @@ data "aws_iam_policy_document" "oidc_assume_plan_role_member" {
 # OIDC Provider for GitHub Actions Apply
 #trivy:ignore:AVD-AWS-0345: Required for GitHub Actions to access Terraform state in S3
 module "github_actions_apply_role" {
-  source              = "github.com/ministryofjustice/modernisation-platform-github-oidc-role?ref=62b8a16c73d8e4422cd81923e46948e8f4b5cf48" # v3.2.0
+  source              = "github.com/ministryofjustice/modernisation-platform-github-oidc-role?ref=b40748ec162b446f8f8d282f767a85b6501fd192" # v4.0.0
   github_repositories = ["ministryofjustice/modernisation-platform", "ministryofjustice/modernisation-platform-ami-builds", "ministryofjustice/modernisation-platform-security"]
   role_name           = "github-actions-apply"
   policy_arns         = ["arn:aws:iam::aws:policy/AdministratorAccess"]
@@ -270,7 +270,7 @@ module "github_actions_apply_role" {
 # OIDC resources
 
 module "github-oidc" {
-  source                      = "github.com/ministryofjustice/modernisation-platform-github-oidc-provider?ref=82f546bd5f002674138a2ccdade7d7618c6758b3" # v3.0.0
+  source                      = "github.com/ministryofjustice/modernisation-platform-github-oidc-provider?ref=5dc9bc211d10c58de4247fa751c318a3985fc87b" # v4.0.0
   additional_permissions      = data.aws_iam_policy_document.oidc-deny-specific-actions.json
   additional_managed_policies = ["arn:aws:iam::aws:policy/AdministratorAccess"]
   github_repositories         = ["ministryofjustice/modernisation-platform:*", "ministryofjustice/modernisation-platform-ami-builds:*", "ministryofjustice/modernisation-platform-security:*"]
@@ -294,7 +294,7 @@ data "aws_iam_policy_document" "oidc-deny-specific-actions" {
 # OIDC Provider for GitHub Actions Secrets Reader
 #trivy:ignore:AVD-AWS-0345: 
 module "github_actions_read_secrets_role" {
-  source = "github.com/ministryofjustice/modernisation-platform-github-oidc-role?ref=62b8a16c73d8e4422cd81923e46948e8f4b5cf48" # v3.2.0
+  source = "github.com/ministryofjustice/modernisation-platform-github-oidc-role?ref=b40748ec162b446f8f8d282f767a85b6501fd192" # v4.0.0
   github_repositories = [
     "ministryofjustice/modernisation-platform",
     "ministryofjustice/modernisation-platform-environments",

--- a/terraform/modernisation-platform-account/monitoring.tf
+++ b/terraform/modernisation-platform-account/monitoring.tf
@@ -1,4 +1,5 @@
-module "core_monitoring" {
-  source                     = "../modules/core-monitoring"
-  pagerduty_integration_keys = local.pagerduty_integration_keys
+module "pagerduty_core_alerts" {
+  source                    = "github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration?ref=d88bd90d490268896670a898edfaba24bba2f8ab" # v3.0.0
+  sns_topics                = ["config", "securityhub-alarms", "cloudtrail"]
+  pagerduty_integration_key = var.pagerduty_integration_keys["core_alerts_cloudwatch"]
 }

--- a/terraform/modernisation-platform-account/monitoring.tf
+++ b/terraform/modernisation-platform-account/monitoring.tf
@@ -1,5 +1,20 @@
 module "pagerduty_core_alerts" {
   source                    = "github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration?ref=d88bd90d490268896670a898edfaba24bba2f8ab" # v3.0.0
   sns_topics                = ["config", "securityhub-alarms", "cloudtrail"]
-  pagerduty_integration_key = var.pagerduty_integration_keys["core_alerts_cloudwatch"]
+  pagerduty_integration_key = local.pagerduty_integration_keys["core_alerts_cloudwatch"]
+}
+
+moved {
+  from = module.core_monitoring.module.pagerduty_core_alerts.aws_sns_topic_subscription.pagerduty_subscription["cloudtrail"]
+  to   = module.pagerduty_core_alerts.aws_sns_topic_subscription.pagerduty_subscription["cloudtrail"]
+}
+
+moved {
+  from = module.core_monitoring.module.pagerduty_core_alerts.aws_sns_topic_subscription.pagerduty_subscription["config"]
+  to   = module.pagerduty_core_alerts.aws_sns_topic_subscription.pagerduty_subscription["config"]
+}
+
+moved {
+  from = module.core_monitoring.module.pagerduty_core_alerts.aws_sns_topic_subscription.pagerduty_subscription["securityhub-alarms"]
+  to   = module.pagerduty_core_alerts.aws_sns_topic_subscription.pagerduty_subscription["securityhub-alarms"]
 }

--- a/terraform/modernisation-platform-account/observability.tf
+++ b/terraform/modernisation-platform-account/observability.tf
@@ -1,6 +1,6 @@
 module "observability_platform_tenant" {
 
-  source = "github.com/ministryofjustice/terraform-aws-observability-platform-tenant?ref=fbbe5c8282786bcc0a00c969fe598e14f12eea9b" # v1.2.0
+  source = "github.com/ministryofjustice/terraform-aws-observability-platform-tenant?ref=f69b36c79ba18976d8e500e7cf61cf407158eb61" # v2.0.0
 
   observability_platform_account_id = local.environment_management.account_ids["observability-platform-production"]
 

--- a/terraform/modernisation-platform-account/s3.tf
+++ b/terraform/modernisation-platform-account/s3.tf
@@ -103,7 +103,7 @@ resource "aws_kms_alias" "s3_state_bucket_eu-west-1_replication" {
 }
 
 module "state-bucket" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=474f27a3f9bf542a8826c76fb049cc84b5cf136f" # v8.2.1
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=9facf9fc8f8b8e3f93ffbda822028534b9a75399" # v9.0.0
 
   providers = {
     aws.bucket-replication = aws.modernisation-platform-eu-west-1
@@ -541,7 +541,7 @@ data "aws_iam_policy_document" "allow-state-access-from-root-account" {
 }
 
 module "cost-management-bucket" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=474f27a3f9bf542a8826c76fb049cc84b5cf136f" # v8.2.1
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=9facf9fc8f8b8e3f93ffbda822028534b9a75399" # v9.0.0
   providers = {
     aws.bucket-replication = aws.modernisation-platform-eu-west-1
   }
@@ -578,7 +578,7 @@ data "aws_iam_policy_document" "cost_management_bucket_policy" {
 }
 
 module "member_information_bucket" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=474f27a3f9bf542a8826c76fb049cc84b5cf136f" # v8.2.1
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=9facf9fc8f8b8e3f93ffbda822028534b9a75399" # v9.0.0
   providers = {
     aws.bucket-replication = aws.modernisation-platform-eu-west-1
   }

--- a/terraform/modernisation-platform-account/versions.tf
+++ b/terraform/modernisation-platform-account/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 6.0"
       source  = "hashicorp/aws"
     }
     archive = {

--- a/terraform/modules/collaborators/versions.tf
+++ b/terraform/modules/collaborators/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
     time = {
       source  = "hashicorp/time"

--- a/terraform/modules/core-monitoring/versions.tf
+++ b/terraform/modules/core-monitoring/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/terraform/modules/core-monitoring/versions.tf
+++ b/terraform/modules/core-monitoring/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "~> 5.0"
     }
   }
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/10509

## How does this PR fix the problem?

Updates the `modernisation-platform-account` code to be compatible with v6 of the aws terraform provider.

I've also migrated the code away from using the local `core-monitoring` module (as it's just a local module that calls a remote module so seems like an uneccessary extra level of obfuscation). I can remove the `moved` blocks in a follow-up PR.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
