### PR TITLE
Added DMS vpc endpoint to production

### DIFF
--- a/environments-networks/hmpps-production.json
+++ b/environments-networks/hmpps-production.json
@@ -35,6 +35,7 @@
     "additional_cidrs": [],
     "additional_endpoints": [
       "com.amazonaws.eu-west-2.athena",
+      "com.amazonaws.eu-west-2.dms",
       "com.amazonaws.eu-west-2.email-smtp",
       "com.amazonaws.eu-west-2.execute-api",
       "com.amazonaws.eu-west-2.glue",


### PR DESCRIPTION
## A reference to the issue / Description of it
I am creating a DMS extract validation service. Within the Lambda I need communicate to the dms api via boto3 to retrieve the Replication Task Name via its arn value (which is provided from the DMS Task Complete Event)

## How does this PR fix the problem?

Allows communication to the dms endpoint

## How has this been tested?

Manual Testing in Dev - Successful State Machine &  Lambda Execution (Print Screens below)

<img width="3030" height="904" alt="image" src="https://github.com/user-attachments/assets/fc1ef096-79ff-49d0-acf8-e29048c9b3f8" />
<img width="3048" height="1038" alt="image" src="https://github.com/user-attachments/assets/fe5b720c-8c42-45ab-bfbd-cee43b691ca8" />



## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

N/A

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [X] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)
