### PR TITLE
Add rules and association to allow laa-test to ecp

### DIFF
--- a/environments-networks/laa-test.json
+++ b/environments-networks/laa-test.json
@@ -36,7 +36,7 @@
       "com.amazonaws.eu-west-2.sns",
       "com.amazonaws.eu-west-2.sqs"
     ],
-    "additional_private_zones": [],
+    "additional_private_zones": ["aws.prd.legalservices.gov.uk"],
     "additional_vpcs": [],
     "dns_zone_extend": []
   }

--- a/terraform/environments/core-network-services/firewall-rules/test_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/test_rules.json
@@ -565,5 +565,12 @@
     "destination_ip": "${cloud-platform}",
     "destination_port": "1521",
     "protocol": "TCP"
+  },
+  "laa_test_to_laa_ecp_2484": {
+    "action": "PASS",
+    "source_ip": "${laa-test}",
+    "destination_ip": "$LAA_ECP_DATABASES",
+    "destination_port": "2484",
+    "protocol": "TCP"
   }
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

enterprise service bus lambda functions need connectivity to ECP

## How does this PR fix the problem?

allows name resolution and passage through inspection firewall

## How has this been tested?

Tested through CI pipeline

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
