### PR TITLE
Security group quarantine script

### DIFF
--- a/scripts/internal/quarantine-security-groups.sh
+++ b/scripts/internal/quarantine-security-groups.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
+
 # Script to remove all security group rules from all security groups in an AWS environment
+# Usage: Export AWS credentials and run the script
+# Example:
+#   export AWS_ACCESS_KEY_ID="your_access_key_id"
+#   export AWS_SECRET_ACCESS_KEY="your_secret_access_key"
+#   export AWS_SESSION_TOKEN="your_session_token"
+#   ./scripts/internal/quarantine-security-groups.sh
+
 set -e
 
 # Color codes for output


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/11525

## How does this PR fix the problem?

This pull request introduces a new script, `quarantine-security-groups.sh` which automates the process of quarantining an environment on the Modernisation Platform in the event of a security incident. It is designed to be ran locally from the command line to speed up the process which would otherwise be time-consuming, taking multiple actions in the AWS console. 

- It discovers all AWS security groups in the target environment and deletes all the associated ingress and egress rules. 

- Implements multiple user confirmations and clear warnings before making any destructive changes, reducing the risk of accidental rule removal.

- Automatically creates both JSON and human-readable text backups of all security group rules before any changes, and logs the entire process to a timestamped log file for auditing and potential recovery.

- Provides a summary of affected security groups and rules, and displays a final report including the number of rules removed and any failures encountered.

**NB** I will raise a separate PR to update the network revoking runbook to point to this new script

## How has this been tested?

I've tested this script in cooker by creating test security groups and rules and running the script to see how it behaves in all manner of scenarios. 