### PR TITLE
Update VPN OIDC role name to make it unique

### DIFF
--- a/terraform/environments/core-network-services/iam.tf
+++ b/terraform/environments/core-network-services/iam.tf
@@ -262,7 +262,7 @@ resource "aws_iam_role_policy" "read_firewall" {
 
 module "vpn_environment_check_oidc" {
   source                      = "github.com/ministryofjustice/modernisation-platform-github-oidc-provider?ref=6dd6f177091fb1664998aa37a1d0d5cf5894c10a" # v4.2.0
-  role_name                   = "github-actions-vpn-maintenance"
+  role_name                   = "github-actions-vpn-environment-check"
   create_github_oidc_provider = false
   github_repositories         = ["ministryofjustice/modernisation-platform-environments:*"]
   additional_permissions      = data.aws_iam_policy_document.vpn_environment_check_permissions.json


### PR DESCRIPTION
## A reference to the issue / Description of it

This job errored https://github.com/ministryofjustice/modernisation-platform/actions/runs/17318196272/job/49165281553#step:17:1323
due to duplicate role names for the VPN OIDC roles

## How does this PR fix the problem?

Updates name tag for new role so that it is unique

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
