### PR TITLE
add `issues: write` to permissions in create-newenv.yml

### DIFF
--- a/.github/workflows/create-newenv.yml
+++ b/.github/workflows/create-newenv.yml
@@ -10,8 +10,9 @@ jobs:
   handle-request:
     permissions:
       contents: write
+      issues: write 
       pull-requests: write
-      security-events: write 
+      security-events: write
     if: contains(github.event.issue.labels.*.name, 'New Account')
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## A reference to the issue / Description of it

The create new env workflow is failing to post coments to the newly created issue e.g.

https://github.com/ministryofjustice/modernisation-platform/actions/runs/21720154958

```
Run PR_TITLE="Automated environment amendment request for $APP_NAME"
PR URL: 
GraphQL: Resource not accessible by integration (addComment)
```

## How does this PR fix the problem?

Adds permissions for the workflow to post comments to issues.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
