### PR TITLE
issue/12518 - Adds new service-area tag to locals.tags in core-security

### DIFF
--- a/terraform/environments/core-security/locals.tf
+++ b/terraform/environments/core-security/locals.tf
@@ -14,6 +14,7 @@ locals {
 
   tags = {
     business-unit = "Platforms"
+    service-area  = "Hosting"
     application   = "Modernisation Platform: ${terraform.workspace}"
     is-production = local.is-production
     owner         = "Modernisation Platform: modernisation-platform@digital.justice.gov.uk"


### PR DESCRIPTION
## A reference to the issue / Description of it

#12518 

## How does this PR fix the problem?

Adds new `service-area = "Hosting"` tag to locals.tags

Plan output:

`Plan: 2 to add, 69 to change, 0 to destroy.`

2 resources to be created:

- module.vpc_attachment["live_data"].aws_ec2_tag.retag["service-area"]
- module.vpc_attachment["non_live_data"].aws_ec2_tag.retag["service-area"]

A description on the purpose of the aws_ec2_tag resource is covered in this PR - https://github.com/ministryofjustice/modernisation-platform/pull/12593

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
