### PR TITLE
Fix: Redact quoted AWS account numbers in terraform plan/apply logs

### DIFF
--- a/scripts/redact-output.sh
+++ b/scripts/redact-output.sh
@@ -10,5 +10,6 @@ sed -u -E \
     -e "s/\[id=[^]]*\]/\[id=<REDACTED>]/g" \
     -e "s/::[0-9]{12}:/::REDACTED:/g" \
     -e "s/:[0-9]{12}:/:REDACTED:/g" \
+    -e "s/\"[0-9]{12}\"/\"REDACTED\"/g" \
     -e "s/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/<REDACTED_EMAIL>/g" \
     -e "s/AKIA[0-9A-Z]{16}/AKIA<REDACTED>/g" 


### PR DESCRIPTION
### Problem

The `redact-output.sh` script was not redacting AWS account numbers that appeared as quoted strings in JSON output from terraform plans. While account numbers in ARN format (e.g., `arn:aws:iam::123456789012:role/...`) were being redacted, standalone quoted account numbers in JSON arrays were exposed in GitHub Actions logs:

```json
"aws:PrincipalAccount" = [
    "012345678901",
    "987654321098",
]
```

### Solution
Added a new regex pattern `s/\"[0-9]{12}\"/\"REDACTED\"/g` to catch and redact any 12-digit number surrounded by quotes. This ensures account numbers in JSON structures are properly redacted.

The script now redacts:
✅ Account numbers in ARNs: `::123456789012:` → `::REDACTED:`
✅ Quoted account numbers: `"123456789012"` → `"REDACTED"`
✅ AWS access keys: `AKIA...` → `AKIA<REDACTED>`
✅ Email addresses