### PR TITLE
Add `nuke_rebuild_account_ids` to secrets rotation exemption list

### DIFF
--- a/.github/workflows/secrets-rotation-reminder.yml
+++ b/.github/workflows/secrets-rotation-reminder.yml
@@ -85,7 +85,7 @@ jobs:
             secrets=$(aws secretsmanager list-secrets --region $AWS_REGION --query "SecretList[].Name" --output text)
             
             # Remove secrets from list that are exempt from rotation
-            delete=("environment_management" "nuke_account_ids" "nuke_account_blocklist" "mod-platform-circleci" "pagerduty_integration_keys" "nonmp-account-ids")
+            delete=("environment_management" "nuke_account_ids" "nuke_account_blocklist" "nuke_rebuild_account_ids" "mod-platform-circleci" "pagerduty_integration_keys" "nonmp-account-ids")
             for del in ${delete[@]}
             do
               secrets=("${secrets[@]/$del}")


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/12307
The scretes rotation reminder workflow has flagged the `nuke_rebuild_account_ids` secret for rotation, but it's a list of account ids rather than a secret token.

## How does this PR fix the problem?

Added `nuke_rebuild_account_ids` to secrets rotation exemption list.
