### PR TITLE
Grant GitHub teams write access to `modernisation-platform` repository

### DIFF
--- a/terraform/github/locals.tf
+++ b/terraform/github/locals.tf
@@ -150,6 +150,7 @@ locals {
   ]
 
   repositories_with_full_team_access = [
+    "modernisation-platform",
     "modernisation-platform-ami-builds",
     "modernisation-platform-configuration-management",
     "modernisation-platform-environments"


### PR DESCRIPTION
All GitHub teams defined in the environment JSON files will have write access to the `modernisation-platform` repository. #11865 