### PR TITLE
#issue/9293 - Adds github-actions-terraform-read-only policy to the trust role policy of modify-dns-records.

### DIFF
--- a/terraform/environments/core-network-services/iam.tf
+++ b/terraform/environments/core-network-services/iam.tf
@@ -87,7 +87,7 @@ resource "aws_iam_role" "dns" {
           "Condition" : {
             "ForAnyValue:StringLike" : {
               "aws:PrincipalOrgPaths" : ["${data.aws_organizations_organization.root_account.id}/*/${local.environment_management.modernisation_platform_organisation_unit_id}/*"],
-              "aws:PrincipalArn" : ["arn:aws:iam::*:role/github-actions", "arn:aws:iam::*:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_AdministratorAccess_*"]
+              "aws:PrincipalArn" : ["arn:aws:iam::*:role/github-actions", "arn:aws:iam::*:role/github-actions-terraform-read-only", "arn:aws:iam::*:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_AdministratorAccess_*"]
             }
           }
         }


### PR DESCRIPTION

## A reference to the issue / Description of it

#9293 

## How does this PR fix the problem?

Adds github-actions-terraform-read-only to the trust tole policy of the modify-dns-records role. This is required as the role is assumed during any the use of the above read-only role during a terraform plan.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
