### PR TITLE
Update collaborators_group module to v6.0

### DIFF
--- a/terraform/modernisation-platform-account/iam.tf
+++ b/terraform/modernisation-platform-account/iam.tf
@@ -13,17 +13,17 @@ module "iam" {
 module "collaborators_group" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   #checkov:skip=CKV_TF_2:Module registry does not support tags
-  source  = "terraform-aws-modules/iam/aws//modules/iam-group-with-policies"
-  version = "~> 5.0"
+  source  = "terraform-aws-modules/iam/aws//modules/iam-group"
+  version = "~> 6.0"
   name    = "collaborators"
 
-  group_users = [for user in module.collaborators : user.username]
+  users = [for user in module.collaborators : user.username]
 
-  custom_group_policy_arns = [
-    data.aws_iam_policy.ForceMFA.arn,
-    aws_iam_policy.collaborator_local_plan.arn,
-    aws_iam_policy.modernisation_account_limited_read.arn
-  ]
+  policies = {
+    ForceMFA                        = data.aws_iam_policy.ForceMFA.arn,
+    collaborator-local-plan         = aws_iam_policy.collaborator_local_plan.arn,
+    ModernisationAccountLimitedRead = aws_iam_policy.modernisation_account_limited_read.arn
+  }
 }
 
 data "aws_iam_policy" "ForceMFA" {


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/pull/11266
Dependabot noted a new [release](https://github.com/terraform-aws-modules/terraform-aws-iam/releases/tag/v6.0.0) is available to suppport v6.0

## How does this PR fix the problem?

Updates to v6.0 and changes naming conventions etc.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
