### PR TITLE
Generate CODEOWNERS entries for core-shared-services teams

### DIFF
--- a/.github/workflows/new-environment-files.yml
+++ b/.github/workflows/new-environment-files.yml
@@ -40,6 +40,8 @@ jobs:
           PASSPHRASE: ${{ secrets.PASSPHRASE }}
       - name: Provision environment directories
         run: bash ./scripts/provision-environment-directories.sh
+      - name: Generate CODEOWNERS for core-shared-services teams
+        run: bash ./scripts/generate-team-codeowners.sh
       - name: Commit changes to GitHub
         run: bash ./scripts/git-setup.sh
       - name: Commit and Create PR with Signed Commit

--- a/environments/sprinkler.json
+++ b/environments/sprinkler.json
@@ -67,3 +67,4 @@
   "go-live-date": "",
   "github-oidc-team-repositories": [""]
 }
+

--- a/scripts/generate-team-codeowners.sh
+++ b/scripts/generate-team-codeowners.sh
@@ -1,0 +1,37 @@
+codeowners_file=.github/CODEOWNERS
+environment_json_dir=environments
+
+generate_codeowners() {
+
+  cat > "$codeowners_file" << EOL
+# This file is auto-generated here, do not manually amend.
+# https://github.com/ministryofjustice/modernisation-platform/blob/main/scripts/generate-team-codeowners.sh
+
+* @ministryofjustice/modernisation-platform
+EOL
+
+  for file in "$environment_json_dir"/*.json; do
+    application_name=$(basename "$file" .json)
+    account_type=$(jq -r '."account-type"' "$file")
+
+    if [ "$account_type" = "core" ]; then
+      echo "Skipping core account: $application_name"
+      continue
+    fi
+
+    directory="/terraform/environments/core-shared-services/teams/$application_name"
+
+    # Prefer codeowners if present
+    if jq -e '.codeowners != null and (.codeowners | length > 0)' "$file" >/dev/null 2>&1; then
+      codeowners=$(jq -r '(.codeowners | if type=="array" then . else [.] end)[] | select(length > 0) | "@ministryofjustice/" + .' "$file" | grep -v '^@ministryofjustice/azure-aws-sso' | sort -u | tr '\n' ' ')
+      echo "Adding $directory $codeowners to CODEOWNERS"
+      echo "$directory $codeowners" >> "$codeowners_file"
+    else
+      sso_group_names=$(jq -r '.environments[].access[].sso_group_name | "@ministryofjustice/" + .' "$file" | grep -v '^@ministryofjustice/azure-aws-sso' | sort -u | tr '\n' ' ')
+      echo "Adding $directory $sso_group_names to CODEOWNERS"
+      echo "$directory $sso_group_names" >> "$codeowners_file"
+    fi
+  done
+}
+
+generate_codeowners


### PR DESCRIPTION
## A reference to the issue / Description of it

Adds automated generation of CODEOWNERS entries for `core-shared-services` team directories. #11865

## How does this PR fix the problem?

Team ownership for core-shared-services environments needs to be derived directly from environment configuration to ensure the correct GitHub teams are required to approve changes.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
