### PR TITLE
NACL for public LAA subnets for inbound tcp 22

### DIFF
--- a/terraform/modules/vpc-nacls/locals.tf
+++ b/terraform/modules/vpc-nacls/locals.tf
@@ -80,4 +80,21 @@ locals {
 
   laa_custom_tcp_rules_to_apply = local.apply_laa_custom_tcp_rules ? local.laa_custom_egress_tcp_acl_rules : {}
 
+
+  laa_public_ssh_ingress = {
+    cidr_block  = "0.0.0.0/0"
+    egress      = false
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    rule_action = "allow"
+    rule_number = 6053
+  }
+
+  laa_public_ssh_ingress_rules = contains(local.laa_vpc_keys, var.vpc_name)
+
+  laa_public_ssh_rules_to_apply = laa_public_ssh_ingress_rules? local.laa_public_ssh_ingress : {}
+
+
+
 }

--- a/terraform/modules/vpc-nacls/locals.tf
+++ b/terraform/modules/vpc-nacls/locals.tf
@@ -93,8 +93,6 @@ locals {
 
   laa_public_ssh_ingress_rules = contains(local.laa_vpc_keys, var.vpc_name)
 
-  laa_public_ssh_rules_to_apply = laa_public_ssh_ingress_rules? local.laa_public_ssh_ingress : {}
-
-
+  laa_public_ssh_rules_to_apply = local.laa_public_ssh_ingress_rules ? {"ssh" = local.laa_public_ssh_ingress} : {}
 
 }

--- a/terraform/modules/vpc-nacls/main.tf
+++ b/terraform/modules/vpc-nacls/main.tf
@@ -260,12 +260,14 @@ resource "aws_network_acl_rule" "laa_custom_tcp_rules" {
 
 resource "aws_network_acl_rule" "laa_public_ssh_ingress_rule" {
   for_each       = local.laa_public_ssh_rules_to_apply
-  cidr_block     = local.laa_public_ssh_ingress.cidr_block
-  egress         = local.laa_public_ssh_ingress.value.egress
-  from_port      = local.laa_public_ssh_ingress.value.from_port
+
+  cidr_block     = each.value.cidr_block
+  egress         = each.value.egress
+  from_port      = each.value.from_port
+  to_port        = each.value.to_port
+  protocol       = each.value.protocol
+  rule_action    = each.value.rule_action
+  rule_number    = each.value.rule_number
+
   network_acl_id = aws_network_acl.general-public.id
-  protocol       = local.laa_public_ssh_ingress.protocol
-  rule_action    = local.laa_public_ssh_ingress.rule_action
-  rule_number    = local.laa_public_ssh_ingress.rule_number
-  to_port        = local.laa_public_ssh_ingress.to_port
 }

--- a/terraform/modules/vpc-nacls/main.tf
+++ b/terraform/modules/vpc-nacls/main.tf
@@ -257,3 +257,15 @@ resource "aws_network_acl_rule" "laa_custom_tcp_rules" {
   rule_number    = each.value.rule_number
   to_port        = each.value.to_port
 }
+
+resource "aws_network_acl_rule" "laa_public_ssh_ingress_rule" {
+  for_each       = local.laa_public_ssh_rules_to_apply
+  cidr_block     = laa_public_ssh_ingress.cidr_block
+  egress         = laa_public_ssh_ingress.value.egress
+  from_port      = laa_public_ssh_ingress.value.from_port
+  network_acl_id = aws_network_acl.general-public.id
+  protocol       = laa_public_ssh_ingress.protocol
+  rule_action    = laa_public_ssh_ingress.rule_action
+  rule_number    = laa_public_ssh_ingress.rule_number
+  to_port        = laa_public_ssh_ingress.to_port
+}

--- a/terraform/modules/vpc-nacls/main.tf
+++ b/terraform/modules/vpc-nacls/main.tf
@@ -260,12 +260,12 @@ resource "aws_network_acl_rule" "laa_custom_tcp_rules" {
 
 resource "aws_network_acl_rule" "laa_public_ssh_ingress_rule" {
   for_each       = local.laa_public_ssh_rules_to_apply
-  cidr_block     = laa_public_ssh_ingress.cidr_block
-  egress         = laa_public_ssh_ingress.value.egress
-  from_port      = laa_public_ssh_ingress.value.from_port
+  cidr_block     = local.laa_public_ssh_ingress.cidr_block
+  egress         = local.laa_public_ssh_ingress.value.egress
+  from_port      = local.laa_public_ssh_ingress.value.from_port
   network_acl_id = aws_network_acl.general-public.id
-  protocol       = laa_public_ssh_ingress.protocol
-  rule_action    = laa_public_ssh_ingress.rule_action
-  rule_number    = laa_public_ssh_ingress.rule_number
-  to_port        = laa_public_ssh_ingress.to_port
+  protocol       = local.laa_public_ssh_ingress.protocol
+  rule_action    = local.laa_public_ssh_ingress.rule_action
+  rule_number    = local.laa_public_ssh_ingress.rule_number
+  to_port        = local.laa_public_ssh_ingress.to_port
 }


### PR DESCRIPTION

## A reference to the issue / Description of it

#11165 

## How does this PR fix the problem?

Adds tcp 22 (ssh) ingress to laa public subnets to support xhibit sftp endpoint hosting.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
