### PR TITLE
🐏 Add RAM access to Platform Engineer Admin role

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -639,6 +639,7 @@ data "aws_iam_policy_document" "platform_engineer_additional_additional" {
       "oam:*",
       "organizations:DescribeOrganization",
       "quicksight:*",
+      "ram:*",
       "rds-data:*",
       "rds-db:*",
       "rds:*",


### PR DESCRIPTION
## A reference to the issue / Description of it

I was applying Lake Formation resource locally with my platform engineer admin role, but was ultimately missing any RAM permissions

## How does this PR fix the problem?

Adds them

## How has this been tested?

I added it manually via IAM while completing my tasks, but every so often it will revert when whatever job reconciles policies runs

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

Its additive, so no

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
