### PR TITLE
issue/9293 - Adds github-actions-terraform-dev-test to cooker and example only.

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -1309,7 +1309,7 @@ module "github_actions_terraform_dev_test" {
 
 #trivy:ignore:AVD-AWS-0345: Required for OIDC role to access Terraform state in S3
 data "aws_iam_policy_document" "github_actions_terraform_dev_test" {
-  count               = can(regex("example$|cooker$", terraform.workspace)) ? 1 : 0
+  count = can(regex("^(example|cooker)", terraform.workspace)) ? 1 : 0
   # checkov:skip=CKV_AWS_111: "Cannot restrict by KMS alias so leaving open"
   # checkov:skip=CKV_AWS_356: "Cannot restrict by KMS alias so leaving open"
   statement {


### PR DESCRIPTION

## A reference to the issue / Description of it

#9293 

## How does this PR fix the problem?

Adds github-actions-terraform-dev-test role to bootstrap for cooker and example only.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
