### PR TITLE
TM-1912: firewall-rules: allow access to FSX in core-shared-services

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/live_data_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/live_data_rules.json
@@ -47,5 +47,12 @@
     "destination_ip": "$AD_HMPP_RD_LICENSING",
     "destination_port": "$RD_LICENSING_TCP",
     "protocol": "TCP"
+  },
+  "mojo_to_mp_core_shared_services_additional_smb_TCP": {
+    "action": "PASS",
+    "source_ip": "${mojo-end-user-devices}",
+    "destination_ip": "${mp-core-shared-services-additional}",
+    "destination_port": "445",
+    "protocol": "TCP"
   }
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

The recently built FSX in core-shared-services in the 10.27 range (for NART$ file share amongst other things) is not accessible outside of MP. 

See https://github.com/ministryofjustice/modernisation-platform/pull/12564

## How does this PR fix the problem?

Adds the required firewall rule

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

The domain controllers are in the same subnet and these are accessible from Mojo devices.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
