### PR TITLE
Add private hosted zone to resolve ECP addresses

### DIFF
--- a/environments-networks/laa-production.json
+++ b/environments-networks/laa-production.json
@@ -29,7 +29,7 @@
       "com.amazonaws.eu-west-2.secretsmanager",
       "com.amazonaws.eu-west-2.email-smtp"
     ],
-    "additional_private_zones": [],
+    "additional_private_zones": ["aws.prd.legalservices.gov.uk"],
     "additional_vpcs": [],
     "dns_zone_extend": []
   }

--- a/terraform/environments/core-network-services/route53.tf
+++ b/terraform/environments/core-network-services/route53.tf
@@ -22,11 +22,11 @@ locals {
   }
 
   private-application-zones = {
-    yjaf-development   = "development.yjaf"
-    yjaf-test          = "test.yjaf",
-    yjaf-preproduction = "preproduction.yjaf",
-    yjaf-production    = "production.yjaf"
-
+    aws-prd-legalservices-gov-uk = "aws.prd.legalservices.gov.uk"
+    yjaf-development             = "development.yjaf"
+    yjaf-test                    = "test.yjaf",
+    yjaf-preproduction           = "preproduction.yjaf",
+    yjaf-production              = "production.yjaf"
   }
 
   legalservices_records = {
@@ -194,6 +194,20 @@ resource "aws_route53_record" "portal" {
   alias {
     name                   = "d1yzmx9d5z0sdz.cloudfront.net"
     zone_id                = "Z2FDTNDATAQYW2"
+    evaluate_target_health = false
+  }
+}
+
+# aws.prd.legalservices.gov.uk record
+resource "aws_route53_record" "cwa-prod-db" {
+  # checkov:skip=CKV2_AWS_23: "Route53 A Record has Attached Resource"
+  zone_id = aws_route53_zone.private_application_zones["aws-prd-legalservices-gov-uk"].zone_id
+  name    = "cwa-prod-db"
+  type    = "A"
+
+  alias {
+    name                   = "cwa-production-database-nlb-12d44851fda0f196.elb.eu-west-2.amazonaws.com"
+    zone_id                = "ZD4D7Y8KGAS4G"
     evaluate_target_health = false
   }
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

LAA applications that need to communicate with components hosted on ECP require DNS resolution

## How does this PR fix the problem?

Adds a private hosted zone, record, and associates the PHZ with the LAA-Production VPC

## How has this been tested?

Tested through CI

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
