### PR TITLE
Allow smtp traffic for CICA Environments

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/inline_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/inline_rules.json
@@ -111,21 +111,21 @@
     "destination_port": "587",
     "protocol": "TCP"
   },
-    "cica_test_to_internet_smtps": {
+  "cica_test_to_internet_smtps": {
     "action": "PASS",
     "source_ip": "${cica-test}",
     "destination_ip": "0.0.0.0/0",
     "destination_port": "587",
     "protocol": "TCP"
   },
-    "cica_preproduction_to_internet_smtps": {
+  "cica_preproduction_to_internet_smtps": {
     "action": "PASS",
     "source_ip": "${cica-preproduction}",
     "destination_ip": "0.0.0.0/0",
     "destination_port": "587",
     "protocol": "TCP"
   },
-    "cica_production_to_internet_smtps": {
+  "cica_production_to_internet_smtps": {
     "action": "PASS",
     "source_ip": "${cica-production}",
     "destination_ip": "0.0.0.0/0",


### PR DESCRIPTION
Following successful testing of https://github.com/ministryofjustice/modernisation-platform/pull/11980 this PR adds the firewall change to the remaining CICA environments. 