### PR TITLE
Feature/11061 send public dns logs to xsiam

### DIFF
--- a/.github/workflows/secrets-rotation-reminder.yml
+++ b/.github/workflows/secrets-rotation-reminder.yml
@@ -97,7 +97,7 @@ jobs:
               if [ $age -gt $threshold ] && [ -z "$open_issue" ]; then
               echo "$secret secret is older than 180 days (age: $((age / (24 * 60 * 60))) days)"
               echo "Creating GitHub Issue to rotate $secret"
-              gh issue create --title "Rotate $secret Credential" --label "security, kanban" --project "Modernisation Platform" --body "The [secrets-rotation-reminder workflow](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) has identified that the $secret credential requires rotation as it is close to or exceeding the threshold of 180 days. 
+              gh issue create --title "Rotate $secret Credential" --label "security,kanban" --project "Modernisation Platform" --body "The [secrets-rotation-reminder workflow](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) has identified that the $secret credential requires rotation as it is close to or exceeding the threshold of 180 days. 
 
               Consult [this documentation](https://user-guide.modernisation-platform.service.justice.gov.uk/runbooks/rotating-secrets.html#how-to-rotate-secrets) which describes the process for rotation."
               else 

--- a/architecture-decision-record/README.md
+++ b/architecture-decision-record/README.md
@@ -40,7 +40,7 @@ This is our architecture decision log, made during the design and build of the M
 1. ❌ [Use of AWS Cloud Map](0034-use-cloud-map.md)
 1. ✅ [Use of Terraform Workspaces](0035-terraform-workspaces.md)
 1. ✅ [Use of Component Isolation](0036-managing-environment-collaboration-with-component-isolation.md)
-1. ✅ [Permissions to manage Unwanted EBS Volumes](0037-give-teams-the-permission-to-manage-unwanted-volumes.md)
+1. ✅ [Permissions to manage Unwanted EBS Volumes](0037-give-teams-the-permissions-to-manage-unwanted-volumes.md)
 
 ## Statuses
 

--- a/scripts/iam-monitoring/collaborators-inactivity-monitoring/collaborator_user_deletion_issue.sh
+++ b/scripts/iam-monitoring/collaborators-inactivity-monitoring/collaborator_user_deletion_issue.sh
@@ -10,7 +10,7 @@ if [ -f final_users.list ]; then
             echo "Creating GitHub Issue to delete collaborator user $username"
             gh issue create \
                 --title "Inactive IAM Collaborator Deletion Required - Username: $username" \
-                --label "security, kanban" \
+                --label "security,kanban" \
                 --project "Modernisation Platform" \
                 --body "The Collaborator-Inactivity-Monitoring workflow has detected that the username $username is inactive for more than 180 days.
                 Consult [this documentation](https://user-guide.modernisation-platform.service.justice.gov.uk/runbooks/adding-collaborators.html#removing-collaborators) which describes the process for deleting the collaborator user."

--- a/terraform/environments/core-logging/iam_cortex.tf
+++ b/terraform/environments/core-logging/iam_cortex.tf
@@ -33,6 +33,7 @@ data "aws_iam_policy_document" "cortex_user_policy" {
       aws_sqs_queue.mp_cloudtrail_log_queue.arn,
       aws_sqs_queue.mp_modernisation_platform_waf_logs_queue.arn,
       aws_sqs_queue.mp_config_logs_queue.arn,
+      aws_sqs_queue.r53_public_dns_logs_queue.arn,
       [for key in aws_sqs_queue.logging : key.arn]
     ])
   }
@@ -47,7 +48,9 @@ data "aws_iam_policy_document" "cortex_user_policy" {
         module.s3-bucket-modernisation-platform-waf-logs.bucket.arn,
         "${module.s3-bucket-modernisation-platform-waf-logs.bucket.arn}/*",
         module.s3_bucket_config_logs.bucket.arn,
-        "${module.s3_bucket_config_logs.bucket.arn}/*"
+        "${module.s3_bucket_config_logs.bucket.arn}/*",
+        module.s3_bucket_r53_public_dns_logs.bucket.arn,
+        "${module.s3_bucket_r53_public_dns_logs.bucket.arn}/*"
       ],
       [for key in aws_s3_bucket.logging : "${key.arn}/*"]
     )

