### PR TITLE
New repo download script

### DIFF
--- a/scripts/repo-clone.sh
+++ b/scripts/repo-clone.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Check if GITHUB_TOKEN is set
+
+# Ensure GITHUB_TOKEN is set
+if [[ -z "$GITHUB_TOKEN" ]]; then
+  echo "GITHUB_TOKEN is not set. Please export it in your .zshrc."
+  exit 1
+fi
+
+# Search for repos with 'modernisation-platform' in the name
+REPOS=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+    "https://api.github.com/search/repositories?q=modernisation-platform+in:name&per_page=100" | \
+    jq -r '.items[].clone_url')
+
+# Loop and clone each repo
+for REPO in $REPOS; do
+    echo "Cloning $REPO"
+    git clone "$REPO"
+done


### PR DESCRIPTION
## A reference to the issue / Description of it

Created a script to download all repos with the name modernisation-platform this script can be be run in any folder but lives in the modernisation repo

to run the script you will need to have a github_token set in your profile

## How does this PR fix the problem?

this fix's an issue where after getting a new/replacment laptop you would have to go and manually connect to each repo and copy and past the ssh clone command this just pulls it all down in one command

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

tested this locally on my new mac

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
