### PR TITLE
Fix secret rotation job raising duplicate issues

### DIFF
--- a/.github/workflows/secrets-rotation-reminder.yml
+++ b/.github/workflows/secrets-rotation-reminder.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - "main" 
     paths:
-      - ".github/workflows/secrets-rotation-reminder.yaml"
+      - ".github/workflows/secrets-rotation-reminder.yml"
   schedule: 
       - cron: '30 11 * * *' # run at 11:30 daily 
   workflow_dispatch:
@@ -85,7 +85,7 @@ jobs:
             secrets=$(aws secretsmanager list-secrets --region $AWS_REGION --query "SecretList[].Name" --output text)
             
             # Remove secrets from list that are exempt from rotation
-            delete=("environment_management" "nuke_account_ids" "nuke_account_blocklist" "mod-platform-circleci" "pagerduty_integration_keys")
+            delete=("environment_management" "nuke_account_ids" "nuke_account_blocklist" "mod-platform-circleci" "pagerduty_integration_keys" "nonmp-account-ids")
             for del in ${delete[@]}
             do
               secrets=("${secrets[@]/$del}")
@@ -110,16 +110,16 @@ jobs:
               age=$((current_timestamp - $(date -d "$last_changed" +%s)))
 
               # Check if there is an existing open issue to rotate the secret
-              open_issue=$(gh issue list -R ministryofjustice/modernisation-platform --search "Rotate $secret in:title" --state open)
+              open_issue_count=$(gh issue list -R ministryofjustice/modernisation-platform --state open --limit 500 --json title --jq "[.[] | select(.title | contains(\"Rotate $secret\"))] | length")
             
-              # Check if the secret is older than the threshold and if there is an existing open issue to rotate it, if required raise a new issue
-              if [ $age -gt $threshold ] && [ -z "$open_issue" ]; then
-              echo "$secret secret is older than 180 days (age: $((age / (24 * 60 * 60))) days)"
-              echo "Creating GitHub Issue to rotate $secret"
-              gh issue create --title "Rotate $secret Credential" --label "security,kanban" --project "Modernisation Platform" --body "The [secrets-rotation-reminder workflow](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) has identified that the $secret credential requires rotation as it is close to or exceeding the threshold of 180 days. 
-
-              Consult [this documentation](https://user-guide.modernisation-platform.service.justice.gov.uk/runbooks/rotating-secrets.html#how-to-rotate-secrets) which describes the process for rotation."
+              # Check if the secret is older than the threshold and if there is no existing open issue to rotate it, raise a new issue
+              if [ $age -gt $threshold ] && [ "$open_issue_count" -eq 0 ]; then
+                echo "$secret secret is older than 180 days (age: $((age / (24 * 60 * 60))) days)"
+                echo "Creating GitHub Issue to rotate $secret"
+                gh issue create --title "Rotate $secret Credential" --label "security,kanban" --project "Modernisation Platform" --body "The secrets-rotation-reminder workflow has identified that the $secret credential requires rotation as it is close to or exceeding the threshold of 180 days. Consult the [documentation](https://user-guide.modernisation-platform.service.justice.gov.uk/runbooks/rotating-secrets.html#how-to-rotate-secrets) which describes the process for rotation."
+              elif [ $age -gt $threshold ] && [ "$open_issue_count" -gt 0 ]; then
+                echo "$secret secret is older than 180 days (age: $((age / (24 * 60 * 60))) days) but an issue has already been raised to address this"
               else 
-              echo "The $secret secret has not been identified for rotation (age: $((age / (24 * 60 * 60))) days)"
+                echo "The $secret secret has not been identified for rotation (age: $((age / (24 * 60 * 60))) days)"
               fi
-            done              
+            done


### PR DESCRIPTION
## A reference to the issue / Description of it

The secrets rotation reminder workflow was creating duplicate GitHub issues daily for the same secrets that needed rotation. For example, the `xsoar` secret had 12 duplicate open issues created over consecutive days.

## How does this PR fix the problem?

The issue was caused by the GitHub App token being unable to use the GitHub search API (`gh issue list --search`), which meant the duplicate check was always returning empty results. 

The fix:
- Changed from using `gh issue list --search` to `gh issue list --json --jq` which uses the direct API
- Increased the limit from 100 to 500 to ensure all open issues are checked (repo currently has 177 open issues)
- Added better logging to show when secrets are past threshold but already have open issues
- I've also added `nonmp-account-ids` to the list of secrets that don't need rotating.

## How has this been tested?

- Ran the workflow manually on the `fix/duplicate-secret-reminders` branch
- Confirmed it correctly detected 12 existing open issues for `xsoar` and `nonmp-account-ids`
- Verified it did NOT create duplicate issues when existing ones were found

SEE EXAMPLE RUN: https://github.com/ministryofjustice/modernisation-platform/actions/runs/19858423274/job/56902111975#step:8:1

**NB** The check on this PR will fail as the IAM role to assume only works on `main`, I had to edit this to test it.

## Deployment Plan / Instructions

No deployment impact. This is a fix to the secrets rotation reminder workflow itself. The workflow will run on its normal daily schedule and will stop creating duplicate issues.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

The 12 duplicate issues for `xsoar` and `nonmp-account-ids` should be manually closed, keeping only one open issue for each secret.