### PR TITLE
issue/12518 - Adds the "service-area" mandatory tag to core-logging locals.tags

### DIFF
--- a/terraform/environments/core-logging/locals.tf
+++ b/terraform/environments/core-logging/locals.tf
@@ -17,6 +17,7 @@ locals {
 
   tags = {
     business-unit = "Platforms"
+    service-area  = "Hosting"
     application   = "Modernisation Platform: ${terraform.workspace}"
     is-production = local.is-production
     owner         = "Modernisation Platform: modernisation-platform@digital.justice.gov.uk"


### PR DESCRIPTION
## A reference to the issue / Description of it

#12591 

## How does this PR fix the problem?

Adds to core-logging  locals.tags the tag `service-area  = "Hosting"`

`Plan: 3 to add, 204 to change, 1 to destroy.`

Of the above:

Two `aws_ec2_tag.retag` resources to be created:

- https://github.com/ministryofjustice/modernisation-platform/actions/runs/22357582231/job/64701528792?pr=12593#step:17:7482

- https://github.com/ministryofjustice/modernisation-platform/actions/runs/22357582231/job/64701528792?pr=12593#step:17:7509

- One of module.pagerduty_r53_dns_firewall.aws_sns_topic_subscription.pagerduty_subscription will be replaced

The aws_ec2_tag resources applies a single tag to an AWS resource that cannot be tagged through its own resource block. It exists specifically for resources where the AWS provider doesn't expose a tags argument directly — the most common case being Transit Gateway VPC Attachment tags on the attachment side (not the TGW owner side).

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
