### PR TITLE
Removed duplicate subscription and ensuring alarm for tgw changes works

### DIFF
--- a/terraform/environments/core-network-services/monitoring.tf
+++ b/terraform/environments/core-network-services/monitoring.tf
@@ -374,22 +374,6 @@ resource "aws_cloudwatch_log_metric_filter" "tgw_unauthorized_changes" {
   }
 }
 
-# TGW tag change monitoring
-# TGW IDs are present under requestParameters.resourcesSet.items[*].resourceId
-
-resource "aws_cloudwatch_log_metric_filter" "tgw_unauthorized_tag_changes" {
-  name           = "tgw_unauthorized_tag_changes_filter"
-  log_group_name = "cloudtrail"
-
-  pattern = "{ ($.eventSource = \"ec2.amazonaws.com\") && (($.eventName = \"CreateTags\") || ($.eventName = \"DeleteTags\")) && ( ($.requestParameters.resourcesSet.items[0].resourceId = \"${aws_ec2_transit_gateway.transit-gateway.id}\") || ($.requestParameters.resourcesSet.items[1].resourceId = \"${aws_ec2_transit_gateway.transit-gateway.id}\") || ($.requestParameters.resourcesSet.items[2].resourceId = \"${aws_ec2_transit_gateway.transit-gateway.id}\") || ($.requestParameters.resourcesSet.items[3].resourceId = \"${aws_ec2_transit_gateway.transit-gateway.id}\") || ($.requestParameters.resourcesSet.items[4].resourceId = \"${aws_ec2_transit_gateway.transit-gateway.id}\") ) && (($.userIdentity.type != \"AssumedRole\") || ($.userIdentity.sessionContext.sessionIssuer.userName != \"${local.tgw_unauthorized_role_name}\")) }"
-
-  metric_transformation {
-    name      = "TGWUnauthorizedChange"
-    namespace = "TransitGateway/Security"
-    value     = "1"
-  }
-}
-
 resource "aws_cloudwatch_metric_alarm" "tgw_unauthorized_change" {
   alarm_name        = "unauthorized-tgw-change"
   alarm_description = "High priority alert: Transit Gateway change detected outside of ${local.tgw_unauthorized_role_name} automation role. This may indicate unauthorized manual modification."


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/12151

- My [last PR](https://github.com/ministryofjustice/modernisation-platform/pull/12449) created a duplicate SNS subscription which is not needed as the topic and PagerDuty subscription are already managed in baselines.

<img width="1443" height="616" alt="Screenshot 2026-02-06 at 13 11 50" src="https://github.com/user-attachments/assets/388909d2-34fd-4be6-a741-8034f9549862" />

- Trust relationship changes to the ModernisationPlatformAccess role correctly triggered an alarm; however, Transit Gateway tag changes did not. 
## How does this PR fix the problem?

PR removes the duplicate subscription and ensures The TGW tag change metric filter triggers when a change is made

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
