### PR TITLE
Add route to ECP connection test VPC

### DIFF
--- a/terraform/environments/core-network-services/transit_gateway_connections.tf
+++ b/terraform/environments/core-network-services/transit_gateway_connections.tf
@@ -221,3 +221,9 @@ resource "aws_ec2_transit_gateway_route" "inspection_static_routes_ecp_safedb" {
   transit_gateway_attachment_id  = data.aws_ec2_transit_gateway_peering_attachment.ecp_tgw.id
   transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.external_inspection_out.id
 }
+
+resource "aws_ec2_transit_gateway_route" "inspection_static_routes_ecp_conntest" {
+  destination_cidr_block         = "10.205.15.0/24"
+  transit_gateway_attachment_id  = data.aws_ec2_transit_gateway_peering_attachment.ecp_tgw.id
+  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.external_inspection_out.id
+}


### PR DESCRIPTION
## A reference to the issue / Description of it

N/A

## How does this PR fix the problem?

As a follow-up to https://github.com/ministryofjustice/modernisation-platform/pull/11231, this PR adds a route to the ECP connection test VPC

## How has this been tested?

Tested through CI checks

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
