### PR TITLE
Giving github team access to HUB 2.0 Dev account

### DIFF
--- a/environments/laa-enterprise-service-bus.json
+++ b/environments/laa-enterprise-service-bus.json
@@ -12,6 +12,10 @@
         {
           "sso_group_name": "v1-hub20-developers",
           "level": "sandbox"
+        },
+        {
+          "sso_group_name": "hub20-validation",
+          "level": "sandbox"
         }
       ],
       "nuke": "exclude"


### PR DESCRIPTION
## A reference to the issue / Description of it

Giving the hub20-validation github team access to the laa-enterprise-service-bus-development account

## How does this PR fix the problem?

{Please write here}

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
