### PR TITLE
TM-1387 adding SIT team for db access

### DIFF
--- a/environments/delius-core.json
+++ b/environments/delius-core.json
@@ -44,6 +44,11 @@
           "sso_group_name": "probation-integration",
           "level": "developer",
           "github_action_reviewer": "false"
+        },
+        {
+          "sso_group_name": "version-1-sit-team",
+          "level": "developer",
+          "github_action_reviewer": "false"
         }
       ],
       "nuke": "exclude"
@@ -82,6 +87,11 @@
           "sso_group_name": "probation-integration",
           "level": "developer",
           "github_action_reviewer": "false"
+        },
+        {
+          "sso_group_name": "version-1-sit-team",
+          "level": "developer",
+          "github_action_reviewer": "false"
         }
       ]
     },
@@ -113,6 +123,11 @@
         },
         {
           "sso_group_name": "probation-integration",
+          "level": "developer",
+          "github_action_reviewer": "false"
+        },
+        {
+          "sso_group_name": "version-1-sit-team",
           "level": "developer",
           "github_action_reviewer": "false"
         }


### PR DESCRIPTION
## A reference to the issue / Description of it

SIT team needs access to Delius database in MP

## How does this PR fix the problem?

Adding SIT team to allow access to the account and databases.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

standard process to grant access to teams

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

no

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
