### PR TITLE
Grants new `terraform-certificate-dns-validations` module access to GitHub Actions secrets role

### DIFF
--- a/terraform/modernisation-platform-account/iam.tf
+++ b/terraform/modernisation-platform-account/iam.tf
@@ -323,7 +323,8 @@ module "github_actions_read_secrets_role" {
     "ministryofjustice/modernisation-platform-terraform-aws-data-firehose",
     "ministryofjustice/modernisation-platform-terraform-cross-account-access",
     "ministryofjustice/modernisation-platform-security",
-    "ministryofjustice/modernisation-platform-terraform-aws-waf"
+    "ministryofjustice/modernisation-platform-terraform-aws-waf",
+    "ministryofjustice/modernisation-platform-terraform-certificate-dns-validations"
   ]
   role_name    = "github-actions-read-secrets"
   policy_jsons = [data.aws_iam_policy_document.oidc_assume_read_secrets_role_member.json]


### PR DESCRIPTION
## A reference to the issue / Description of it

Unit test workflow failing in new module... https://github.com/ministryofjustice/modernisation-platform-terraform-certificate-dns-validations/actions/runs/20802429871/job/59749879180#step:2:21

## How does this PR fix the problem?

This update grants new `terraform-certificate-dns-validations` module access to GitHub Actions secrets role. 


