### PR TITLE
Core-logging - cloudtrail KMS Policy changes

### DIFF
--- a/terraform/environments/core-logging/s3_logging.tf
+++ b/terraform/environments/core-logging/s3_logging.tf
@@ -90,6 +90,30 @@ data "aws_iam_policy_document" "kms_logging_cloudtrail" {
   }
 
   statement {
+    sid    = "Allow use of the key by the ModernisationPlatformAccess role in all MP accounts"
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::*:role/ModernisationPlatformAccess"]
+    }
+    actions = [
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:Encrypt*",
+      "kms:Describe*",
+      "kms:Decrypt*"
+    ]
+    resources = ["*"]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalOrgID"
+      values = [
+        data.aws_organizations_organization.moj_root_account.id
+      ]
+    }
+  }
+
+  statement {
     sid    = "Allow key decryption to STS bucket replication roles"
     effect = "Allow"
     actions = [


### PR DESCRIPTION


## A reference to the issue / Description of it

Amends cloudtrail kms policy to allow encrypt and decrypt actions the MPAccess role in MP accounts. Required for operations such as baselines.

## How does this PR fix the problem?

The baselines job was failing when the cloudtrail cloudwatch log was created in the member account during the secure-baselines run. This change follows advice by AWS Engineers.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Tested via direct change to KMS policy. This now includes the org condition.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
