### PR TITLE
Remove Slack webhook URL from mp repo github secrets

### DIFF
--- a/terraform/github/repositories.tf
+++ b/terraform/github/repositories.tf
@@ -10,10 +10,6 @@ module "core" {
     "aws",
     "documentation"
   ]
-  secrets = {
-    # Slack app webhook url
-    SLACK_WEBHOOK_URL = data.aws_secretsmanager_secret_version.slack_webhook_url.secret_string
-  }
 }
 
 module "terraform-module-baselines" {


### PR DESCRIPTION
## A reference to the issue / Description of it

While working on an [issue](https://github.com/ministryofjustice/modernisation-platform/issues/11764) to rotate the `slack_webhook_url` I've been reviewing the runbook which required you to update the secret in the GitHub repo but we are no longer using this secret, we now retrieve this secret directly from AWS using our centralised secret GH action.

## How does this PR fix the problem?

Removes Slack webhook URL from mp repo github secrets.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
