### PR TITLE
OIDC change for new github repo

### DIFF
--- a/terraform/modernisation-platform-account/iam.tf
+++ b/terraform/modernisation-platform-account/iam.tf
@@ -259,7 +259,7 @@ data "aws_iam_policy_document" "oidc_assume_plan_role_member" {
 #trivy:ignore:AVD-AWS-0345: Required for GitHub Actions to access Terraform state in S3
 module "github_actions_apply_role" {
   source              = "github.com/ministryofjustice/modernisation-platform-github-oidc-role?ref=b40748ec162b446f8f8d282f767a85b6501fd192" # v4.0.0
-  github_repositories = ["ministryofjustice/modernisation-platform", "ministryofjustice/modernisation-platform-ami-builds", "ministryofjustice/modernisation-platform-security"]
+  github_repositories = ["ministryofjustice/modernisation-platform", "ministryofjustice/modernisation-platform-github", "ministryofjustice/modernisation-platform-ami-builds", "ministryofjustice/modernisation-platform-security"]
   role_name           = "github-actions-apply"
   policy_arns         = ["arn:aws:iam::aws:policy/AdministratorAccess"]
   policy_jsons        = [data.aws_iam_policy_document.oidc-deny-specific-actions.json]
@@ -310,6 +310,7 @@ module "github_actions_read_secrets_role" {
     "ministryofjustice/modernisation-platform-terraform-member-vpc",
     "ministryofjustice/modernisation-platform-terraform-module-template",
     "ministryofjustice/modernisation-platform-github-oidc-role",
+    "ministryofjustice/modernisation-platform-github",
     "ministryofjustice/modernisation-platform-terraform-environments",
     "ministryofjustice/modernisation-platform-terraform-ecs-cluster",
     "ministryofjustice/modernisation-platform-github-oidc-provider",


### PR DESCRIPTION
## A reference to the issue / Description of it

have found that the new github repo is unable to access secrets due to the oidc role 

## How does this PR fix the problem?

this PR fix's this by adding the repo to the OIDC role

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
