### PR TITLE
Update last reviewed date for AWS credentials guide

### DIFF
--- a/source/user-guide/getting-aws-credentials.html.md.erb
+++ b/source/user-guide/getting-aws-credentials.html.md.erb
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#modernisation-platform"
 title: Getting AWS Credentials
-last_reviewed_on: 2025-02-24
+last_reviewed_on: 2026-02-25
 review_in: 6 months
 ---
 


### PR DESCRIPTION
## A reference to the issue / Description of it

Doc review date wrong

## How does this PR fix the problem?

Changed it to 2026


