### PR TITLE
Adding CICA on-prem wired users, grants access to MP CICA envs.

### DIFF
--- a/terraform/environments/core-network-services/cidr-ranges.tf
+++ b/terraform/environments/core-network-services/cidr-ranges.tf
@@ -135,6 +135,7 @@ locals {
     cica-aws-prod-b       = "10.13.110.0/24"
     cica-aws-prod-c       = "10.13.20.0/24"
     cica-aws-prod-d       = "10.13.120.0/24"
+    cica-onprem-lan       = "10.7.11.0/24"
 
 
 

--- a/terraform/environments/core-network-services/firewall-rules/development_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/development_rules.json
@@ -726,5 +726,19 @@
     "destination_ip": "${cica-development}",
     "destination_port": "1521",
     "protocol": "TCP"
+  },
+  "cica_onprem_lan_to_cica_tariff_dev": {
+    "action": "PASS",
+    "source_ip": "${cica-onprem-lan}",
+    "destination_ip": "${cica-development}",
+    "destination_port": "$TARIFF_TCP",
+    "protocol": "TCP"
+  },
+  "cica_tariff_dev_to_cica_onprem_lan": {
+    "action": "PASS",
+    "source_ip": "${cica-development}",
+    "destination_ip": "${cica-onprem-lan}",
+    "destination_port": "ANY",
+    "protocol": "TCP"
   }
 }

--- a/terraform/environments/core-network-services/firewall-rules/production_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/production_rules.json
@@ -587,5 +587,19 @@
     "destination_ip": "${cica-production}",
     "destination_port": "1521",
     "protocol": "TCP"
+  },
+  "cica_onprem_lan_to_cica_tariff_prod": {
+    "action": "PASS",
+    "source_ip": "${cica-onprem-lan}",
+    "destination_ip": "${cica-production}",
+    "destination_port": "$TARIFF_TCP",
+    "protocol": "TCP"
+  },
+  "cica_tariff_production_to_cica_onprem_lan": {
+    "action": "PASS",
+    "source_ip": "${cica-production}",
+    "destination_ip": "${cica-onprem-lan}",
+    "destination_port": "ANY",
+    "protocol": "TCP"
   }
 }

--- a/terraform/environments/core-network-services/firewall-rules/test_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/test_rules.json
@@ -572,5 +572,19 @@
     "destination_ip": "$LAA_ECP_DATABASES",
     "destination_port": "2484",
     "protocol": "TCP"
+  },
+  "cica_onprem_lan_to_cica_tariff_test": {
+    "action": "PASS",
+    "source_ip": "${cica-onprem-lan}",
+    "destination_ip": "${cica-test}",
+    "destination_port": "$TARIFF_TCP",
+    "protocol": "TCP"
+  },
+  "cica_tariff_test_to_cica_onprem_lan": {
+    "action": "PASS",
+    "source_ip": "${cica-test}",
+    "destination_ip": "${cica-onprem-lan}",
+    "destination_port": "ANY",
+    "protocol": "TCP"
   }
 }


### PR DESCRIPTION
This pull request adds support for a new on-premises LAN CIDR range (`cica-onprem-lan`) and updates firewall rules to allow TCP traffic between this new range and the CICA tariff environments (development, test, and production). The changes ensure controlled, bidirectional access between the on-prem LAN and each environment.

**Network configuration:**

* Added new CIDR range `cica-onprem-lan` (`10.7.11.0/24`) to the `locals` block in `cidr-ranges.tf`.

**Firewall rule updates (by environment):**

* **Development:**
  * Added rules to allow TCP traffic from `cica-onprem-lan` to the CICA development environment on the tariff port, and from CICA development back to `cica-onprem-lan` on any port.

* **Test:**
  * Added rules to allow TCP traffic from `cica-onprem-lan` to the CICA test environment on the tariff port, and from CICA test back to `cica-onprem-lan` on any port.

* **Production:**
  * Added rules to allow TCP traffic from `cica-onprem-lan` to the CICA production environment on the tariff port, and from CICA production back to `cica-onprem-lan` on any port.