### PR TITLE
Suggested changes to the New Environment Request Template and Workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-environment.yml
+++ b/.github/ISSUE_TEMPLATE/new-environment.yml
@@ -207,7 +207,7 @@ body:
   id: slack-channel-placeholder
   attributes:
     label: Slack Channel
-    description: Please provide the name of the Slack channel you will use for operational communication about this application, e.g. #my-app-support. This is important so that we can ensure you receive relevant notifications from AWS.
+    description: Please provide the name of the Slack channel you will use for operational communication about this application but without the leading "#" character, e.g. my-app-support. This is important so that we can ensure you receive relevant notifications from AWS.
     value:
 - type: markdown
   attributes:

--- a/.github/workflows/create-newenv.yml
+++ b/.github/workflows/create-newenv.yml
@@ -71,6 +71,13 @@ jobs:
             echo "GITHUB_REVIEWERS=$GITHUB_REVIEWERS"
           } >> $GITHUB_ENV
 
+      - name: Validate Slack field (no #)
+        run: |
+          if [[ "${SLACK}" == *"#"* ]]; then
+            echo "::error title=Invalid Slack Channel::SLACK must not include '#'. Please enter the channel name without the leading hash (e.g. 'my-channel' not '#my-channel'). Value: '${SLACK}'"
+            exit 1
+          fi
+
       - name: Extract environment selections
         run: |
           ENVIRONMENTS=""


### PR DESCRIPTION
Two small suggested changes to the new environment request template &workflow to ensure that "#" characters are not added to the slack channel tag. # characters are not supported in tag names or values and will cause the new account creation process to fail.

As such it is better to fail the workflow that creates the new issue & new env file if a # is found than it is to fail the new environment workflow which is messy to recover from.

## A reference to the issue / Description of it

{Please write here}

## How does this PR fix the problem?

{Please write here}

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
