### PR TITLE
Add additional email to status page subscribers

### DIFF
--- a/terraform/pagerduty/status-page-subscriptions.tf
+++ b/terraform/pagerduty/status-page-subscriptions.tf
@@ -6,8 +6,7 @@ locals {
   # Additional emails to subscribe that aren't in environments/*.json files
   # Add any ad-hoc email addresses here as needed
   additional_subscriber_emails = [
-    # Example: "team-name@justice.gov.uk",
-    # Example: "external-team@example.com",
+    "alistair.curtis@digital.justice.gov.uk"
   ]
 
   # Read all environment JSON files


### PR DESCRIPTION
## A reference to the issue / Description of it

Member has asked for their email to be subscribed to our PD status updates

## How does this PR fix the problem?

Adds `alistair.curtis@digital.justice.gov.uk` as an additional subscriber to PD updates
