### PR TITLE
Removing Ewa's digital user from PD

### DIFF
--- a/terraform/pagerduty/locals.tf
+++ b/terraform/pagerduty/locals.tf
@@ -18,11 +18,6 @@ locals {
       email = "edward.proctor${local.justice_email_suffix}"
       role  = "user"
     },
-    ewa_stempel = {
-      name  = "Ewa Stempel"
-      email = "ewa.stempel${local.digital_email_suffix}"
-      role  = "user"
-    },
     sukesh_reddygade = {
       name  = "Sukesh Reddy Gade"
       email = "sukesh.reddygade${local.digital_email_suffix}"


### PR DESCRIPTION
Now that Ewa's justice user is added to the team and the schedule, deleting Ewa's digital user.

The automation may not have the permissions needed to delete the user, in which case, the clean up will be done manually.
The code still needs updating regardless though.