### PR TITLE
Adds checkov skips to kms policy in core-logging.

### DIFF
--- a/terraform/environments/core-logging/logs_s3.tf
+++ b/terraform/environments/core-logging/logs_s3.tf
@@ -117,10 +117,10 @@ resource "aws_s3_bucket_public_access_block" "logging" {
   restrict_public_buckets = true
 }
 
-# checkov:skip=CKV_AWS_109: Scope constrained via principal
-# checkov:skip=CKV_AWS_356: Wider permissions follows other kms policies
-# checkov:skip=CKV_AWS_111: Wider permissions follows other kms policies
 data "aws_iam_policy_document" "logging_kms" {
+  # checkov:skip=CKV_AWS_111: "policy is directly related to the resource"
+  # checkov:skip=CKV_AWS_356: "policy is directly related to the resource"
+  # checkov:skip=CKV_AWS_109: "role is restricted by limited actions in member account"
   for_each = local.cortex_logging_buckets
 
   statement {


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/actions/runs/21575189681/job/62161116525#step:4:67

## How does this PR fix the problem?

Adds checkov skips as the Principal element of the statement limits access & wider permissions needed for key admin that follows other kms policies e.g. https://github.com/ministryofjustice/modernisation-platform/blob/main/terraform/environments/core-logging/logs_cloudtrail_s3_kms.tf#L13

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
