### PR TITLE
add fslinux alias

### DIFF
--- a/terraform/environments/core-shared-services/ad-fixngo.tf
+++ b/terraform/environments/core-shared-services/ad-fixngo.tf
@@ -371,7 +371,7 @@ locals {
         ad_domain_name                      = "azure.hmpp.root"
         ad_file_system_administrators_group = "AWS FSx Admins"
         ad_username                         = "svc_fsx_windows"
-        aliases                             = ["fs.azure.hmpp.root", "fsprisonretail.azure.hmpp.root", "fsbranstonstaff.azure.hmpp.root"]
+        aliases                             = ["fs.azure.hmpp.root", "fsprisonretail.azure.hmpp.root", "fsbranstonstaff.azure.hmpp.root", "fslinux.azure.hmpp.root"]
         deployment_type                     = "MULTI_AZ_1"
         security_group_name                 = "ad_hmpp_fsx_sg"
         storage_capacity                    = 100


### PR DESCRIPTION
## A reference to the issue / Description of it

Linux doesn't handle active/standby ip addresses for fileshares well. Need to create an alias that just points to the active ip so that linux doesnt intermittently fail when mounting the fileshare. These IPs will stay constant while this FSX exists and when there is a failover it'll fail back to the active as per the aws docs.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

tested on NCR preprod vm

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
