### PR TITLE
Remove access to connectivity test vpc

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/production_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/production_rules.json
@@ -475,12 +475,5 @@
     "destination_ip": "${laa-ecp-safedb}",
     "destination_port": "2484",
     "protocol": "TCP"
-  },
-  "laa_production_to_laa_ecp_443": {
-    "action": "PASS",
-    "source_ip": "${laa-production}",
-    "destination_ip": "${laa-ecp-conntest}",
-    "destination_port": "443",
-    "protocol": "TCP"
   }
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

N/A

## How does this PR fix the problem?

ECP will be removing the connectivity test VPC as it's served its purpose.

## How has this been tested?

Tested through CI checks

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
