### PR TITLE
Adds aws-waf repo to the GitHub OIDC trust policy for the `github-actions-read-secrets` IAM role.

### DIFF
--- a/terraform/modernisation-platform-account/iam.tf
+++ b/terraform/modernisation-platform-account/iam.tf
@@ -321,7 +321,8 @@ module "github_actions_read_secrets_role" {
     "ministryofjustice/modernisation-platform-terraform-loadbalancer",
     "ministryofjustice/modernisation-platform-terraform-aws-data-firehose",
     "ministryofjustice/modernisation-platform-terraform-cross-account-access",
-    "ministryofjustice/modernisation-platform-security"
+    "ministryofjustice/modernisation-platform-security",
+    "ministryofjustice/modernisation-platform-terraform-aws-waf"
   ]
   role_name    = "github-actions-read-secrets"
   policy_jsons = [data.aws_iam_policy_document.oidc_assume_read_secrets_role_member.json]


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform-terraform-aws-waf/actions/runs/19634489635/attempts/1
The aws-waf repository was missing from the github-actions-read-secrets IAM role trust policy, causing OIDC authentication failures in GitHub Actions.

This adds the repository to the allowed list, enabling the fetch-secrets workflow to retrieve secrets needed for Go terratest runs.


## How does this PR fix the problem?

{Please write here}

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
