### PR TITLE
Allowing root account sso admins to access mp terraform state

### DIFF
--- a/terraform/modernisation-platform-account/s3.tf
+++ b/terraform/modernisation-platform-account/s3.tf
@@ -565,27 +565,12 @@ data "aws_iam_policy_document" "allow-state-access-for-root-account-sso-admins" 
   }
 
   statement {
-    sid       = "AllowGetObjectForRootAccountSSOAdmins"
+    sid       = "AllowGetAndPutObjectForRootAccountSSOAdmins"
     effect    = "Allow"
-    actions   = ["s3:GetObject"]
-    resources = ["${module.state-bucket.bucket.arn}/*"]
-
-    principals {
-      type        = "AWS"
-      identifiers = ["*"]
-    }
-
-    condition {
-      test     = "ArnEquals"
-      variable = "aws:PrincipalArn"
-      values   = ["arn:aws:iam::${data.aws_organizations_organization.root_account.master_account_id}:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_AdministratorAccess_*"]
-    }
-  }
-
-  statement {
-    sid       = "AllowPutObjectForRootAccountSSOAdmins"
-    effect    = "Allow"
-    actions   = ["s3:PutObject"]
+    actions   = [
+      "s3:GetObject",
+      "s3:PutObject",
+    ]
     resources = ["${module.state-bucket.bucket.arn}/*"]
 
     principals {


### PR DESCRIPTION
## A reference to the issue / Description of it
This is the first step to implement:
[{11168}](https://github.com/ministryofjustice/modernisation-platform/issues/11168) 

This is to add permissions for the root account SSO admins.

## How has this been tested?

The local terraform plan has been run with no errors and the plan shows the expected changes. The permission testing will happen after this is merged.

## Deployment Plan / Instructions

Deployment on merge

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
