### PR TITLE
Restrict CircleCI IAM role to specific CircleCI projects via trust policy

### DIFF
--- a/source/runbooks/revoking-user-access.html.md.erb
+++ b/source/runbooks/revoking-user-access.html.md.erb
@@ -86,7 +86,7 @@ To remove this role for member accounts through code:
 
 #### CircleCI Role
 
-Digital Prison Reporting and Youth Justice App Framework make use of CircleCI for their pipeline. We manage `circleci_roles` on their behalf which is defined in code in the following files: [dpr/iam.tf](https://github.com/ministryofjustice/modernisation-platform/blob/376d57912a779f13b91f4ccbc27d1e06c12f7560/terraform/environments/digital-prison-reporting/iam.tf#L1) and [yjaf/iam.tf](https://github.com/ministryofjustice/modernisation-platform/blob/main/terraform/environments/youth-justice-app-framework/iam.tf#L1).
+Digital Prison Reporting and Youth Justice App Framework make use of CircleCI for their pipeline. We manage a `circleci_iam_role` on their behalf which is defined in code in the following files: [dpr/iam.tf](https://github.com/ministryofjustice/modernisation-platform/blob/376d57912a779f13b91f4ccbc27d1e06c12f7560/terraform/environments/digital-prison-reporting/iam.tf#L1) and [yjaf/iam.tf](https://github.com/ministryofjustice/modernisation-platform/blob/main/terraform/environments/youth-justice-app-framework/iam.tf#L1).
 
 Removing access would be as simple as raising a PR to either remove this code entirely or edit the permissions of the associated policy so that it has limited or no access.
 

--- a/source/runbooks/revoking-user-access.html.md.erb
+++ b/source/runbooks/revoking-user-access.html.md.erb
@@ -86,7 +86,7 @@ To remove this role for member accounts through code:
 
 #### CircleCI Role
 
-Digital Prison Reporting make use of CircleCI for their pipeline. We manage a `circleci_iam_role` on their behalf which is defined in code [here](https://github.com/ministryofjustice/modernisation-platform/blob/376d57912a779f13b91f4ccbc27d1e06c12f7560/terraform/environments/digital-prison-reporting/iam.tf#L1)
+Digital Prison Reporting and Youth Justice App Framework make use of CircleCI for their pipeline. We manage `circleci_roles` on their behalf which is defined in code in the following files: [dpr/iam.tf](https://github.com/ministryofjustice/modernisation-platform/blob/376d57912a779f13b91f4ccbc27d1e06c12f7560/terraform/environments/digital-prison-reporting/iam.tf#L1) and [yjaf/iam.tf](https://github.com/ministryofjustice/modernisation-platform/blob/main/terraform/environments/youth-justice-app-framework/iam.tf#L1).
 
 Removing access would be as simple as raising a PR to either remove this code entirely or edit the permissions of the associated policy so that it has limited or no access.
 

--- a/terraform/environments/youth-justice-app-framework/iam.tf
+++ b/terraform/environments/youth-justice-app-framework/iam.tf
@@ -57,25 +57,6 @@ resource "aws_iam_role" "circleci_roles" {
     }]
   })
 }
-resource "aws_iam_role" "circleci_iam_role" {
-  name                 = "circleci_iam_role"
-  max_session_duration = 7200
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17",
-    Statement = [{
-      Action = "sts:AssumeRoleWithWebIdentity",
-      Effect = "Allow",
-      Principal = {
-        Federated = aws_iam_openid_connect_provider.circleci_oidc_provider.arn
-      },
-      Condition = {
-        StringLike = {
-          "${aws_iam_openid_connect_provider.circleci_oidc_provider.url}:sub" = "org/${local.secret_json.organisation_id}/*"
-        }
-      }
-    }]
-  })
-}
 
 #tfsec:ignore:aws-iam-no-policy-wildcards
 data "aws_iam_policy_document" "circleci_iam_policy" {

--- a/terraform/environments/youth-justice-app-framework/iam.tf
+++ b/terraform/environments/youth-justice-app-framework/iam.tf
@@ -287,17 +287,14 @@ data "aws_iam_policy_document" "circleci_iam_policy" {
     resources = ["*"]
   }
 }
-
 resource "aws_iam_policy" "circleci_iam_policy" {
   name        = "circleci_iam_policy"
   description = "Policy for CircleCI"
   policy      = data.aws_iam_policy_document.circleci_iam_policy.json
 }
 
-# Attach policy to each role
 resource "aws_iam_policy_attachment" "circleci_policy_attachment" {
-  for_each   = aws_iam_role.circleci_roles
   policy_arn = aws_iam_policy.circleci_iam_policy.arn
-  roles      = [each.value.name]
-  name       = "circleci_policy_attachment_${each.key}"
+  roles      = [aws_iam_role.circleci_iam_role.name]
+  name       = "circleci_policy_attachment"
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

Addresses issue 56 in mod-platform security repo. to tighten who can assume CircleCI role.

## How does this PR fix the problem?

This change improves security by ensuring only authorised CircleCI projects can assume the CircleCI role, reducing the risk of unauthorised access.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
