### PR TITLE
Add transit gateway routes and network firewall rules for CWA SafeDB 2

### DIFF
--- a/terraform/environments/core-network-services/cidr-ranges.tf
+++ b/terraform/environments/core-network-services/cidr-ranges.tf
@@ -73,6 +73,7 @@ locals {
     laa-appstream-vpc_additional   = "10.200.68.0/22"
     laa-ecp-db-lb                  = "10.205.10.0/24"
     laa-ecp-safedb-1               = "10.205.14.0/24"
+    laa-ecp-safedb-2               = "10.205.15.0/24"
     laa-ecp-safedb-3               = "10.205.11.0/24"
 
     # NEC cidr ranges

--- a/terraform/environments/core-network-services/firewall-rules/sets.json
+++ b/terraform/environments/core-network-services/firewall-rules/sets.json
@@ -46,6 +46,7 @@
     "LAA_ECP_DATABASES": [
       "${laa-ecp-db-lb}",
       "${laa-ecp-safedb-1}",
+      "${laa-ecp-safedb-2}",
       "${laa-ecp-safedb-3}"
     ],
     "LAA_PRIVATE_DATA_SUBNETS_DEV": [

--- a/terraform/environments/core-network-services/transit_gateway_connections.tf
+++ b/terraform/environments/core-network-services/transit_gateway_connections.tf
@@ -217,7 +217,7 @@ resource "aws_ec2_transit_gateway_route_table_association" "external_inspection_
 }
 
 resource "aws_ec2_transit_gateway_route" "inspection_static_routes_ecp_safedb" {
-  for_each                       = toset(["10.205.10.0/24", "10.205.11.0/24", "10.205.14.0/24", ])
+  for_each                       = toset(["10.205.10.0/24", "10.205.11.0/24", "10.205.14.0/24", "10.205.15.0/24"])
   destination_cidr_block         = each.key
   transit_gateway_attachment_id  = data.aws_ec2_transit_gateway_peering_attachment.ecp_tgw.id
   transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.external_inspection_out.id


### PR DESCRIPTION
## A reference to the issue / Description of it

The CWA team want to make a new database available

## How does this PR fix the problem?

Adds routes and firewall rules to allow traffic to reach the new database on a TLS port

## How has this been tested?

Tested through CI Pipeline checks

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
