### PR TITLE
Pin github provider version to 6.8.0

### DIFF
--- a/terraform/environments/versions.tf
+++ b/terraform/environments/versions.tf
@@ -5,7 +5,7 @@ terraform {
       source  = "hashicorp/aws"
     }
     github = {
-      version = "~> 6.0"
+      version = "=6.8.0"
       source  = "integrations/github"
     }
   }


### PR DESCRIPTION

## A reference to the issue / Description of it

Error https://github.com/ministryofjustice/modernisation-platform/actions/runs/19433996957/job/55599963003.

Also issue https://github.com/integrations/terraform-provider-github/issues/2903

## How does this PR fix the problem?

Pins the github provider to 6.8.0 due to a validation bug with the latest version - 6.8.2.

Note that the state file in question has not been updated since the 13/11 when 6.8.0 was the latest version, so no restore should be required.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
