### PR TITLE
Adding George Hill to the DSO Pagerduty schedule, and removing Robert Sweetman

### DIFF
--- a/terraform/pagerduty/member-services-integrations.tf
+++ b/terraform/pagerduty/member-services-integrations.tf
@@ -1850,7 +1850,6 @@ locals {
   # add users to this list once they've signed into PagerDuty via SSO for first time
   # avoid putting full email as public repo
   dso_team_members = {
-    "robertsweetman"   = "@pm.me"
     "dave.kent"        = local.justice_email_suffix
     "william.gibbon"   = local.digital_email_suffix
     "antony.gowland"   = local.digital_email_suffix
@@ -1962,8 +1961,8 @@ resource "pagerduty_schedule" "dso" {
 
   layer {
     name                         = "Primary Schedule"
-    start                        = "2025-10-10T00:00:00Z"
-    rotation_virtual_start       = "2025-10-10T00:00:00Z"
+    start                        = "2025-11-04T00:00:00Z"
+    rotation_virtual_start       = "2025-11-04T00:00:00Z"
     rotation_turn_length_seconds = 86400
 
     users = [


### PR DESCRIPTION
## Adding myself (George Hill) to the DSO PagerDuty schedule, and removing Robert Sweetman

This is so that I can be on the concierge rota to provide support. Additionally, this removes Robert Sweetman from the DSO rota.

## How does this PR fix the problem?

This references my PagerDuty user as appropriate, and is intended to honour the existing DSO schedule. It also removes the reference to Robert Sweetman, due to Robert's account being disabled