### PR TITLE
TM-1464: dso firewall rules improvements v7

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
@@ -337,14 +337,14 @@
     "destination_port": "636",
     "protocol": "TCP"
   },
-  "rfc_10-0-0-0-8_to_mp_hmpp_preproduction_http": {
+  "rfc1918_10-0-0-0-8_to_mp_hmpp_preproduction_http": {
     "action": "PASS",
     "source_ip": "10.0.0.0/8",
     "destination_ip": "${hmpps-preproduction}",
     "destination_port": "80",
     "protocol": "TCP"
   },
-  "rfc_10-0-0-0-8_to_mp_hmpps_preproduction_https": {
+  "rfc1918_10-0-0-0-8_to_mp_hmpps_preproduction_https": {
     "action": "PASS",
     "source_ip": "10.0.0.0/8",
     "destination_ip": "${hmpps-preproduction}",

--- a/terraform/environments/core-network-services/firewall-rules/production_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/production_rules.json
@@ -364,14 +364,14 @@
     "destination_port": "5432",
     "protocol": "TCP"
   },
-  "rfc_10-0-0-0-8_to_mp_hmpps_production_http": {
+  "rfc1918_10-0-0-0-8_to_mp_hmpps_production_http": {
     "action": "PASS",
     "source_ip": "10.0.0.0/8",
     "destination_ip": "${hmpps-production}",
     "destination_port": "80",
     "protocol": "TCP"
   },
-  "rfc_10-0-0-0-8_to_mp_hmpps_production_https": {
+  "rfc1918_10-0-0-0-8_to_mp_hmpps_production_https": {
     "action": "PASS",
     "source_ip": "10.0.0.0/8",
     "destination_ip": "${hmpps-production}",


### PR DESCRIPTION
## A reference to the issue / Description of it

Some DSO firewall rules are too wide, e.g. to and from Azure estate. Other DSO firewall rules can be simplified by use of IP sets and port sets. A series of PRs will tighten the existing firewall rules and simplify using IP/port sets. This will make the platform more secure, and the firewall rules will be easier to manage.

## How does this PR fix the problem?

At some point, a 10.0.0.0/8 rule has been added for end user compute in preprod and prod for HTTP/HTTPS which removes the need for some older HMPPS rules that can now be removed. The 10/8 rule is renamed to be consistent with naming, and a 10.0.0.0/8 HTTP is added for clarity (it's already allowed under a CSR set but some other HMPPS apps need it):

The following http/https HMPPS rules can all be removed as they are a subset of the wider 10/8 rules:
- gp (10.184.0.0/14)
- moj-core-azure-1 (10.50.25.0/27)
- moj-core-azure-2 (10.50.26.0/24)
- atos_arkc_ras (10.175.0.0/16)
- atos_arkf_ras (10.176.0.0/16)
- vodafone_wan_nicts_aggregate (10.80.0.0/12)
- parole_board (10.50.0.0/16)

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Validated the given rules are safe to remove using both a python script and a manual review

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
