### PR TITLE
Fix IAM policy character limit by splitting member-access policy

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -106,19 +106,19 @@ module "member-access" {
 
 resource "aws_iam_role_policy_attachment" "member_infrastructure_access_role_compute" {
   count      = (local.account_data.account-type == "member" && terraform.workspace != "testing-test" && terraform.workspace != "sprinkler-development") ? 1 : 0
-  role       = module.member-access[0].role_name
+  role       = "MemberInfrastructureAccess"
   policy_arn = aws_iam_policy.member-access-compute[0].arn
 }
 
 resource "aws_iam_role_policy_attachment" "member_infrastructure_access_role_data" {
   count      = (local.account_data.account-type == "member" && terraform.workspace != "testing-test" && terraform.workspace != "sprinkler-development") ? 1 : 0
-  role       = module.member-access[0].role_name
+  role       = "MemberInfrastructureAccess"
   policy_arn = aws_iam_policy.member-access-data[0].arn
 }
 
 resource "aws_iam_role_policy_attachment" "member_infrastructure_access_role_network" {
   count      = (local.account_data.account-type == "member" && terraform.workspace != "testing-test" && terraform.workspace != "sprinkler-development") ? 1 : 0
-  role       = module.member-access[0].role_name
+  role       = "MemberInfrastructureAccess"
   policy_arn = aws_iam_policy.member-access-network[0].arn
 }
 
@@ -132,19 +132,19 @@ module "member-access-sprinkler" {
 
 resource "aws_iam_role_policy_attachment" "member_infrastructure_access_sprinkler_role_compute" {
   count      = (terraform.workspace == "sprinkler-development") ? 1 : 0
-  role       = module.member-access-sprinkler[0].role_name
+  role       = "MemberInfrastructureAccess"
   policy_arn = aws_iam_policy.member-access-compute[0].arn
 }
 
 resource "aws_iam_role_policy_attachment" "member_infrastructure_access_sprinkler_role_data" {
   count      = (terraform.workspace == "sprinkler-development") ? 1 : 0
-  role       = module.member-access-sprinkler[0].role_name
+  role       = "MemberInfrastructureAccess"
   policy_arn = aws_iam_policy.member-access-data[0].arn
 }
 
 resource "aws_iam_role_policy_attachment" "member_infrastructure_access_sprinkler_role_network" {
   count      = (terraform.workspace == "sprinkler-development") ? 1 : 0
-  role       = module.member-access-sprinkler[0].role_name
+  role       = "MemberInfrastructureAccess"
   policy_arn = aws_iam_policy.member-access-network[0].arn
 }
 


### PR DESCRIPTION
## A reference to the issue / Description of it

The `member-access` IAM policy has exceeded AWS's 6144 non-whitespace character limit for managed policies, causing the following error:

> Your policy exceeds the non-whitespace character limit of 6144. Use the JSON editor for more information about the character count.

This prevents successful Terraform applies and blocks infrastructure updates.
## How does this PR fix the problem?

Split the single large `member-access` policy into **three separate managed policies**:

1. **`MemberAccessCompute`** - Compute, Containers, and Core Services
   
2. **`MemberAccessData`** - Data and Analytics Services
   
3. **`MemberAccessNetwork`** - Networking, Security, and Additional Services

All three policies are attached to the `MemberInfrastructureAccess` role, maintaining identical effective permissions as before.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
