### PR TITLE
🔧 PR: Centralize Secret Decryption in Publish gh-pages Workflow

### DIFF
--- a/.github/workflows/publish-gh-pages.yml
+++ b/.github/workflows/publish-gh-pages.yml
@@ -9,13 +9,11 @@ on:
       - "source/**"
       - "config/**"
 
-# GITHUB_TOKEN permissions to allow deployment to GitHub Pages
 permissions:
   contents: read
   pages: write
   id-token: write
 
-# Allow one concurrent deployment
 concurrency:
   group: "pages"
   cancel-in-progress: true
@@ -27,21 +25,27 @@ jobs:
       MODERNISATION_PLATFORM_ACCOUNT_NUMBER: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_NUMBER }}
       PASSPHRASE: ${{ secrets.PASSPHRASE }}
 
-  build:
+  decrypt-secrets:
     runs-on: ubuntu-latest
     needs: fetch-secrets
+    outputs:
+      slack_webhook_url: ${{ steps.decrypt.outputs.slack_webhook_url }}
+    steps:
+      - name: Decrypt Slack webhook secret
+        id: decrypt
+        uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@7f78ec79dd45ec7db8966ecb619c85712d4e68d7 # v3.4.2
+        with:
+          PASSPHRASE: ${{ secrets.PASSPHRASE }}
+          slack_webhook_url: ${{ needs.fetch-secrets.outputs.slack_webhook_url }}
+
+  build:
+    runs-on: ubuntu-latest
+    needs: decrypt-secrets
     container:
       image: ghcr.io/ministryofjustice/tech-docs-github-pages-publisher@sha256:c55eb7a18eb667a2e616e16cf0918b26c1932fc03e6ad8e9bfe6961fd746692e # v6.0.1
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-
-      - name: Decrypt Slack webhook secret
-        id: decrypt-slack
-        uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@7f78ec79dd45ec7db8966ecb619c85712d4e68d7 # v3.4.2
-        with:
-          PASSPHRASE: ${{ secrets.PASSPHRASE }}
-          slack_webhook_url: ${{ needs.fetch-secrets.outputs.slack_webhook_url }}
 
       - name: Compile Markdown to HTML and create artifact
         run: /usr/local/bin/package
@@ -61,22 +65,18 @@ jobs:
             {"blocks":[{"type": "section","text": {"type": "mrkdwn","text": ":no_entry: Failed GitHub Action:"}},{"type": "section","fields":[{"type": "mrkdwn","text": "*Workflow:*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>"},
             {"type": "mrkdwn","text": "*Job:*\n${{ github.job }}"},{"type": "mrkdwn","text": "*Repo:*\n${{ github.repository }}"}]}]}
         env:
-          SLACK_WEBHOOK_URL: ${{ steps.decrypt-slack.outputs.slack_webhook_url }}
+          SLACK_WEBHOOK_URL: ${{ needs.decrypt-secrets.outputs.slack_webhook_url }}
         if: ${{ failure() }}
 
   deploy:
-    needs: [build, fetch-secrets]
     runs-on: ubuntu-latest
+    needs: [build, decrypt-secrets]
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - name: Decrypt Slack webhook secret
-        id: decrypt-slack
-        uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@7f78ec79dd45ec7db8966ecb619c85712d4e68d7 # v3.4.2
-        with:
-          PASSPHRASE: ${{ secrets.PASSPHRASE }}
-          slack_webhook_url: ${{ needs.fetch-secrets.outputs.slack_webhook_url }}
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Setup Pages
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
@@ -93,5 +93,5 @@ jobs:
             {"blocks":[{"type": "section","text": {"type": "mrkdwn","text": ":no_entry: Failed GitHub Action:"}},{"type": "section","fields":[{"type": "mrkdwn","text": "*Workflow:*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>"},
             {"type": "mrkdwn","text": "*Job:*\n${{ github.job }}"},{"type": "mrkdwn","text": "*Repo:*\n${{ github.repository }}"}]}]}
         env:
-          SLACK_WEBHOOK_URL: ${{ steps.decrypt-slack.outputs.slack_webhook_url }}
+          SLACK_WEBHOOK_URL: ${{ needs.decrypt-secrets.outputs.slack_webhook_url }}
         if: ${{ failure() }}


### PR DESCRIPTION
**Summary**
This PR refactors the `Publish gh-pages` GitHub Actions workflow to centralise the decryption of secrets in a dedicated job (`decrypt-secrets`) that runs immediately after `fetch-secrets`. This avoids duplicating decryption logic across jobs and resolves container-related failures caused by missing dependencies (bash, gpg).

**✅ Changes**
- Added a new decrypt-secrets job that:
  - Runs outside of any container.
  - Decrypts the slack_webhook_url using the decrypt-secrets action.
  - Exposes the decrypted value as a job output.
- Updated build and deploy jobs to:
  - Depend on decrypt-secrets.
  - Use the decrypted Slack webhook via needs.decrypt-secrets.outputs.slack_webhook_url.
   - Removed inline decryption steps from container jobs.

**🐛 Problem Solved**
Previously, the `decrypt-secrets` step was executed inside a container that lacked required tools (bash, gpg), causing the job to fail with:

> OCI runtime exec failed: exec failed: unable to start container process: exec: "bash": executable file not found in $PATH

This PR resolves that by moving decryption to a standard runner environment.