### PR TITLE
Retro experiment - Add kanban label to issues automatically

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-collaborator.yml
+++ b/.github/ISSUE_TEMPLATE/new-collaborator.yml
@@ -1,114 +1,114 @@
 name: New Collaborator
 description: Add a Modernisation Platform collaborator.
 title: "New collaborator: "
-labels: ["collaborator"]
+labels: [ "collaborator", "kanban" ]
 body:
-  - type: markdown
-    attributes:
-      value: |
-        Please complete this template to facilitate adding a new external collaborator.
-  - type: markdown
-    attributes:
-      value: "## Requestor details"
-  - type: input
-    id: requestor-name
-    attributes:
-      label: Requestor name
-      description: The full name of the person making this request.
-      placeholder: e.g., Bilbo Baggins
-    validations:
-      required: true
-  - type: input
-    id: requestor-slack
-    attributes:
-      label: Requestor Slack handle
-      description: The Slack handle of the person making this request.
-      placeholder: e.g., @bilbo-baggins
-    validations:
-      required: true
-  - type: markdown
-    attributes:
-      value: "## Collaborator details"
-  - type: input
-    id: collaborator-name
-    attributes:
-      label: Collaborator name
-      description: The full name of the new external collaborator.
-      placeholder: e.g., Frodo Baggins
-    validations:
-      required: true
-  - type: dropdown
-    id: collaborator-email
-    attributes:
-      label: Collaborator email address
-      description: Can you provide a valid email address for the new external collaborator?
-      options:
-        - "Yes"
-        - "No"
-    validations:
-      required: true
-  - type: input
-    id: collaborator-github
-    attributes:
-      label: Collaborator GitHub username
-      description: The GitHub username of the new external collaborator.
-      placeholder: e.g., Ffffrodo
-    validations:
-      required: true
-  - type: input
-    id: collaborator-application
-    attributes:
-      label: Collaborator requested application
-      description: The name of the Modernisation Platform application that new external collaborator requires access to.
-      placeholder: e.g., `rivendell`
-    validations:
-      required: true
-  - type: textarea
-    id: collaborator-account-access
-    attributes:
-      label: Collaborator required accounts and access levels
-      description: Which application accounts and access levels does the new external collaborator require?
-      placeholder: |
-        ```
-        {
-          "account-name": "rivendell-development",
-          "access": "ring-bearer"
-        },
-        ```
-      value: |        
-        ```
-        {
-          "account-name": "$account-$environment",
-          "access": "read-only"
-        },
-        ```
-      render: json
-    validations:
-      required: true
-  - type: markdown
-    attributes:
-      value: "## Additional information"
-  - type: markdown
-    attributes:
-      value: |
-        Does this collaborator need `push` permissions for the following repositories?
-        - [ ] "modernisation-platform-environments"
-        - [ ] "modernisation-platform-ami-builds"
-  - type: dropdown
-    id: additional-approve-deployments
-    attributes:
-      label: Additional deployment approval access
-      description: Does this collaborator need the ability to approve deployments through GitHub Actions?
-      options:
-        - "Yes"
-        - "No"
-    validations:
-      required: false
-  - type: textarea
-    id: additional-information
-    attributes:
-      label: Additional information
-      description: Add any supporting information which relates to your request here.
-      render: markdown
-    validations:
-      required: false
+- type: markdown
+  attributes:
+    value: |
+      Please complete this template to facilitate adding a new external collaborator.
+- type: markdown
+  attributes:
+    value: "## Requestor details"
+- type: input
+  id: requestor-name
+  attributes:
+    label: Requestor name
+    description: The full name of the person making this request.
+    placeholder: e.g., Bilbo Baggins
+  validations:
+    required: true
+- type: input
+  id: requestor-slack
+  attributes:
+    label: Requestor Slack handle
+    description: The Slack handle of the person making this request.
+    placeholder: e.g., @bilbo-baggins
+  validations:
+    required: true
+- type: markdown
+  attributes:
+    value: "## Collaborator details"
+- type: input
+  id: collaborator-name
+  attributes:
+    label: Collaborator name
+    description: The full name of the new external collaborator.
+    placeholder: e.g., Frodo Baggins
+  validations:
+    required: true
+- type: dropdown
+  id: collaborator-email
+  attributes:
+    label: Collaborator email address
+    description: Can you provide a valid email address for the new external collaborator?
+    options:
+    - "Yes"
+    - "No"
+  validations:
+    required: true
+- type: input
+  id: collaborator-github
+  attributes:
+    label: Collaborator GitHub username
+    description: The GitHub username of the new external collaborator.
+    placeholder: e.g., Ffffrodo
+  validations:
+    required: true
+- type: input
+  id: collaborator-application
+  attributes:
+    label: Collaborator requested application
+    description: The name of the Modernisation Platform application that new external collaborator requires access to.
+    placeholder: e.g., `rivendell`
+  validations:
+    required: true
+- type: textarea
+  id: collaborator-account-access
+  attributes:
+    label: Collaborator required accounts and access levels
+    description: Which application accounts and access levels does the new external collaborator require?
+    placeholder: |
+      ```
+      {
+        "account-name": "rivendell-development",
+        "access": "ring-bearer"
+      },
+      ```
+    value: |
+      ```
+      {
+        "account-name": "$account-$environment",
+        "access": "read-only"
+      },
+      ```
+    render: json
+  validations:
+    required: true
+- type: markdown
+  attributes:
+    value: "## Additional information"
+- type: markdown
+  attributes:
+    value: |
+      Does this collaborator need `push` permissions for the following repositories?
+      - [ ] "modernisation-platform-environments"
+      - [ ] "modernisation-platform-ami-builds"
+- type: dropdown
+  id: additional-approve-deployments
+  attributes:
+    label: Additional deployment approval access
+    description: Does this collaborator need the ability to approve deployments through GitHub Actions?
+    options:
+    - "Yes"
+    - "No"
+  validations:
+    required: false
+- type: textarea
+  id: additional-information
+  attributes:
+    label: Additional information
+    description: Add any supporting information which relates to your request here.
+    render: markdown
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/new-environment.yml
+++ b/.github/ISSUE_TEMPLATE/new-environment.yml
@@ -1,227 +1,227 @@
 name: New Modernisation Platform Environment
 description: Request a new Modernisation Platform Environment
