### PR TITLE
Keep the delius-core-preproduciton EC2s running

### DIFF
--- a/environments/delius-core.json
+++ b/environments/delius-core.json
@@ -141,7 +141,8 @@
           "level": "developer",
           "github_action_reviewer": "false"
         }
-      ]
+      ],
+      "instance_scheduler_skip": ["true"]
     },
     {
       "name": "production",


### PR DESCRIPTION
## A reference to the issue / Description of it

Prevent the delius-core-preproduction EC2s from being shut down.

## How does this PR fix the problem?

Skips the instance scheduler.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

N/A

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

N/A

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

N/A