--- a/terraform/environments/core-logging/logs_r53_public_dns_cloudwatch.tf
+++ b/terraform/environments/core-logging/logs_r53_public_dns_cloudwatch.tf
@@ -1,0 +1,59 @@
+# CloudWatch Logs Destination for cross-account R53 Public DNS log delivery
+resource "aws_cloudwatch_log_destination" "r53_public_dns_logs" {
+  name       = "r53-public-dns-logs-destination"
+  role_arn   = aws_iam_role.cwl_to_firehose_r53_public_dns.arn
+  target_arn = aws_kinesis_firehose_delivery_stream.r53_public_dns_logs_to_s3.arn
+
+  depends_on = [
+    aws_kinesis_firehose_delivery_stream.r53_public_dns_logs_to_s3,
+    aws_iam_role_policy.cwl_to_firehose_policy_r53_public_dns
+  ]
+}
+
+# Allows all member accounts to use this destination
+resource "aws_cloudwatch_log_destination_policy" "r53_public_dns_logs" {
+  destination_name = aws_cloudwatch_log_destination.r53_public_dns_logs.name
+  access_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [{
+      Effect    = "Allow",
+      Principal = "*",
+      Action    = "logs:PutSubscriptionFilter",
+      Resource  = aws_cloudwatch_log_destination.r53_public_dns_logs.arn,
+      Condition = {
+        StringEquals = {
+          "aws:PrincipalAccount" = local.environment_management.account_ids["core-network-services-production"]
+        }
+      }
+    }]
+  })
+}
+
+resource "aws_iam_role" "cwl_to_firehose_r53_public_dns" {
+  name = "CWLtoFirehoseRoleR53PublicDNS"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement : [{
+      Effect = "Allow",
+      Principal : {
+        Service = "logs.amazonaws.com"
+      },
+      Action : "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "cwl_to_firehose_policy_r53_public_dns" {
+  name = "Permissions-Policy-For-CWL-R53-Public-DNS"
+  role = aws_iam_role.cwl_to_firehose_r53_public_dns.name
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement : [{
+      Effect   = "Allow",
+      Action   = ["firehose:*"],
+      Resource = [aws_kinesis_firehose_delivery_stream.r53_public_dns_logs_to_s3.arn]
+    }]
+  })
+}

--- a/terraform/environments/core-logging/logs_r53_public_dns_firehose.tf
+++ b/terraform/environments/core-logging/logs_r53_public_dns_firehose.tf
@@ -1,0 +1,81 @@
+# Kinesis Firehose stream for centralized r53 public DNS query logging
+resource "aws_iam_role" "firehose_to_s3_r53_public_dns" {
+  name = "firehose_to_s3_r53_public_dns"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = [
+            "firehose.amazonaws.com",
+            "logs.amazonaws.com"
+          ]
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "firehose_to_s3_r53_public_dns_policy" {
+  role = aws_iam_role.firehose_to_s3_r53_public_dns.id
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:PutObject",
+          "s3:PutObjectAcl"
+        ]
+        Resource = "${module.s3_bucket_r53_public_dns_logs.bucket.arn}/*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "kms:Encrypt",
+          "kms:Decrypt",
+          "kms:GenerateDataKey*",
+          "kms:DescribeKey"
+        ]
+        Resource = aws_kms_key.r53_public_dns_logs.arn
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "firehose:PutRecord",
+          "firehose:PutRecordBatch"
+        ]
+        Resource = "arn:aws:firehose:eu-west-2:${data.aws_caller_identity.current.account_id}:deliverystream/r53-public-dns-logs-to-s3"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "logs:PutLogEvents"
+        ]
+        Resource = "arn:aws:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/kinesisfirehose/r53-public-dns-logs-to-s3:*"
+      }
+    ]
+  })
+}
+
+resource "aws_kinesis_firehose_delivery_stream" "r53_public_dns_logs_to_s3" {
+  # checkov:skip=CKV_AWS_240: "Encryption is enabled with a CMK via kms_key_arn"
+  # checkov:skip=CKV_AWS_241: "Encryption is enabled with a CMK via kms_key_arn"
+  name        = "r53-public-dns-logs-to-s3"
+  destination = "extended_s3"
+
+  extended_s3_configuration {
+    role_arn            = aws_iam_role.firehose_to_s3_r53_public_dns.arn
+    bucket_arn          = module.s3_bucket_r53_public_dns_logs.bucket.arn
+    prefix              = "r53-public-dns-logs/"
+    error_output_prefix = "r53-public-dns-logs-error/"
+    buffering_interval  = 300
+    buffering_size      = 5
+    compression_format  = "GZIP"
+    kms_key_arn         = aws_kms_key.r53_public_dns_logs.arn
+  }
+
+  depends_on = [aws_iam_role_policy.firehose_to_s3_r53_public_dns_policy]
+}

