### PR TITLE
TM-1550: add dns alias for ad-fixngo fileshare

### DIFF
--- a/terraform/environments/core-shared-services/ad-fixngo.tf
+++ b/terraform/environments/core-shared-services/ad-fixngo.tf
@@ -371,7 +371,7 @@ locals {
         ad_domain_name                      = "azure.hmpp.root"
         ad_file_system_administrators_group = "AWS FSx Admins"
         ad_username                         = "svc_fsx_windows"
-        aliases                             = ["fs.azure.hmpp.root"]
+        aliases                             = ["fs.azure.hmpp.root", "fsprisonretail.azure.hmpp.root", "fsbranstonstaff.azure.hmpp.root"]
         deployment_type                     = "MULTI_AZ_1"
         security_group_name                 = "ad_hmpp_fsx_sg"
         storage_capacity                    = 100


### PR DESCRIPTION
## A reference to the issue / Description of it

To support Prison Retail and Branston Staff File migrations. Both need a file share on the central HMPP FSX - ensure each is using a unique DNS alias for future flexibility.

## How does this PR fix the problem?

Adds DNS alias to file share for prison retail and branston staff files.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Not tested, but a DNS alias already exists and up to 50 are supported by the resource.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
