### PR TITLE
Fix GitHub Repository Ruleset `actor_id` for OrganizationAdmin

### DIFF
--- a/terraform/github/modules/repository/main.tf
+++ b/terraform/github/modules/repository/main.tf
@@ -95,7 +95,7 @@ resource "github_repository_ruleset" "default" {
   }
 
   bypass_actors {
-    actor_id    = 1
+    actor_id    = 0
     actor_type  = "OrganizationAdmin"
     bypass_mode = "always"
   }


### PR DESCRIPTION
## Summary
Corrects the `actor_id` for the `OrganizationAdmin` bypass actor in the repository ruleset from `1` to `0`, resolving state drift issues across all repositories.

## Problem
Terraform plans were showing unwanted updates across all repository rulesets, attempting to change the `actor_id` from `0` to `1` for the OrganizationAdmin bypass actor:

```hcl
~ bypass_actors {
  ~ actor_id    = 0 -> 1
    # (2 unchanged attributes hidden)
}
```

## Changes
Updated `terraform/github/modules/repository/main.tf`:
- Changed `actor_id` from `1` to `0` for the `OrganizationAdmin` bypass actor in the tag protection ruleset

## Reason
According to GitHub's API and the Terraform GitHub provider documentation, when using `actor_type = "OrganizationAdmin"`, the `actor_id` must be `0` (it's a role-based identifier, not a specific actor ID). Repository-specific role IDs like `1` (admin), `2` (maintain), and `5` (write) are only used for `RepositoryRole` types.

## Impact
- Eliminates unnecessary Terraform plan updates for all repository rulesets
- Aligns Terraform configuration with actual GitHub state
- No functional change to repository permissions or ruleset behaviour