--- a/terraform/environments/core-logging/logs_r53_public_dns_kms.tf
+++ b/terraform/environments/core-logging/logs_r53_public_dns_kms.tf
@@ -1,0 +1,137 @@
+## KMS Key - Source Region (eu-west-2)
+resource "aws_kms_key" "r53_public_dns_logs" {
+  description             = "KMS key for encrypting Route 53 public DNS logs"
+  enable_key_rotation     = true
+  deletion_window_in_days = 30
+  policy                  = data.aws_iam_policy_document.kms_r53_public_dns_logs.json
+  tags                    = { Name = "modernisation-platform-r53-public-dns-logs-kms" }
+}
+
+resource "aws_kms_alias" "r53_public_dns_logs" {
+  name          = "alias/r53-public-dns-logs-kms"
+  target_key_id = aws_kms_key.r53_public_dns_logs.id
+}
+
+## KMS Policy Document (Source Region)
+data "aws_iam_policy_document" "kms_r53_public_dns_logs" {
+  # checkov:skip=CKV_AWS_109: "Policy is restricted to internal account and roles"
+  # checkov:skip=CKV_AWS_111: "Write access allowed only for approved services"
+  # checkov:skip=CKV_AWS_356: "Wildcard used in internal context and not public"
+
+  statement {
+    sid       = "AllowKeyAdmin"
+    effect    = "Allow"
+    actions   = ["kms:*"]
+    resources = ["*"]
+    principals {
+      type        = "AWS"
+      identifiers = [data.aws_caller_identity.current.account_id]
+    }
+  }
+
+  statement {
+    sid    = "AllowFirehoseAndLogsEncrypt"
+    effect = "Allow"
+    actions = [
+      "kms:Encrypt",
+      "kms:Decrypt",
+      "kms:GenerateDataKey*",
+      "kms:DescribeKey"
+    ]
+    resources = ["*"]
+    principals {
+      type = "Service"
+      identifiers = [
+        "firehose.amazonaws.com",
+        "logs.${data.aws_region.current.region}.amazonaws.com"
+      ]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [local.environment_management.account_ids["core-network-services-production"]]
+    }
+  }
+
+  statement {
+    sid    = "AllowSQSDecrypt"
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+      "kms:DescribeKey"
+    ]
+    resources = ["*"]
+    principals {
+      type        = "Service"
+      identifiers = ["sqs.amazonaws.com"]
+    }
+  }
+
+  statement {
+    sid    = "AllowS3Replication"
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+      "kms:Encrypt",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:DescribeKey"
+    ]
+    resources = ["*"]
+    principals {
+      type = "AWS"
+      identifiers = [
+        format(
+          "arn:aws:sts::%s:assumed-role/AWSS3BucketReplication-r53-public-dns-logs/s3-replication",
+          data.aws_caller_identity.current.account_id
+        )
+      ]
+    }
+  }
+}
+
+resource "aws_kms_key" "r53_public_dns_logs_replication" {
+  provider                = aws.modernisation-platform-eu-west-1
+  description             = "KMS key for replicated Route 53 public DNS logs in eu-west-1"
+  enable_key_rotation     = true
+  deletion_window_in_days = 30
+  policy                  = data.aws_iam_policy_document.kms_r53_public_dns_logs_replication.json
+  tags                    = { Name = "modernisation-platform-r53-public-dns-logs-kms-replication" }
+}
+
+resource "aws_kms_alias" "r53_public_dns_logs_replication" {
+  provider      = aws.modernisation-platform-eu-west-1
+  name          = "alias/r53-public-dns-logs-kms-replication"
+  target_key_id = aws_kms_key.r53_public_dns_logs_replication.id
+}
+
+
+## KMS Policy Document (Replication)
+data "aws_iam_policy_document" "kms_r53_public_dns_logs_replication" {
+  # checkov:skip=CKV_AWS_111: "policy is directly related to the resource"
+  # checkov:skip=CKV_AWS_356: "policy is directly related to the resource"
+  # checkov:skip=CKV_AWS_109: "role is resticted by limited actions in member account"
+  statement {
+    sid       = "AllowRootAccess"
+    effect    = "Allow"
+    actions   = ["kms:*"]
+    resources = ["*"]
+    principals {
+      type        = "AWS"
+      identifiers = [data.aws_caller_identity.current.account_id]
+    }
+  }
+
+  statement {
+    sid       = "AllowReplicationAccess"
+    effect    = "Allow"
+    actions   = ["kms:ReEncrypt*", "kms:Encrypt", "kms:Describe"]
+    resources = ["*"]
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:sts::${data.aws_caller_identity.current.account_id}:assumed-role/AWSS3BucketReplication-r53-public-dns-logs/s3-replication"
+      ]
+    }
+  }
+}

