### PR TITLE
Update destination for 'AP dev to CICA MP dev' FW rule

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/development_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/development_rules.json
@@ -720,10 +720,10 @@
     "destination_port": "1522",
     "protocol": "TCP"
   },
-  "ap_ingest_dev_to_cica_mp_tariff_uat": {
+  "ap_ingest_dev_to_cica_mp_tariff_dev": {
     "action": "PASS",
     "source_ip": "${analytical-platform-ingest-dev}",
-    "destination_ip": "${cica-test}",
+    "destination_ip": "${cica-development}",
     "destination_port": "1521",
     "protocol": "TCP"
   }


### PR DESCRIPTION
Update following this [PR](https://github.com/ministryofjustice/modernisation-platform/pull/11979) - change of target environment.

This PR changes the destination environment and IP for a rule allowing traffic from the Analytical Platform Ingest development environment to the CICA MP Tariff development environment.

- Firewall rule update:
  * Renamed the rule from `ap_ingest_dev_to_cica_mp_tariff_uat` to `ap_ingest_dev_to_cica_mp_tariff_dev`, and changed the destination IP from `${cica-test}` to `${cica-development}` in `development_rules.json` to correctly reflect the intended development-to-development connection.