### PR TITLE
Update CloudWatch log metric filter for UnauthorisedTransit Gateway attachment creation

### DIFF
--- a/terraform/environments/core-network-services/monitoring.tf
+++ b/terraform/environments/core-network-services/monitoring.tf
@@ -291,7 +291,7 @@ resource "aws_cloudwatch_metric_alarm" "ErrorPortAllocation" {
 # Alerts on attachment creation outside of ModernisationPlatformAccess role
 resource "aws_cloudwatch_log_metric_filter" "tgw_attachment_created" {
   name           = "tgw_attachment_created_filter"
-  pattern        = "{ ($.eventSource = \"ec2.amazonaws.com\") && ($.eventName = \"CreateTransitGatewayVpcAttachment\") && ($.userIdentity.sessionContext.sessionIssuer.userName != \"ModernisationPlatformAccess\") }"
+  pattern        = "{ ($.eventSource = \"ec2.amazonaws.com\") && ($.eventName = \"CreateTransitGatewayVpcAttachment\") && (($.userIdentity.type != \"AssumedRole\") || ($.userIdentity.sessionContext.sessionIssuer.userName != \"ModernisationPlatformAccess\")) }"
   log_group_name = "cloudtrail"
 
   metric_transformation {


### PR DESCRIPTION
 to include AssumedRole check

## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/12154

## How does this PR fix the problem?

This pull request updates the CloudWatch metric filter for monitoring Transit Gateway VPC attachment creation to more accurately capture events not initiated by the `ModernisationPlatformAccess` role. 

Monitoring improvements:

* Updated the `pattern` in the `aws_cloudwatch_log_metric_filter.tgw_attachment_created` resource in `monitoring.tf` to trigger on events where the user is not using an assumed role, or where the assumed role is not `ModernisationPlatformAccess`. This broadens the scope of monitoring for unauthorised attachment creation events.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
