### PR TITLE
Update hmpps-test.json

### DIFF
--- a/environments-networks/hmpps-test.json
+++ b/environments-networks/hmpps-test.json
@@ -29,6 +29,8 @@
       "com.amazonaws.eu-west-2.execute-api",
       "com.amazonaws.eu-west-2.glue",
       "com.amazonaws.eu-west-2.kinesis-streams",
+      "com.amazonaws.eu-west-2.kms",
+      "com.amazonaws.eu-west-2.monitoring",
       "com.amazonaws.eu-west-2.lambda",
       "com.amazonaws.eu-west-2.lakeformation",
       "com.amazonaws.eu-west-2.secretsmanager",


### PR DESCRIPTION
## A reference to the issue / Description of it

Add VPC interface endpoints for CloudWatch (monitoring) and KMS to allow VPC attached Lambdas to access AWS APIs without NAT. this prevents the [MDSS daily failure digest Lambda ](https://github.com/ministryofjustice/electronic-monitoring-data-lambda-functions/blob/main/lambdas/mdss_daily_failure_digest/mdss_daily_failure_digest.py)in test environment from hanging and timing out when calling CloudWatch and SNS

## How does this PR fix the problem?

Fixes MDSS daily failure digest Lambda timing out due to lack of egress to AWS service endpoints when running inside the VPC.

error below from lambda testing https://eu-west-2.console.aws.amazon.com/lambda/home?region=eu-west-2#/functions/mdss_daily_failure_digest?tab=testing :

```
{
  "errorType": "Sandbox.Timedout",
  "errorMessage": "RequestId: 5124f417-705d-4eb8-9e18-3ac1466d60b0 Error: Task timed out after 60.00 seconds"
}
```

[link to cloudwatch log ](https://eu-west-2.console.aws.amazon.com/cloudwatch/home?region=eu-west-2#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fmdss_daily_failure_digest/log-events/2026$252F01$252F14$252F$255B$2524LATEST$255Ddfe176817e9b4594a53517d14e79a83d)

AWS account: electronic-monitoring-data-test 396913731313

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
