### PR TITLE
Adds mandatory tag "service-area" to locals.tags in core-shared-services

### DIFF
--- a/terraform/environments/core-shared-services/locals.tf
+++ b/terraform/environments/core-shared-services/locals.tf
@@ -49,6 +49,7 @@ locals {
 
   tags = {
     business-unit = "Platforms"
+    service-area  = "Hosting"
     application   = "Modernisation Platform: ${terraform.workspace}"
     is-production = local.is-production
     owner         = "Modernisation Platform: modernisation-platform@digital.justice.gov.uk"


### PR DESCRIPTION
## A reference to the issue / Description of it

#12518

## How does this PR fix the problem?

Adds the `service-owner` mandatory tag to core-shared-services locals.tags.

Plan - Plan: 5 to add, 263 to change, 3 to destroy.

Created:

- module.vpc_attachment["live_data"].aws_ec2_tag.retag["service-area"] [here](https://github.com/ministryofjustice/modernisation-platform/actions/runs/22359246094/job/64707631147?pr=12594#step:17:7293)
- module.vpc_attachment["non_live_data"].aws_ec2_tag.retag["service-area"] [here](https://github.com/ministryofjustice/modernisation-platform/actions/runs/22359246094/job/64707631147?pr=12594#step:17:7320)

The reasons for the creation of the aws_ec2_tag.retag is covered in an earlier [PR](https://github.com/ministryofjustice/modernisation-platform/pull/12593)

Replaced:

- module.pagerduty_core_alerts.aws_sns_topic_subscription.pagerduty_subscription
- module.pagerduty_core_alerts.aws_sns_topic_subscription.pagerduty_subscription["instance-scheduler-event-notification-topic-on-success"]
- module.pagerduty_malware_alerts.aws_sns_topic_subscription.pagerduty_subscription["s3-malware-scan-alerts"]

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
