### PR TITLE
property account users to assume data-engineer role

### DIFF
--- a/environments/property-cafm-data-migration.json
+++ b/environments/property-cafm-data-migration.json
@@ -7,7 +7,7 @@
       "access": [
         {
           "sso_group_name": "property-datahub",
-          "level": "developer"
+          "level": "data-engineer"
         }
       ]
     },
@@ -16,7 +16,7 @@
       "access": [
         {
           "sso_group_name": "property-datahub",
-          "level": "developer"
+          "level": "data-engineer"
         }
       ]
     },
@@ -25,7 +25,7 @@
       "access": [
         {
           "sso_group_name": "property-datahub",
-          "level": "developer"
+          "level": "data-engineer"
         }
       ]
     }


### PR DESCRIPTION
## A reference to the issue / Description of it

Users in the property account require data-engineer permissions. Glue:DeleteTable and Lakeformation permissions along with state machine redrive permission.

## How does this PR fix the problem?

The users of the account will now assume the data-engineer sso role which has the correct permissions.

## How has this been tested?

The permissions have been used in other accounts using the data-engineer sso role.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

