### PR TITLE
Add additional reviewer to hmcts-claude-provider.json

### DIFF
--- a/environments/hmcts-claude-provider.json
+++ b/environments/hmcts-claude-provider.json
@@ -8,6 +8,9 @@
           "sso_group_name": "modernisation-platform",
           "level": "developer"
         }
+      ],
+      "additional_reviewers": [
+        "linusnorton"
       ]
     }
   ],


### PR DESCRIPTION
Adds linusnorton as additional reviewer

## A reference to the issue / Description of it

Linus doesn't have access to review deployments, discussed here https://mojdt.slack.com/archives/C01A7QK5VM1/p1759156969485449?thread_ts=1759155286.388579&cid=C01A7QK5VM1

## How does this PR fix the problem?

Added `linusnorton` as additional reviewer

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
