### PR TITLE
changes to use high priority alarm

### DIFF
--- a/terraform/environments/core-network-services/monitoring.tf
+++ b/terraform/environments/core-network-services/monitoring.tf
@@ -337,11 +337,9 @@ resource "aws_cloudwatch_metric_alarm" "mpa_trust_policy_changed" {
   tags = local.tags
 }
 
-
 # Transit Gateway change monitoring
 # All Transit Gateway changes MUST be performed via the ModernisationPlatformAccess automation role.
 # Any TGW change outside this role will raise an alert.
-
 
 locals {
   tgw_unauthorized_role_name = "ModernisationPlatformAccess"
@@ -403,8 +401,8 @@ resource "aws_cloudwatch_metric_alarm" "tgw_unauthorized_change" {
   alarm_name        = "unauthorized-tgw-change"
   alarm_description = "High priority alert: Transit Gateway change detected outside of ${local.tgw_unauthorized_role_name} automation role. This may indicate unauthorized manual modification."
 
-  alarm_actions = [aws_sns_topic.tgw_monitoring_production.arn]
-  ok_actions    = [aws_sns_topic.tgw_monitoring_production.arn]
+  alarm_actions = [aws_sns_topic.high_priority_alerts.arn]
+  ok_actions    = [aws_sns_topic.high_priority_alerts.arn]
 
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"


### PR DESCRIPTION
## A reference to the issue / Description of it

[#12151](https://github.com/ministryofjustice/modernisation-platform/issues/12151)

## How does this PR fix the problem?

This PR ensures that unauthorised Transit Gateway changes and changes to the ModernisationPlatformAccess trust relationship are surfaced via the high-priority alerts channel, rather than triggering service-specific call-out alerts.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

See below

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)
