### PR TITLE
issue/12518 - Adds service-area to locals.tags in terraform/environments/bootstrap

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/locals.tf
+++ b/terraform/environments/bootstrap/delegate-access/locals.tf
@@ -20,6 +20,7 @@ locals {
 
   environments = {
     business-unit = "Platforms"
+    service-area  = "Hosting"
     application   = "Modernisation Platform: Environments Management"
     is-production = true
     owner         = "Modernisation Platform: modernisation-platform@digital.justice.gov.uk"

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -1320,7 +1320,7 @@ module "github_actions_terraform_dev_test" {
   github_repositories = ["ministryofjustice/modernisation-platform-environments"]
   role_name           = "github-actions-terraform-dev-test"
   policy_jsons        = [data.aws_iam_policy_document.github_actions_terraform_dev_test[0].json]
-  tags                = { "Name" = "github-actions-terraform-dev-test", "service-area" = "Hosting" }
+  tags                = { "Name" = "github-actions-terraform-dev-test" }
 }
 
 #trivy:ignore:AVD-AWS-0345: Required for OIDC role to access Terraform state in S3

--- a/terraform/environments/bootstrap/member-bootstrap/locals.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/locals.tf
@@ -55,6 +55,7 @@ locals {
 
   tags = {
     business-unit = "Platforms"
+    service-area  = "Hosting"
     application   = "Modernisation Platform: Member Bootstrap"
     is-production = true
     owner         = "Modernisation Platform: modernisation-platform@digital.justice.gov.uk"

--- a/terraform/environments/bootstrap/secure-baselines/locals.tf
+++ b/terraform/environments/bootstrap/secure-baselines/locals.tf
@@ -19,6 +19,7 @@ locals {
   ]
   environments = {
     business-unit = "Platforms"
+    service-area  = "Hosting"
     application   = "Modernisation Platform: Environments Management"
     is-production = true
     owner         = "Modernisation Platform: modernisation-platform@digital.justice.gov.uk"


### PR DESCRIPTION
## A reference to the issue / Description of it

#12518 

## How does this PR fix the problem?

Adds the service-area tag to locals.tags to delegate-access, secure-baselines and member-bootstrap. Removes role-specific tag to avoid duplication.

When applied to Sprinkler:

Delegate-Access - no changes

Secure-Baselines - `Plan: 1 to add, 131 to change, 6 to destroy.`

- `module.baselines.module.securityhub-alarms.module.pagerduty_high_priority_alerts.aws_sns_topic_subscription.pagerduty_subscription["high-priority-alarms-topic"]` replaced

- 5 backup related resources not added to main branch being removed.

Member-Bootstrap - `Plan: 3 to add, 39 to change, 0 to destroy.`

- `module.core_monitoring.module.pagerduty_core_alerts.aws_sns_topic_subscription.pagerduty_subscription["cloudtrail"]`
- `module.core_monitoring.module.pagerduty_core_alerts.aws_sns_topic_subscription.pagerduty_subscription["config"]`
- `module.core_monitoring.module.pagerduty_core_alerts.aws_sns_topic_subscription.pagerduty_subscription["securityhub-alarms"]`


## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
