### PR TITLE
Add GuardDuty EC2 malware alert

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/guardduty-ec2-malware-protection.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/guardduty-ec2-malware-protection.tf
@@ -12,7 +12,7 @@ resource "aws_kms_key" "kms_guardduty_ec2_malware" {
 # Attach an Alias for the KMS Key 
 resource "aws_kms_alias" "alias_guardduty_ec2_malware" {
   count         = local.enable_malware_notifications ? 1 : 0
-  name          = "alias/kms_guardduty_ec2_malware"
+  name          = "alias/guardduty_ec2_malware"
   target_key_id = aws_kms_key.kms_guardduty_ec2_malware[0].id
 }
 
@@ -57,7 +57,7 @@ data "aws_iam_policy_document" "sns_kms_key_policy" {
 # SNS Topic
 resource "aws_sns_topic" "sns_guardduty_ec2_malware" {
   count             = local.enable_malware_notifications ? 1 : 0
-  name              = "sns_guardduty_ec2_malware"
+  name              = "guardduty_ec2_malware"
   kms_master_key_id = aws_kms_key.kms_guardduty_ec2_malware[0].arn
 }
 
@@ -122,7 +122,7 @@ data "aws_iam_policy_document" "s3_malware_scan_sns_policy" {
 resource "aws_iam_role" "eventbridge_guardduty_ec2_malware" {
   count = local.enable_malware_notifications ? 1 : 0
 
-  name = "eventbridge_guardduty_ec2_malware"
+  name = "guardduty_ec2_malware"
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
@@ -140,7 +140,7 @@ resource "aws_iam_role" "eventbridge_guardduty_ec2_malware" {
 
 resource "aws_iam_role_policy" "eventbridge_guardduty_ec2_malware" {
   count = local.enable_malware_notifications ? 1 : 0
-  name  = "eventbridge_guardduty_ec2_malware"
+  name  = "guardduty_ec2_malware"
   role  = aws_iam_role.eventbridge_guardduty_ec2_malware[0].id
 
   policy = jsonencode({


### PR DESCRIPTION
This PR introduces an automated alert for EC2 malware findings detected by GuardDuty. The alert uses EventBridge to capture findings and routes notifications to slack via SNS and pagerduty. The setup is restricted to Terraform workspaces starting with `ccms-ebs` #11455 

Alerts tested in the high-priority channel