### PR TITLE
✨ Add `Platforms` as Parent Team

### DIFF
--- a/terraform/github/locals.tf
+++ b/terraform/github/locals.tf
@@ -165,4 +165,6 @@ locals {
   testing_tags = merge(
     jsondecode(data.http.environments_file.response_body).tags,
   { "source-code" = "https://github.com/ministryofjustice/modernisation-platform/tree/main/terraform/github" })
+
+  platforms_team_id = "9733829"
 }

--- a/terraform/github/teams.tf
+++ b/terraform/github/teams.tf
@@ -1,11 +1,12 @@
 # Everyone, with access to the above repositories
 module "core-team" {
-  source      = "./modules/team"
-  name        = "modernisation-platform"
-  description = "Modernisation Platform team"
-  maintainers = local.maintainers
-  members     = local.everyone
-  ci          = local.ci_users
+  source         = "./modules/team"
+  name           = "modernisation-platform"
+  description    = "Modernisation Platform team"
+  maintainers    = local.maintainers
+  members        = local.everyone
+  ci             = local.ci_users
+  parent_team_id = local.platforms_team_id
 }
 
 # People who need full AWS access


### PR DESCRIPTION
## A reference to the issue / Description of it

- In an effort to create and align to an Organisational Structure with GitHub Teams as recommended by GitHub

## How does this PR fix the problem?

- Adds our main team to live under the Organisational Structure by defining it's parent as `Platforms`

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

- Plan checked

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

- No, adding a parent team won't impact the platform

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

NA
