### PR TITLE
data.aws_ram_source_share.secondary fails to resolve for vpcs that have no secondary subnets

### DIFF
--- a/terraform/modules/ram-principal-association/main.tf
+++ b/terraform/modules/ram-principal-association/main.tf
@@ -2,12 +2,6 @@ locals {
   share_secondary = var.vpc_name == "hmpps" && var.environment == "production" ? true : false
 }
 
- resource "null_resource" "show_vpc_name" {
- 	provisioner "local-exec" {
- 		command = "echo ${local.share_secondary}"
- 	}
- }
-
 data "aws_ram_resource_share" "default" {
   provider = aws.share-host
 


### PR DESCRIPTION

## A reference to the issue / Description of it

#9293 

## How does this PR fix the problem?

Amends the data resource aws_ram_source_share.secondary to only create if vpc has secondary subnets. This fixes a bug whereby the data lookup fails if no secondary subnets exist & results in the [terraform-member-environments](https://github.com/ministryofjustice/modernisation-platform/blob/main/.github/workflows/terraform-member-environment.yml) workflow to fail at the plan stage.

This is a short-term fix until the issue of secondary subnets is addressed and is structured to avoid updating module variables that would require changes to the calling terraform.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
