### PR TITLE
Allow access between cp and house-sandbox vpc on mp 

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/sandbox_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/sandbox_rules.json
@@ -1,0 +1,38 @@
+{
+    "default_block_sandbox_house_ingress": {
+    "action": "DROP",
+    "source_ip": "0.0.0.0/0",
+    "destination_ip": "${mp-sandbox-house}",
+    "destination_port": "ANY",
+    "protocol": "IP"
+  },
+    "cp_to_mp_cooker_web_server_http": {
+    "action": "PASS",
+    "source_ip": "${cloud-platform}",
+    "destination_ip": "${mp-sandbox-house}",
+    "destination_port": "80",
+    "protocol": "TCP"
+  },
+  "cp_to_mp_cooker_web_server_https": {
+    "action": "PASS",
+    "source_ip": "${cloud-platform}",
+    "destination_ip": "${mp-sandbox-house}",
+    "destination_port": "443",
+    "protocol": "TCP"
+  },
+    "mp_to_cp_cooker_web_server_http": {
+    "action": "PASS",
+    "source_ip": "${mp-sandbox-house}",
+    "destination_ip": "${cloud-platform}",
+    "destination_port": "80",
+    "protocol": "TCP"
+  },
+  "mp_to_cp_cooker_web_server_https": {
+    "action": "PASS",
+    "source_ip": "${mp-sandbox-house}",
+    "destination_ip": "${cloud-platform}",
+    "destination_port": "443",
+    "protocol": "TCP"
+  }
+
+}

--- a/terraform/environments/core-network-services/locals.tf
+++ b/terraform/environments/core-network-services/locals.tf
@@ -36,6 +36,7 @@ locals {
     "core-network-services-live_data-attachment",
   ]
 
+  sandbox_rules         = fileexists("./firewall-rules/sandbox_rules.json") ? { for k in sort(keys(jsondecode(templatefile("./firewall-rules/sandbox_rules.json", local.all_cidr_ranges)))) : k => jsondecode(templatefile("./firewall-rules/sandbox_rules.json", local.all_cidr_ranges))[k] } : {}
   development_rules     = fileexists("./firewall-rules/development_rules.json") ? { for k in sort(keys(jsondecode(templatefile("./firewall-rules/development_rules.json", local.all_cidr_ranges)))) : k => jsondecode(templatefile("./firewall-rules/development_rules.json", local.all_cidr_ranges))[k] } : {}
   test_rules            = fileexists("./firewall-rules/test_rules.json") ? { for k in sort(keys(jsondecode(templatefile("./firewall-rules/test_rules.json", local.all_cidr_ranges)))) : k => jsondecode(templatefile("./firewall-rules/test_rules.json", local.all_cidr_ranges))[k] } : {}
   preproduction_rules   = fileexists("./firewall-rules/preproduction_rules.json") ? { for k in sort(keys(jsondecode(templatefile("./firewall-rules/preproduction_rules.json", local.all_cidr_ranges)))) : k => jsondecode(templatefile("./firewall-rules/preproduction_rules.json", local.all_cidr_ranges))[k] } : {}
@@ -47,6 +48,7 @@ locals {
 
 
   firewall_rules = merge(
+    local.sandbox_rules,
     local.development_rules,
     local.test_rules,
     local.preproduction_rules,


### PR DESCRIPTION
## A reference to the issue / Description of it

Testing network revoke access runbook.. https://user-guide.modernisation-platform.service.justice.gov.uk/runbooks/revoke-network-access.html#revoke-network-access-if-required

## How does this PR fix the problem?

I'm not sure that we've ever done this before but I believe it should work in theory, I have templated out a new `sandbox_rules.json` file and added default drop and pass rules for http/https between cp and the house-sandbox vpc. 

Also, added new locals so this should be picked up by the deployment.

the aim is to test network connection and then implement the runbook to test an effective block of network acces to MP.


## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
