### PR TITLE
move cdpt-chaps from ecr_repos

### DIFF
--- a/terraform/environments/core-shared-services/cdpt-chaps.tf
+++ b/terraform/environments/core-shared-services/cdpt-chaps.tf
@@ -1,0 +1,20 @@
+module "cdpt_chaps_ecr_repo" {
+  source = "../../modules/app-ecr-repo"
+
+  app_name = "cdpt-chaps"
+
+  push_principals = [
+    "arn:aws:iam::${local.environment_management.account_ids["cdpt-chaps-development"]}:role/modernisation-platform-oidc-cicd",
+    "arn:aws:iam::${local.environment_management.account_ids["cdpt-chaps-preproduction"]}:role/modernisation-platform-oidc-cicd",
+    "arn:aws:iam::${local.environment_management.account_ids["cdpt-chaps-production"]}:role/modernisation-platform-oidc-cicd"
+  ]
+
+  pull_principals = [
+    local.environment_management.account_ids["cdpt-chaps-development"],
+    local.environment_management.account_ids["cdpt-chaps-preproduction"],
+    local.environment_management.account_ids["cdpt-chaps-production"]
+  ]
+
+  # Tags
+  tags_common = local.tags
+}

--- a/terraform/environments/core-shared-services/ecr_repos.tf
+++ b/terraform/environments/core-shared-services/ecr_repos.tf
@@ -765,26 +765,6 @@ module "data_platform_jml_ecr_repo" {
   tags_common = local.tags
 }
 
-module "cdpt_chaps_ecr_repo" {
-  source = "../../modules/app-ecr-repo"
-
-  app_name = "cdpt-chaps"
-
-  push_principals = [
-    "arn:aws:iam::${local.environment_management.account_ids["cdpt-chaps-development"]}:role/modernisation-platform-oidc-cicd",
-    "arn:aws:iam::${local.environment_management.account_ids["cdpt-chaps-preproduction"]}:role/modernisation-platform-oidc-cicd",
-    "arn:aws:iam::${local.environment_management.account_ids["cdpt-chaps-production"]}:role/modernisation-platform-oidc-cicd"
-  ]
-
-  pull_principals = [
-    local.environment_management.account_ids["cdpt-chaps-development"],
-    local.environment_management.account_ids["cdpt-chaps-preproduction"],
-    local.environment_management.account_ids["cdpt-chaps-production"]
-  ]
-
-  # Tags
-  tags_common = local.tags
-}
 
 module "cdpt_ifs_ecr_repo" {
   source = "../../modules/app-ecr-repo"


### PR DESCRIPTION
## A reference to the issue / Description of it

https://mojdt.slack.com/archives/C01A7QK5VM1/p1768900300761949

## How does this PR fix the problem?

moves cdpt-ifs to its own tf file.

## How has this been tested?

-

## Deployment Plan / Instructions


{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x ] I have performed a self-review of my own code
- [ x] All checks have passed
- [x ] I have made corresponding changes to the documentation
- [ x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
