### PR TITLE
Fix truncation of environment names in Slack notifications for JSON changes

### DIFF
--- a/.github/workflows/new-environment.yml
+++ b/.github/workflows/new-environment.yml
@@ -485,8 +485,8 @@ jobs:
       - name: Send notification to Slack
         if: steps.environment_json_changes.outputs.files != ''
         run: |
-          DECODED_FILES=$(echo ${{ steps.environment_json_changes.outputs.files }} | base64 --decode)
-          for file in $DECODED_FILES; do
+          DECODED_FILES=$(echo "${{ steps.environment_json_changes.outputs.files }}" | base64 --decode)
+          echo "$DECODED_FILES" | while IFS= read -r file; do
           PR_PATH="https://github.com/${GITHUB_REPOSITORY}/pull/${{ steps.pr_number.outputs.pr_number }}/files"
           slack_channel=$(jq -r '.tags["slack-channel"] // empty' "environments/$file")
           if [[ -z "$slack_channel" ]]; then


### PR DESCRIPTION
**Summary**
This PR fixes a bug where environment names were truncated in the Slack notification step of the `environment_json_changes_notification` job. The truncation caused "No such file or directory" errors when filenames like `analytical-platform-compute.json` were processed incorrectly.

**Root cause**
The bug was caused by how the Slack notification step decoded and iterated over modified filenames.

The workflow:

1. Collected changed `environments/*.json` files.
1. Stripped the `environments/` prefix.
1. Base64-encoded the list.
1. Decoded it back in the Slack step.
1. Iterated with:

```bash
for file in $DECODED_FILES; do ...
```
which splits on spaces, tabs, and newlines.

Because base64 output wraps at 76 characters by default, a newline was inserted in the encoded output mid-way through a long filename such as `analytical-platform-compute.json`.

When decoded, that newline caused the filename to be split into:

```pgsql
analytical-platform-compu
te.json
```
The first part failed the `jq` lookup with:

```lua
jq: error: Could not open file environments/analytical-platform-compu: No such file or directory
```
**Fix**

The loop has been changed to:
```bash
echo "$DECODED_FILES" | while IFS= read -r file; do ...
```
which:
- Reads the decoded list line-by-line.
- Preserves the full filename (no splitting on spaces or base64 wrap newlines).
- Handles special characters safely.

**Impact**
This fix ensures Slack notifications correctly reference all changed environment JSON files without errors, improving visibility of environment updates.