### PR TITLE
Modify assume_role_policy for member-delegation role

### DIFF
--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -1,3 +1,5 @@
+data "aws_organizations_organization" "current" {}
+
 # lookups for DNS
 
 data "aws_route53_zone" "public" {


### PR DESCRIPTION
Related to this ticket - https://github.com/ministryofjustice/modernisation-platform-security/issues/78

This change improves the security of the member-delegation-* IAM roles by adding an AWS Organisations boundary to their trust policies.

Previously, the roles could be assumed by any principal in the listed member accounts, with no additional constraints. This was flagged by security tooling under the finding “Cross-Account AssumeRole Policy Lacks External ID and MFA”.

This enforces that only principals belonging to our AWS Organisation can assume these roles, even if an external account were mistakenly added to the trust policy in future etc. 

It shouldn't change anything, but adds another layer of protection.


Testing it - The plan looks good, and makes sense. 

If the next time the role is used as it doesn't like it.. we back it out. 

