### PR TITLE
Remove command to select workspace as already set in TF_WORKSPACE env var

### DIFF
--- a/.github/workflows/terraform-unlock-state.yml
+++ b/.github/workflows/terraform-unlock-state.yml
@@ -87,11 +87,6 @@ jobs:
         working-directory: ${{ env.TF_PATH }}
         run: terraform init
 
-      - name: Select Workspace (if not default)
-        if: env.TF_WORKSPACE != 'default'
-        working-directory: ${{ env.TF_PATH }}
-        run: terraform workspace select ${{ env.TF_WORKSPACE }}
-
       - name: Force Unlock State
         working-directory: ${{ env.TF_PATH }}
         run: terraform force-unlock -force ${{ github.event.inputs.lock_id }}


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/actions/runs/16522619124

Error using state unlock job:

```
The selected workspace is currently overridden using the TF_WORKSPACE
environment variable.

To select a new workspace, either update this environment variable or unset
it and then run this command again.
```
## How does this PR fix the problem?

Removes the step to sleect workspace as it is already set in a previous step in env vars.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
