### PR TITLE
HUB-136, adding firewall rule so HUB 2.0 Lambdas in MP LAA Test can c…

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/test_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/test_rules.json
@@ -244,6 +244,13 @@
     "destination_port": "$LAA_MAAT_TCP",
     "protocol": "TCP"
   },
+  "mp_laa_test_to_laa_uat_hub20": {
+    "action": "PASS",
+    "source_ip": "${laa-test}",
+    "destination_ip": "${laa-lz-uat}",
+    "destination_port": "1521",
+    "protocol": "TCP"
+  },
   "laa_shared_services_nonprod_to_mp_laa_test": {
     "action": "PASS",
     "source_ip": "${laa-lz-shared-services-nonprod}",

--- a/terraform/environments/core-network-services/firewall-rules/test_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/test_rules.json
@@ -248,7 +248,7 @@
     "action": "PASS",
     "source_ip": "${laa-test}",
     "destination_ip": "${laa-lz-uat}",
-    "destination_port": "1521",
+    "destination_port": "1571",
     "protocol": "TCP"
   },
   "laa_shared_services_nonprod_to_mp_laa_test": {


### PR DESCRIPTION
…onnect to LZ UAT through port 1521

## A reference to the issue / Description of it

HUB 2.0 Lambda in Test env needs to be able to connect to CWA Database instance in LZ UAT through port 1571

## How does this PR fix the problem?

{Please write here}

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
