### PR TITLE
Remove hash symbol from slack-channel in cloud-platform-non-live.json

### DIFF
--- a/environments/cloud-platform-non-live.json
+++ b/environments/cloud-platform-non-live.json
@@ -45,7 +45,7 @@
     "business-unit": "platforms",
     "infrastructure-support": "cloudplatform@justice.gov.uk",
     "owner": "cloudplatform@justice.gov.uk",
-    "slack-channel": "#cloud-platform",
+    "slack-channel": "cloud-platform",
     "critical-national-infrastructure": false
   },
   "github-oidc-team-repositories": [],


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/11927

## How does this PR fix the problem?
Remove hash symbol from slack-channel in cloud-platform-non-live.json which we think causes the error..

```
Error: creating AWS Organizations Account (cloud-platform-non-live-development): operation error Organizations: CreateAccount, https response error StatusCode: 400, RequestID: 1dd653cc-1301-4368-8409-aab6abb1c973, InvalidInputException: You provided a value that does not match the required pattern.
```

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
