### PR TITLE
Allow iam:PassRole in us-east-1 by Lambda execution roles.

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -485,9 +485,7 @@ data "aws_iam_policy_document" "member-access-us-east" {
   statement {
     actions = ["iam:PassRole"]
     effect  = "Allow"
-    resources = [
-      "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/MemberInfrastructureAccessUSEast"
-    ]
+    resources = ["*"]
     condition {
       test     = "StringEquals"
       variable = "iam:PassedToService"


### PR DESCRIPTION
Allows lambda to use iam:PassRole for its execution role in us-east-1. This is required for situations where teams want to use lambda with cloudfront.

## A reference to the issue / Description of it

{Please write here}

## How does this PR fix the problem?

{Please write here}

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
