### PR TITLE
Add delius test access for hmpps-community-payback

### DIFF
--- a/environments/delius-core.json
+++ b/environments/delius-core.json
@@ -97,6 +97,11 @@
           "sso_group_name": "version-1-sit-team",
           "level": "developer",
           "github_action_reviewer": "false"
+        },
+        {
+          "sso_group_name": "hmpps-community-payback",
+          "level": "developer",
+          "github_action_reviewer": "false"
         }
       ]
     },


### PR DESCRIPTION
## A reference to the issue / Description of it

Add delius test access for hmpps-community-payback

## How does this PR fix the problem?

Gives delius test access to hmpps-community-payback devs to allow them to analyse the data.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed