### PR TITLE
issue/9293 - Excludes the two COAT accounts from the new role deployment.

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -1315,7 +1315,7 @@ data "aws_iam_policy_document" "iam_hygiene_policy" {
 # Uses the same deployment conditions as the OIDC provider deployment - module.github-oidc
 
 module "github_actions_terraform_dev_test" {
-  count               = (local.account_data.account-type == "member" && terraform.workspace != "testing-test" && terraform.workspace != "sprinkler-development") ? 1 : 0
+  count               = (local.account_data.account-type == "member" && terraform.workspace != "testing-test" && terraform.workspace != "sprinkler-development" && !can(regex("^coat-", terraform.workspace))) ? 1 : 0
   source              = "github.com/ministryofjustice/modernisation-platform-github-oidc-role?ref=b40748ec162b446f8f8d282f767a85b6501fd192" # v4.0.0
   github_repositories = ["ministryofjustice/modernisation-platform-environments"]
   role_name           = "github-actions-terraform-dev-test"
@@ -1326,7 +1326,7 @@ module "github_actions_terraform_dev_test" {
 
 #trivy:ignore:AVD-AWS-0345: Required for OIDC role to access Terraform state in S3
 data "aws_iam_policy_document" "github_actions_terraform_dev_test" {
-  count = (local.account_data.account-type == "member" && terraform.workspace != "testing-test" && terraform.workspace != "sprinkler-development") ? 1 : 0
+  count = (local.account_data.account-type == "member" && terraform.workspace != "testing-test" && terraform.workspace != "sprinkler-development" && !can(regex("^coat-", terraform.workspace))) ? 1 : 0
   # checkov:skip=CKV_AWS_111: "Cannot restrict by KMS alias so leaving open"
   # checkov:skip=CKV_AWS_356: "Cannot restrict by KMS alias so leaving open"
   statement {


### PR DESCRIPTION
## A reference to the issue / Description of it

#9293 

## How does this PR fix the problem?

Adds COAT accounts to the exclusion of the github-actions-terraform-dev-test role. This is to ensure alignment with org-wide SCPs for those accounts. As such it will not result in any changes but rather unblocks the scheduled baselines job for the accounts in question.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
