### PR TITLE
Refine CloudWatch log destination policy for organization paths access

### DIFF
--- a/terraform/environments/core-logging/logs_r53_public_dns_cloudwatch.tf
+++ b/terraform/environments/core-logging/logs_r53_public_dns_cloudwatch.tf
@@ -21,8 +21,8 @@ resource "aws_cloudwatch_log_destination_policy" "r53_public_dns_logs" {
       Action    = "logs:PutSubscriptionFilter",
       Resource  = aws_cloudwatch_log_destination.r53_public_dns_logs.arn,
       Condition = {
-        StringEquals = {
-          "aws:PrincipalAccount" = local.environment_management.account_ids["core-network-services-production"]
+        StringLike = {
+          "aws:PrincipalOrgPaths" = ["${data.aws_organizations_organization.root_account.id}/*/${local.environment_management.modernisation_platform_organisation_unit_id}/*"]
         }
       }
     }]


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/11061 

Code failed due to issue with IAM policy.. https://github.com/ministryofjustice/modernisation-platform/actions/runs/18312351854/job/52143798635#step:17:1963

## How does this PR fix the problem?

Updates the CloudWatch log destination policy to allow access based on organization paths rather than specific account IDs.