### PR TITLE
Add New OIDC Role for VPN environment check

### DIFF
--- a/terraform/environments/core-network-services/iam.tf
+++ b/terraform/environments/core-network-services/iam.tf
@@ -259,7 +259,28 @@ resource "aws_iam_role_policy" "read_firewall" {
 }
 
 # GitHub OIDC Role assumed by GitHub Actions workflows to perform VPN maintenance tasks
-module "vpn-maintenance-oidc" {
+
+module "vpn_environment_check_oidc" {
+  source                      = "github.com/ministryofjustice/modernisation-platform-github-oidc-provider?ref=6dd6f177091fb1664998aa37a1d0d5cf5894c10a" # v4.2.0
+  role_name                   = "github-actions-vpn-maintenance"
+  create_github_oidc_provider = false
+  github_repositories         = ["ministryofjustice/modernisation-platform-environments:*"]
+  additional_permissions      = data.aws_iam_policy_document.vpn_environment_check_permissions.json
+  tags_common                 = { "Name" = format("%s-oidc", terraform.workspace) }
+  tags_prefix                 = ""
+}
+
+data "aws_iam_policy_document" "vpn_environment_check_permissions" {
+  version = "2012-10-17"
+  statement {
+    effect = "Allow"
+    actions = [
+      "ec2:DescribeVpnConnections"
+    ]
+    resources = local.vpn_lifecycle_control_arns
+  }
+}
+module "vpn_maintenance_oidc" {
   source                      = "github.com/ministryofjustice/modernisation-platform-github-oidc-provider?ref=6dd6f177091fb1664998aa37a1d0d5cf5894c10a" # v4.2.0
   role_name                   = "github-actions-vpn-maintenance"
   create_github_oidc_provider = false


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/11200

## How does this PR fix the problem?

Adds a separate OIDC role used to verify the environment to use for VPN maintenance. 

This is deliberately more open as you cannot limit to an environment until you know which one to limit it to.

This is the associated draft PR with the workflow https://github.com/ministryofjustice/modernisation-platform-environments/pull/12675

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
