### PR TITLE
Bump David's permissions so he can do more in PagerDuty with ECP

### DIFF
--- a/terraform/pagerduty/locals.tf
+++ b/terraform/pagerduty/locals.tf
@@ -11,7 +11,7 @@ locals {
     david_sibley = {
       name  = "David Sibley"
       email = "david.sibley${local.digital_email_suffix}"
-      role  = "user"
+      role  = "manager"
     },
     edward_proctor = {
       name  = "Edward Proctor"


### PR DESCRIPTION
## A reference to the issue / Description of it

I need a little more Slack access to set up ECP PagerDuty integrations with Slack

## How does this PR fix the problem?

Sets my role to manager for Slack Connection Management as noted [here](https://support.pagerduty.com/main/docs/slack-integration-guide#:~:text=Slack%20Connection%20Management%3A).

## How has this been tested?

Test through CI pipeline

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
