### PR TITLE
Allow bucket access from the management account for SSO Admins

### DIFF
--- a/terraform/modernisation-platform-account/locals.tf
+++ b/terraform/modernisation-platform-account/locals.tf
@@ -10,7 +10,6 @@ locals {
     "arn:aws:iam::${local.root_account.master_account_id}:user/DavidElliott",
     "arn:aws:iam::${local.root_account.master_account_id}:user/EwaStempel",
     "arn:aws:iam::${local.root_account.master_account_id}:role/ModernisationPlatformGithubActionsRole", # Role with the same permissions as ModernisationPlatformOrganisationManagement for Github OIDC
-    "arn:aws:iam::${local.root_account.master_account_id}:role/ModernisationPlatformGithubActionsRole",
     "arn:aws:iam::${local.root_account.master_account_id}:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_AdministratorAccess_*"
   ])
 


### PR DESCRIPTION
## A reference to the issue / Description of it

This is to implement one of the steps from: [{Issue 11168}](https://github.com/ministryofjustice/modernisation-platform/issues/11168)

## How does this PR fix the problem?

Add access to the bucket from the management account for the SSO admins.

## How has this been tested?

The role will be used to run tf plan to test this, once it is merged.

## Deployment Plan / Instructions

on merge

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

