### PR TITLE
Fix file list encoding for workflow to prevent truncation and invalid format 

### DIFF
--- a/.github/workflows/new-environment.yml
+++ b/.github/workflows/new-environment.yml
@@ -464,8 +464,11 @@ jobs:
       - name: Get modified JSON files
         id: environment_json_changes
         run: |
-          files=$(git diff --name-only --diff-filter=M @^ -- 'environments/*.json' | uniq | sed 's#environments/##' | base64 )
-          echo "files=$files" >> $GITHUB_OUTPUT
+          files=$(git diff --name-only --diff-filter=M @^ -- 'environments/*.json' \
+          | uniq \
+          | sed 's#environments/##' \
+          | base64 -w0)
+          printf "files=%s\n" "$files" >> "$GITHUB_OUTPUT"     
       - name: Install Python
         if: steps.environment_json_changes.outputs.files != ''
         uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1


### PR DESCRIPTION
**Summary**
This PR updates the workflow step that collects modified `environments/*.json` files so that the file list is encoded and written to `$GITHUB_OUTPUT` in a format that GitHub Actions accepts.

**The problem**
Previously:
- `base64` inserted newlines by default, which broke the `$GITHUB_OUTPUT` format and caused
`Error: Invalid format` during execution.
- When decoding, some file names appeared truncated (e.g., `analytical-platform-compu`) due to how the list was being split and processed.

**The fix**
- Added `-w0` to the `base64` command to produce a single-line output with no embedded newlines.
- Kept filenames intact when decoding, ensuring that the full *`.json` names are passed to downstream steps.

**Benefits**
- Fixes the `"Invalid format"` error when updating multiple environments in a single PR.
- Ensures all filenames are processed correctly in Slack notifications and other workflow steps.