### PR TITLE
Allow LAA VPCs to Cloud Platform

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/development_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/development_rules.json
@@ -160,6 +160,13 @@
     "destination_port": "1521",
     "protocol": "TCP"
   },
+  "mp_laa_development_to_cp_https": {
+    "action": "PASS",
+    "source_ip": "${laa-development}",
+    "destination_ip": "${cloud-platform}",
+    "destination_port": "443",
+    "protocol": "TCP"
+  },
   "analytical_platform_to_mp_laa_development_oracledb": {
     "action": "PASS",
     "source_ip": "${analytical-platform-airflow-dev}",

--- a/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
@@ -483,5 +483,12 @@
     "destination_ip": "${laa-preproduction}",
     "destination_port": "$LAA_CCMS_SOA",
     "protocol": "TCP"
+  },
+  "laa_preproduction_to_cloud_platform_https": {
+    "action": "PASS",
+    "source_ip": "${laa-preproduction}",
+    "destination_ip": "${cloud-platform}",
+    "destination_port": "443",
+    "protocol": "TCP"
   }
 }

--- a/terraform/environments/core-network-services/firewall-rules/production_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/production_rules.json
@@ -482,5 +482,12 @@
     "destination_ip": "${laa-ecp-safedb}",
     "destination_port": "2484",
     "protocol": "TCP"
+  },
+  "laa_production_to_cloud_platform_https": {
+    "action": "PASS",
+    "source_ip": "${laa-production}",
+    "destination_ip": "${cloud-platform}",
+    "destination_port": "443",
+    "protocol": "TCP"
   }
 }

--- a/terraform/environments/core-network-services/firewall-rules/test_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/test_rules.json
@@ -530,5 +530,12 @@
     "destination_ip": "${platforms-test}",
     "destination_port": "443",
     "protocol": "TCP"
+  },
+  "laa_test_to_cloud_platform_https": {
+    "action": "PASS",
+    "source_ip": "${laa-test}",
+    "destination_ip": "${cloud-platform}",
+    "destination_port": "443",
+    "protocol": "TCP"
   }
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/11558

## How does this PR fix the problem?

This PR works around the problem; traffic to the Cloud Platform FQDN in question should be allowed by the FQDN rule, but is being dropped by a deny rule

## How has this been tested?

Tested through CI

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
