### PR TITLE
Add KMS policy statement to allow decryption for Cortex XSIAM role

### DIFF
--- a/terraform/environments/core-logging/logs_r53_public_dns_kms.tf
+++ b/terraform/environments/core-logging/logs_r53_public_dns_kms.tf
@@ -54,6 +54,20 @@ data "aws_iam_policy_document" "kms_r53_public_dns_logs" {
   }
 
   statement {
+    sid    = "AllowCortexXsiamDecrypt"
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+      "kms:DescribeKey"
+    ]
+    resources = ["*"]
+    principals {
+      type        = "AWS"
+      identifiers = [aws_iam_role.cortex_xsiam_role.arn]
+    }
+  }
+
+  statement {
     sid    = "AllowSQSDecrypt"
     effect = "Allow"
     actions = [


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/11061

When troubleshooting the xsiam connection issues with Vinnie we encountered the error:

`
error creating GZIP reader for file "r53-public-dns-logs/2025/10/15/10/r53-public-dns-logs-to-s3-2-2025-10-15-10-07-47-59a27961-4151-4fdb-bbec-025ebc3e38ef" (event: "ObjectCreated:Put", bucket: "modernisation-platform-logs-r53-public-dns-logs"): AccessDenied: User: arn:aws:sts::624384546187:assumed-role/cortex_xsiam20240930112820077540000001/xdr-collection is not authorized to perform: kms:Decrypt on resource: arn:aws:kms:eu-west-2:624384546187:key/b997e702-260d-456b-95c4-270624f53307 because no identity-based policy allows the kms:Decrypt action status code: 403, request id: TMZDENVDWQ8V6JV53, host id: 6Av1FXprlxRXDazevV+VEmp2Y9AImBndpQe9biZPA/uW2nBGR9RKxrILhF+2qTlGANGDKJ6yH/rQ=
`

## How does this PR fix the problem?

I have rectified this by adding permissions for the xsiam role to decrypt the KMS key.

FYI: I manually updated the policy for testing purposes so the TF plan may show as no changes are required.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
