### PR TITLE
Skip member delegation role for cloud-platform

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -917,7 +917,8 @@ data "aws_iam_policy_document" "oidc_assume_role_member" {
     sid    = "AllowOIDCToAssumeRoles"
     effect = "Allow"
     resources = [
-      format("arn:aws:iam::%s:role/member-delegation-%s-%s", local.environment_management.account_ids[format("core-vpc-%s", local.application_environment)], lower(local.business_unit), local.application_environment),
+      # skip for cloud-platform as it uses a different account naming convention and does not need a member-delegation role
+      local.application_name != "cloud-platform" ? format("arn:aws:iam::%s:role/member-delegation-%s-%s", local.environment_management.account_ids[format("core-vpc-%s", local.application_environment)], lower(local.business_unit), local.application_environment) : "",
       format("arn:aws:iam::%s:role/modify-dns-records", local.environment_management.account_ids["core-network-services-production"]),
       format("arn:aws:iam::%s:role/modernisation-account-limited-read-member-access", local.environment_management.modernisation_platform_account_id),
       format("arn:aws:iam::%s:role/ModernisationPlatformSSOReadOnly", local.environment_management.aws_organizations_root_account_id),


### PR DESCRIPTION


## A reference to the issue / Description of it

See member bootstrap failure here https://github.com/ministryofjustice/modernisation-platform/actions/runs/21071708169/job/60606285937#step:8:5752

## How does this PR fix the problem?

This role uses the environment name to look up the relevan core-vpc-environment.  This breaks be cause cloud-platform uses nonlive and live environments. Cloud-platform also doesn't need this role as it doesn't use the shared core-vpc networking.

## How has this been tested?

Local plan against cloud-platform-development, cloud-platform-nonlive and cloud-platform-live all gave expected changes.
Local plan against sprinkler-development gave no changes.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
