### PR TITLE
Update to v6 aws provider

### DIFF
--- a/terraform/modules/ram-ec2-retagging/versions.tf
+++ b/terraform/modules/ram-ec2-retagging/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version               = ">= 3.47.0"
+      version               = "~> 6.0"
       source                = "hashicorp/aws"
       configuration_aliases = [aws.share-host, aws.share-tenant]
     }

--- a/terraform/modules/ram-principal-association/versions.tf
+++ b/terraform/modules/ram-principal-association/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version               = ">= 3.47.0"
+      version               = "~> 6.0"
       source                = "hashicorp/aws"
       configuration_aliases = [aws.share-host, aws.share-tenant, aws.share-acm]
     }


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/10509

## How does this PR fix the problem?

Updates RAM modules to AWS Terraform provider version 6
