### PR TITLE
Removing Dave and David from the PD rota

### DIFF
--- a/terraform/pagerduty/policy-schedules.tf
+++ b/terraform/pagerduty/policy-schedules.tf
@@ -77,8 +77,6 @@ resource "pagerduty_schedule" "primary" {
     rotation_virtual_start       = "2022-07-25T06:00:00Z"
     rotation_turn_length_seconds = 604800
     users = [
-      local.david_sibley,
-      local.david_elliott,
       local.richard_green,
       local.edward_proctor,
       local.ewa_stempel,
@@ -110,10 +108,8 @@ resource "pagerduty_schedule" "secondary" {
     rotation_virtual_start       = "2022-07-25T06:00:00Z"
     rotation_turn_length_seconds = 604800
     users = [
-      local.david_elliott,
-      local.richard_green,
-      local.david_sibley,
       local.ewa_stempel,
+      local.richard_green,
       local.edward_proctor,
       local.sukesh_reddygade,
       local.mark_roberts,


### PR DESCRIPTION
Dave and David are now part of the ECP on-call rota and there will be time when their ECP schedules clash with MP schedules. This is to update the on-call schedule in Pager Duty for the Modernisation Platform to remove Dave and David from the rota.
This was agreed between the teams and discussed within the MP team.

See thread for further details on the changes implementation: https://mojdt.slack.com/archives/C013RM6MFFW/p1758809588520189 
