### PR TITLE
Update policies.tf

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -497,7 +497,11 @@ data "aws_iam_policy_document" "data_engineering_additional" {
     sid       = ""
     effect    = "Allow"
     actions   = ["iam:PassRole"]
-    resources = ["arn:aws:iam::${local.environment_management.account_ids["analytical-platform-data-production"]}:role/data-first-data-science", "arn:aws:iam::${local.environment_management.account_ids["electronic-monitoring-data-production"]}:role/glue-notebook-role-tf"]
+    resources = [
+      "arn:aws:iam::${local.environment_management.account_ids["analytical-platform-data-production"]}:role/data-first-data-science",
+      "arn:aws:iam::${local.environment_management.account_ids["electronic-monitoring-data-production"]}:role/glue-notebook-role-tf",
+      "arn:aws:iam::${local.environment_management.account_ids["electronic-monitoring-data-test"]}:role/AWSS3BucketReplication*"
+    ]
   }
 
   statement {


### PR DESCRIPTION
## A reference to the issue / Description of it

To create job in s3, you need pass role permissions.

<img width="1382" height="251" alt="Screenshot 2026-02-02 at 11 01 41" src="https://github.com/user-attachments/assets/42ea78f6-b983-4cb4-80b0-01dbfe24029c" />

## How does this PR fix the problem?

I've set this up for 6 buckets, so ive used `*` at the end of the role to save me writing it out 6 times. This should give the data-eng role access to pass those roles to the s3 job.

## How has this been tested?

n/a

## Deployment Plan / Instructions

n/a

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)
