### PR TITLE
Wider port range for egress rule.

### DIFF
--- a/terraform/modules/vpc-nacls/locals.tf
+++ b/terraform/modules/vpc-nacls/locals.tf
@@ -102,10 +102,11 @@ locals {
       rule_action = "allow"
       rule_number = 2015
     }
+    # Note - egress ports are ephemeral and so need to wider in scope than just 1521.
     cica_general_private_subnets_ap_db_egress = {
       egress      = true
-      from_port   = 1521
-      to_port     = 1521
+      from_port   = 1024
+      to_port     = 65535
       protocol    = "tcp"
       rule_action = "allow"
       rule_number = 2015


### PR DESCRIPTION
## A reference to the issue / Description of it

The return traffic is still being blocked as the return ports are wider than just 1521 as demonstrated by the VPC flow log.

## How does this PR fix the problem?

{Please write here}

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
