### PR TITLE
Split testing-ci CI user secret into separate secrets for Access Key  and Secret Access Key

### DIFF
--- a/terraform/github/testing-ci.tf
+++ b/terraform/github/testing-ci.tf
@@ -127,15 +127,39 @@ resource "time_static" "key_rotate_period" {
   rfc3339 = time_rotating.key_rotate_period.rfc3339
 }
 
-resource "aws_secretsmanager_secret" "testing_ci_iam_user_access_key_id" {
+# Old combined secret (for backward compatibility)
+resource "aws_secretsmanager_secret" "testing_ci_iam_user_keys" {
   # checkov:skip=CKV2_AWS_57:Auto rotation done via Terraform
-  name        = "testing_ci_iam_user_access_key_id"
+  name        = "testing_ci_iam_user_keys"
   policy      = data.aws_iam_policy_document.testing_ci_iam_user_secrets_manager_policy.json
   kms_key_id  = aws_kms_key.testing_ci_iam_user_kms_key.id
   description = "Access keys for the testing CI user, this secret is used by GitHub to set the correct repository secrets."
   tags        = local.testing_tags
 }
 
+resource "aws_secretsmanager_secret_version" "testing_ci_iam_user_keys" {
+  secret_id = aws_secretsmanager_secret.testing_ci_iam_user_keys.id
+  secret_string = jsonencode({
+    AWS_ACCESS_KEY_ID     = aws_iam_access_key.testing_ci.id
+    AWS_SECRET_ACCESS_KEY = aws_iam_access_key.testing_ci.secret
+  })
+}
+# New split secret:  Access Key ID
+resource "aws_secretsmanager_secret" "testing_ci_iam_user_access_key_id" {
+  # checkov:skip=CKV2_AWS_57:Auto rotation done via Terraform
+  name        = "testing_ci_iam_user_access_key_id"
+  policy      = data.aws_iam_policy_document.testing_ci_iam_user_secrets_manager_policy.json
+  kms_key_id  = aws_kms_key.testing_ci_iam_user_kms_key.id
+  description = "Access Key ID for the testing CI user, this secret is used by GitHub to set the correct repository secrets."
+  tags        = local.testing_tags
+}
+
+resource "aws_secretsmanager_secret_version" "testing_ci_iam_user_access_key_id" {
+  secret_id     = aws_secretsmanager_secret.testing_ci_iam_user_access_key_id.id
+  secret_string = aws_iam_access_key.testing_ci.id
+}
+
+# New split secret: Secret Access Key
 resource "aws_secretsmanager_secret" "testing_ci_iam_user_secret_access_key" {
   # checkov:skip=CKV2_AWS_57:Auto rotation done via Terraform
   name        = "testing_ci_iam_user_secret_access_key"
@@ -143,11 +167,6 @@ resource "aws_secretsmanager_secret" "testing_ci_iam_user_secret_access_key" {
   kms_key_id  = aws_kms_key.testing_ci_iam_user_kms_key.id
   description = "Secret Access Key for the testing CI user, this secret is used by GitHub to set the correct repository secrets."
   tags        = local.testing_tags
-}
-
-resource "aws_secretsmanager_secret_version" "testing_ci_iam_user_access_key_id" {
-  secret_id     = aws_secretsmanager_secret.testing_ci_iam_user_access_key_id.id
-  secret_string = aws_iam_access_key.testing_ci.id
 }
 
 resource "aws_secretsmanager_secret_version" "testing_ci_iam_user_secret_access_key" {


### PR DESCRIPTION
## A reference to the issue / Description of it

https://mojdt.slack.com/archives/C013RM6MFFW/p1763638223099179

## How does this PR fix the problem?

- Simplifies retrieval and use in CI/CD systems, no need for JSON parsing
- Improves security and clarity by separating credentials into distinct secrets.
- Keeps workflows safer and easier to manage as each secret now contains only the corresponding credential, rather than a JSON object holding both.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
