### PR TITLE
Normalise email addresses to lowercase for consistency in subscriptions

### DIFF
--- a/scripts/manage_status_page_subscriptions.sh
+++ b/scripts/manage_status_page_subscriptions.sh
@@ -68,7 +68,8 @@ get_existing_subscribers() {
 # Get existing subscribers
 echo "📊 Fetching current subscribers..."
 EXISTING_RAW=$(get_existing_subscribers)
-EXISTING_EMAILS=$(echo "$EXISTING_RAW" | grep -v '^$' | cut -d'|' -f1 | sort || echo "")
+# Normalise existing emails to lowercase for comparison (preserve original case in raw data for deletion)
+EXISTING_EMAILS=$(echo "$EXISTING_RAW" | grep -v '^$' | cut -d'|' -f1 | tr '[:upper:]' '[:lower:]' | sort || echo "")
 
 # Handle empty existing emails
 if [ -z "$EXISTING_EMAILS" ]; then
@@ -152,8 +153,8 @@ if [ -n "$TO_REMOVE" ]; then
     while IFS= read -r email; do
         [ -z "$email" ] && continue
         
-        # Get subscription ID for this email
-        subscription_id=$(echo "$EXISTING_RAW" | grep "^${email}|" | cut -d'|' -f2)
+        # Get subscription ID for this email (case-insensitive match)
+        subscription_id=$(echo "$EXISTING_RAW" | grep -i "^${email}|" | cut -d'|' -f2)
         
         if [ -z "$subscription_id" ]; then
             echo -e "   ${RED}✗${NC} Could not find subscription ID for: ${email}"

--- a/terraform/pagerduty/status-page-subscriptions.tf
+++ b/terraform/pagerduty/status-page-subscriptions.tf
@@ -19,15 +19,22 @@ locals {
   }
 
   # Extract unique infrastructure-support emails (non-null only)
+  # Normalise to lowercase to handle case-sensitivity inconsistencies across JSON files
   infrastructure_support_emails = distinct(compact([
     for file, config in local.environment_configs :
-    try(config.tags["infrastructure-support"], null)
+    try(lower(config.tags["infrastructure-support"]), null)
   ]))
+
+  # Normalise additional emails to lowercase for consistency
+  normalised_additional_emails = [
+    for email in local.additional_subscriber_emails :
+    lower(email)
+  ]
 
   # Combine emails from JSON files with additional hardcoded emails
   all_subscriber_emails = distinct(concat(
     local.infrastructure_support_emails,
-    local.additional_subscriber_emails
+    local.normalised_additional_emails
   ))
 
   # Sort for consistent ordering and create a hash to detect ANY changes


### PR DESCRIPTION
## A reference to the issue / Description of it

PagerDuty email subscription script failed: https://github.com/ministryofjustice/modernisation-platform/actions/runs/21284285828/job/61261537561#step:20:524

**Problem:** 
Case-inconsistencies in environment JSON files (e.g., Infrastructure@cica.gov.uk vs infrastructure@cica.gov.uk) created duplicate entries. Terraform treated them as separate emails, causing the script to fail when trying to add duplicates to PagerDuty.

## How does this PR fix the problem?

**Solution:**

Terraform - Normalised all emails to lowercase before deduplication
Script - Normalised PagerDuty emails to lowercase when comparing

## How has this been tested?

I've run this through locally to correct it so the PD terraform will show as no changes.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
