### PR TITLE
Test updated `signed-commit` action for failing worklows

### DIFF
--- a/.github/workflows/new-environment-files.yml
+++ b/.github/workflows/new-environment-files.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Commit changes to GitHub
         run: bash ./scripts/git-setup.sh
       - name: Commit and Create PR with Signed Commit
-        uses: ministryofjustice/modernisation-platform-github-actions/signed-commit@c25ccb3c17e1ac869ceafc5430a4caf7e39be2ee # v3.4.0
+        uses: ministryofjustice/modernisation-platform-github-actions/signed-commit@bug/sc-remote-branch-commit # test branch
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           git_path: terraform/environments

--- a/.github/workflows/new-member-environment-files.yml
+++ b/.github/workflows/new-member-environment-files.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Commit changes to GitHub
         run: bash ./core-repo/scripts/git-setup.sh ./modernisation-platform-environments
       - name: Commit and Create PR with Signed Commit
-        uses: ministryofjustice/modernisation-platform-github-actions/signed-commit@c25ccb3c17e1ac869ceafc5430a4caf7e39be2ee # v3.4.0
+        uses: ministryofjustice/modernisation-platform-github-actions/signed-commit@bug/sc-remote-branch-commit # test branch
         with:
           github_token: ${{ secrets.TERRAFORM_GITHUB_TOKEN }} # use this token as writing to a different repo
           remote_repository: "ministryofjustice/modernisation-platform-environments"


### PR DESCRIPTION
This PR switches the workflow to use the `bug/sc-remote-branch-commit` branch for testing some improved logic to resolve issues with the current failing new member environment files: https://github.com/ministryofjustice/modernisation-platform/actions/runs/16593206436