### PR TITLE
Update monitoring.tf

### DIFF
--- a/terraform/modernisation-platform-account/monitoring.tf
+++ b/terraform/modernisation-platform-account/monitoring.tf
@@ -30,13 +30,13 @@ resource "aws_securityhub_automation_rule" "suppress_tf_state_bucket_cross_accou
 
   criteria {
     resource_id {
-      comparison = "EQUALS"
+      comparison = "PREFIX"
       value      = "arn:aws:s3:::modernisation-platform-terraform-state"
     }
 
-    security_control_id {
+    title {
       comparison = "EQUALS"
-      value      = "S3.6"
+      value      = "S3 general purpose bucket policies should restrict access to other AWS accounts"
     }
   }
 


### PR DESCRIPTION
This pull request introduces a new automation rule to AWS SecurityHub to automatically suppress a specific cross-account S3 policy finding for the Terraform state bucket. This helps reduce unnecessary alerts by acknowledging an approved exception for controlled cross-account access required by the Terraform backend.

SecurityHub automation enhancements:

* Added a new `aws_securityhub_automation_rule` resource to suppress findings related to cross-account S3 policy for the `modernisation-platform-terraform-state` bucket, including a note explaining the exception.## A reference to the issue / Description of it


For this ticket - https://github.com/ministryofjustice/modernisation-platform/issues/12395

Adds Security Hub automation rule to suppress S3.6 finding for the terraform state bucket.
Cross-account access is required for MP backend operation and has been reviewed and accepted.