### PR TITLE
Add pentester to yjaf accounts

### DIFF
--- a/collaborators.json
+++ b/collaborators.json
@@ -1783,6 +1783,32 @@
           "access": "developer"
         }
       ]
+    },
+    {
+    "username": "james.davis",
+      "github-username": "no-value-supplied",
+      "accounts": [
+        {
+          "account-name": "youth-justice-app-framework-production",
+          "access": "read-only"
+        },
+        {
+          "account-name": "youth-justice-app-framework-preproduction",
+          "access": "read-only"
+        },
+        {
+          "account-name": "youth-justice-app-framework-test" ,
+          "access": "read-only"
+        },
+        {
+          "account-name": "youth-justice-app-framework-development",
+          "access": "read-only"
+        },
+         {
+          "account-name": "youth-justice-networking-production",
+          "access": "read-only"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

Requested [here](https://mojdt.slack.com/archives/C013RM6MFFW/p1753363147488309)

## How does this PR fix the problem?

Grants pen-tester read-only access to all yjaf accounts

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
