### PR TITLE
Switching test any rule to alert mode

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/test_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/test_rules.json
@@ -49,7 +49,7 @@
     "protocol": "TCP"
   },
   "laa_test_to_mp_laa_test": {
-    "action": "PASS",
+    "action": "ALERT",
     "source_ip": "${laa-lz-test}",
     "destination_ip": "${laa-test}",
     "destination_port": "ANY",


### PR DESCRIPTION
## A reference to the issue / Description of it

now we have the soa rules added to test and there have been no issues on dev we are moving to switch test any rule to alert mode

## How does this PR fix the problem?

switches the any rule to alert mode

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
