### PR TITLE
Add `transfer:*` permissions to sandbox IAM policy

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -836,6 +836,7 @@ data "aws_iam_policy_document" "sandbox_additional" {
       "states:*",
       "support:*",
       "textract:*",
+      "transfer:*",
       "wafv2:*",
       "wellarchitected:*",
       "workspaces-web:*"


### PR DESCRIPTION
## A reference to the issue / Description of it

Requested in slack https://mojdt.slack.com/archives/C01A7QK5VM1/p1762771455361999

## How does this PR fix the problem?

This PR adds `transfer:*` permissions to sandbox IAM policy.

This seems justifyable as we allow these permissions in the MemberInfrastructureAccess [role](https://github.com/ministryofjustice/modernisation-platform/blob/main/terraform/environments/bootstrap/member-bootstrap/iam.tf#L223C1-L224C1) which is the main role for memebers to deploy their infra via TF in their environments.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
