### PR TITLE
✨ Add `Billing` & `OPERATIONS` Alternate Contact to `Modernisation Platform` Account

### DIFF
--- a/terraform/modernisation-platform-account/account.tf
+++ b/terraform/modernisation-platform-account/account.tf
@@ -1,0 +1,15 @@
+resource "aws_account_alternate_contact" "operations" {
+  alternate_contact_type = "OPERATIONS"
+  email_address          = "modernisation-platform@digital.justice.gov.uk"
+  name                   = "Modernisation Platform Team"
+  title                  = "Modernisation Platform Team"
+  phone_number           = "+0000000000"
+}
+
+resource "aws_account_alternate_contact" "billing" {
+  alternate_contact_type = "BILLING"
+  email_address          = "modernisation-platform@digital.justice.gov.uk"
+  name                   = "Modernisation Platform Team"
+  title                  = "Modernisation Platform Team"
+  phone_number           = "+0000000000"
+}


### PR DESCRIPTION
## A reference to the issue / Description of it

- The `Modernisation Platform` doesn't have any alternate contacts, meaning all comms are only sent to the root user email, which is only accessible by the Hosting Leads. Adding these alternate contacts means that the Modernisation Platform Team will start to receive communications about the `Modernisation Platform` Account

## How does this PR fix the problem?

- Adds the `Billing` & `OPERATIONS` Alternate Contact to `Modernisation Platform` Account - setting these values as the team email address

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

- Will be tested live

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

- No impact

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

- These alternate contacts may be used in the future by the SOC team to send security comms to account owners, so best we have them in place
- I've opted to use our `@digital.justice.gov.uk` email to keep it the same as all the other emails we have set. May want a seperate ticket to update to our `@justice.gov.uk` in the future.
