### PR TITLE
Fix/firewall-rules-for-network-test

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/sandbox_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/sandbox_rules.json
@@ -6,34 +6,6 @@
     "destination_port": "ANY",
     "protocol": "IP"
   },
-    "cp_to_mp_cooker_web_server_http": {
-    "action": "PASS",
-    "source_ip": "${cloud-platform}",
-    "destination_ip": "${mp-sandbox-house}",
-    "destination_port": "80",
-    "protocol": "TCP"
-  },
-  "cp_to_mp_cooker_web_server_https": {
-    "action": "PASS",
-    "source_ip": "${cloud-platform}",
-    "destination_ip": "${mp-sandbox-house}",
-    "destination_port": "443",
-    "protocol": "TCP"
-  },
-    "mp_to_cp_cooker_web_server_http": {
-    "action": "PASS",
-    "source_ip": "${mp-sandbox-house}",
-    "destination_ip": "${cloud-platform}",
-    "destination_port": "80",
-    "protocol": "TCP"
-  },
-  "mp_to_cp_cooker_web_server_https": {
-    "action": "PASS",
-    "source_ip": "${mp-sandbox-house}",
-    "destination_ip": "${cloud-platform}",
-    "destination_port": "443",
-    "protocol": "TCP"
-  },
   "mp_garden_to_house_sandbox_https": {
     "action": "PASS",
     "source_ip": "${mp-sandbox-garden}",

--- a/terraform/environments/core-network-services/firewall-rules/test_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/test_rules.json
@@ -523,5 +523,12 @@
     "destination_ip": "${hmpps-test}",
     "destination_port": "443",
     "protocol": "TCP"
+  },
+  "cp_to_platforms_test_https": {
+    "action": "PASS",
+    "source_ip": "${cloud-platform}",
+    "destination_ip": "${platforms-test}",
+    "destination_port": "443",
+    "protocol": "TCP"
   }
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/11460

## How does this PR fix the problem?

Adds a rule to allow traffic from cp to platforms test
Removes some rules for cp to sandbox VPCs and vice versa

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
