### PR TITLE
🛂 Add EC2 Encryption Control Permissions

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -236,7 +236,7 @@ data "aws_iam_policy_document" "member-access" {
       "ec2:*NatGateway*",
       "ec2:*TransitGatewayVpcAttachment*",
       "ec2:*ManagedPrefixList*",
-      "ec2:*EncryptionControl*"
+      "ec2:*EncryptionControl*",
       "ecr-public:*",
       "ecr:*",
       "ecs:*",


### PR DESCRIPTION
## A reference to the issue / Description of it

I am trying to enable encrytion control on my VPC

https://github.com/ministryofjustice/modernisation-platform-environments/actions/runs/21518433651/job/62002904816?pr=14629#step:11:543

## How does this PR fix the problem?

Adds wildcard encryption control permissions

## How has this been tested?

I did added it to the policy in the console

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No, it's additive

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
