### PR TITLE
Update deny OIDC permissions

### DIFF
--- a/terraform/modernisation-platform-account/iam.tf
+++ b/terraform/modernisation-platform-account/iam.tf
@@ -283,9 +283,7 @@ data "aws_iam_policy_document" "oidc-deny-specific-actions" {
     effect = "Deny"
     actions = [
       "iam:ChangePassword",
-      "iam:CreateLoginProfile",
-      "iam:DeleteUser",
-      "iam:DeleteVirtualMFADevice"
+      "iam:CreateLoginProfile"
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
https://github.com/ministryofjustice/modernisation-platform/actions/runs/22667809901/job/65703920770#step:21:1215

> Error: removing IAM User (helen.curtis) Virtual MFA devices: deleting IAM Virtual MFA Device (arn:aws:iam::***:mfa/helen.curtis): operation error IAM: DeleteVirtualMFADevice, https response error StatusCode: 403, RequestID: , api error AccessDenied: User: arn:aws:sts::***:assumed-role/github-actions/githubactionsrolesession is not authorized to perform: iam:DeleteVirtualMFADevice on resource: arn:aws:iam::***:mfa/helen.curtis with an explicit deny in an identity-based policy: arn:aws:iam::***:policy/github-actions