### PR TITLE
issue/12063-fix-pagerduty-secret

### DIFF
--- a/terraform/pagerduty/aws.tf
+++ b/terraform/pagerduty/aws.tf
@@ -74,7 +74,7 @@ resource "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {
     laa_cis_nonprod_alarms               = pagerduty_service_integration.cis_non_prod.integration_key
     performance_hub_nonprod_alarms       = pagerduty_service_integration.performance_hub_non_prod.integration_key
     performance_hub_prod_alarms          = pagerduty_service_integration.performance_hub_prod.integration_key
-    security_hub_alerts_critical_priority = pagerduty_service.integration.security_hub_alerts_critical_priority.integration_key
+    security_hub_alerts_critical_priority = pagerduty_service_integration.security_hub_alerts_critical_priority.integration_key
     },
     {
       for key, integration in pagerduty_service_integration.integrations : key => integration.integration_key


### PR DESCRIPTION

## A reference to the issue / Description of it

#12063 

## How does this PR fix the problem?

Adds the integration key secret for security_hub_alerts_critical_priority. Required for the SNS subscription & slack message routing.

Also amended some of the formatting to keep aligned.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
