### PR TITLE
Docs Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,12 @@ These modules are used by the Modernisation Platform's core infrastructure
 | --------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
 | [modernisation-platform-terraform-baselines](https://github.com/ministryofjustice/modernisation-platform-terraform-baselines)                       | Module for enabling and configuring common baseline services such as SecurityHub               |
 | [modernisation-platform-terraform-cross-account-access](https://github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access) | Module for creating an IAM role that can be assumed from another account                       |
+| [modernisation-platform-terraform-dns-certificates](https://github.com/ministryofjustice/modernisation-platform-terraform-dns-certificates)         | Module for created DNS certificates                                                            |
 | [modernisation-platform-terraform-environments](https://github.com/ministryofjustice/modernisation-platform-terraform-environments)                 | Module for creating organizational units and accounts within AWS Organizations from JSON files |
 | [modernisation-platform-terraform-iam-superadmins](https://github.com/ministryofjustice/modernisation-platform-terraform-iam-superadmins)           | Module for creating defined IAM users as superadmins                                           |
 | [modernisation-platform-terraform-member-vpc](https://github.com/ministryofjustice/modernisation-platform-terraform-member-vpc)                     | Module for member VPC accounts                                                                 |
 | [modernisation-platform-github-oidc-provider](https://github.com/ministryofjustice/modernisation-platform-github-oidc-provider)                     | Module for creating OIDC providers to use in GitHub Actions                                    |
+| [modernisation-platform-github-oidc-role](https://github.com/ministryofjustice/modernisation-platform-github-oidc-role)                             | Module for creating OIDC roles to use in GitHub Actions                                        |
 
 ### Tools
 

--- a/source/user-guide/deploying-your-infrastructure.html.md.erb
+++ b/source/user-guide/deploying-your-infrastructure.html.md.erb
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#modernisation-platform"
 title: Deploying Your Infrastructure
-last_reviewed_on: 2025-04-15
+last_reviewed_on: 2025-07-28
 review_in: 6 months
 ---
 
@@ -26,7 +26,7 @@ The first step is to create a pull request this will trigger the [GitHub actions
 
 Workflow files are found [here](https://github.com/ministryofjustice/modernisation-platform-environments/tree/main/.github/workflows) and are named after your application.
 
-Depending on what [environments](creating-environments.html) you have, some jobs in the workflow may be commented out if they are not needed. They can be uncommented if more enviroments are added or safely removed if not needed.
+Depending on what [environments](creating-environments.html) you have, some jobs in the workflow may be commented out if they are not needed. They can be uncommented if more environments are added or safely removed if not needed.
 
 Any changes to your workflow file will need approval from the Modernisation Platform team.
 
@@ -76,7 +76,7 @@ Some additional workflow checks will run when you create a pull request, this is
 
 | Check                                                                                                                                                 | Description                                                                                                                                                                                                                                                                                                                   | Required                                            |
 | ----------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
-| [Code Formatter](https://github.com/ministryofjustice/github-actions/tree/v18.6.0)                                                                    | Runs a code formatter and commits any changes back to the branch                                                                                                                                                                                                                                                              | No                                                  |
+| [Code Formatter](https://github.com/ministryofjustice/modernisation-platform-github-actions/tree/main/format-code)                                    | Runs a code formatter and commits any changes back to the branch                                                                                                                                                                                                                                                              | No                                                  |
 | [Open Policy Agent (OPA) validation](https://github.com/ministryofjustice/modernisation-platform-environments/blob/main/policies/terraform/deny.rego) | Runs OPA tests which check the Terraform and prevents certain changes for security reasons. If you want to make a change which is not allowed by the validation, please contact the Modernisation Platform team                                                                                                               | Yes                                                 |
 | [Terraform Static Code Analysis](https://github.com/ministryofjustice/modernisation-platform-github-actions/tree/main/terraform-static-analysis)      | Runs any changes through [TFSEC](https://github.com/tfsec/tfsec), [Checkov](https://github.com/bridgecrewio/checkov) and [tflint](https://github.com/terraform-linters/tflint). If any issues are flagged please try to fix them, if there is a valid reason not to fix them they can be ignored with inline ignore comments. | No - but we may make this mandatory at a later date |
 


### PR DESCRIPTION
Small update to remove reference to legacy GitHub-Actions repo and also add two repo's to our MP readme which appear to be missing:
- modernisation-platform-terraform-dns-certificates
- modernisation-platform-github-oidc-role