### PR TITLE
Swapping Ewa's identities in the policy schedule.

### DIFF
--- a/terraform/pagerduty/locals.tf
+++ b/terraform/pagerduty/locals.tf
@@ -20,8 +20,8 @@ locals {
     },
     ewa_stempel = {
       name  = "Ewa Stempel"
-      email = "ewa.stempel${local.digital_email_suffix}"
-      role  = "user"
+      email = "ewa.stempel${local.justice_email_suffix}"
+      role  = "manager"
     },
     sukesh_reddygade = {
       name  = "Sukesh Reddy Gade"
@@ -100,6 +100,7 @@ data "pagerduty_user" "aaron_robinson" {
 data "pagerduty_user" "richard_green" {
   email = "richard.green${local.digital_email_suffix}"
 }
+
 data "pagerduty_user" "khatra_farah" {
   email = "khatra.farah${local.digital_email_suffix}"
 }

--- a/terraform/pagerduty/policy-schedules.tf
+++ b/terraform/pagerduty/policy-schedules.tf
@@ -89,6 +89,8 @@ resource "pagerduty_schedule" "primary" {
   }
 
   teams = [pagerduty_team.modernisation_platform.id]
+
+  depends_on = [pagerduty_team_membership.modernisation_platform_membership]
 }
 
 resource "pagerduty_schedule" "secondary" {
@@ -120,4 +122,6 @@ resource "pagerduty_schedule" "secondary" {
   }
 
   teams = [pagerduty_team.modernisation_platform.id]
+
+  depends_on = [pagerduty_team_membership.modernisation_platform_membership]
 }


### PR DESCRIPTION
This is to update the pager duty schedule with my justice identity and to update my role.
It also introduces depends on, so that users are added to the team first and then the policy schedule gets updated.

In case a new policy schedule is generated, the screenshots of the rota have been taken to preserve the schedule. This is unlikely to happen as the order of the users in the schedule has been intact. 


