### PR TITLE
#9293 - Removes the "== Active" test 

### DIFF
--- a/terraform/modules/ram-principal-association/main.tf
+++ b/terraform/modules/ram-principal-association/main.tf
@@ -39,7 +39,7 @@ data "aws_ram_resource_share" "secondary" {
 
 resource "aws_ram_principal_association" "secondary" {
   provider = aws.share-host
-  count = local.share_secondary && data.aws_ram_resource_share.secondary[0].status == "ACTIVE" ? 1 : 0
+  count = local.share_secondary ? 1 : 0
 
   principal          = var.principal
   resource_share_arn = data.aws_ram_resource_share.secondary[0].arn


### PR DESCRIPTION

## A reference to the issue / Description of it

#9293 

## How does this PR fix the problem?

Removes the "== Active" test from the ram sharing resource as this errors during account deletion. The local.share_secondary is sufficient for the requirement.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
