### PR TITLE
#11165 - Adds tcp 22 (ssh) ingress to laa public subnets to support xhibit sftp endpoint hosting.

### DIFF
--- a/terraform/modules/vpc-nacls/locals.tf
+++ b/terraform/modules/vpc-nacls/locals.tf
@@ -84,7 +84,7 @@ locals {
 # LAA TCP 22 Public Subnets Ingress
 
   laa_ssh_ingress_public_acl_rules = {
-    laa_public_ssh_subnet_a = {
+    laa_public_ssh_subnets = {
       cidr_block  = "0.0.0.0/0"
       egress      = false
       from_port   = 22
@@ -92,24 +92,6 @@ locals {
       protocol    = "tcp"
       rule_action = "allow"
       rule_number = 6053
-    }
-    laa_public_ssh_subnet_b = {
-      cidr_block  = "0.0.0.0/0"
-      egress      = false
-      from_port   = 22
-      to_port     = 22
-      protocol    = "tcp"
-      rule_action = "allow"
-      rule_number = 6054
-    }
-    laa_public_ssh_subnet_c = {
-      cidr_block  = "0.0.0.0/0"
-      egress      = false
-      from_port   = 22
-      to_port     = 22
-      protocol    = "tcp"
-      rule_action = "allow"
-      rule_number = 6055
     }
   }
 

--- a/terraform/modules/vpc-nacls/locals.tf
+++ b/terraform/modules/vpc-nacls/locals.tf
@@ -80,4 +80,44 @@ locals {
 
   laa_custom_tcp_rules_to_apply = local.apply_laa_custom_tcp_rules ? local.laa_custom_egress_tcp_acl_rules : {}
 
+
+# LAA TCP 22 Public Subnets Ingress
+
+  laa_ssh_ingress_public_acl_rules = {
+    laa_public_ssh_subnet_a = {
+      cidr_block  = "0.0.0.0/0"
+      egress      = false
+      from_port   = 22
+      to_port     = 22
+      protocol    = "tcp"
+      rule_action = "allow"
+      rule_number = 6053
+    }
+    laa_public_ssh_subnet_b = {
+      cidr_block  = "0.0.0.0/0"
+      egress      = false
+      from_port   = 22
+      to_port     = 22
+      protocol    = "tcp"
+      rule_action = "allow"
+      rule_number = 6054
+    }
+    laa_public_ssh_subnet_c = {
+      cidr_block  = "0.0.0.0/0"
+      egress      = false
+      from_port   = 22
+      to_port     = 22
+      protocol    = "tcp"
+      rule_action = "allow"
+      rule_number = 6055
+    }
+  }
+
+  apply_laa_ssh_ingress_public_acl_rules = contains(local.laa_vpc_keys, var.vpc_name)
+
+  laa_ssh_ingress_public_acl_rules_to_apply = local.apply_laa_ssh_ingress_public_acl_rules ? local.laa_ssh_ingress_public_acl_rules : {}
+
+
+
+
 }

--- a/terraform/modules/vpc-nacls/main.tf
+++ b/terraform/modules/vpc-nacls/main.tf
@@ -257,3 +257,15 @@ resource "aws_network_acl_rule" "laa_custom_tcp_rules" {
   rule_number    = each.value.rule_number
   to_port        = each.value.to_port
 }
+
+resource "aws_network_acl_rule" "laa_ssh_public_ingress_rules" {
+  for_each       = local.laa_ssh_ingress_public_acl_rules_to_apply
+  cidr_block     = each.value.cidr_block
+  egress         = each.value.egress
+  from_port      = each.value.from_port
+  network_acl_id = aws_network_acl.general-public.id
+  protocol       = each.value.protocol
+  rule_action    = each.value.rule_action
+  rule_number    = each.value.rule_number
+  to_port        = each.value.to_port
+}


### PR DESCRIPTION
## A reference to the issue / Description of it

#11165 

## How does this PR fix the problem?

Adds tcp 22 (ssh) ingress to laa public subnets to support xhibit sftp endpoint hosting. Note that a single ACL rule is sufficient as the acl in question is associated with all three public subnets.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

See tests.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
