### PR TITLE
issue/9293 - Amends Trust Policies for access from github-actions-terraform-dev-test

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -126,7 +126,7 @@ module "member-access-sprinkler" {
   count                  = (terraform.workspace == "sprinkler-development") ? 1 : 0
   source                 = "github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access?ref=321b0bcb8699b952a2a66f60c6242876048480d5" #v4.0.0
   account_id             = data.aws_ssm_parameter.modernisation_platform_account_id.value
-  additional_trust_roles = [data.aws_iam_role.sprinkler_oidc[0].arn, data.aws_iam_role.sprinkler_terraform_read_only[0].arn, one(data.aws_iam_roles.member-sso-admin-access.arns)]
+  additional_trust_roles = [data.aws_iam_role.sprinkler_oidc[0].arn, data.aws_iam_role.sprinkler_terraform_read_only[0].arn, data.aws_iam_role.sprinkler_terraform_dev_test[0].arn, one(data.aws_iam_roles.member-sso-admin-access.arns)]
   role_name              = "MemberInfrastructureAccess"
 }
 
@@ -610,7 +610,7 @@ module "member-access-us-east-sprinkler" {
   count                  = (terraform.workspace == "sprinkler-development") ? 1 : 0
   source                 = "github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access?ref=321b0bcb8699b952a2a66f60c6242876048480d5" #v4.0.0
   account_id             = data.aws_ssm_parameter.modernisation_platform_account_id.value
-  additional_trust_roles = [data.aws_iam_role.sprinkler_oidc[0].arn, data.aws_iam_role.sprinkler_terraform_read_only[0].arn, one(data.aws_iam_roles.member-sso-admin-access.arns)]
+  additional_trust_roles = [data.aws_iam_role.sprinkler_oidc[0].arn, data.aws_iam_role.sprinkler_terraform_read_only[0].arn, data.aws_iam_role.sprinkler_terraform_dev_test[0].arn, one(data.aws_iam_roles.member-sso-admin-access.arns)]
   policy_arn             = aws_iam_policy.member-access-us-east[0].id
   role_name              = "MemberInfrastructureAccessUSEast"
 }
@@ -915,7 +915,7 @@ module "member-access-eu-central-sprinkler" {
   count                  = (terraform.workspace == "sprinkler-development") ? 1 : 0
   source                 = "github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access?ref=321b0bcb8699b952a2a66f60c6242876048480d5" #v4.0.0
   account_id             = data.aws_ssm_parameter.modernisation_platform_account_id.value
-  additional_trust_roles = [data.aws_iam_role.sprinkler_oidc[0].arn, data.aws_iam_role.sprinkler_terraform_read_only[0].arn, one(data.aws_iam_roles.member-sso-admin-access.arns)]
+  additional_trust_roles = [data.aws_iam_role.sprinkler_oidc[0].arn, data.aws_iam_role.sprinkler_terraform_read_only[0].arn, data.aws_iam_role.sprinkler_terraform_dev_test[0].arn, one(data.aws_iam_roles.member-sso-admin-access.arns)]
   policy_arn             = aws_iam_policy.member-access-eu-central[0].id
   role_name              = "MemberInfrastructureBedrockEuCentral"
 }

--- a/terraform/environments/bootstrap/member-bootstrap/locals.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/locals.tf
@@ -31,6 +31,11 @@ data "aws_iam_role" "sprinkler_terraform_read_only" {
   name  = "github-actions-terraform-read-only"
 }
 
+data "aws_iam_role" "sprinkler_terraform_dev_test" {
+  count = (terraform.workspace == "sprinkler-development") ? 1 : 0
+  name  = "github-actions-terraform-dev-test"
+}
+
 data "http" "environments_file" {
   url = format("https://raw.githubusercontent.com/ministryofjustice/modernisation-platform/main/environments/%s.json", local.application_name)
 }

--- a/terraform/environments/core-network-services/iam.tf
+++ b/terraform/environments/core-network-services/iam.tf
@@ -87,7 +87,7 @@ resource "aws_iam_role" "dns" {
           "Condition" : {
             "ForAnyValue:StringLike" : {
               "aws:PrincipalOrgPaths" : ["${data.aws_organizations_organization.root_account.id}/*/${local.environment_management.modernisation_platform_organisation_unit_id}/*"],
-              "aws:PrincipalArn" : ["arn:aws:iam::*:role/github-actions", "arn:aws:iam::*:role/github-actions-terraform-read-only", "arn:aws:iam::*:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_AdministratorAccess_*"]
+              "aws:PrincipalArn" : ["arn:aws:iam::*:role/github-actions", "arn:aws:iam::*:role/github-actions-terraform-read-only", "arn:aws:iam::*:role/github-actions-terraform-dev-test", "arn:aws:iam::*:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_AdministratorAccess_*"]
             }
           }
         }


### PR DESCRIPTION


## A reference to the issue / Description of it

#9293 

## How does this PR fix the problem?

Adds github-actions-terraform-dev-test to the trust policies for sprinkler MemberInfrastructureAccess and to modify-dns-records in core-network-services.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
