### PR TITLE
Remove corporate-staff-rostering accounts from development and test configurations

### DIFF
--- a/environments-networks/hmpps-development.json
+++ b/environments-networks/hmpps-development.json
@@ -4,7 +4,6 @@
       "general": {
         "cidr": "10.26.24.0/21",
         "accounts": [
-          "corporate-staff-rostering-development",
           "delius-alfresco-development",
           "delius-core-development",
           "delius-iaps-development",

--- a/environments-networks/hmpps-test.json
+++ b/environments-networks/hmpps-test.json
@@ -4,7 +4,6 @@
       "general": {
         "cidr": "10.26.8.0/21",
         "accounts": [
-          "corporate-staff-rostering-test",
           "delius-alfresco-test",
           "delius-core-test",
           "delius-jitbit-test",

--- a/environments/corporate-staff-rostering.json
+++ b/environments/corporate-staff-rostering.json
@@ -2,44 +2,6 @@
   "account-type": "member",
   "environments": [
     {
-      "name": "development",
-      "access": [
-        {
-          "sso_group_name": "hosting-migrations",
-          "level": "developer"
-        },
-        {
-          "sso_group_name": "studio-webops",
-          "level": "developer"
-        },
-        {
-          "sso_group_name": "azure-aws-sso-digital-studio-operations",
-          "level": "developer"
-        }
-      ]
-    },
-    {
-      "name": "test",
-      "access": [
-        {
-          "sso_group_name": "hosting-migrations",
-          "level": "developer"
-        },
-        {
-          "sso_group_name": "studio-webops",
-          "level": "developer"
-        },
-        {
-          "sso_group_name": "csr-application-support",
-          "level": "developer"
-        },
-        {
-          "sso_group_name": "azure-aws-sso-digital-studio-operations",
-          "level": "developer"
-        }
-      ]
-    },
-    {
       "name": "preproduction",
       "access": [
         {

--- a/policies/networking/expected.rego
+++ b/policies/networking/expected.rego
@@ -138,7 +138,6 @@ expected :=
       "general": {
         "cidr": "10.26.24.0/21",
         "accounts": [
-          "corporate-staff-rostering-development",
           "delius-alfresco-development",
           "delius-core-development",
           "delius-iaps-development",
@@ -171,7 +170,6 @@ expected :=
           "delius-jitbit-test",
           "nomis-combined-reporting-test",
           "nomis-data-hub-test",
-          "corporate-staff-rostering-test",
           "hmpps-oem-test",
           "hmpps-domain-services-test",
           "delius-core-test",


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/11687

## How does this PR fix the problem?

Removes`corporate-staff-rostering-development` and `corporate-staff-rostering-test` accounts

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
