### PR TITLE
Amends cloudtrail bucket policy to fix PutObject AccessDenied errors.

### DIFF
--- a/terraform/environments/core-logging/s3_logging.tf
+++ b/terraform/environments/core-logging/s3_logging.tf
@@ -217,20 +217,46 @@ module "s3-bucket-cloudtrail" {
 
 data "aws_iam_policy_document" "cloudtrail_bucket_policy" {
   statement {
-    sid       = "AllowCloudTrailPutObjectAndGetBucketACLWithinOrg"
-    effect    = "Allow"
-    actions   = ["s3:PutObject", "s3:GetBucketAcl"]
-    resources = ["${module.s3-bucket-cloudtrail.bucket.arn}/*", module.s3-bucket-cloudtrail.bucket.arn]
+    sid     = "AWSCloudTrailAclAndLocationCheck"
+    effect  = "Allow"
+    actions = ["s3:GetBucketAcl", "s3:GetBucketLocation"]
+    resources = [
+      module.s3-bucket-cloudtrail.bucket.arn
+    ]
     principals {
       type        = "Service"
       identifiers = ["cloudtrail.amazonaws.com"]
     }
     condition {
       test     = "StringEquals"
-      variable = "aws:SourceOrgID"
+      variable = "aws:PrincipalOrgID"
       values   = [data.aws_organizations_organization.moj_root_account.id]
     }
   }
+
+  statement {
+    sid     = "AWSCloudTrailWrite"
+    effect  = "Allow"
+    actions = ["s3:PutObject"]
+    resources = [
+      "${module.s3-bucket-cloudtrail.bucket.arn}/*"
+    ]
+    principals {
+      type        = "Service"
+      identifiers = ["cloudtrail.amazonaws.com"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "s3:x-amz-acl"
+      values   = ["bucket-owner-full-control"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalOrgID"
+      values   = [data.aws_organizations_organization.moj_root_account.id]
+    }
+  }
+
 }
 
 module "s3-bucket-cloudtrail-logging" {


### PR DESCRIPTION
## A reference to the issue / Description of it

Fixes a large number of AccessDenied errors incurred by cloudtrail when writing the log data so s3.

## How does this PR fix the problem?

Amends the bucket policy to fix the following issues:

- Changes aws:SourceOrgID to aws:PrincipalOrgID in the condition as cloudtrail does not resolve the former.
- Splits the statement into two so that s3:GetBucketAcl is not resolved against bucket-arn/*
- Added s3:GetBucketLocation

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
