### PR TITLE
Issue #12063 - Updates ref of modernisation-platform-terraform-baselines to v8.2.2

### DIFF
--- a/terraform/environments/bootstrap/secure-baselines/locals.tf
+++ b/terraform/environments/bootstrap/secure-baselines/locals.tf
@@ -31,5 +31,9 @@ locals {
     "long-term-storage-production",
     "^core-.*"
   ]
-  is_core_account = length(regexall(join("|", local.mp_owned_workspaces), terraform.workspace)) > 0
+  is_core_account                   = length(regexall(join("|", local.mp_owned_workspaces), terraform.workspace)) > 0
+
+  # Locals that are passed to the Baselines module for slack alerts for SecurityHub issues.
+  securityhub_slack_alerts_accounts = local.is_core_account && !strcontains(terraform.workspace, "core-shared-services") # All core accounts excluding terraform workspaces containing core-shared-services.
+  securityhub_slack_alerts_scope    = ["CRITICAL"] # The type of alert to generate alerts for. 
 }

--- a/terraform/environments/bootstrap/secure-baselines/main.tf
+++ b/terraform/environments/bootstrap/secure-baselines/main.tf
@@ -6,7 +6,7 @@ data "aws_kms_key" "cloudtrail_key" {
 
 #trivy:ignore:AVD-AWS-0136
 module "baselines" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=4b7ea74934801bce5cbf16d75af9132f4d49d4ab" # v8.2.1
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=40f09a75429e5f9096a08d3216b3eabca3bdd346" # v8.2.2
   providers = {
     # Default and replication regions
     aws                    = aws.workspace-eu-west-2
@@ -79,6 +79,12 @@ module "baselines" {
 
   # PagerDuty Key for High Priority Alarms
   high_priority_pagerduty_integration_key = local.pagerduty_integration_keys["core_alerts_high_priority_cloudwatch"]
+
+  # Individual Slack Alerts for CRITICAL and other severity SecurityHub alerts if the account is in scope and the criticality is set.
+  enable_securityhub_slack_alerts                     = local.securityhub_slack_alerts_accounts
+  securityhub_slack_alerts_scope                      = local.securityhub_slack_alerts_scope
+  securityhub_slack_alerts_pagerduty_integration_key   = local.pagerduty_integration_keys["security_hub_alerts_critical_priority"]
+
 }
 
 # Keys for pagerduty


### PR DESCRIPTION
## A reference to the issue / Description of it

#12063

## How does this PR fix the problem?

Updates baselines module to v8.2.2 along with new locals and vars for SecurityHub Alerts.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

This was deployed into Sprinkler using amended conditions for the accounts and severity levels - https://github.com/ministryofjustice/modernisation-platform/actions/runs/20137735882/job/57795984558

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
