### PR TITLE
🔧  Build CW Log Destination in `us-east-1`

### DIFF
--- a/terraform/environments/core-logging/logs_r53_public_dns_cloudwatch.tf
+++ b/terraform/environments/core-logging/logs_r53_public_dns_cloudwatch.tf
@@ -1,5 +1,6 @@
 # CloudWatch Logs Destination for cross-account R53 Public DNS log delivery
 resource "aws_cloudwatch_log_destination" "r53_public_dns_logs" {
+  provider   = aws.aws-us-east-1
   name       = "r53-public-dns-logs-destination"
   role_arn   = aws_iam_role.cwl_to_firehose_r53_public_dns.arn
   target_arn = aws_kinesis_firehose_delivery_stream.r53_public_dns_logs_to_s3.arn
@@ -12,6 +13,7 @@ resource "aws_cloudwatch_log_destination" "r53_public_dns_logs" {
 
 # Allows all member accounts to use this destination
 resource "aws_cloudwatch_log_destination_policy" "r53_public_dns_logs" {
+  provider         = aws.aws-us-east-1
   destination_name = aws_cloudwatch_log_destination.r53_public_dns_logs.name
   access_policy = jsonencode({
     Version = "2012-10-17",
@@ -30,14 +32,15 @@ resource "aws_cloudwatch_log_destination_policy" "r53_public_dns_logs" {
 }
 
 resource "aws_iam_role" "cwl_to_firehose_r53_public_dns" {
-  name = "CWLtoFirehoseRoleR53PublicDNS"
+  provider = aws.aws-us-east-1
+  name     = "CWLtoFirehoseRoleR53PublicDNS"
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17",
     Statement : [{
       Effect = "Allow",
       Principal : {
-        Service = "logs.amazonaws.com"
+        Service = "logs.us-east-1.amazonaws.com"
       },
       Action : "sts:AssumeRole"
     }]
@@ -45,8 +48,9 @@ resource "aws_iam_role" "cwl_to_firehose_r53_public_dns" {
 }
 
 resource "aws_iam_role_policy" "cwl_to_firehose_policy_r53_public_dns" {
-  name = "Permissions-Policy-For-CWL-R53-Public-DNS"
-  role = aws_iam_role.cwl_to_firehose_r53_public_dns.name
+  provider = aws.aws-us-east-1
+  name     = "Permissions-Policy-For-CWL-R53-Public-DNS"
+  role     = aws_iam_role.cwl_to_firehose_r53_public_dns.name
 
   policy = jsonencode({
     Version = "2012-10-17",


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/11061

## How does this PR fix the problem?

I'm rebuilding the cloudwatch logs destination resources in `us-east-1` as the firehose lives in that region and they need to be in the same region to link up.

