### PR TITLE
Update revoke-network-access documentation 

### DIFF
--- a/source/runbooks/revoke-network-access.html.md.erb
+++ b/source/runbooks/revoke-network-access.html.md.erb
@@ -62,6 +62,7 @@ This is the best option to deploy where the incident is contained to a single ap
 2. Select the `Access keys` link for the `AdministratorAccess` role
 3. Copy the `Option 1: Set AWS environment variables` details into your terminal
     e.g.
+    
     ```
     export AWS_ACCESS_KEY_ID="your_access_key_id"
     export AWS_SECRET_ACCESS_KEY="your_secret_access_key"


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/11525

## How does this PR fix the problem?

This enhances the network revoking runbook by replacing clickops instructions with new steps for running the `quarantine-security-groups.sh` script
