### PR TITLE
fix: correct variable case in PR URL extraction for issue comment

### DIFF
--- a/.github/workflows/create-newenv.yml
+++ b/.github/workflows/create-newenv.yml
@@ -174,7 +174,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           PR_TITLE="Automated environment amendment request for $APP_NAME"
-          PR_URL=$(gh pr list --state open --search "$PR_TITLE in:title" --json url -q '.[0].url')
+          PR_URL=$(gh pr list --state open --search "$pr_title in:title" --json url -q '.[0].url')
           echo "PR URL: $PR_URL"
           REPO="${{ github.repository }}"
           gh issue comment $ISSUE_NUMBER --repo "$REPO" --body "A pull request has been created for your environment request: $PR_URL"


### PR DESCRIPTION
## A reference to the issue / Description of it

The comment on new env ironment issues is now working although the link to the PR is not being correctly added e.g.
https://github.com/ministryofjustice/modernisation-platform/issues/12439#issuecomment-3859084309

## How does this PR fix the problem?

I believe the issue is the case of the `$PR_TITLE` value as the `signed-commit` action outputs this as `$pr_title`

## How has this been tested?

Tested locally

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
