### PR TITLE
🛂 Gives Data Platform Engineering access to environments and state

### DIFF
--- a/environments/data-platform.json
+++ b/environments/data-platform.json
@@ -1,57 +1,48 @@
 {
   "account-type": "member",
-  "codeowners": ["data-platform-apps-and-tools", "data-platform-labs"],
+  "codeowners": ["data-platform-engineering"],
   "environments": [
     {
       "name": "development",
       "access": [
         {
-          "sso_group_name": "data-platform-development-sandbox",
-          "level": "sandbox"
-        },
-        {
-          "sso_group_name": "data-platform-audit-and-security",
-          "level": "security-audit"
+          "sso_group_name": "data-platform-engineering",
+          "level": "platform-engineer-admin",
+          "github_action_reviewer": "true"
         }
       ],
+      "instance_scheduler_skip": ["true"],
       "nuke": "exclude"
     },
     {
       "name": "test",
       "access": [
         {
-          "sso_group_name": "data-platform-test-developer",
-          "level": "developer"
-        },
-        {
-          "sso_group_name": "data-platform-audit-and-security",
-          "level": "security-audit"
+          "sso_group_name": "data-platform-engineering",
+          "level": "platform-engineer-admin",
+          "github_action_reviewer": "true"
         }
-      ]
+      ],
+      "instance_scheduler_skip": ["true"]
     },
     {
       "name": "preproduction",
       "access": [
         {
-          "sso_group_name": "data-platform-preproduction-developer",
-          "level": "developer"
-        },
-        {
-          "sso_group_name": "data-platform-audit-and-security",
-          "level": "security-audit"
+          "sso_group_name": "data-platform-engineering",
+          "level": "platform-engineer-admin",
+          "github_action_reviewer": "true"
         }
-      ]
+      ],
+      "instance_scheduler_skip": ["true"]
     },
     {
       "name": "production",
       "access": [
         {
-          "sso_group_name": "data-platform-production-developer",
-          "level": "developer"
-        },
-        {
-          "sso_group_name": "data-platform-audit-and-security",
-          "level": "security-audit"
+          "sso_group_name": "data-platform-engineering",
+          "level": "platform-engineer-admin",
+          "github_action_reviewer": "true"
         }
       ]
     }


### PR DESCRIPTION
## A reference to the issue / Description of it

Data Platform accounts are currently unused but we're looking at using them soon

## How does this PR fix the problem?

Gives the same level of access as we already have for Analytical Platform 

## How has this been tested?

It hasn't, but its additional

## Deployment Plan / Instructions

It will only impact Data Platform

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

Resolves https://github.com/ministryofjustice/data-platform/issues/5
