### PR TITLE
Add CIDR range and rule allowing traffic to connection test vpc on 443

### DIFF
--- a/terraform/environments/core-network-services/cidr-ranges.tf
+++ b/terraform/environments/core-network-services/cidr-ranges.tf
@@ -72,6 +72,7 @@ locals {
     laa-appstream-vpc              = "10.200.32.0/19"
     laa-appstream-vpc_additional   = "10.200.68.0/22"
     laa-ecp-safedb                 = "10.205.7.0/24"
+    laa-ecp-conntest               = "10.205.15.0/24"
 
     # NEC cidr ranges
     nec-nonprod = "10.120.0.147/32"

--- a/terraform/environments/core-network-services/firewall-rules/production_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/production_rules.json
@@ -804,5 +804,12 @@
     "destination_ip": "${laa-ecp-safedb}",
     "destination_port": "2484",
     "protocol": "TCP"
+  },
+  "laa_production_to_laa_ecp_443": {
+    "action": "PASS",
+    "source_ip": "${laa-production}",
+    "destination_ip": "${laa-ecp-conntest}",
+    "destination_port": "443",
+    "protocol": "TCP"
   }
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

N/A

## How does this PR fix the problem?

Allows traffic to the ECP connection test VPC, for reachability testing prior to allowing hosts to reach other destinations on ECP

## How has this been tested?

Tested through CI

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
