### PR TITLE
developer delete glue table

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -244,6 +244,7 @@ data "aws_iam_policy_document" "developer_additional" {
       "events:DisableRule",
       "events:EnableRule",
       "fis:*",
+      "glue:DeleteTable",
       "glue:GetConnection",
       "glue:GetConnections",
       "guardduty:*",


### PR DESCRIPTION
## A reference to the issue / Description of it

When the load balancer schema gets changed in terraform aws glue schema does not get updated. As a developer, being able to delete the glue table /schema (does not delete actual data) we can run terraform after to recreate the schema

## How does this PR fix the problem?

{Please write here}

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
