### PR TITLE
Dev access for hmpps-community-payback team

### DIFF
--- a/environments/delius-core.json
+++ b/environments/delius-core.json
@@ -49,6 +49,11 @@
           "sso_group_name": "version-1-sit-team",
           "level": "developer",
           "github_action_reviewer": "false"
+        },
+        {
+          "sso_group_name": "hmpps-community-payback",
+          "level": "developer",
+          "github_action_reviewer": "false"
         }
       ],
       "nuke": "exclude"


### PR DESCRIPTION
## A reference to the issue / Description of it

 hmpps-community-payback are working on delivering UPW diary for beta, and will need to update delius via integration layer. Access required for analysis and future testing.

## How does this PR fix the problem?

Gives access to hmpps-community-payback team to view the dev DB for analysis.
