### PR TITLE
Update secure-baselines to baselines v8.3.0

### DIFF
--- a/terraform/environments/bootstrap/secure-baselines/main.tf
+++ b/terraform/environments/bootstrap/secure-baselines/main.tf
@@ -6,7 +6,7 @@ data "aws_kms_key" "cloudtrail_key" {
 
 #trivy:ignore:AVD-AWS-0136
 module "baselines" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=40f09a75429e5f9096a08d3216b3eabca3bdd346" # v8.2.2
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=28b05cf3fd0f446eeb41a461b485760415ec2f0d" # v8.3.0
   providers = {
     # Default and replication regions
     aws                    = aws.workspace-eu-west-2


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/orgs/ministryofjustice/projects/17/views/4?pane=issue&itemId=142896351&issue=ministryofjustice%7Cmodernisation-platform%7C12065  

Security Hub finding: **Amazon EBS Snapshots should not be publicly accessible**

Code changes were made in this [PR](https://github.com/ministryofjustice/modernisation-platform-terraform-baselines/pull/972), and a new [release](https://github.com/ministryofjustice/modernisation-platform-terraform-baselines/releases/tag/v8.3.0) was introduced. This PR pins those changes in the Modernisation Platform secure baselines.

## How does this PR fix the problem?

Updates the `secure-baselines` configuration to consume **modernisation-platform-terraform-baselines v8.3.0**, which introduces a new always-on baseline to block public Amazon EBS snapshot sharing across all supported AWS regions.

By pinning to the v8.3.0 release commit, this ensures the EBS snapshot public access control is applied consistently without changing existing EBS encryption behaviour or regional enablement.

## How has this been tested?

Tested by updating the baselines module source to the v8.3.0 release commit and running Terraform plan/apply in test environments.

Verified that:
- No unexpected resource changes are introduced
- The EBS snapshot public access block is enforced by the baselines module
- Existing EBS encryption and regional behaviour remain unchanged

## Deployment Plan / Instructions

This change will be applied automatically on the next Terraform apply for environments consuming `secure-baselines`.

No manual steps or account-level intervention are required.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code  
- [x] All checks have passed  
- [ ] I have made corresponding changes to the documentation  
- [x] Plan and discussed how it should be deployed to PROD (If needed)  
