### PR TITLE
TM-1464: dso firewall improvements v6

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/production_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/production_rules.json
@@ -434,62 +434,6 @@
     "destination_port": "5439",
     "protocol": "TCP"
   },
-  "noms_mgmt_live_to_planetfm_production_sql_1434_udp": {
-    "action": "PASS",
-    "source_ip": "${noms-mgmt-live-vnet}",
-    "destination_ip": "${hmpps-production-general-private-subnets}",
-    "destination_port": "1434",
-    "protocol": "UDP"
-  },
-  "mojo_to_csr_production_http": {
-    "action": "PASS",
-    "source_ip": "${mojo-end-user-devices}",
-    "destination_ip": "${hmpps-production-general-private-subnets}",
-    "destination_port": "80",
-    "protocol": "TCP"
-  },
-  "mojo_to_csr_production_app_core_7770": {
-    "action": "PASS",
-    "source_ip": "${mojo-end-user-devices}",
-    "destination_ip": "${hmpps-production-general-private-subnets}",
-    "destination_port": "7770",
-    "protocol": "TCP"
-  },
-  "mojo_to_csr_production_app_core_7771": {
-    "action": "PASS",
-    "source_ip": "${mojo-end-user-devices}",
-    "destination_ip": "${hmpps-production-general-private-subnets}",
-    "destination_port": "7771",
-    "protocol": "TCP"
-  },
-  "mojo_to_csr_production_app_custom_7780": {
-    "action": "PASS",
-    "source_ip": "${mojo-end-user-devices}",
-    "destination_ip": "${hmpps-production-general-private-subnets}",
-    "destination_port": "7780",
-    "protocol": "TCP"
-  },
-  "mojo_to_csr_production_app_custom_7781": {
-    "action": "PASS",
-    "source_ip": "${mojo-end-user-devices}",
-    "destination_ip": "${hmpps-production-general-private-subnets}",
-    "destination_port": "7781",
-    "protocol": "TCP"
-  },
-  "mojo_to_csr_production_2109": {
-    "action": "PASS",
-    "source_ip": "${mojo-end-user-devices}",
-    "destination_ip": "${hmpps-production-general-private-subnets}",
-    "destination_port": "2109",
-    "protocol": "TCP"
-  },
-  "mojo_to_csr_production_45054": {
-    "action": "PASS",
-    "source_ip": "${mojo-end-user-devices}",
-    "destination_ip": "${hmpps-production-general-private-subnets}",
-    "destination_port": "45054",
-    "protocol": "TCP"
-  },
   "mp-prod-preprod_to_moj-smtp-relay-1": {
     "action": "PASS",
     "source_ip": "${mp-preproduction-production}",
@@ -516,48 +460,6 @@
     "source_ip": "${mp-preproduction-production}",
     "destination_ip": "${moj-smtp-relay2}",
     "destination_port": "587",
-    "protocol": "TCP"
-  },
-  "mojo_to_planetfm_production_netbios_137_udp": {
-    "action": "PASS",
-    "source_ip": "${mojo-end-user-devices}",
-    "destination_ip": "${hmpps-production-general-private-subnets}",
-    "destination_port": "137",
-    "protocol": "UDP"
-  },
-  "mojo_to_planetfm_production_smb_445_tcp": {
-    "action": "PASS",
-    "source_ip": "${mojo-end-user-devices}",
-    "destination_ip": "${hmpps-production-general-private-subnets}",
-    "destination_port": "445",
-    "protocol": "TCP"
-  },
-  "mojo_to_planetfm_production_sql_1433_tcp": {
-    "action": "PASS",
-    "source_ip": "${mojo-end-user-devices}",
-    "destination_ip": "${hmpps-production-general-private-subnets}",
-    "destination_port": "1433",
-    "protocol": "TCP"
-  },
-  "mojo_to_planetfm_production_sql_1434_udp": {
-    "action": "PASS",
-    "source_ip": "${mojo-end-user-devices}",
-    "destination_ip": "${hmpps-production-general-private-subnets}",
-    "destination_port": "1434",
-    "protocol": "UDP"
-  },
-  "mojo_to_planetfm_production_cfam_scheduling_7071_tcp": {
-    "action": "PASS",
-    "source_ip": "${mojo-end-user-devices}",
-    "destination_ip": "${hmpps-production-general-private-subnets}",
-    "destination_port": "7071",
-    "protocol": "TCP"
-  },
-  "mojo_to_planetfm_production_cafm_licensing_7073_tcp": {
-    "action": "PASS",
-    "source_ip": "${mojo-end-user-devices}",
-    "destination_ip": "${hmpps-production-general-private-subnets}",
-    "destination_port": "7073",
     "protocol": "TCP"
   },
   "data_engineering_to_hmpps_production_oracledb": {


### PR DESCRIPTION
## A reference to the issue / Description of it

Some DSO firewall rules are too wide, e.g. to and from Azure estate. Other DSO firewall rules can be simplified by use of IP sets and port sets. A series of PRs will tighten the existing firewall rules and simplify using IP/port sets. This will make the platform more secure, and the firewall rules will be easier to manage.

## How does this PR fix the problem?

Removes prod rules that have been superceded by portset introduced in https://github.com/ministryofjustice/modernisation-platform/pull/11256
Preprod rules have already been removed by https://github.com/ministryofjustice/modernisation-platform/pull/11258

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Validated the rules are subset of existing rules using a python script. Also applied to preprod first.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
