### PR TITLE
♻️ Refactor Cloud Trail S3 Logging Bucket to Use Bucket Policy Instead of ACLs

### DIFF
--- a/terraform/environments/core-logging/s3_logging.tf
+++ b/terraform/environments/core-logging/s3_logging.tf
@@ -212,7 +212,7 @@ module "s3-bucket-cloudtrail-logging" {
     aws.bucket-replication = aws.modernisation-platform-eu-west-1
   }
 
-  acl                        = "log-delivery-write"
+  bucket_policy              = [data.aws_iam_policy_document.cloudtrail_logging_bucket_policy.json]
   bucket_name                = "modernisation-platform-logs-cloudtrail-logging"
   replication_bucket         = "modernisation-platform-logs-cloudtrail-logging-replication"
   suffix_name                = "-cloudtrail-logging"
@@ -221,42 +221,31 @@ module "s3-bucket-cloudtrail-logging" {
 
   replication_enabled = true
   replication_region  = "eu-west-1"
-  versioning_enabled  = true
-
-  lifecycle_rule = [
-    {
-      id      = "main"
-      enabled = "Enabled"
-      prefix  = ""
-      tags    = {}
-      transition = [
-        {
-          days          = 90
-          storage_class = "STANDARD_IA"
-          }, {
-          days          = 365
-          storage_class = "GLACIER"
-        }
-      ]
-      expiration = {
-        days = 730
-      }
-      noncurrent_version_transition = [
-        {
-          days          = 90
-          storage_class = "STANDARD_IA"
-          }, {
-          days          = 365
-          storage_class = "GLACIER"
-        }
-      ]
-      noncurrent_version_expiration = {
-        days = 730
-      }
-    }
-  ]
 
   tags = local.tags
+}
+
+data "aws_iam_policy_document" "cloudtrail_logging_bucket_policy" {
+  statement {
+    sid       = "AllowS3ServerAccessLoggingPutObjectFromSourceBucketWithinAccount"
+    effect    = "Allow"
+    actions   = ["s3:PutObject"]
+    resources = ["${module.s3-bucket-cloudtrail-logging.bucket.arn}/*"]
+    principals {
+      type        = "Service"
+      identifiers = ["logging.s3.amazonaws.com"]
+    }
+    condition {
+      test     = "ArnEquals"
+      variable = "aws:SourceArn"
+      values   = [module.s3-bucket-cloudtrail-logging.bucket.arn]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
+  }
 }
 
 ##########################


### PR DESCRIPTION
## A reference to the issue / Description of it

- In relation to #10511 
- To align with AWS best practices by using Policies over ACLs https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-server-access-logging.html#grant-log-delivery-permissions-bucket-policy

## How does this PR fix the problem?

- Removes bucket ACLs and replaces it with a Bucket Policy

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

- Will need to test live 🧪 

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

- Potential to lose some access logs if things go wrong, but access logs are delivered on a [best effort](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerLogs.html#LogDeliveryBestEffort) basis anyways - so robustness is not essential here

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

NA
