### PR TITLE
Fix bootstrap for CP envs

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -916,7 +916,7 @@ data "aws_iam_policy_document" "oidc_assume_role_member" {
   statement {
     sid    = "AllowOIDCToAssumeRoles"
     effect = "Allow"
-    resources = [
+    resources = compact([
       # skip for cloud-platform as it uses a different account naming convention and does not need a member-delegation role
       local.application_name != "cloud-platform" ? format("arn:aws:iam::%s:role/member-delegation-%s-%s", local.environment_management.account_ids[format("core-vpc-%s", local.application_environment)], lower(local.business_unit), local.application_environment) : "",
       format("arn:aws:iam::%s:role/modify-dns-records", local.environment_management.account_ids["core-network-services-production"]),
@@ -924,7 +924,7 @@ data "aws_iam_policy_document" "oidc_assume_role_member" {
       format("arn:aws:iam::%s:role/ModernisationPlatformSSOReadOnly", local.environment_management.aws_organizations_root_account_id),
       # the following are required as cooker have development accounts but are in the sandbox vpc
       local.application_name == "cooker" ? format("arn:aws:iam::%s:role/member-delegation-house-sandbox", local.environment_management.account_ids["core-vpc-sandbox"]) : format("arn:aws:iam::%s:role/modernisation-account-limited-read-member-access", local.environment_management.modernisation_platform_account_id)
-    ]
+    ])
     condition {
       test     = "StringEquals"
       variable = "aws:PrincipalOrgID"


### PR DESCRIPTION

## A reference to the issue / Description of it

The terraform was failing as you cannot have an empty string in a policy.  

## How does this PR fix the problem?

By adding `compact` we remove any empty strings, allowing this line to be skipped for `cloud-platform` environments.


## How has this been tested?

Applied locally on cloud-platform bootstrap to test


## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
