### PR TITLE
DPR2-1897 add Athena: ListTagsForResource action to allow circleci to return the list of tags

### DIFF
--- a/terraform/environments/digital-prison-reporting/iam.tf
+++ b/terraform/environments/digital-prison-reporting/iam.tf
@@ -27,6 +27,7 @@ data "aws_iam_policy_document" "circleci_iam_policy" {
   #checkov:skip=CKV_AWS_111
   statement {
     actions = [
+      "athena:ListTagsForResource",
       "athena:StartQueryExecution",
       "athena:GetQueryExecution",
       "athena:CreateDataCatalog",


### PR DESCRIPTION
## A reference to the issue / Description of it

The CircleCI Digital Prison Reporting pipeline is failing as the CirclCI "circleci_iam_role" role does not have permission to list tags for Athena resources.
See the error below:
```
Error: listing tags for Athena Data Catalog (arn:aws:athena:eu-west-2:771283872747:datacatalog/dps_prison_reg): operation error Athena: ListTagsForResource, https response error StatusCode: 400, RequestID: a59782c1-b9d1-44fd-9f80-f2273e677de0, api error AccessDeniedException: You are not authorized to perform: athena:ListTagsForResource on the resource. After your AWS administrator or you have updated your permissions, please try again.
│ 
│   with aws_athena_data_catalog.dps_data_catalog["dps-prison-reg"],
│   on main.tf line 1163, in resource "aws_athena_data_catalog" "dps_data_catalog":
│ 1163: resource "aws_athena_data_catalog" "dps_data_catalog" {
│ 
╵
╷
│ Error: listing tags for Athena Data Catalog (arn:aws:athena:eu-west-2:771283872747:datacatalog/dps_testing2): operation error Athena: ListTagsForResource, https response error StatusCode: 400, RequestID: d47c072e-86cd-44d0-b147-2de693b150d3, api error AccessDeniedException: You are not authorized to perform: athena:ListTagsForResource on the resource. After your AWS administrator or you have updated your permissions, please try again.
│ 
│   with aws_athena_data_catalog.dps_data_catalog["dps-testing2"],
│   on main.tf line 1163, in resource "aws_athena_data_catalog" "dps_data_catalog":
│ 1163: resource "aws_athena_data_catalog" "dps_data_catalog" {
│ 
╵
╷
│ Error: listing tags for Athena Data Catalog (arn:aws:athena:eu-west-2:771283872747:datacatalog/dps_csip): operation error Athena: ListTagsForResource, https response error StatusCode: 400, RequestID: 8e039f5f-3d81-48e5-9a16-9170242c84e7, api error AccessDeniedException: You are not authorized to perform: athena:ListTagsForResource on the resource. After your AWS administrator or you have updated your permissions, please try again.
│ 
│   with aws_athena_data_catalog.dps_data_catalog["dps-csip"],
│   on main.tf line 1163, in resource "aws_athena_data_catalog" "dps_data_catalog":
│ 1163: resource "aws_athena_data_catalog" "dps_data_catalog" {
│ 
╵
╷
│ Error: listing tags for Athena Data Catalog (arn:aws:athena:eu-west-2:771283872747:datacatalog/dps_basm): operation error Athena: ListTagsForResource, https response error StatusCode: 400, RequestID: 58bffd3c-4f92-4c49-ad32-b5809a4d786d, api error AccessDeniedException: You are not authorized to perform: athena:ListTagsForResource on the resource. After your AWS administrator or you have updated your permissions, please try again.
│ 
│   with aws_athena_data_catalog.dps_data_catalog["dps-basm"],
│   on main.tf line 1163, in resource "aws_athena_data_catalog" "dps_data_catalog":
│ 1163: resource "aws_athena_data_catalog" "dps_data_catalog" {
│ 
╵
╷
│ Error: listing tags for Athena Data Catalog (arn:aws:athena:eu-west-2:771283872747:datacatalog/dps_test_db): operation error Athena: ListTagsForResource, https response error StatusCode: 400, RequestID: 5363ea1e-c7d7-43a2-937e-d5d717ff98e5, api error AccessDeniedException: You are not authorized to perform: athena:ListTagsForResource on the resource. After your AWS administrator or you have updated your permissions, please try again.
│ 
│   with aws_athena_data_catalog.dps_data_catalog["dps-test-db"],
│   on main.tf line 1163, in resource "aws_athena_data_catalog" "dps_data_catalog":
│ 1163: resource "aws_athena_data_catalog" "dps_data_catalog" {
│ 
╵
╷
│ Error: listing tags for Athena Data Catalog (arn:aws:athena:eu-west-2:771283872747:datacatalog/dps_activities): operation error Athena: ListTagsForResource, https response error StatusCode: 400, RequestID: 2d61e7b3-a5df-4877-9f73-9a75b1be359e, api error AccessDeniedException: You are not authorized to perform: athena:ListTagsForResource on the resource. After your AWS administrator or you have updated your permissions, please try again.
│ 
│   with aws_athena_data_catalog.dps_data_catalog["dps-activities"],
│   on main.tf line 1163, in resource "aws_athena_data_catalog" "dps_data_catalog":
│ 1163: resource "aws_athena_data_catalog" "dps_data_catalog" {
│ 
╵
╷
│ Error: listing tags for Athena Data Catalog (arn:aws:athena:eu-west-2:771283872747:datacatalog/dps_alerts): operation error Athena: ListTagsForResource, https response error StatusCode: 400, RequestID: eb5c8104-772f-4c18-8190-bd73fc7c7c01, api error AccessDeniedException: You are not authorized to perform: athena:ListTagsForResource on the resource. After your AWS administrator or you have updated your permissions, please try again.
│ 
│   with aws_athena_data_catalog.dps_data_catalog["dps-alerts"],
│   on main.tf line 1163, in resource "aws_athena_data_catalog" "dps_data_catalog":
│ 1163: resource "aws_athena_data_catalog" "dps_data_catalog" {
│ 
╵
╷
│ Error: listing tags for Athena Data Catalog (arn:aws:athena:eu-west-2:771283872747:datacatalog/dps_organisations): operation error Athena: ListTagsForResource, https response error StatusCode: 400, RequestID: d6c569f2-92e0-48d8-827e-59e586f88551, api error AccessDeniedException: You are not authorized to perform: athena:ListTagsForResource on the resource. After your AWS administrator or you have updated your permissions, please try again.
│ 
│   with aws_athena_data_catalog.dps_data_catalog["dps-organisations"],
│   on main.tf line 1163, in resource "aws_athena_data_catalog" "dps_data_catalog":
│ 1163: resource "aws_athena_data_catalog" "dps_data_catalog" {
│ 
╵
╷
│ Error: listing tags for Athena Data Catalog (arn:aws:athena:eu-west-2:771283872747:datacatalog/dps_mj_and_ma): operation error Athena: ListTagsForResource, https response error StatusCode: 400, RequestID: 4c0838e9-7872-4a4e-872d-371bd66ca776, api error AccessDeniedException: You are not authorized to perform: athena:ListTagsForResource on the resource. After your AWS administrator or you have updated your permissions, please try again.
│ 
│   with aws_athena_data_catalog.dps_data_catalog["dps-mj-and-ma"],
│   on main.tf line 1163, in resource "aws_athena_data_catalog" "dps_data_catalog":
│ 1163: resource "aws_athena_data_catalog" "dps_data_catalog" {
│ 
╵
╷
│ Error: listing tags for Athena Data Catalog (arn:aws:athena:eu-west-2:771283872747:datacatalog/dps_case_notes): operation error Athena: ListTagsForResource, https response error StatusCode: 400, RequestID: 01fedb61-17fe-4521-b7f4-1c2b9cdfe125, api error AccessDeniedException: You are not authorized to perform: athena:ListTagsForResource on the resource. After your AWS administrator or you have updated your permissions, please try again.
│ 
│   with aws_athena_data_catalog.dps_data_catalog["dps-case-notes"],
│   on main.tf line 1163, in resource "aws_athena_data_catalog" "dps_data_catalog":
│ 1163: resource "aws_athena_data_catalog" "dps_data_catalog" {
│ 
╵
╷
│ Error: listing tags for Athena Data Catalog (arn:aws:athena:eu-west-2:771283872747:datacatalog/dps_inc_reporting): operation error Athena: ListTagsForResource, https response error StatusCode: 400, RequestID: e88fa572-9c53-440c-aef7-43aec9257c92, api error AccessDeniedException: You are not authorized to perform: athena:ListTagsForResource on the resource. After your AWS administrator or you have updated your permissions, please try again.
│ 
│   with aws_athena_data_catalog.dps_data_catalog["dps-inc-reporting"],
│   on main.tf line 1163, in resource "aws_athena_data_catalog" "dps_data_catalog":
│ 1163: resource "aws_athena_data_catalog" "dps_data_catalog" {
│ 
╵
╷
│ Error: listing tags for Athena Data Catalog (arn:aws:athena:eu-west-2:771283872747:datacatalog/dps_locations): operation error Athena: ListTagsForResource, https response error StatusCode: 400, Request
Exited with code exit status 1
```
https://app.circleci.com/pipelines/github/ministryofjustice/digital-prison-reporting-domains/3276/workflows/5d0d8871-9e16-4bb4-b26e-ba922ff31515/jobs/11197

## How does this PR fix the problem?

The CircleCI pipeline needs to be able to apply terraform changes which allow it to list tags for Athena resources. This PR adds the following actions to the existing `circleci_iam_policy` policy  attached to the `circleci_iam_role` role: 
 ```
    "athena:ListTagsForResource"
```

## How has this been tested?
The pipeline will be re-triggered to run terraform apply again. 
Note: This error takes place only during apply and not as part of plan.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?
No.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

N/A