### PR TITLE
🔧 Fix CloudTrail Access Logs by Using The Right SourceARN

### DIFF
--- a/terraform/environments/core-logging/s3_logging.tf
+++ b/terraform/environments/core-logging/s3_logging.tf
@@ -239,7 +239,7 @@ data "aws_iam_policy_document" "cloudtrail_logging_bucket_policy" {
     condition {
       test     = "ArnEquals"
       variable = "aws:SourceArn"
-      values   = [module.s3-bucket-cloudtrail-logging.bucket.arn]
+      values   = [module.s3-bucket-cloudtrail.bucket.arn]
     }
     condition {
       test     = "StringEquals"


### PR DESCRIPTION
## A reference to the issue / Description of it

- Fixes #10923 

## How does this PR fix the problem?

- Currently seeing access denied in the core-logging account for this bucket, took me a while but realised that the condition specifies the logging bucket and it should specify the source bucket 🙈 ([CloudTrail logs](https://eu-west-2.console.aws.amazon.com/cloudwatch/home?region=eu-west-2#logsV2:log-groups/log-group/cloudtrail/log-events$3FfilterPattern$3D$257B$2528$2524.requestParameters.bucketName+$253D+$2522modernisation-platform-logs-cloudtrail-logging$2522$2529$257D$26start$3D-7200000) for the logging bucket)

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

- It will be in live 🚀 

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

- Nope

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

oops
