### PR TITLE
✏️ Fix duplicate rule due to copy paste

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/production_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/production_rules.json
@@ -567,7 +567,7 @@
     "destination_port": "$TARIFF_TCP",
     "protocol": "TCP"
   },
-  "cica_tariff_test_to_cica_aws_ss": {
+  "cica_tariff_production_to_cica_aws_ss": {
     "action": "PASS",
     "source_ip": "${cica-production}",
     "destination_ip": "$CICA_AWS_SS",


### PR DESCRIPTION


## A reference to the issue / Description of it

Fixes name of firewall rule from cica_tariff_test_to_cica_aws_ss to cica_tariff_production_to_cica_aws_ss

## How does this PR fix the problem?

removes duplicate rule by renaming the prod one correctly

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.


## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

yes

## Checklist (check `x` in `[ ]` of list items)

- [x ] I have performed a self-review of my own code
- [x ] All checks have passed
- [x ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
