### PR TITLE
Revert Pinned Version of Terraform GitHub Provider

### DIFF
--- a/terraform/environments/versions.tf
+++ b/terraform/environments/versions.tf
@@ -5,7 +5,7 @@ terraform {
       source  = "hashicorp/aws"
     }
     github = {
-      version = "=6.7.1"
+      version = "~> 6.0"
       source  = "integrations/github"
     }
   }

--- a/terraform/github/modules/contributor/versions.tf
+++ b/terraform/github/modules/contributor/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = "~> 1.0"
   required_providers {
     github = {
-      version = "=6.7.1"
+      version = "~> 6.0"
       source  = "integrations/github"
     }
   }

--- a/terraform/github/modules/repository/versions.tf
+++ b/terraform/github/modules/repository/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = "~> 1.0"
   required_providers {
     github = {
-      version = "=6.7.1"
+      version = "~> 6.0"
       source  = "integrations/github"
     }
   }

--- a/terraform/github/modules/team/versions.tf
+++ b/terraform/github/modules/team/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = "~> 1.0"
   required_providers {
     github = {
-      version = "=6.7.1"
+      version = "~> 6.0"
       source  = "integrations/github"
     }
   }

--- a/terraform/github/versions.tf
+++ b/terraform/github/versions.tf
@@ -10,7 +10,7 @@ terraform {
       source  = "hashicorp/external"
     }
     github = {
-      version = "=6.7.1"
+      version = "~> 6.0"
       source  = "integrations/github"
     }
     time = {


### PR DESCRIPTION
Reverting pinned version of Terraform GitHub Provider as version 6.7.5 appears to be stable https://github.com/integrations/terraform-provider-github/releases/tag/v6.7.5