### PR TITLE
Updating permissions for CP non-live app

### DIFF
--- a/environments/cloud-platform-non-live.json
+++ b/environments/cloud-platform-non-live.json
@@ -23,6 +23,11 @@
         {
           "sso_group_name": "cloud-platform-engineers",
           "level": "platform-engineer-admin"
+        },
+        {
+          "sso_group_name": "modernisation-platform",
+          "level": "developer",
+          "github_action_reviewer": "true"
         }
       ]
     },


### PR DESCRIPTION
Please, this is to aid my  hijacking of the GH action in the cloud-platform-non-live-development account.

I need to add MP team as GH action approver, so that I can run the workflow and deploy to the dev env.

This is related to this ticket: https://github.com/ministryofjustice/modernisation-platform/issues/12637