### PR TITLE
Adding platform eng access level plus a workspaces secure browser component

### DIFF
--- a/environments/laa-pui-secure-browser.json
+++ b/environments/laa-pui-secure-browser.json
@@ -1,5 +1,11 @@
 {
   "account-type": "member",
+  "components": [
+    {
+      "name": "workspaces-secure-browser",
+      "sso_group_name": "ecp-admin"
+    }
+  ],
   "codeowners": ["laa-sre-admins"],
   "environments": [
     {
@@ -8,6 +14,10 @@
         {
           "sso_group_name": "laa-sre-admins",
           "level": "sandbox"
+        },
+        {
+          "sso_group_name": "ecp-admin",
+          "level": "platform-engineer-admin"
         }
       ],
       "nuke": "exclude"
@@ -18,6 +28,10 @@
         {
           "sso_group_name": "laa-sre-admins",
           "level": "developer"
+        },
+        {
+          "sso_group_name": "ecp-admin",
+          "level": "platform-engineer-admin"
         }
       ]
     },
@@ -27,6 +41,10 @@
         {
           "sso_group_name": "laa-sre-admins",
           "level": "developer"
+        },
+        {
+          "sso_group_name": "ecp-admin",
+          "level": "platform-engineer-admin"
         }
       ]
     },
@@ -36,6 +54,10 @@
         {
           "sso_group_name": "laa-sre-admins",
           "level": "developer"
+        },
+        {
+          "sso_group_name": "ecp-admin",
+          "level": "platform-engineer-admin"
         }
       ]
     }


### PR DESCRIPTION
## A reference to the issue / Description of it

Adding a new component for secure browser and new access level to all laa-pui-secure-browser

## How does this PR fix the problem?

Creates the component and adds new access

## How has this been tested?

Post-deployment

## Deployment Plan / Instructions

N/A

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [X] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
