### PR TITLE
Contact Code Owners once per year.

### DIFF
--- a/.github/workflows/confirm-contacts-for-environments.yml
+++ b/.github/workflows/confirm-contacts-for-environments.yml
@@ -12,7 +12,7 @@ env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  
     TEMPLATE_ID: "1f0f5ccc-0f67-4ee2-942f-6e48804828ea"
     EXPECTED_TEMPLATE_VERSION: 1 # Set the expected template version here
-    PERIOD: "12" # This variable determines the number of months we look back for created dates. For production it will be 6.
+    PERIOD: "12" # This variable determines the number of months we look back for created dates.
 
 permissions:
     id-token: write


### PR DESCRIPTION

## A reference to the issue / Description of it

Sets the interval for which the owner is contacted to once per year rather than once per six months.

## How does this PR fix the problem?

We do not need to contact the owners as frequently as every 6 months. The scripts backing the workflow supports values from 1 (i.e. once per month) through to 5 years+ donated as whole months.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
