### PR TITLE
TM-1464: dso firewall rules improvement v9 prod

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/production_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/production_rules.json
@@ -129,28 +129,28 @@
     "action": "PASS",
     "source_ip": "${noms-live-vnet}",
     "destination_ip": "${hmpps-production}",
-    "destination_port": "ANY",
+    "destination_port": "$AZURE_FIXNGO_MP_TCP",
     "protocol": "TCP"
   },
   "mp_hmpps_production_to_noms_live": {
     "action": "PASS",
     "source_ip": "${hmpps-production}",
     "destination_ip": "${noms-live-vnet}",
-    "destination_port": "ANY",
+    "destination_port": "$AZURE_FIXNGO_MP_TCP",
     "protocol": "TCP"
   },
   "noms_mgmt_live_to_mp_hmpps_production": {
     "action": "PASS",
     "source_ip": "${noms-mgmt-live-vnet}",
     "destination_ip": "${hmpps-production}",
-    "destination_port": "ANY",
+    "destination_port": "$AZURE_FIXNGO_MP_TCP",
     "protocol": "TCP"
   },
   "mp_hmpps_production_to_noms_mgmt_live": {
     "action": "PASS",
     "source_ip": "${hmpps-production}",
     "destination_ip": "${noms-mgmt-live-vnet}",
-    "destination_port": "ANY",
+    "destination_port": "$AZURE_FIXNGO_MP_TCP",
     "protocol": "TCP"
   },
   "mp_hmpps_production_to_dom1_dcs_TCP": {


### PR DESCRIPTION
## A reference to the issue / Description of it

Some DSO firewall rules are too wide, e.g. to and from Azure estate. Other DSO firewall rules can be simplified by use of IP sets and port sets. A series of PRs will tighten the existing firewall rules and simplify using IP/port sets. This will make the platform more secure, and the firewall rules will be easier to manage.

## How does this PR fix the problem?

This replaces the ANY rule for Azure FixNGo to MP prod with a set of ports. This has been running in devtest and preprod without issue since last week, see https://github.com/ministryofjustice/modernisation-platform/pull/11263

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Used a python script to help validate the new rule set against requirements.
Used VPC flow logs to verify ports actually in use between Azure and MP.
Applied to dev/test/preprod first to identify any potential issues.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

Risk is low - the only remaining resources in Azure which maybe affected by this change are Nomis and OASys reporting. I will notify users to keep an eye out for issues via DSO channels