### PR TITLE
🦁 Fix wildcard statement for Data Platform

### DIFF
--- a/terraform/modernisation-platform-account/s3.tf
+++ b/terraform/modernisation-platform-account/s3.tf
@@ -535,7 +535,7 @@ data "aws_iam_policy_document" "allow-state-access-from-root-account" {
       "s3:GetObject",
       "s3:PutObject"
     ]
-    resources = ["${module.state-bucket.bucket.arn}/environments/members/data-platform-*/*"]
+    resources = ["${module.state-bucket.bucket.arn}/environments/members/data-platform*/*"]
     principals {
       type        = "AWS"
       identifiers = ["*"]
@@ -567,7 +567,7 @@ data "aws_iam_policy_document" "allow-state-access-from-root-account" {
     sid       = "AllowDataPlatformEngineersDeleteLock"
     effect    = "Allow"
     actions   = ["s3:DeleteObject"]
-    resources = ["${module.state-bucket.bucket.arn}/environments/members/data-platform-*/*.tflock"]
+    resources = ["${module.state-bucket.bucket.arn}/environments/members/data-platform*/*.tflock"]
     principals {
       type        = "AWS"
       identifiers = ["*"]


### PR DESCRIPTION
## A reference to the issue / Description of it

Following #11437, my local apply fails when writing to `arn:aws:s3:::modernisation-platform-terraform-state/environments/members/data-platform/data-platform-development/terraform.tfstate`

## How does this PR fix the problem?

Removes the hyphen from the wildcard statement

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

It hasn't

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

I've left it as a wildcard without the hyphen to cover any future environments