-labels: ["onboarding", "member request"]
+labels: [ "onboarding", "member request", "kanban" ]
 body:
-  - type: markdown
-    attributes:
-      value: |
-        Please complete the following details and submit the new issue.
-  - type: textarea
-    id: environment-details
-    attributes:
-      label: Environment details
-      value:
-    validations:
-      required: true
-  - type: input
-    id: app-name
-    attributes: 
-      label: Application Name
-      description: Name of the application being created. The name must be in lowercase and a maximum of 30 characters and also follow MoJ guidance for naming things https://ministryofjustice.github.io/technical-guidance/documentation/standards/naming-things.html#naming-things
-      value:
-    validations:
-      required: true
-  - type: textarea
-    id: app-description
-    attributes:
-      label: Description of application
-      description: Brief description of the application and what it looks like. What does the application do?, What technologies does it use?
-      value:
-    validations:
-      required: true
-  - type: input
-    id: sso-group-name
-    attributes:
-      label: SSO Group Name
-      description: The Identity Center group name used for SSO, which can be a GitHub team name. This github team must be part of the ministryofjustice github organisation. You can have multiple GitHub teams with different access levels if required.
-      value:
-    validations:
-      required: true
-  - type: input
-    id: codeowners
-    attributes:
-      label: GitHub code owner team slug
-      description: By default members of the github team/s specified can both access the aws environments and approve pull requests to release changes. If you would like to seperate the permissions so that a different github team acts as a code owner to review changes before they are released then specify this here.
-      value:
-    validations:
-      required: false
-  - type: input
-    id: github_action_reviewers
-    attributes:
-      label: GitHub actions reviewer team slug
-      description: By default members of the github team/s specified can both access the aws environments and approve Github action runs. If you would like to seperate the permissions so that a different github team can review these, then specify this here.
-      value:
-    validations:
-      required: false
-  - type: checkboxes
-    id: environment
-    attributes:
-      label: Environments
-      description: Which environments would you like for your application, (we recommend production and one non production environment if possible),The access level determines what actions you can do in the AWS console, see here for more information see https://user-guide.modernisation-platform.service.justice.gov.uk/user-guide/creating-environments.html#access. Choose one access level per environment.
-      options: 
-        - label: Development
-        - label: test
-        - label: Preproduction
-        - label: Production
-    validations:
-      required: true
-  - type: dropdown
-    id: environment-access-dev
-    attributes:
-      label: Environment access level Development
-      description:
-      multiple: true 
-      options:
-        - view-only
-        - developer
-        - sandbox
-    validations:
-      required: false
-  - type: dropdown
-    id: environment-access-test
-    attributes:
-      label: Environment access level Test
-      description:
-      multiple: true 
-      options:
-        - view-only
-        - developer
-        - sandbox
-    validations:
-      required: false
-  - type: dropdown
-    id: environment-access-preprod
-    attributes:
-      label: Environment access level Preproduction
-      description:
-      multiple: true 
-      options:
-        - view-only
-        - developer
-        - sandbox
-    validations:
-      required: false
-  - type: dropdown
-    id: environment-access-production
-    attributes:
-      label: Environment access level Production
-      description:
-      multiple: true
-      options:
-        - view-only
-        - developer
-        - sandbox
-    validations:
-      required: false
-  - type: markdown
-    attributes:
-      value: |
-        ## Tags
-        These will be used to tag your AWS resources, for further details on tagging please see here 
-        https://ministryofjustice.github.io/technical-guidance/documentation/standards/documenting-infrastructure-owners.html#tags-you-should-use
+- type: markdown
+  attributes:
+    value: |
+      Please complete the following details and submit the new issue.
+- type: textarea
+  id: environment-details
+  attributes:
+    label: Environment details
+    value:
+  validations:
+    required: true
+- type: input
+  id: app-name
+  attributes:
+    label: Application Name
+    description: Name of the application being created. The name must be in lowercase and a maximum of 30 characters and also follow MoJ guidance for naming things https://ministryofjustice.github.io/technical-guidance/documentation/standards/naming-things.html#naming-things
+    value:
+  validations:
+    required: true
+- type: textarea
+  id: app-description
+  attributes:
+    label: Description of application
+    description: Brief description of the application and what it looks like. What does the application do?, What technologies does it use?
+    value:
+  validations:
+    required: true
+- type: input
+  id: sso-group-name
+  attributes:
+    label: SSO Group Name
+    description: The Identity Center group name used for SSO, which can be a GitHub team name. This github team must be part of the ministryofjustice github organisation. You can have multiple GitHub teams with different access levels if required.
+    value:
+  validations:
+    required: true
+- type: input
+  id: codeowners
+  attributes:
+    label: GitHub code owner team slug
+    description: By default members of the github team/s specified can both access the aws environments and approve pull requests to release changes. If you would like to seperate the permissions so that a different github team acts as a code owner to review changes before they are released then specify this here.
+    value:
+  validations:
+    required: false
+- type: input
+  id: github_action_reviewers
+  attributes:
+    label: GitHub actions reviewer team slug
+    description: By default members of the github team/s specified can both access the aws environments and approve Github action runs. If you would like to seperate the permissions so that a different github team can review these, then specify this here.
+    value:
+  validations:
+    required: false
+- type: checkboxes
+  id: environment
+  attributes:
+    label: Environments
+    description: Which environments would you like for your application, (we recommend production and one non production environment if possible),The access level determines what actions you can do in the AWS console, see here for more information see https://user-guide.modernisation-platform.service.justice.gov.uk/user-guide/creating-environments.html#access. Choose one access level per environment.
+    options:
+    - label: Development
+    - label: test
+    - label: Preproduction
+    - label: Production
+  validations:
+    required: true
+- type: dropdown
+  id: environment-access-dev
+  attributes:
+    label: Environment access level Development
+    description:
+    multiple: true
+    options:
+    - view-only
+    - developer
+    - sandbox
+  validations:
+    required: false
+- type: dropdown
+  id: environment-access-test
+  attributes:
+    label: Environment access level Test
+    description:
+    multiple: true
+    options:
+    - view-only
+    - developer
+    - sandbox
+  validations:
+    required: false
+- type: dropdown
+  id: environment-access-preprod
+  attributes:
+    label: Environment access level Preproduction
+    description:
+    multiple: true
+    options:
+    - view-only
+    - developer
+    - sandbox
+  validations:
+    required: false
+- type: dropdown
+  id: environment-access-production
+  attributes:
+    label: Environment access level Production
+    description:
+    multiple: true
+    options:
+    - view-only
+    - developer
+    - sandbox
+  validations:
+    required: false
+- type: markdown
+  attributes:
+    value: |
+      ## Tags
+      These will be used to tag your AWS resources, for further details on tagging please see here 
+      https://ministryofjustice.github.io/technical-guidance/documentation/standards/documenting-infrastructure-owners.html#tags-you-should-use
 
