### PR TITLE
Remove last any rule from laa networks

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/test_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/test_rules.json
@@ -454,13 +454,6 @@
     "destination_port": "$YJB_TCP",
     "protocol": "TCP"
   },
-  "laa_uat_to_mp_laa_test": {
-    "action": "ALERT",
-    "source_ip": "${laa-lz-uat}",
-    "destination_ip": "${laa-test}",
-    "destination_port": "ANY",
-    "protocol": "IP"
-  },
   "laa_test_data_a_ses": {
     "action": "PASS",
     "source_ip": "${laa-mp-test-general-data-subnets-a}",


### PR DESCRIPTION
## A reference to the issue / Description of it

remove last rule in the test env for laa and any

## How does this PR fix the problem?

any rule removed

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
