### PR TITLE
Allow delius-mp test 1521/1522

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/test_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/test_rules.json
@@ -314,13 +314,6 @@
     "destination_port": "636",
     "protocol": "TCP"
   },
-  "hmpps_test_to_delius_test_oracle": {
-    "action": "PASS",
-    "source_ip": "${hmpps-test}",
-    "destination_ip": "${delius-test}",
-    "destination_port": "1521",
-    "protocol": "TCP"
-  },
   "mp_hmpps_test_to_noms_mgmt_vnet_ntp": {
     "action": "PASS",
     "source_ip": "${hmpps-test}",
@@ -550,6 +543,34 @@
     "source_ip": "${laa-lz-uat}",
     "destination_ip": "${laa-test}",
     "destination_port": "$LAA_CCMS_SOA",
+    "protocol": "TCP"
+  },
+  "delius_test_to_hmpps_test_oracledb_1521": {
+    "action": "PASS",
+    "source_ip": "${delius-test}",
+    "destination_ip": "${hmpps-test}",
+    "destination_port": "1521",
+    "protocol": "TCP"
+  },
+  "delius_test_to_hmpps_test_oracledb_1522": {
+    "action": "PASS",
+    "source_ip": "${delius-test}",
+    "destination_ip": "${hmpps-test}",
+    "destination_port": "1522",
+    "protocol": "TCP"
+  },
+  "hmpps_test_to_delius_test_oracledb_1521": {
+    "action": "PASS",
+    "source_ip": "${hmpps-test}",
+    "destination_ip": "${delius-test}",
+    "destination_port": "1521",
+    "protocol": "TCP"
+  },
+  "hmpps_test_to_delius_test_oracledb_1522": {
+    "action": "PASS",
+    "source_ip": "${hmpps-test}",
+    "destination_ip": "${delius-test}",
+    "destination_port": "1522",
     "protocol": "TCP"
   }
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

We're migration Delius test DBs from legacy account to MP. Connectivity will be required bidirectionally between these accounts over port 1521/1522.

## How does this PR fix the problem?

Creates firewall rules.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

N/A

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

N/A

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
