### PR TITLE
bug fix for firewall rules

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/fqdn_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/fqdn_rules.json
@@ -38,5 +38,5 @@
     "stats.microsoft.com",
     "wustat.windows.com"
   ],
-  "fw_home_net_ips": ["10.26.0.0/16", "10.27.0.0/16"]
+  "fw_home_net_ips": ["10.26.0.0/16", "10.27.0.0/16", "172.20.0.0/16"]
 }

--- a/terraform/modules/firewall-policy/main.tf
+++ b/terraform/modules/firewall-policy/main.tf
@@ -26,8 +26,8 @@ resource "aws_networkfirewall_firewall_policy" "main" {
     stateful_rule_group_reference {
       resource_arn = aws_networkfirewall_rule_group.fqdn-stateful.arn
     }
+    stateless_fragment_default_actions = ["aws:forward_to_sfe"]
     stateless_default_actions          = ["aws:forward_to_sfe"]
-    stateless_fragment_default_actions = ["aws:drop"]
   }
   lifecycle {
     create_before_destroy = false


### PR DESCRIPTION
## A reference to the issue / Description of it

Traffic from the LAA VPC (`172.20.0.0/16`) to Cloud Platform services was being dropped, despite the destination being included in the FQDN allowlist. Investigation showed that the FQDN rule group wasn’t being applied to these flows because the LAA CIDR was not listed in `fw_home_net_ips`. As a result, the traffic bypassed FQDN inspection and was caught by default layer-4 drop rules.

Additionally, the firewall policy was configured with `stateless_fragment_default_actions = ["aws:drop"]`, which caused fragmented packets to be dropped before reaching the stateful engine for FQDN evaluation.


## How does this PR fix the problem?

 Added `172.20.0.0/16` to the `fw_home_net_ips` list so FQDN rules apply to flows sourced from the LAA VPC.  
- Updated firewall policy to set `stateless_fragment_default_actions = ["aws:forward_to_sfe"]`, ensuring fragments are passed to the stateful engine for inspection.  
- Reordered stateful rule groups so the FQDN allowlist is evaluated before general stateful rules, preventing broad drop rules from shadowing domain matches.

These changes ensure that traffic from the LAA VPC to allowed FQDN destinations is correctly permitted.


## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions


- Deploy through the standard Terraform pipeline.  
- This change affects the firewall policy and rule groups only; no application downtime is expected.  
- After deployment, monitor CloudWatch Network Firewall logs to confirm that traffic from the LAA VPC is allowed as expected and that no unintended traffic is dropped.  
- **Rollback plan:** revert `fw_home_net_ips` to the previous version and restore the old fragment default action if needed.

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
