### PR TITLE
HMPPS addition of secondary CIDR - Prod

### DIFF
--- a/cidr-allocation.md
+++ b/cidr-allocation.md
@@ -90,7 +90,7 @@
 | 10.27.144.0 | /21  | yjb-preproduction - general                         |
 | 10.27.152.0 | /21  | yjb-production - general                            |
 | 10.27.160.0 | /21  | -                                                   |
-| 10.27.168.0 | /21  | -                                                   |
+| 10.27.168.0 | /21  | hmpps production - general secondary                |
 | 10.27.176.0 | /21  | -                                                   |
 | 10.27.184.0 | /21  | -                                                   |
 | 10.27.192.0 | /21  | -                                                   |

--- a/environments-networks/hmpps-production.json
+++ b/environments-networks/hmpps-production.json
@@ -33,7 +33,7 @@
   "options": {
     "bastion_linux": false,
     "additional_cidrs": [],
-    "secondary_cidr_blocks": [],
+    "secondary_cidr_blocks": ["10.27.168.0/21"],
     "additional_endpoints": [
       "com.amazonaws.eu-west-2.athena",
       "com.amazonaws.eu-west-2.execute-api",


### PR DESCRIPTION
Following the successful deployment and removal of a secondary CIDR block to sandbox, dev, test and preproduction environments, I am adding the additional CIDR to HMPPS-Production to increase IP capacity - full details can be found at https://github.com/ministryofjustice/modernisation-platform/issues/12093 

<img width="463" height="120" alt="image" src="https://github.com/user-attachments/assets/f6886fd9-5ec1-4c39-9cd7-5f87a92653d7" />
