### PR TITLE
tm-1648-update-patchmanager-module

### DIFF
--- a/terraform/environments/core-shared-services/ad-fixngo.tf
+++ b/terraform/environments/core-shared-services/ad-fixngo.tf
@@ -1288,6 +1288,7 @@ resource "aws_ssm_parameter" "ad_fixngo" {
 
 #trivy:ignore:AVD-AWS-0345: Required for SSM patching module to access S3 buckets
 module "ad_fixngo_ssm_patching" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions; this is an internal module so commit hashes are not needed
   source = "github.com/ministryofjustice/modernisation-platform-terraform-ssm-patching.git?ref=v5.1.0"
   providers = {
     aws.bucket-replication = aws


### PR DESCRIPTION
## A reference to the issue / Description of it

Update to the latest version of the patch manager module to take advantage of the new 'simple_patching' option.

## How does this PR fix the problem?

Prevents proliferation of cloudwatch log groups through the use of lambda functions.

## How has this been tested?

As deployed in hmpps-domain-services.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

Will update patching routines on hosted dso instances. 

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

