### PR TITLE
:wrench: Add check for existence of lock file

### DIFF
--- a/.github/workflows/terraform-unlock-state.yml
+++ b/.github/workflows/terraform-unlock-state.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
         with:
-          role-to-assume: "arn:aws:iam::${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_NUMBER }}:role/github-actions"
+          role-to-assume: "arn:aws:iam::${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_NUMBER }}:role/github-actions-apply"
           role-session-name: githubactionsrolesession
           aws-region: "eu-west-2"
 


### PR DESCRIPTION
## Issue
At times we run the state unlock workflow when the lock has already resolved itself which results in an error e.g. https://github.com/ministryofjustice/modernisation-platform/actions/runs/20912053095/job/60076752339#step:7:14


## How does this PR fix the problem?
Implements a check for the existence of the Terraform state lock file before attempting to unlock it, ensuring that the unlock operation only proceeds if the lock file is present. Updates the S3 key determination for the lock file based on the workspace.

## How has this been tested?
Tested by running the Terraform unlock workflow in various scenarios, including cases where the lock file exists and where it does not, verifying the correct behavior in each case.

## Deployment Plan / Instructions
This deployment will not impact the platform or services, as it primarily modifies the unlock workflow logic.

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)
None.

