### PR TITLE
NACL for public LAA subnets for inbound tcp 22

### DIFF
--- a/terraform/modules/vpc-nacls/locals.tf
+++ b/terraform/modules/vpc-nacls/locals.tf
@@ -76,6 +76,17 @@ locals {
     }
   }
 
+  laa_public_ssh_ingress = {
+    cidr_block  = "0.0.0.0/0"
+    egress      = false
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    rule_action = "allow"
+    rule_number = 6053
+  }
+  
+
   apply_laa_custom_tcp_rules = contains(local.laa_vpc_keys, var.vpc_name)
 
   laa_custom_tcp_rules_to_apply = local.apply_laa_custom_tcp_rules ? local.laa_custom_egress_tcp_acl_rules : {}

--- a/terraform/modules/vpc-nacls/main.tf
+++ b/terraform/modules/vpc-nacls/main.tf
@@ -257,3 +257,14 @@ resource "aws_network_acl_rule" "laa_custom_tcp_rules" {
   rule_number    = each.value.rule_number
   to_port        = each.value.to_port
 }
+
+resource "aws_network_acl_rule" "laa_public_ssh_ingress_rule" {
+  cidr_block     = laa_public_ssh_ingress.cidr_block
+  egress         = laa_public_ssh_ingress.value.egress
+  from_port      = laa_public_ssh_ingress.value.from_port
+  network_acl_id = aws_network_acl.general-public.id
+  protocol       = laa_public_ssh_ingress.protocol
+  rule_action    = laa_public_ssh_ingress.rule_action
+  rule_number    = laa_public_ssh_ingress.rule_number
+  to_port        = laa_public_ssh_ingress.to_port
+}


### PR DESCRIPTION

## A reference to the issue / Description of it

#11165 

## How does this PR fix the problem?

Adds tcp 22 (ssh) ingress to laa public subnets to support xhibit sftp endpoint hosting.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
