### PR TITLE
AMI and EBS cleanup runbook

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -117,6 +117,7 @@ This documentation is for anyone interested in the Modernisation Platform and it
 - [Applying VPN maintenance](runbooks/applying-vpn-maintenance.html)
 - [Backup and Restore of Terraform Statefile & EC2](runbooks/backup-restore-process.html)
 - [Changing environment (AWS account) details](runbooks/changing-environment-details.html)
+- [Clean up of unused (AMIs) and unattached EBS volumes](runbooks/ami-and-ebs-cleanup.html.md)
 - [CloudWatch networking alarms](runbooks/cloudwatch-networking-alarms.html)
 - [Creating Automated Terraform Documentation](user-guide/creating-automated-terraform-documentation.html)
 - [Creating new DNS zones](runbooks/creating-new-dns-zones.html)

--- a/source/runbooks/ami-and-ebs-cleanup.html.md.erb
+++ b/source/runbooks/ami-and-ebs-cleanup.html.md.erb
@@ -15,7 +15,7 @@ The goal is to reduce costs and keep environments clean by automatically deletin
 
 The cleanup runs in two phases:
 
-1. **Preview (dry run)** — lists candidates for deletion and produces a [summary](https://github.com/ministryofjustice/modernisation-platform-environments/actions/runs/19268860979#summary-55091517918) and  CSV reports.
+1. **Preview (dry run)** — lists candidates for deletion and produces a summary and  CSV reports.
 2. **Live (deletion)** — deregisters unused AMIs, deletes associated snapshots, and removes unattached EBS volumes.
 
 ---
@@ -37,7 +37,7 @@ Run this workflow when:
 
 ## How to trigger the cleanup
 
-1. Go to the [**Modernisation Platform Enviroments**](https://github.com/ministryofjustice/modernisation-platform-environments) repository in GitHub.  
+1. Go to the [**Modernisation Platform Environments**](https://github.com/ministryofjustice/modernisation-platform-environments) repository in GitHub.  
 
 2. Select the [**Actions**](https://github.com/ministryofjustice/modernisation-platform-environments/actions) tab.  
 3. Choose [**Cloud Clean Up AMI and EBS**](https://github.com/ministryofjustice/modernisation-platform-environments/actions/workflows/ami_cleanup.yml) in the left-hand list.  
@@ -62,7 +62,7 @@ Run this workflow when:
   - AMIs referenced in Terraform (`ami = "..."` or `ami_name = "..."`).
   - AMIs in use by running instances.
   - AMIs or snapshots tagged `AwsBackup`, `Retain=true`, or `Backup=true`.
-- Generates reports and a [cleanup summary](https://github.com/ministryofjustice/modernisation-platform-environments/actions/runs/19268860979#summary-55091517918) in Github actions showing ami, snapshots and ebs candidates to be deleted.
+- Generates reports and a cleanup summary in Github actions showing ami, snapshots and ebs candidates to be deleted.
 
 ### Phase 2 – Live (deletion)
 - Runs after the dry run and requires approval from the team before execution.


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/orgs/ministryofjustice/projects/17/views/4?pane=issue&itemId=125298921&issue=ministryofjustice%7Cmodernisation-platform%7C11321

## How does this PR fix the problem?

PR has a run book that explains how to use the AMI and EBS cleanup pipeline to identify and remove unused Amazon Machine Images (AMIs) and unattached EBS volumes in Modernisation Platform environments.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Followed the run book and saw the results that are needed

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
