### PR TITLE
GH OIDC role for VPN Maintenance

### DIFF
--- a/terraform/environments/core-network-services/iam.tf
+++ b/terraform/environments/core-network-services/iam.tf
@@ -257,3 +257,25 @@ resource "aws_iam_role_policy" "read_firewall" {
     ]
   })
 }
+
+# GitHub OIDC Role assumed by GitHub Actions workflows to perform VPN maintenance tasks
+module "vpn-maintenance-oidc" {
+  source                 = "github.com/ministryofjustice/modernisation-platform-github-oidc-provider?ref=5dc9bc211d10c58de4247fa751c318a3985fc87b" # v4.0.0
+  role_name              = "github-actions-vpn-maintenance"
+  github_repositories    = local.github_repository_environments_from_vpns
+  additional_permissions = data.aws_iam_policy_document.vpn_maintenance_permissions.json
+  tags_common            = { "Name" = format("%s-oidc", terraform.workspace) }
+  tags_prefix            = ""
+}
+
+data "aws_iam_policy_document" "vpn_maintenance_permissions" {
+  version = "2012-10-17"
+  statement {
+    effect = "Allow"
+    actions = [
+      "ec2:DescribeVpnConnections",
+      "ec2:ReplaceVpnTunnel"
+    ]
+    resources = local.vpn_lifecycle_control_arns
+  }
+}

--- a/terraform/environments/core-network-services/vpn.tf
+++ b/terraform/environments/core-network-services/vpn.tf
@@ -65,6 +65,7 @@ resource "aws_vpn_connection" "this" {
   tags = merge(
     local.tags,
     { "Name" = replace(each.key, "_", "-") },
+    try({ "github-environment" = each.value.github_environment }, {})
   )
 
   lifecycle {

--- a/terraform/environments/core-network-services/vpn_attachments.json
+++ b/terraform/environments/core-network-services/vpn_attachments.json
@@ -4,6 +4,7 @@
     "customer_gateway_ip": "20.254.177.179",
     "dx_gateway_id": "",
     "dx_gateway_owner_account_id": "",
+    "github_environment": "nomis-production",
     "remote_ipv4_network_cidr": "0.0.0.0/0",
     "tunnel1_inside_cidr": "169.254.21.128/30",
     "tunnel2_inside_cidr": "169.254.22.128/30",
@@ -18,6 +19,7 @@
     "customer_gateway_ip": "20.254.177.202",
     "dx_gateway_id": "",
     "dx_gateway_owner_account_id": "",
+    "github_environment": "nomis-production",
     "remote_ipv4_network_cidr": "0.0.0.0/0",
     "tunnel1_inside_cidr": "169.254.21.132/30",
     "tunnel2_inside_cidr": "169.254.22.132/30",
@@ -47,6 +49,7 @@
   "YJB-Juniper-vSRX01-VPN": {
     "bgp_asn": "64523",
     "customer_gateway_ip": "35.176.77.66",
+    "github_environment": "youth-justice-networking-production",
     "remote_ipv4_network_cidr": "0.0.0.0/0",
     "static_routes_only": true,
     "tunnel1_inside_cidr": "169.254.21.140/30",
@@ -68,6 +71,7 @@
   "YJB-Juniper-vSRX02-VPN": {
     "bgp_asn": "64523",
     "customer_gateway_ip": "3.9.228.137",
+    "github_environment": "youth-justice-networking-production",
     "remote_ipv4_network_cidr": "0.0.0.0/0",
     "static_routes_only": true,
     "tunnel1_inside_cidr": "169.254.21.144/30",


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/11200

## How does this PR fix the problem?

This PR does the following:

1. Creates a new github oidc role to allow a GitHub actions workflow to carry out VPN maintenance on VPNs with tunnel lifecycle control enabled
1. Adds a `github-environment` tag to VPNS with tunnel lifecycle control enabled using an appropriate GH team

Another PR will generate a GH workflow in the MP Environments repo which will use the OIDC role to...
1. Query the `github-environment` tag of the VPN the user is trying to maintain
1. Pin the maintenance job in the workflow to the relevant github environment


## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
