### PR TITLE
update of hmpps-community-payback-devs github team name

### DIFF
--- a/environments/delius-core.json
+++ b/environments/delius-core.json
@@ -51,7 +51,7 @@
           "github_action_reviewer": "false"
         },
         {
-          "sso_group_name": "hmpps-community-payback",
+          "sso_group_name": "hmpps-community-payback-devs",
           "level": "developer",
           "github_action_reviewer": "false"
         }
@@ -99,7 +99,7 @@
           "github_action_reviewer": "false"
         },
         {
-          "sso_group_name": "hmpps-community-payback",
+          "sso_group_name": "hmpps-community-payback-devs",
           "level": "developer",
           "github_action_reviewer": "false"
         }


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/actions/runs/19462354355/job/55689422719#step:9:156

## How does this PR fix the problem?

PR fixes the error by updating the latest github name for mpps-community-payback to hmpps-community-payback-devs.

Dhruv Patel, confirmed that Github team name was updated.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Please see tests below

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
