### PR TITLE
fix: a component added for ebs

### DIFF
--- a/environments/ccms-ebs.json
+++ b/environments/ccms-ebs.json
@@ -4,6 +4,10 @@
     {
       "name": "workspaces-secure-browser",
       "sso_group_name": "aws-root-account-admin-team"
+    },
+    {
+      "name": "ccms-ebs-ssogen",
+      "sso_group_name": "laa-sre-admins"
     }
   ],
   "environments": [


### PR DESCRIPTION
## A reference to the issue / Description of it

A new component of ssogen under ccms ebs

## How does this PR fix the problem?

Creates a new component where we can use aws certs and export it

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Just followed the guide at https://user-guide.modernisation-platform.service.justice.gov.uk/runbooks/creating-components-for-member-applications.html#requirements

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [n/a] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

Primarily to use aws provider version 6.4
