### PR TITLE
TM-1639: Enable-fixngo-cloudwatch-event-logs-iam

### DIFF
--- a/terraform/environments/core-shared-services/ad-fixngo.tf
+++ b/terraform/environments/core-shared-services/ad-fixngo.tf
@@ -244,9 +244,23 @@ locals {
             actions = [
               "ec2:DescribeVolumes",
               "ec2:DescribeTags",
-              "ec2:DescribeInstances"
+              "ec2:DescribeInstances",
+              "cloudwatch:PutMetricData",
+              "logs:DescribeLogGroups"
             ]
             resources = ["*"]
+          },
+          {
+            sid    = "CloudWatchAgentLogGroupAccess"
+            effect = "Allow"
+            actions = [
+              "logs:PutLogEvents",
+              "logs:CreateLogStream",
+              "logs:DescribeLogStreams"
+            ]
+            resources = [
+              "arn:aws:logs:*:*:log-group:cwagent-windows-*:*"
+            ]
           }
         ]
       }
@@ -1322,7 +1336,7 @@ module "ad_fixngo_ssm_patching" {
 }
 
 resource "aws_cloudwatch_log_group" "ad_fixngo" {
-  for_each          = local.ad_fixngo.cloudwatch_log_groups
+  for_each = local.ad_fixngo.cloudwatch_log_groups
 
   name              = each.key
   retention_in_days = each.value.retention_in_days


### PR DESCRIPTION
## Description

Adds the minimum IAM roles to allow the cloudwatch agents to write to their respective log groups.

## How has this been tested?

Roles as per DSO accounts, limited to iso pre-created log groups where possible.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

no

## Checklist

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)
