### PR TITLE
Add security architect team sso for data-factory-moj

### DIFF
--- a/environments/data-factory-moj.json
+++ b/environments/data-factory-moj.json
@@ -7,6 +7,10 @@
         {
           "sso_group_name": "data-engineering",
           "level": "sandbox"
+        },
+        {
+          "sso_group_name": "data-factory-security-team",
+          "level": "security-audit"
         }
       ],
       "nuke": "rebuild"


### PR DESCRIPTION
## A reference to the issue / Description of it

Giving [security-audit](https://user-guide.modernisation-platform.service.justice.gov.uk/user-guide/platform-user-roles.html#security-audit) access for security architect contractors for aiding in securing new account.

## How does this PR fix the problem?

Gives the data-factory-security-team github team `security-audit` permission.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.


## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

only adding to development account

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)


