### PR TITLE
Fix log group name and update KMS encryption context for public DNS query logging

### DIFF
--- a/terraform/environments/core-network-services/logging.tf
+++ b/terraform/environments/core-network-services/logging.tf
@@ -38,11 +38,10 @@ module "stream_firewall_logs" {
 # Public DNS Query Logging
 resource "aws_cloudwatch_log_group" "public_dns_query_logging" {
   provider          = aws.aws-us-east-1
-  name              = "/aws/route53/resolver/core-public-dns-query-logging"
+  name              = "/aws/route53/core-public-dns-query-logging"
   retention_in_days = 365
   kms_key_id        = aws_kms_key.public_dns_query_logging.arn
   tags              = local.tags
-  depends_on        = [aws_kms_key.public_dns_query_logging]
 }
 
 resource "aws_cloudwatch_log_resource_policy" "public_dns_query_logging" {
@@ -72,7 +71,6 @@ resource "aws_route53_query_log" "public_dns_query_logging" {
   for_each                 = aws_route53_zone.application_zones
   zone_id                  = each.value.zone_id
   cloudwatch_log_group_arn = aws_cloudwatch_log_group.public_dns_query_logging.arn
-  depends_on               = [aws_cloudwatch_log_resource_policy.public_dns_query_logging]
 }
 
 resource "aws_kms_key" "public_dns_query_logging" {
@@ -120,7 +118,7 @@ resource "aws_kms_key_policy" "public_dns_query_logging" {
         Resource = "*"
         Condition = {
           StringEquals = {
-            "kms:EncryptionContext:aws:logs:arn" = "arn:aws:logs:us-east-1:${local.environment_management.account_ids["core-network-services-production"]}:log-group:${aws_cloudwatch_log_group.public_dns_query_logging.name}"
+            "kms:EncryptionContext:aws:logs:arn" = "arn:aws:logs:us-east-1:${local.environment_management.account_ids["core-network-services-production"]}:log-group:/aws/route53/core-public-dns-query-logging"
           }
         }
       }


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/actions/runs/18223102990

My PR failed again

## How does this PR fix the problem?

The issue was the name of the cw log group could not be added dynamically in the kms key policy so teh name has to be hardcoded for TF to be able to create it.

This is fixed now and deployed it locally. I'm pushing this PR to get the code into main.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