--- a/terraform/environments/core-logging/logs_r53_public_dns_s3.tf
+++ b/terraform/environments/core-logging/logs_r53_public_dns_s3.tf
@@ -1,0 +1,102 @@
+## S3 Bucket Module for AWS Route 53 Public DNS Query Logs
+module "s3_bucket_r53_public_dns_logs" {
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=9facf9fc8f8b8e3f93ffbda822028534b9a75399" # v9.0.0
+
+  providers = {
+    aws.bucket-replication = aws.modernisation-platform-eu-west-1
+  }
+  bucket_policy              = [data.aws_iam_policy_document.r53_public_dns_logs_bucket_policy.json]
+  bucket_name                = "modernisation-platform-logs-r53-public-dns-logs"
+  replication_bucket         = "modernisation-platform-logs-r53-public-dns-logs-replication"
+  suffix_name                = "-r53-public-dns-logs"
+  custom_kms_key             = aws_kms_key.r53_public_dns_logs.arn
+  custom_replication_kms_key = aws_kms_key.r53_public_dns_logs_replication.arn
+  replication_enabled        = true
+  replication_region         = "eu-west-1"
+  versioning_enabled         = true
+
+  lifecycle_rule = [
+    {
+      id      = "main"
+      enabled = "Enabled"
+      prefix  = ""
+      tags    = {}
+      transition = [
+        {
+          days          = 90
+          storage_class = "STANDARD_IA"
+          }, {
+          days          = 365
+          storage_class = "GLACIER"
+        }
+      ]
+      expiration = {
+        days = 730
+      }
+      noncurrent_version_transition = [
+        {
+          days          = 90
+          storage_class = "STANDARD_IA"
+          }, {
+          days          = 365
+          storage_class = "GLACIER"
+        }
+      ]
+      noncurrent_version_expiration = {
+        days = 730
+      }
+    }
+  ]
+
+  tags = local.tags
+}
+
+data "aws_iam_policy_document" "r53_public_dns_logs_bucket_policy" {
+  statement {
+    sid       = "AllowFirehosePut"
+    effect    = "Allow"
+    actions   = ["s3:PutObject"]
+    resources = ["arn:aws:s3:::modernisation-platform-logs-r53-public-dns-logs/*"]
+    principals {
+      type        = "Service"
+      identifiers = ["firehose.amazonaws.com"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [local.environment_management.account_ids["core-network-services-production"]]
+    }
+  }
+
+  statement {
+    sid       = "DenyUnencryptedObjectUploads"
+    effect    = "Deny"
+    actions   = ["s3:PutObject"]
+    resources = ["arn:aws:s3:::modernisation-platform-logs-r53-public-dns-logs/*"]
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+    condition {
+      test     = "Null"
+      variable = "s3:x-amz-server-side-encryption"
+      values   = ["true"]
+    }
+  }
+
+  statement {
+    sid       = "AllowListBucket"
+    effect    = "Allow"
+    actions   = ["s3:ListBucket"]
+    resources = ["arn:aws:s3:::modernisation-platform-logs-r53-public-dns-logs"]
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [local.environment_management.account_ids["core-network-services-production"]]
+    }
+  }
+}

--- a/terraform/environments/core-logging/logs_r53_public_dns_sqs.tf
+++ b/terraform/environments/core-logging/logs_r53_public_dns_sqs.tf
@@ -1,0 +1,45 @@
+# SQS Queue for modernisation platform Route 53 Public DNS Query Logs bucket updates for XSIAM
+resource "aws_sqs_queue" "r53_public_dns_logs_queue" {
+  name                       = "r53_public_dns_logs_queue"
+  sqs_managed_sse_enabled    = true
+  delay_seconds              = 0
+  max_message_size           = 262144
+  message_retention_seconds  = 345600
+  visibility_timeout_seconds = 30
+  tags = {
+    Name = "r53_public_dns_logs_queue"
+  }
+}
+
+resource "aws_sqs_queue_policy" "r53_public_dns_logs_queue_policy" {
+  queue_url = aws_sqs_queue.r53_public_dns_logs_queue.id
+  policy    = data.aws_iam_policy_document.r53_public_dns_logs_queue_policy_document.json
+}
+
+data "aws_iam_policy_document" "r53_public_dns_logs_queue_policy_document" {
+  statement {
+    sid    = "AllowSendMessage"
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["s3.amazonaws.com"]
+    }
+    actions = ["sqs:SendMessage"]
+    resources = [
+      aws_sqs_queue.r53_public_dns_logs_queue.arn
+    ]
+    condition {
+      test     = "ArnEquals"
+      variable = "aws:SourceArn"
+      values   = [module.s3_bucket_r53_public_dns_logs.bucket.arn]
+    }
+  }
+}
+
+resource "aws_s3_bucket_notification" "r53_public_dns_logs_bucket_notification" {
+  bucket = module.s3_bucket_r53_public_dns_logs.bucket.id
+  queue {
+    queue_arn = aws_sqs_queue.r53_public_dns_logs_queue.arn
+    events    = ["s3:ObjectCreated:*"]
+  }
+}

