### PR TITLE
🔧 Update Terraform module source reference to v8.2.0 to add sprinkler to awsnuke

### DIFF
--- a/terraform/environments/environments.tf
+++ b/terraform/environments/environments.tf
@@ -1,5 +1,5 @@
 module "environments" {
-  source                             = "github.com/ministryofjustice/modernisation-platform-terraform-environments?ref=b78577cc957def05bbfc4edd215612fa219491cb" # v8.1.0
+  source                             = "github.com/ministryofjustice/modernisation-platform-terraform-environments?ref=810b0385e0e0537e95ede1db2d968d323959ad5f" # v8.2.0
   environment_directory              = "../../environments"
   environment_parent_organisation_id = local.modernisation_platform_ou_id
   environment_prefix                 = "modernisation-platform"


### PR DESCRIPTION
Bump `modernisation-platform-terraform-environments` module to `v8.2.0` which includes `sprinkler-development` in the aws nuke list.