### PR TITLE
🔧 Fix IAM Policy for CloudTrail Central Log Bucket

### DIFF
--- a/terraform/environments/core-logging/s3_logging.tf
+++ b/terraform/environments/core-logging/s3_logging.tf
@@ -221,7 +221,7 @@ data "aws_iam_policy_document" "cloudtrail_bucket_policy" {
     sid       = "AllowCloudTrailPutObjectWithinOrg"
     effect    = "Allow"
     actions   = ["s3:PutObject"]
-    resources = ["${module.s3-bucket-cloudtrail.bucket.arn}/*"]
+    resources = ["${module.s3-bucket-cloudtrail.bucket.arn}/*", module.s3-bucket-cloudtrail.bucket.arn]
     principals {
       type        = "Service"
       identifiers = ["cloudtrail.amazonaws.com"]


### PR DESCRIPTION
## A reference to the issue / Description of it

Receiving an Access Denied error for the PutObject opertion since remoivng the `module.s3-bucket-cloudtrail.bucket.arn` resource in the IAM Policy

## How does this PR fix the problem?

Adds `module.s3-bucket-cloudtrail.bucket.arn` back into the IAM Policy

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

NA

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

Minimal, logs are retried fairly often if anything goes wrong

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

NA
