### PR TITLE
Allow iam:PassRole in us-east-1 by Lambda execution roles. 

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -485,9 +485,7 @@ data "aws_iam_policy_document" "member-access-us-east" {
   statement {
     actions = ["iam:PassRole"]
     effect  = "Allow"
-    resources = [
-      "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/MemberInfrastructureAccessUSEast"
-    ]
+    resources = ["*"]
     condition {
       test     = "StringEquals"
       variable = "iam:PassedToService"


### PR DESCRIPTION
## A reference to the issue / Description of it

As requested by Mark Butler https://mojdt.slack.com/archives/C01A7QK5VM1/p1760702984395479

## How does this PR fix the problem?

Adds permissions for the creation of lambdas in us-east-1 and the use of iam:PassRole that is required for the lambda execution role.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Tested in sprinkler with lambda created via the console using MemberInfrastructureAccessUSEast as the assumed role.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
