### PR TITLE
TM-1918 allow dev access to teams

### DIFF
--- a/environments/delius-core.json
+++ b/environments/delius-core.json
@@ -116,6 +116,16 @@
         {
           "sso_group_name": "probation-de",
           "level": "developer"
+        },
+        {
+          "sso_group_name": "hmpps-manage-people-on-probation",
+          "level": "developer",
+          "github_action_reviewer": "false"
+        },
+        {
+          "sso_group_name": "hmpps-manage-people-on-probation-dev",
+          "level": "developer",
+          "github_action_reviewer": "false"
         }
       ]
     },
@@ -154,6 +164,16 @@
           "sso_group_name": "version-1-sit-team",
           "level": "developer",
           "github_action_reviewer": "false"
+        },
+        {
+          "sso_group_name": "hmpps-manage-people-on-probation",
+          "level": "developer",
+          "github_action_reviewer": "false"
+        },
+        {
+          "sso_group_name": "hmpps-manage-people-on-probation-dev",
+          "level": "developer",
+          "github_action_reviewer": "false"
         }
       ],
       "instance_scheduler_skip": ["true"]
@@ -181,6 +201,16 @@
         },
         {
           "sso_group_name": "probation-integration",
+          "level": "developer",
+          "github_action_reviewer": "false"
+        },
+        {
+          "sso_group_name": "hmpps-manage-people-on-probation",
+          "level": "developer",
+          "github_action_reviewer": "false"
+        },
+        {
+          "sso_group_name": "hmpps-manage-people-on-probation-dev",
           "level": "developer",
           "github_action_reviewer": "false"
         }


### PR DESCRIPTION
## A reference to the issue / Description of it

allow hmpps-manage-people-on-probation and hmpps-manage-people-on-probation teams to access dev

## How does this PR fix the problem?

{Please write here}

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
