### PR TITLE
Bump VPC module version

### DIFF
--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -89,7 +89,7 @@ module "vpc" {
     aws.transit-gateway-host = aws.core-network-services
   }
   for_each             = local.vpcs[terraform.workspace]
-  source               = "github.com/ministryofjustice/modernisation-platform-terraform-member-vpc?ref=cfbe7ebab97f3aaac777c8376b845a2f732e502e" # v5.0.1
+  source               = "github.com/ministryofjustice/modernisation-platform-terraform-member-vpc?ref=1e9d059bcf93cf947c96641a055ffd3f9adc8cad" # v5.1.0
   additional_endpoints = each.value.options.additional_endpoints
   subnet_sets          = { for key, subnet in each.value.cidr.subnet_sets : key => subnet.cidr }
   transit_gateway_id   = data.aws_ec2_transit_gateway.transit-gateway.id


### PR DESCRIPTION
Testing current configuration with the new release of the vpc module - https://github.com/ministryofjustice/modernisation-platform-terraform-member-vpc/releases/tag/v5.1.0

No changes expected. 