### PR TITLE
Remove `s3:PutObjectAcl` permission from `modernisation-platform-terraform-state` s3 bucket access policy

### DIFF
--- a/terraform/modernisation-platform-account/s3.tf
+++ b/terraform/modernisation-platform-account/s3.tf
@@ -399,7 +399,6 @@ data "aws_iam_policy_document" "allow-state-access-from-root-account" {
     effect = "Allow"
     actions = [
       "s3:PutObject",
-      "s3:PutObjectAcl",
       "s3:GetObject"
     ]
     resources = [
@@ -508,8 +507,7 @@ data "aws_iam_policy_document" "allow-state-access-from-root-account" {
     effect = "Allow"
     actions = [
       "s3:GetObject",
-      "s3:PutObject",
-      "s3:PutObjectAcl"
+      "s3:PutObject"
     ]
     resources = ["${module.state-bucket.bucket.arn}/environments/accounts/*"]
     principals {
@@ -600,7 +598,6 @@ data "aws_iam_policy_document" "allow-state-access-from-root-account" {
     actions = [
       "s3:GetObject",
       "s3:PutObject",
-      "s3:PutObjectAcl",
       "s3:DeleteObject"
     ]
 
@@ -637,7 +634,6 @@ data "aws_iam_policy_document" "allow-state-access-from-root-account" {
     actions = [
       "s3:GetObject",
       "s3:PutObject",
-      "s3:PutObjectAcl",
       "s3:DeleteObject"
     ]
 


### PR DESCRIPTION
## A reference to the issue / Description of it

So this SecHub alert thats been firing daily for the `modernisation-platform-terraform-state` bucket...
https://mojdt.slack.com/archives/C0A3B5K1FR6/p1770805500199999

[[S3.6] - S3 general purpose bucket policies should restrict access to other AWS accounts
](https://docs.aws.amazon.com/securityhub/latest/userguide/s3-controls.html#s3-6)

This is triggering because we have used `s3:PutObjectAcl` in multiple statements in the access policy for the bucket.

We already set the ownership controls to `BucketOwnerEnforced` [here](https://github.com/ministryofjustice/modernisation-platform/blob/main/terraform/modernisation-platform-account/s3.tf#L119) which should disable ACLs entirely meaning any `s3:PutObjectAcl` API call against this bucket will fail with an `AccessControlListNotSupported` error.

I've reviewed the API calls in cloudtrail for the last 12 months and there are no occurrences of `s3:PutObjectAcl` so I believe it's safe to remove them and make our bucket policy compliant with the SecHub standard.

## How does this PR fix the problem?

Removes all  instances of `s3:PutObjectAcl` permission from `modernisation-platform-terraform-state` s3 bucket access policy.

## How has this been tested?

I've reviewed the API calls in cloudtrail for the last 12 months and there are no occurrences of `s3:PutObjectAcl` so I believe it's safe to remove them and make our bucket policy compliant with the SecHub standard.

Also I ran a test like this to verify my assumptions:

```
# Create test object
echo "acl-test" | aws s3 cp - s3://modernisation-platform-terraform-state/test-acl-check.txt

# Try to set an ACL on it 
aws s3api put-object-acl \
  --bucket modernisation-platform-terraform-state \
  --key test-acl-check.txt \
  --acl bucket-owner-full-control
  
 This resulted in:
 An error occurred (AccessControlListNotSupported) when calling the PutObjectAcl operation: The bucket does not allow ACLs
 
```
This confirms redundancy of it being in the access policy.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
