### PR TITLE
temporary permissions data engineering role

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -475,6 +475,7 @@ data "aws_iam_policy_document" "data_engineering_additional" {
       "states:Stop*",
       "states:Start*",
       "states:RedriveExecution",
+      "s3:CreateJob",
       "s3:PutBucketNotificationConfiguration",
       "s3:GetBucketOwnershipControls",
       "s3:PutObjectAcl",


### PR DESCRIPTION
## A reference to the issue / Description of it

User request:

hi, im trying to batch replicate one of my buckets from test to dev accounts but i dont have permissions. is there a way i can temporarily get these? i want to batch replicate from test to dev (if that works then preprod to test and then prod to preprod). alternatively, can i get create job temporarily added to the data-eng role and then removed once ive finished. i was hoping to get this done tmo but no mad rush!
You don't have permission to create a job
Before you can create a job, update your Identity and Access Management (IAM) permissions in the IAM console  to allow the s3:CreateJob permission. Then reload the page. Learn more 
API response
```
User: arn:aws:sts::************:assumed-role/AWSReservedSSO_modernisation-platform-data-eng_40300fd594863a4a/matt-heery@digital.justice.gov.uk is not authorized to perform: s3:CreateJob on resource: "arn:aws:s3:eu-west-2:************:job/*" because no identity-based policy allows the s3:CreateJob action
```


## How does this PR fix the problem?

permission added to the data-engineering role

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
