### PR TITLE
Allow SMTP traffic for CICA-Test

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/inline_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/inline_rules.json
@@ -103,5 +103,12 @@
     "destination_ip": "13.17.132.44",
     "destination_port": "22",
     "protocol": "TCP"
+  },
+    "cica_test_to_internet_smtps": {
+    "action": "PASS",
+    "source_ip": "${cica-test}",
+    "destination_ip": "0.0.0.0/0",
+    "destination_port": "587",
+    "protocol": "TCP"
   }
 }


### PR DESCRIPTION
CICA Test instances are currently failing to reach Office 365 SMTP, This PR adds a firewall rule to allow access. 