-        The is-production tag will be inferred from the environment and is not needed here
-  - type: input
-    id: tag1
-    attributes:
-      label: application 
-      value: 
-    validations:
-      required: true
-  - type: input
-    id: tag2
-    attributes:
-      label: business-unit 
-      value: 
-    validations:
-      required: true
-  - type: input
-    id: tag3
-    attributes:
-      label: infrastructure-support 
-      value: 
-    validations:
-      required: true
-  - type: input
-    id: tag4
-    attributes:
-      label: owner 
-      value: 
-    validations:
-      required: true
-  - type: markdown
-    attributes:
-      value: "Valid business-unit values | HQ,HMPPS,OPG,LAA,HMCTS,CICA,Platforms,CJSE | The infrastructure-support tag should be an email address which will receive AWS Health Operations emails."
-  - type: markdown
-    attributes:
-      value: |
-        ## Networking options
-        If your application requires supplementary AWS VPC Endpoints please see our guidance [here](https://user-guide.modernisation-platform.service.justice.gov.uk/user-guide/adding-vpc-endpoints.)
-  - type: checkboxes
-    id: subnet-sets
-    attributes:
-      label: Subnet sets
-      description: Please choose one of the below, most applications will use the general subnet set for their business unit. This means that they will benefit from out of the box connectivity to other applications, most applications will use the general subnet.  If an application has highly sensitive data it may need to go into a subnet with limited connectivity.
-      options:
-        - label: General
-        - label: Isolated
-    validations:    
-      required: true
-  - type: dropdown
-    id: app-connect
-    attributes:
-      label: How do users connect to the application
-      description: 
-      multiple: false
-      options:
-        - Over the public internet
-        - With a purple cabled device (please give details)
-        - With a MoJ Official device
-    validations:
-      required: true
-  - type: markdown
-    attributes:
-      value: "### Connectivity to other applications or external parties"
-  - type: markdown
-    attributes:
-      value: Please detail here and connectivity that your application needs, eg to other applications or external parties
-  - type: textarea
-    id: add-feat
-    attributes:
-      label: Additional features
-      description: For more information see here https://user-guide.modernisation-platform.service.justice.gov.uk/user-guide/creating-networking.html#certificate-services If you are not sure you can leave these blank and they can be added at a later date
-      value:
+      The is-production tag will be inferred from the environment and is not needed here
+- type: input
+  id: tag1
+  attributes:
+    label: application
+    value:
+  validations:
+    required: true
+- type: input
+  id: tag2
+  attributes:
+    label: business-unit
+    value:
+  validations:
+    required: true
+- type: input
+  id: tag3
+  attributes:
+    label: infrastructure-support
+    value:
+  validations:
+    required: true
+- type: input
+  id: tag4
+  attributes:
+    label: owner
+    value:
+  validations:
+    required: true
+- type: markdown
+  attributes:
+    value: "Valid business-unit values | HQ,HMPPS,OPG,LAA,HMCTS,CICA,Platforms,CJSE | The infrastructure-support tag should be an email address which will receive AWS Health Operations emails."
+- type: markdown
+  attributes:
+    value: |
+      ## Networking options
+      If your application requires supplementary AWS VPC Endpoints please see our guidance [here](https://user-guide.modernisation-platform.service.justice.gov.uk/user-guide/adding-vpc-endpoints.)
+- type: checkboxes
+  id: subnet-sets
+  attributes:
+    label: Subnet sets
+    description: Please choose one of the below, most applications will use the general subnet set for their business unit. This means that they will benefit from out of the box connectivity to other applications, most applications will use the general subnet.  If an application has highly sensitive data it may need to go into a subnet with limited connectivity.
+    options:
+    - label: General
+    - label: Isolated
+  validations:
+    required: true
+- type: dropdown
+  id: app-connect
+  attributes:
+    label: How do users connect to the application
+    description:
+    multiple: false
+    options:
+    - Over the public internet
+    - With a purple cabled device (please give details)
+    - With a MoJ Official device
+  validations:
+    required: true
+- type: markdown
+  attributes:
+    value: "### Connectivity to other applications or external parties"
+- type: markdown
+  attributes:
+    value: Please detail here and connectivity that your application needs, eg to other applications or external parties
+- type: textarea
+  id: add-feat
+  attributes:
+    label: Additional features
+    description: For more information see here https://user-guide.modernisation-platform.service.justice.gov.uk/user-guide/creating-networking.html#certificate-services If you are not sure you can leave these blank and they can be added at a later date
+    value:
 
-        Please check any additional features required 
+      Please check any additional features required
 
-        - [ ] Additional VPC Endpoints
+      - [ ] Additional VPC Endpoints
 
-        - [ ] Extended DNS Zones
+      - [ ] Extended DNS Zones
 
-        - [ ] Other - please specify
+      - [ ] Other - please specify
 
-    validations:
-      required: true
-  - type: textarea
-    id: other-info
-    attributes:
-      label: Other information
-      description: Any other information you feel is relevant, please remember this is a public repository
-      value:
-    validations:
-      required: 
-  - type: textarea
-    id: dod
-    attributes:
-      description: Please clearly and concisely detail the Definition of Done.
-      label: Definition of Done
-      value:
-        
-        Definition of Done
-        
-        - [ ] account created
+  validations:
+    required: true
+- type: textarea
+  id: other-info
+  attributes:
+    label: Other information
+    description: Any other information you feel is relevant, please remember this is a public repository
+    value:
+  validations:
+    required:
+- type: textarea
+  id: dod
+  attributes:
+    description: Please clearly and concisely detail the Definition of Done.
+    label: Definition of Done
+    value:
 
-        - [ ] customer informed
+      Definition of Done
 
-    validations:
-      required: true
+      - [ ] account created
+
+      - [ ] customer informed
+
+  validations:
+    required: true

--- a/.github/workflows/secrets-rotation-reminder.yml
+++ b/.github/workflows/secrets-rotation-reminder.yml
@@ -97,7 +97,7 @@ jobs:
               if [ $age -gt $threshold ] && [ -z "$open_issue" ]; then
               echo "$secret secret is older than 180 days (age: $((age / (24 * 60 * 60))) days)"
               echo "Creating GitHub Issue to rotate $secret"
-              gh issue create --title "Rotate $secret Credential" --label security --project "Modernisation Platform" --body "The [secrets-rotation-reminder workflow](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) has identified that the $secret credential requires rotation as it is close to or exceeding the threshold of 180 days. 
+              gh issue create --title "Rotate $secret Credential" --label "security, kanban" --project "Modernisation Platform" --body "The [secrets-rotation-reminder workflow](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) has identified that the $secret credential requires rotation as it is close to or exceeding the threshold of 180 days. 
 
               Consult [this documentation](https://user-guide.modernisation-platform.service.justice.gov.uk/runbooks/rotating-secrets.html#how-to-rotate-secrets) which describes the process for rotation."
               else 

--- a/scripts/confirm-environment-owner/create-confirm-owner-issue.sh
+++ b/scripts/confirm-environment-owner/create-confirm-owner-issue.sh
@@ -31,7 +31,7 @@ jq -c '.[]' "output.json" | while IFS= read -r row; do
         echo "Creating GitHub Issue to confirm the owner $owner for environment $file"
         issue_url=$(gh issue create \
             -t "$GITHUB_ISSUE_TITLE" \
-            -l "security" \
+            -l "security, kanban" \
             -b "Can you please review the contact details provided in the owner tag in [environments/$file.json](https://github.com/$REPO/blob/main/environments/$file.json) and confirm they are correct. At present the email address we have is $owner. If it needs to be changed you can either:
 
 - Check whether or not any other email addresses are listed in the .json file and include those.

--- a/scripts/iam-monitoring/collaborators-inactivity-monitoring/collaborator_user_deletion_issue.sh
+++ b/scripts/iam-monitoring/collaborators-inactivity-monitoring/collaborator_user_deletion_issue.sh
@@ -10,7 +10,7 @@ if [ -f final_users.list ]; then
             echo "Creating GitHub Issue to delete collaborator user $username"
             gh issue create \
                 --title "Inactive IAM Collaborator Deletion Required - Username: $username" \
-                --label security \
+                --label "security, kanban" \
                 --project "Modernisation Platform" \
                 --body "The Collaborator-Inactivity-Monitoring workflow has detected that the username $username is inactive for more than 180 days.
                 Consult [this documentation](https://user-guide.modernisation-platform.service.justice.gov.uk/runbooks/adding-collaborators.html#removing-collaborators) which describes the process for deleting the collaborator user."


### PR DESCRIPTION
## A reference to the issue / Description of it

As part of [retro actions](https://mojdt.slack.com/archives/C013RM6MFFW/p1756722813133119) we are experimenting with the creation of a new kanban label and project view to make it easier to identify and track these tasks which are completely independently of the sprint cycle.

## How does this PR fix the problem?

Many of the standard tasks which we've agreed are kanban have their issues created by issue template or script. This PR adds the kanban label which will ensure they are highlighted in the project [kanban view](https://github.com/orgs/ministryofjustice/projects/17/views/48) which is still being refined.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