--- a/terraform/environments/core-network-services/firewall-rules/development_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/development_rules.json
@@ -160,6 +160,13 @@
     "destination_port": "1521",
     "protocol": "TCP"
   },
+  "gp_to_laa_development_mp_https": {
+    "action": "PASS",
+    "source_ip": "${global-protect}",
+    "destination_ip": "${laa-development}",
+    "destination_port": "443",
+    "protocol": "TCP"
+  },
   "mp_laa_development_to_cp_https": {
     "action": "PASS",
     "source_ip": "${laa-development}",

--- a/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
@@ -379,6 +379,13 @@
     "destination_port": "1521",
     "protocol": "TCP"
   },
+  "gp_to_laa_preproduction_mp_https": {
+    "action": "PASS",
+    "source_ip": "${global-protect}",
+    "destination_ip": "${laa-preproduction}",
+    "destination_port": "443",
+    "protocol": "TCP"
+  },
   "data_engineering_to_hmpps_preproduction_oracledb": {
     "action": "PASS",
     "source_ip": "${data-engineering-stage}",

--- a/terraform/environments/core-network-services/firewall-rules/production_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/production_rules.json
@@ -427,6 +427,13 @@
     "destination_port": "1521",
     "protocol": "TCP"
   },
+  "gp_to_laa_production_mp_https": {
+    "action": "PASS",
+    "source_ip": "${global-protect}",
+    "destination_ip": "${laa-production}",
+    "destination_port": "443",
+    "protocol": "TCP"
+  },
   "cp_to_mp_laa_production_1522": {
     "action": "PASS",
     "source_ip": "${cloud-platform}",

--- a/terraform/environments/core-network-services/route53.tf
+++ b/terraform/environments/core-network-services/route53.tf
@@ -20,6 +20,7 @@ locals {
     tribunals     = "tribunals.gov.uk",
     wardship      = "wardship-agreements-register.service.justice.gov.uk"
     legalservices = "legalservices.gov.uk"
+    laa           = "laa.service.justice.gov.uk"
   }
 
   private-application-zones = {


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/11061

## How does this PR fix the problem?

This pull request introduces a new centralized logging pipeline for AWS Route 53 public DNS query logs in the core-logging environment. The changes provision all necessary resources for secure log collection, storage, encryption, replication, and notification, supporting cross-account delivery and integration with XSIAM. The implementation includes S3 bucket setup, KMS key management, Kinesis Firehose configuration, CloudWatch log destination and policies, and SQS notifications.

**Centralized S3 Bucket Storage and Policies**
* Adds a new S3 bucket module (`module.s3_bucket_r53_public_dns_logs`) for storing Route 53 public DNS logs, with lifecycle rules, replication to `eu-west-1`, versioning, and strict bucket policies for security and compliance.

**Encryption and Replication**
* Provisions KMS keys and aliases for encrypting logs in both the source and replication regions, along with custom IAM policy documents to control access for Route 53, Firehose, and S3 replication roles.

**Log Ingestion Pipeline**
* Sets up a Kinesis Firehose delivery stream (`aws_kinesis_firehose_delivery_stream.r53_public_dns_logs_to_s3`) with IAM roles and policies for delivering logs securely to S3, including support for encryption and error handling.

**CloudWatch Log Destination and Cross-Account Access**
* Configures a CloudWatch Logs destination and destination policy to allow cross-account log delivery from `core-network-services`, with IAM roles and policies for integration with Firehose.

**SQS Notification for XSIAM Integration**
* Creates an SQS queue and configures S3 bucket notifications to send events when new log objects are created, enabling downstream processing (e.g., by XSIAM).