### PR TITLE
Add the new cloud-platform application

### DIFF
--- a/terraform/modernisation-platform-account/s3.tf
+++ b/terraform/modernisation-platform-account/s3.tf
@@ -624,6 +624,10 @@ data "aws_iam_policy_document" "allow-state-access-from-root-account" {
       variable = "aws:PrincipalAccount"
       values = [
         # Cloud Platform's member account IDs
+        local.environment_management.account_ids["cloud-platform-development"],
+        local.environment_management.account_ids["cloud-platform-preproduction"],
+        local.environment_management.account_ids["cloud-platform-nonlive"],
+        local.environment_management.account_ids["cloud-platform-live"],
         local.environment_management.account_ids["cloud-platform-non-live-development"],
         local.environment_management.account_ids["cloud-platform-non-live-test"],
         local.environment_management.account_ids["cloud-platform-non-live-preproduction"],
@@ -647,8 +651,11 @@ data "aws_iam_policy_document" "allow-state-access-from-root-account" {
 
     resources = ["${module.state-bucket.bucket.arn}/environments/members/cloud-platform*/*"]
     principals {
-      type        = "AWS"
-      identifiers = ["arn:aws:iam::${local.environment_management.account_ids["cloud-platform-non-live-development"]}:role/github-actions-development-cluster"]
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${local.environment_management.account_ids["cloud-platform-non-live-development"]}:role/github-actions-development-cluster",
+        "arn:aws:iam::${local.environment_management.account_ids["cloud-platform-development"]}:role/github-actions-development-cluster"
+      ]
     }
   }
 }


### PR DESCRIPTION


## A reference to the issue / Description of it

The new cloud-platform application doesn't have access to the CP state.

## How does this PR fix the problem?

This is needed for the new cloud-platform application.  The other cloud-platform-non-live/live applications will be removed once the code has been migrated to the new application.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
