### PR TITLE
🔐 Fix: Use Secure GitHub Token for Signed Commits and PR Creation

### DIFF
--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -12,7 +12,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  fetch-secrets:
+    uses: ministryofjustice/modernisation-platform-github-actions/.github/workflows/aws-secrets-management.yml@c25ccb3c17e1ac869ceafc5430a4caf7e39be2ee
+    secrets:
+      MODERNISATION_PLATFORM_ACCOUNT_NUMBER: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_NUMBER }}
+      PASSPHRASE: ${{ secrets.PASSPHRASE }}
   format-code:
+    needs: fetch-secrets
     permissions:
       contents: write
       security-events: write  # needed for SARIF upload
@@ -21,8 +27,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          token: '${{ secrets.GITHUB_TOKEN }}'
+          token: ${{ needs.fetch-secrets.outputs.terraform_github_token }}
           fetch-depth: 0
+
+      - name: Decrypt Secrets
+        uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@c25ccb3c17e1ac869ceafc5430a4caf7e39be2ee
+        with:
+          terraform_github_token: ${{ needs.fetch-secrets.outputs.terraform_github_token }}
+          PASSPHRASE: ${{ secrets.PASSPHRASE }}
 
       - name: Prepare Git options
         run: bash ./scripts/git-setup.sh
@@ -44,6 +56,6 @@ jobs:
       - name: Run Signed Commit Action
         uses: ministryofjustice/modernisation-platform-github-actions/signed-commit@c25ccb3c17e1ac869ceafc5430a4caf7e39be2ee # v3.4.0
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ needs.fetch-secrets.outputs.terraform_github_token }}
           pr_title: "GitHub Actions Code Formatter workflow"
           pr_body: "This pull request includes updates from the GitHub Actions Code Formatter workflow. Please review the changes and merge if everything looks good."


### PR DESCRIPTION
This PR updates the **Format Code** GitHub Actions workflow to **retrieve and use a GitHub token via the** `aws-secrets-management` **reusable workflow**, enabling the signed commit and PR creation steps to complete successfully.

🛠️ **Fixes**
Previously, the `signed-commit` step failed with the error:

> GraphQL: Resource not accessible by integration (createPullRequest)

This occurred because the default `${{ secrets.GITHUB_TOKEN }}` does **not have sufficient permissions** to create pull requests via the GraphQL API used by `signed-commit`.

✅ Solution
- Adds a `fetch-secrets` job using the [aws-secrets-management](https://github.com/ministryofjustice/modernisation-platform-github-actions/blob/main/.github/workflows/aws-secrets-management.yml) reusable workflow.
- Retrieves `terraform_github_token` from AWS Secrets Manager.
- Uses this decrypted token for:
  - Repository checkout
  - Code formatting commits
  - Creating signed commits and pull requests via GraphQL