### PR TITLE
Add firewall rule allowing laa prod to ecp

### DIFF
--- a/terraform/environments/core-network-services/cidr-ranges.tf
+++ b/terraform/environments/core-network-services/cidr-ranges.tf
@@ -71,6 +71,7 @@ locals {
     laa-lz-shared-services-prod    = "10.200.16.0/20"
     laa-appstream-vpc              = "10.200.32.0/19"
     laa-appstream-vpc_additional   = "10.200.68.0/22"
+    laa-ecp                        = "10.205.0.0/20"
 
     # NEC cidr ranges
     nec-nonprod = "10.120.0.147/32"

--- a/terraform/environments/core-network-services/firewall-rules/production_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/production_rules.json
@@ -797,5 +797,12 @@
     "destination_ip": "$LAA_FTP_ENDPOINTS",
     "destination_port": "$LAA_FTP_TCP",
     "protocol": "TCP"
+  },
+  "laa_production_to_laa_ecp_2484": {
+    "action": "PASS",
+    "source_ip": "$laa-production",
+    "destination_ip": "$laa-ecp",
+    "destination_port": "2484",
+    "protocol": "TCP"
   }
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

LAA ECP Provision

## How does this PR fix the problem?

Ensures hosts in LAA Production can initiate TLS connections to Oracle instances

## How has this been tested?

Tested through CI check

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
