### PR TITLE
📝  Fix container address

### DIFF
--- a/.github/workflows/publish-gh-pages.yml
+++ b/.github/workflows/publish-gh-pages.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: decrypt-secrets
     container:
-      image: ghcr.io/ministryofjustice/tech-docs-github-pages-publisher@sha256:4148e6d8fcd5dd625d31fadbca49fcbfe8f432b8 # v6.1.0
+      image: ghcr.io/ministryofjustice/tech-docs-github-pages-publisher@sha256:d8af6ed8a86c63f7ded2276f2d1a8473d255c5a44d261ef8c17163c295916f958 # v6.1.0
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0


### PR DESCRIPTION
Deployment failed of GitHub Pages https://github.com/ministryofjustice/modernisation-platform/actions/runs/17546503115

This PR updates the container link to the correct release sha 