### PR TITLE
add chaps-preprod app zone

### DIFF
--- a/terraform/environments/core-network-services/route53.tf
+++ b/terraform/environments/core-network-services/route53.tf
@@ -3,25 +3,26 @@ locals {
   modernisation-platform-internal-domain = "modernisation-platform.internal"
 
   application-zones = {
-    ccms-ebs       = "ccms-ebs.service.justice.gov.uk",
-    cdpt-chaps     = "correspondence-handling-and-processing.service.justice.gov.uk",
-    cdpt-chaps-dev = "cdpt-chaps.hq-development.modernisation-platform.service.justice.gov.uk",
-    cdpt-ifs       = "integrated-fraud-system.service.justice.gov.uk",
-    dacp           = "divorce-section-search.service.justice.gov.uk",
-    delius-jitbit  = "jitbit.cr.probation.service.justice.gov.uk",
-    equip          = "equip.service.justice.gov.uk",
-    laa-apex       = "laa-apex.service.justice.gov.uk",
-    maat           = "means-assessment-administration.service.justice.gov.uk",
-    mlra           = "maat-libra-administration-tool.service.justice.gov.uk",
-    mojfin         = "laa-finance-data.service.justice.gov.uk",
-    ncas           = "neutral-citation-allocation.service.justice.gov.uk",
-    ppud           = "ppud.justice.gov.uk",
-    pra-register   = "parental-responsibility-agreement.service.justice.gov.uk",
-    tipstaff       = "tipstaff.service.justice.gov.uk",
-    tribunals      = "tribunals.gov.uk",
-    wardship       = "wardship-agreements-register.service.justice.gov.uk"
-    legalservices  = "legalservices.gov.uk"
-    laa            = "laa.service.justice.gov.uk"
+    ccms-ebs            = "ccms-ebs.service.justice.gov.uk",
+    cdpt-chaps          = "correspondence-handling-and-processing.service.justice.gov.uk",
+    cdpt-chaps-dev      = "cdpt-chaps.hq-development.modernisation-platform.service.justice.gov.uk",
+    cdpt-chaps-preprod  = "cdpt-chaps.hq-preproduction.modernisation-platform.service.justice.gov.uk"
+    cdpt-ifs            = "integrated-fraud-system.service.justice.gov.uk",
+    dacp                = "divorce-section-search.service.justice.gov.uk",
+    delius-jitbit       = "jitbit.cr.probation.service.justice.gov.uk",
+    equip               = "equip.service.justice.gov.uk",
+    laa-apex            = "laa-apex.service.justice.gov.uk",
+    maat                = "means-assessment-administration.service.justice.gov.uk",
+    mlra                = "maat-libra-administration-tool.service.justice.gov.uk",
+    mojfin              = "laa-finance-data.service.justice.gov.uk",
+    ncas                = "neutral-citation-allocation.service.justice.gov.uk",
+    ppud                = "ppud.justice.gov.uk",
+    pra-register        = "parental-responsibility-agreement.service.justice.gov.uk",
+    tipstaff            = "tipstaff.service.justice.gov.uk",
+    tribunals           = "tribunals.gov.uk",
+    wardship            = "wardship-agreements-register.service.justice.gov.uk"
+    legalservices       = "legalservices.gov.uk"
+    laa                 = "laa.service.justice.gov.uk"
   }
 
   private-application-zones = {


### PR DESCRIPTION
## A reference to the issue / Description of it

There isn't a fqdn for chaps-preprod in the route53.tf for chaps-preprod

## How does this PR fix the problem?

enters a fqdn for chaps-preprod in the route53.tf for chaps-preprod


## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

/

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

no

## Checklist (check `x` in `[ ]` of list items)

- [ x] I have performed a self-review of my own code
- [x ] All checks have passed
- [x ] I have made corresponding changes to the documentation
- [x ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

/
