### PR TITLE
Add us-east-1 provider for KMS key

### DIFF
--- a/terraform/environments/core-network-services/logging.tf
+++ b/terraform/environments/core-network-services/logging.tf
@@ -76,6 +76,7 @@ resource "aws_route53_query_log" "public_dns_query_logging" {
 }
 
 resource "aws_kms_key" "public_dns_query_logging" {
+  provider                = aws.aws-us-east-1
   description             = "KMS key for encrypting public DNS query logging CloudWatch log group"
   enable_key_rotation     = true
   deletion_window_in_days = 30
@@ -83,6 +84,7 @@ resource "aws_kms_key" "public_dns_query_logging" {
 }
 
 resource "aws_kms_alias" "public_dns_query_logging" {
+  provider      = aws.aws-us-east-1
   name          = "alias/public-dns-query-logging"
   target_key_id = aws_kms_key.public_dns_query_logging.id
 }


### PR DESCRIPTION
## Issue
Initial apply failed to create Public DNS query logging log group...
https://github.com/ministryofjustice/modernisation-platform/actions/runs/18221307213/job/51881689350#step:17:1226

## What's Changed?
* Added a `depends_on` attribute to the `aws_cloudwatch_log_group.public_dns_query_logging` resource to ensure it is created after the associated KMS key.
* Specified the `aws.aws-us-east-1` provider for both the `aws_kms_key.public_dns_query_logging` and `aws_kms_alias.public_dns_query_logging` resources to clarify resource region and avoid provider ambiguity.