### PR TITLE
Add cloudwatch log subscription filter for r53 public DNS logs

### DIFF
--- a/terraform/environments/core-logging/logs_r53_public_dns_firehose.tf
+++ b/terraform/environments/core-logging/logs_r53_public_dns_firehose.tf
@@ -1,6 +1,7 @@
 # Kinesis Firehose stream for centralized r53 public DNS query logging
 resource "aws_iam_role" "firehose_to_s3_r53_public_dns" {
-  name = "firehose_to_s3_r53_public_dns"
+  provider = aws.aws-us-east-1
+  name     = "firehose_to_s3_r53_public_dns"
   assume_role_policy = jsonencode({
     Version = "2012-10-17",
     Statement = [
@@ -19,7 +20,8 @@ resource "aws_iam_role" "firehose_to_s3_r53_public_dns" {
 }
 
 resource "aws_iam_role_policy" "firehose_to_s3_r53_public_dns_policy" {
-  role = aws_iam_role.firehose_to_s3_r53_public_dns.id
+  provider = aws.aws-us-east-1
+  role     = aws_iam_role.firehose_to_s3_r53_public_dns.id
   policy = jsonencode({
     Version = "2012-10-17",
     Statement = [
@@ -47,14 +49,14 @@ resource "aws_iam_role_policy" "firehose_to_s3_r53_public_dns_policy" {
           "firehose:PutRecord",
           "firehose:PutRecordBatch"
         ]
-        Resource = "arn:aws:firehose:eu-west-2:${data.aws_caller_identity.current.account_id}:deliverystream/r53-public-dns-logs-to-s3"
+        Resource = "arn:aws:firehose:us-east-1:${data.aws_caller_identity.current.account_id}:deliverystream/r53-public-dns-logs-to-s3"
       },
       {
         Effect = "Allow"
         Action = [
           "logs:PutLogEvents"
         ]
-        Resource = "arn:aws:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/kinesisfirehose/r53-public-dns-logs-to-s3:*"
+        Resource = "arn:aws:logs:us-east-1:${data.aws_caller_identity.current.account_id}:log-group:/aws/kinesisfirehose/r53-public-dns-logs-to-s3:*"
       }
     ]
   })
@@ -63,6 +65,7 @@ resource "aws_iam_role_policy" "firehose_to_s3_r53_public_dns_policy" {
 resource "aws_kinesis_firehose_delivery_stream" "r53_public_dns_logs_to_s3" {
   # checkov:skip=CKV_AWS_240: "Encryption is enabled with a CMK via kms_key_arn"
   # checkov:skip=CKV_AWS_241: "Encryption is enabled with a CMK via kms_key_arn"
+  provider    = aws.aws-us-east-1
   name        = "r53-public-dns-logs-to-s3"
   destination = "extended_s3"
 

--- a/terraform/environments/core-logging/providers.tf
+++ b/terraform/environments/core-logging/providers.tf
@@ -45,3 +45,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for us-east-1 (required for Route 53 Public DNS logging)
+provider "aws" {
+  alias  = "aws-us-east-1"
+  region = "us-east-1"
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
+  }
+  default_tags { tags = local.tags }
+}


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/11061

## How does this PR fix the problem?

This pull request updates the AWS provider configuration and resource definitions to ensure that Route 53 public DNS query logging and related resources are correctly provisioned in the `us-east-1` region, which is required for Route 53 public DNS logging. It also introduces new IAM roles and policies to support forwarding CloudWatch logs to a centralized logging account.

The most important changes are:

**Provider Configuration and Regionalization:**

* Added a dedicated AWS provider with alias `aws-us-east-1` for the `us-east-1` region, including role assumption and tagging, to support resources that must reside in that region. (`providers.tf`)
* Updated `aws_iam_role`, `aws_iam_role_policy`, and `aws_kinesis_firehose_delivery_stream` resources in `core-network-services` for Route 53 public DNS logging to explicitly use the `aws-us-east-1` provider, ensuring these resources are created in the correct region. (`logs_r53_public_dns_firehose.tf`)

**Resource ARN and Policy Adjustments:**

* Modified ARNs in IAM policies to reference `us-east-1` for Kinesis Firehose and CloudWatch Logs, aligning resource permissions with the correct region for Route 53 logging. (`logs_r53_public_dns_firehose.tf`)

**CloudWatch Log Forwarding Enhancements:**

* Added new resources to enable forwarding of CloudWatch logs to a centralised logging destination in `us-east-1`:
  - Created an IAM role and policy for CloudWatch Logs to assume.
  - Defined a `aws_cloudwatch_log_subscription_filter` to forward logs to the centralised destination. (`logging.tf`)