### PR TITLE
Removing root account IAM users from the state bucket policy

### DIFF
--- a/terraform/modernisation-platform-account/locals.tf
+++ b/terraform/modernisation-platform-account/locals.tf
@@ -5,12 +5,7 @@ locals {
   pagerduty_integration_keys       = jsondecode(data.aws_secretsmanager_secret_version.pagerduty_integration_keys.secret_string)
   reduced_preprod_backup_retention = false
 
-  root_users_with_state_access = sort([ # also includes the organisation GHA Role
-    "arn:aws:iam::${local.root_account.master_account_id}:user/ModernisationPlatformOrganisationManagement",
-    "arn:aws:iam::${local.root_account.master_account_id}:user/DavidElliott",
-    "arn:aws:iam::${local.root_account.master_account_id}:user/EwaStempel",
-    "arn:aws:iam::${local.root_account.master_account_id}:role/ModernisationPlatformGithubActionsRole" # Role with the same permissions as ModernisationPlatformOrganisationManagement for Github OIDC
-  ])
+  root_role_with_state_access = ["arn:aws:iam::${local.root_account.master_account_id}:role/ModernisationPlatformGithubActionsRole"] # Role for Github OIDC
 
   collaborators = jsondecode(file("../../collaborators.json"))
 

--- a/terraform/modernisation-platform-account/s3.tf
+++ b/terraform/modernisation-platform-account/s3.tf
@@ -46,7 +46,7 @@ data "aws_iam_policy_document" "kms_state_bucket" {
       type = "AWS"
       identifiers = concat(
         ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"],
-        local.root_users_with_state_access
+        local.root_role_with_state_access
       )
     }
   }
@@ -164,37 +164,22 @@ data "aws_iam_policy_document" "allow-state-access-from-root-account" {
 
     principals {
       type        = "AWS"
-      identifiers = local.root_users_with_state_access
+      identifiers = local.root_role_with_state_access
     }
   }
 
   statement {
-    sid       = "AllowGetObjectsFromRootAccount"
+    sid       = "AllowGetandPutObjectFromRootAccount"
     effect    = "Allow"
-    actions   = ["s3:GetObject"]
+    actions   = [
+      "s3:GetObject",
+      "s3:PutObject"
+    ]
     resources = ["${module.state-bucket.bucket.arn}/*"]
 
     principals {
       type        = "AWS"
-      identifiers = local.root_users_with_state_access
-    }
-  }
-
-  statement {
-    sid       = "AllowPutObjectsFromRootAccounts"
-    effect    = "Allow"
-    actions   = ["s3:PutObject"]
-    resources = ["${module.state-bucket.bucket.arn}/*"]
-
-    principals {
-      type        = "AWS"
-      identifiers = local.root_users_with_state_access
-    }
-
-    condition {
-      test     = "StringEquals"
-      variable = "s3:x-amz-acl"
-      values   = ["bucket-owner-full-control"]
+      identifiers = local.root_role_with_state_access
     }
   }
 
@@ -206,7 +191,7 @@ data "aws_iam_policy_document" "allow-state-access-from-root-account" {
 
     principals {
       type        = "AWS"
-      identifiers = local.root_users_with_state_access
+      identifiers = local.root_role_with_state_access
     }
   }
 


### PR DESCRIPTION
## A reference to the issue / Description of it
This is to implement step 2 of the [{11168}](https://github.com/ministryofjustice/modernisation-platform/issues/11168) issue.

This is to remove permissions of the root account IAM users (Dave, myself and a headless user that is not being used and that has inactive keys that are 4 years old).

## How has this been tested?

The local terraform plan has been run with no errors and the plan shows the expected changes. The permission testing will happen after this is merged.

## Deployment Plan / Instructions

Deployment on merge

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}