### PR TITLE
Update PagerDuty email

### DIFF
--- a/terraform/pagerduty/locals.tf
+++ b/terraform/pagerduty/locals.tf
@@ -94,7 +94,7 @@ data "pagerduty_user" "mark_roberts" {
 }
 
 data "pagerduty_user" "aaron_robinson" {
-  email = "aaron.robinson1${justice_email_suffix}"
+  email = "aaron.robinson1${local.justice_email_suffix}"
 }
 
 data "pagerduty_user" "richard_green" {


### PR DESCRIPTION
This PR updates my PagerDuty email from `@digal.justice.gov.uk` to `@justice.gov.uk`