### PR TITLE
Associate `LAA-Production` with new private hosted zone

### DIFF
--- a/environments-networks/laa-production.json
+++ b/environments-networks/laa-production.json
@@ -29,7 +29,7 @@
       "com.amazonaws.eu-west-2.secretsmanager",
       "com.amazonaws.eu-west-2.email-smtp"
     ],
-    "additional_private_zones": [],
+    "additional_private_zones": ["aws.prd.legalservices.gov.uk"],
     "additional_vpcs": [],
     "dns_zone_extend": []
   }


### PR DESCRIPTION
## A reference to the issue / Description of it

Follow up to https://github.com/ministryofjustice/modernisation-platform/pull/11238

## How does this PR fix the problem?

This associates the VPC with the new private hosted zone; because the association requires the existence of the zone, the original PR was broken into two chunks.

## How has this been tested?

Tested through CI pipeline

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
