### PR TITLE
Fix label formatting in issue creation for workflows

### DIFF
--- a/.github/workflows/secrets-rotation-reminder.yml
+++ b/.github/workflows/secrets-rotation-reminder.yml
@@ -97,7 +97,7 @@ jobs:
               if [ $age -gt $threshold ] && [ -z "$open_issue" ]; then
               echo "$secret secret is older than 180 days (age: $((age / (24 * 60 * 60))) days)"
               echo "Creating GitHub Issue to rotate $secret"
-              gh issue create --title "Rotate $secret Credential" --label "security, kanban" --project "Modernisation Platform" --body "The [secrets-rotation-reminder workflow](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) has identified that the $secret credential requires rotation as it is close to or exceeding the threshold of 180 days. 
+              gh issue create --title "Rotate $secret Credential" --label "security,kanban" --project "Modernisation Platform" --body "The [secrets-rotation-reminder workflow](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) has identified that the $secret credential requires rotation as it is close to or exceeding the threshold of 180 days. 
 
               Consult [this documentation](https://user-guide.modernisation-platform.service.justice.gov.uk/runbooks/rotating-secrets.html#how-to-rotate-secrets) which describes the process for rotation."
               else 

--- a/scripts/iam-monitoring/collaborators-inactivity-monitoring/collaborator_user_deletion_issue.sh
+++ b/scripts/iam-monitoring/collaborators-inactivity-monitoring/collaborator_user_deletion_issue.sh
@@ -10,7 +10,7 @@ if [ -f final_users.list ]; then
             echo "Creating GitHub Issue to delete collaborator user $username"
             gh issue create \
                 --title "Inactive IAM Collaborator Deletion Required - Username: $username" \
-                --label "security, kanban" \
+                --label "security,kanban" \
                 --project "Modernisation Platform" \
                 --body "The Collaborator-Inactivity-Monitoring workflow has detected that the username $username is inactive for more than 180 days.
                 Consult [this documentation](https://user-guide.modernisation-platform.service.justice.gov.uk/runbooks/adding-collaborators.html#removing-collaborators) which describes the process for deleting the collaborator user."


### PR DESCRIPTION
Correct label formatting in the issue creation commands for secrets rotation and collaborator deletion workflows.

The list of labels is comma seperated and included a whitespace which was being read as part of the label name.