### PR TITLE
Add new repo for hosting an example cp app 

### DIFF
--- a/terraform/github/repositories.tf
+++ b/terraform/github/repositories.tf
@@ -519,3 +519,15 @@ module "modernisation-platform-terraform-aws-data-firehose" {
     AWS_SECRET_ACCESS_KEY                 = local.testing_ci_iam_user_keys.AWS_SECRET_ACCESS_KEY
   }
 }
+
+module "modernisation-platform-network-test" {
+  source      = "./modules/repository"
+  name        = "modernisation-platform-cp-network-test"
+  type        = "core"
+  description = "Repo to test hosting example app in Cloud Platform to test connectivity between Cloud Platform and Modernisation Platform"
+  topics = [
+    "cp",
+    "mp",
+    "testing"
+  ]
+}


### PR DESCRIPTION
## A reference to the issue / Description of it

Testing the network revoking runbook.. https://user-guide.modernisation-platform.service.justice.gov.uk/runbooks/revoke-network-access.html#revoke-network-access-if-required

## How does this PR fix the problem?

Adds a new repo for hosting an example cp app to test networking between platforms. We can delete it later if it's not something we need to keep long term.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
