### PR TITLE
CC-4118: Added rule in Firewall to allow Dom1 to LAA VPC in PROD

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/production_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/production_rules.json
@@ -434,6 +434,13 @@
     "destination_port": "443",
     "protocol": "TCP"
   },
+  "dom1_to_laa_production_mp_https": {
+    "action": "PASS",
+    "source_ip": "${dom1-domain-controllers}",
+    "destination_ip": "${laa-production}",
+    "destination_port": "443",
+    "protocol": "TCP"
+  },
   "cp_to_mp_laa_production_1522": {
     "action": "PASS",
     "source_ip": "${cloud-platform}",


### PR DESCRIPTION
## A reference to the issue / Description of it

Added rule in Firewall to allow Dom1 to LAA VPC in PROD

## How does this PR fix the problem?

Gets Dom1 users to LAA EBS application

## How has this been tested?

By looking at it

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
