### PR TITLE
issue/12518 - Adds the mandatory tag "service-area = Hosting" tag to locals.tags in core-network-services

### DIFF
--- a/terraform/environments/core-network-services/locals.tf
+++ b/terraform/environments/core-network-services/locals.tf
@@ -21,6 +21,7 @@ locals {
 
   tags = {
     business-unit = "Platforms"
+    service-area  = "Hosting"
     application   = "Modernisation Platform: core-network-services"
     is-production = local.is-production
     owner         = "Modernisation Platform: modernisation-platform@digital.justice.gov.uk"


### PR DESCRIPTION
## A reference to the issue / Description of it

#12518 

## How does this PR fix the problem?

We need to add the mandatory tag `service-area` with the value "Hosting" to our core accounts for those resources that are owned and managed by the team. This adds the tag to locals.tags for core-network-services and will update all resources in the account that use those locals as their tags.

Note that 3 resources of type `module.pagerduty_networking_general.aws_sns_topic_subscription.pagerduty_subscription` will be replaced.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
