### PR TITLE
TM-1912: ad-fixngo: add FSX on additional subnets

### DIFF
--- a/terraform/environments/core-shared-services/ad-fixngo.tf
+++ b/terraform/environments/core-shared-services/ad-fixngo.tf
@@ -408,6 +408,24 @@ locals {
         throughput_capacity           = 32
         weekly_maintenance_start_time = "4:04:00" # thu 4am
       }
+      ad-hmpp-fsx-additional = {
+        ad_dns_ips = flatten([
+          module.ad_fixngo_ip_addresses.mp_ips.ad_fixngo_hmpp_domain_controllers,
+        ])
+        ad_domain_name                      = "azure.hmpp.root"
+        ad_file_system_administrators_group = "AWS FSx Admins"
+        ad_username                         = "svc_fsx_windows"
+        aliases                             = ["fs.azure.hmpp.root", "fslinux.azure.hmpp.root"]
+        deployment_type                     = "MULTI_AZ_1"
+        security_group_name                 = "ad_hmpp_fsx_sg"
+        storage_capacity                    = 100
+        subnet_ids = [
+          aws_subnet.live-data-additional["eu-west-2a"].id,
+          aws_subnet.live-data-additional["eu-west-2b"].id,
+        ]
+        throughput_capacity           = 32
+        weekly_maintenance_start_time = "4:04:00" # thu 4am
+      }
     }
 
     route53_resolver_endpoints = {


### PR DESCRIPTION
## A reference to the issue / Description of it

The current HMPP FSX is accessible by both preproduction and production accounts. However, as part of the NDMIS migration, we also need it accessible via the Legacy Delius AWS accounts. The existing FSX is on 10.20 range and this is not reachable.

## How does this PR fix the problem?

Moving the FSX to the 10.27 network will achieve this. This is reachable by legacy delius and end user devices. The first step is to create a second HMPP FSX on the 10.27 network. The existing FSX will be deleted after migration to the new FSX completes.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

n/a. Terraform is cut and paste of the existing FSX but with different subnets.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
