### PR TITLE
#9293 - oidc readonly role to Sprinkler

### DIFF
--- a/terraform/environments/sprinkler/iam.tf
+++ b/terraform/environments/sprinkler/iam.tf
@@ -52,110 +52,47 @@ data "aws_iam_policy_document" "oidc_deny_specific_actions" {
   }
 }
 
-module "github_actions_test_role" {
-  source              = "github.com/ministryofjustice/modernisation-platform-github-oidc-role?ref=b40748ec162b446f8f8d282f767a85b6501fd192" # v4.0.0
-  github_repositories = ["ministryofjustice/modernisation-platform"]
-  role_name           = "github-actions-test"
-  tags                = { "Name" = "GitHub Actions Test" }
+# Terraform Read Only Role for use from Modernisation-Platform-Environments
+
+module "github_actions_terraform_read_only" {
+  source               = "github.com/ministryofjustice/modernisation-platform-github-oidc-role?ref=b40748ec162b446f8f8d282f767a85b6501fd192" # v4.0.0
+  github_repositories  = ["ministryofjustice/modernisation-platform-environments"]
+  role_name            = "github-actions-terraform-read-only"
+  policy_jsons         = [data.aws_iam_policy_document.github_actions_terraform_read_only.json]
+  tags                 = local.tags
 }
 
-resource "aws_iam_role" "terraform_plan_role" {
-  name = "terraform-plan-role"
-
-  # Trust relationship policy allowing github-action-test to assume this role
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = "sts:AssumeRole"
-        Principal = {
-          AWS = "arn:aws:iam::${local.environment_management.account_ids["sprinkler-development"]}:role/github-actions-test"
-        }
-      }
-    ]
-  })
-}
-
-resource "aws_iam_role_policy_attachment" "terraform_plan_role_readonly" {
-  role       = aws_iam_role.terraform_plan_role.name
-  policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
-}
-#trivy:ignore:AVD-AWS-0345: Required for test OIDC role to access Terraform state in S3
-data "aws_iam_policy_document" "oidc_deny_specific_actions_test" {
+data "aws_iam_policy_document" "github_actions_terraform_read_only" {
   # checkov:skip=CKV_AWS_111: "Cannot restrict by KMS alias so leaving open"
   # checkov:skip=CKV_AWS_356: "Cannot restrict by KMS alias so leaving open"
-  # Allow OIDC role to decrypt using KMS
+  # checkov:skip=CKV_AWS_108: "Allowing secretsmanager:GetSecretValue with open resource due to specific use case"
   statement {
-    sid       = "AllowOIDCToDecryptKMS"
+    sid       = "AllowDecryptKMS"
     effect    = "Allow"
     resources = ["*"]
-    actions   = ["kms:Decrypt"]
+    actions = [
+      "kms:Decrypt",
+      "secretsmanager:GetSecretValue"
+    ]
   }
 
-  # Allow OIDC role to list S3 objects in a specific bucket
   statement {
-    sid    = "AllowOIDCReadState"
-    effect = "Allow"
-    resources = [
-      "arn:aws:s3:::modernisation-platform-terraform-state/*",
-      "arn:aws:s3:::modernisation-platform-terraform-state/"
-    ]
-    actions = ["s3:List*"]
+    sid       = "AllowOIDCReadState"
+    effect    = "Allow"
+    resources = ["arn:aws:s3:::modernisation-platform-terraform-state/*", "arn:aws:s3:::modernisation-platform-terraform-state/"]
+    actions   = ["s3:List*"]
   }
 
-  # Allow OIDC role to delete specific S3 lock files
   statement {
-    sid    = "AllowOIDCDeleteLock"
-    effect = "Allow"
-    resources = [
-      "arn:aws:s3:::modernisation-platform-terraform-state/single-sign-on/*.tflock",
-      "arn:aws:s3:::modernisation-platform-terraform-state/environments/bootstrap/*/sprinkler-development/*.tflock"
+    sid       = "AllowOIDCDeleteLock"
+    effect    = "Allow"
+    resources = ["arn:aws:s3:::modernisation-platform-terraform-state/environments/members/sprinkler/*.tflock"]
+    actions   = [
+      "s3:DeleteObject",
+      "s3:PutObject",
+      "s3:PutObjectAcl",
+      "s3:GetObject"
     ]
-    actions = ["s3:DeleteObject"]
   }
 }
 
-resource "aws_iam_policy" "oidc_deny_specific_actions_test" {
-  name        = "github-actions-test"
-  description = "Policy for allowing specific OIDC actions"
-  policy      = data.aws_iam_policy_document.oidc_deny_specific_actions_test.json
-}
-
-resource "aws_iam_role_policy_attachment" "terraform_plan_role_custom" {
-  role       = aws_iam_role.terraform_plan_role.name
-  policy_arn = aws_iam_policy.oidc_deny_specific_actions_test.arn
-}
-
-resource "aws_iam_role" "terraform_apply_role" {
-  name = "terraform-apply-role"
-
-  # Trust relationship policy allowing github-action-test to assume this role
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = "sts:AssumeRole"
-        Principal = {
-          AWS = "arn:aws:iam::${local.environment_management.account_ids["sprinkler-development"]}:role/github-actions-test"
-        }
-      }
-    ]
-  })
-}
-
-resource "aws_iam_role_policy_attachment" "terraform_apply_role" {
-  # checkov:skip=CKV_AWS_274: "AdministratorAccess is required for Terraform Apply role"
-  role       = aws_iam_role.terraform_apply_role.name
-  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
-}
-
-resource "aws_iam_role_policy_attachment" "terraform_apply_role_custom" {
-  role       = aws_iam_role.terraform_apply_role.name
-  policy_arn = data.aws_iam_policy.github_actions.arn
-}
-
-data "aws_iam_policy" "github_actions" {
-  name = "github-actions"
-}


### PR DESCRIPTION
## A reference to the issue / Description of it

#9293 

## How does this PR fix the problem?

Adds new read-only OIDC role for use by sprinkler in the environments repo. Adding first is required for the bootstrap data calls to resolve. Colocating the new role with the OIDC provider.

Also removes older redundant IAM resources that were added for a POC in 2025 but which are no longer being used.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Already deployed to sprinkler via command line.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
