### PR TITLE
Grant CICA MI Quicksight tool in AP, access to CICA MP UAT and Prod

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/development_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/development_rules.json
@@ -719,5 +719,12 @@
     "destination_ip": "${hmpps-development}",
     "destination_port": "1522",
     "protocol": "TCP"
+  },
+  "ap_ingest_dev_to_cica_mp_tariff_uat": {
+    "action": "PASS",
+    "source_ip": "${analytical-platform-ingest-dev}",
+    "destination_ip": "${cica-test}",
+    "destination_port": "1521",
+    "protocol": "TCP"
   }
 }

--- a/terraform/environments/core-network-services/firewall-rules/production_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/production_rules.json
@@ -573,5 +573,12 @@
     "destination_ip": "$CICA_AWS_SS",
     "destination_port": "ANY",
     "protocol": "TCP"
+  },
+  "ap_ingest_prod_to_cica_mp_tariff_prod": {
+    "action": "PASS",
+    "source_ip": "${analytical-platform-ingest-prod}",
+    "destination_ip": "${cica-production}",
+    "destination_port": "1521",
+    "protocol": "TCP"
   }
 }


### PR DESCRIPTION
This pull request adds new firewall rules to both the development and production environments to allow connectivity from the Analytical Platform Ingest services to CICA MP Tariff databases. These rules enable TCP traffic on port 1521 from the respective ingest service to the appropriate CICA environment.

**Firewall rule additions:**

* Development environment:
  - Added rule `ap_ingest_dev_to_cica_mp_tariff_uat` to allow TCP traffic on port 1521 from `${analytical-platform-ingest-dev}` to `${cica-test}`.

* Production environment:
  - Added rule `ap_ingest_prod_to_cica_mp_tariff_prod` to allow TCP traffic on port 1521 from `${analytical-platform-ingest-prod}` to `${cica-production}`.