### PR TITLE
Test network access between the sandboxes

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/sandbox_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/sandbox_rules.json
@@ -33,6 +33,19 @@
     "destination_ip": "${cloud-platform}",
     "destination_port": "443",
     "protocol": "TCP"
-  }
-
+  },
+  "mp_garden_to_house_sandbox_https": {
+    "action": "PASS",
+    "source_ip": "${mp-sandbox-garden}",
+    "destination_ip": "${mp-sandbox-house}",
+    "destination_port": "443",
+    "protocol": "TCP"
+  },
+    "mp_house_to_garden_sandbox_https": {
+        "action": "PASS",
+        "source_ip": "${mp-sandbox-house}",
+        "destination_ip": "${mp-sandbox-garden}",
+        "destination_port": "443",
+        "protocol": "TCP"
+    }
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/11460

## How does this PR fix the problem?

I'm testing in sandboxes to avoid intefering with real apps. This PR adds a firewall rule to allow https between the garden and house sandbox VPCs so I can test the revoking network access runbook.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
