### PR TITLE
Add `WorkflowStatus=NEW` filter and update logic to Security Hub insight script

### DIFF
--- a/scripts/extract-securityhub-severity-summary.sh
+++ b/scripts/extract-securityhub-severity-summary.sh
@@ -14,7 +14,10 @@ create_or_get_insight() {
         #Creating new Security Hub insight...
         INSIGHT_ARN=$(aws securityhub create-insight --region "$REGION" \
             --name "$INSIGHT_NAME" \
-            --filters '{"RecordState": [{"Value": "ACTIVE", "Comparison": "EQUALS"}]}' \
+            --filters '{
+                "RecordState": [{"Value": "ACTIVE", "Comparison": "EQUALS"}],
+                "WorkflowStatus": [{"Value": "NEW", "Comparison": "EQUALS"}]
+            }' \
             --group-by-attribute "SeverityLabel" \
             --query "InsightArn" \
             --output text)


### PR DESCRIPTION
Enhance the Security Hub insight script to include `WorkflowStatus=NEW` in the filters.  
Also, add logic to update an existing insight if it already exists instead of only creating a new one.