### PR TITLE
Add monitoring for TGW attachment acceptance to detect unauthorised access

### DIFF
--- a/terraform/environments/core-network-services/monitoring.tf
+++ b/terraform/environments/core-network-services/monitoring.tf
@@ -284,3 +284,37 @@ resource "aws_cloudwatch_metric_alarm" "ErrorPortAllocation" {
 
   tags = local.tags
 }
+
+# Transit Gateway attachment monitoring
+# This catches attachments from ANY account, including unauthorized accounts that may have been granted illicit RAM sharing
+
+# CloudTrail log metric filter for TGW attachment acceptance
+resource "aws_cloudwatch_log_metric_filter" "tgw_attachment_accepted" {
+  name           = "tgw_attachment_accepted_filter"
+  pattern        = "{ ($.eventSource = \"ec2.amazonaws.com\") && ($.eventName = \"AcceptTransitGatewayVpcAttachment\") && ($.userIdentity.sessionContext.sessionIssuer.userName != \"ModernisationPlatformAccess\") }"
+  log_group_name = "cloudtrail"
+
+  metric_transformation {
+    name      = "TGWAttachmentAccepted"
+    namespace = "TransitGateway/Security"
+    value     = "1"
+  }
+}
+
+# CloudWatch alarm for TGW attachment acceptance
+resource "aws_cloudwatch_metric_alarm" "tgw_attachment_accepted" {
+  alarm_name          = "tgw-attachment-accepted-outside-automation"
+  alarm_description   = "High priority alert: Transit Gateway VPC attachment accepted from any account outside of GitHub Actions automation. This may indicate unauthorized network access attempt via illicit RAM sharing or manual attachment creation."
+  alarm_actions       = [aws_sns_topic.tgw_monitoring_production.arn]
+  ok_actions          = [aws_sns_topic.tgw_monitoring_production.arn]
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "TGWAttachmentAccepted"
+  namespace           = "TransitGateway/Security"
+  period              = "60"
+  statistic           = "Sum"
+  threshold           = "0"
+  treat_missing_data  = "notBreaching"
+
+  tags = local.tags
+}


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/12154

## How does this PR fix the problem?

This pull request adds monitoring for AWS Transit Gateway (TGW) VPC attachment acceptance events. The new resources detect and alert when a TGW attachment is accepted in `core-network-services` when not having been initiated by the expected automation IAM role, helping to catch unauthorised or illicit network access attempts.

**Transit Gateway attachment monitoring:**

* Added a `aws_cloudwatch_log_metric_filter` resource (`tgw_attachment_accepted`) to detect CloudTrail events where a TGW VPC attachment is accepted by any user except the automation account (`ModernisationPlatformAccess`). This helps identify potentially unauthorized attachments, including those created via illicit RAM sharing.
* Added a `aws_cloudwatch_metric_alarm` resource (`tgw_attachment_accepted`) that triggers an alert if such an event is detected, sending notifications to the specified SNS topic for immediate attention.

## How has this been tested?

After this merges, I will test manually again to make sure the alert triggers.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
