### PR TITLE
Add Sec Hub Slack channel for CICA Tariff

### DIFF
--- a/environments/cica-tariff.json
+++ b/environments/cica-tariff.json
@@ -43,7 +43,8 @@
     "business-unit": "CICA",
     "infrastructure-support": "Infrastructure@cica.gov.uk",
     "owner": "alan.terry@cica.gov.uk",
-    "critical-national-infrastructure": true
+    "critical-national-infrastructure": true,
+    "securityhub-slack-channel": "cica-devops"
   },
   "github-oidc-team-repositories": [""],
   "go-live-date": "2025-11-29"


### PR DESCRIPTION
CICA Tariff: adding Slack channel for Security Hub.