### PR TITLE
Add `amal.saeed` as a collaborator with `data-scientist` access

### DIFF
--- a/collaborators.json
+++ b/collaborators.json
@@ -1591,6 +1591,20 @@
           "access": "developer"
         }
       ]
+    },
+    {
+      "username": "amal.saeed",
+      "github-username": "no-value-supplied",
+      "accounts": [
+        {
+          "account-name": "youth-justice-app-framework-preproduction",
+          "access": "data-scientist"
+        },
+        {
+          "account-name": "youth-justice-app-framework-production",
+          "access": "data-scientist"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Include amal.saeed as a collaborator with data-scientist access to both preproduction and production environments of the youth-justice-app-framework.