### PR TITLE
TM-1917: core-shared-services: remove old fixngo share

### DIFF
--- a/terraform/environments/core-shared-services/ad-fixngo.tf
+++ b/terraform/environments/core-shared-services/ad-fixngo.tf
@@ -390,24 +390,6 @@ locals {
         throughput_capacity                 = 128
         weekly_maintenance_start_time       = "2:04:00" # tue 4am
       }
-      ad-hmpp-fsx = {
-        ad_dns_ips = flatten([
-          module.ad_fixngo_ip_addresses.mp_ips.ad_fixngo_hmpp_domain_controllers,
-        ])
-        ad_domain_name                      = "azure.hmpp.root"
-        ad_file_system_administrators_group = "AWS FSx Admins"
-        ad_username                         = "svc_fsx_windows"
-        aliases                             = ["fs.azure.hmpp.root", "fsprisonretail.azure.hmpp.root", "fsbranstonstaff.azure.hmpp.root", "fslinux.azure.hmpp.root"]
-        deployment_type                     = "MULTI_AZ_1"
-        security_group_name                 = "ad_hmpp_fsx_sg"
-        storage_capacity                    = 100
-        subnet_ids = [
-          module.vpc["live_data"].non_tgw_subnet_ids_map.private[0],
-          module.vpc["live_data"].non_tgw_subnet_ids_map.private[1],
-        ]
-        throughput_capacity           = 32
-        weekly_maintenance_start_time = "4:04:00" # thu 4am
-      }
       ad-hmpp-fsx-additional = {
         ad_dns_ips = flatten([
           module.ad_fixngo_ip_addresses.mp_ips.ad_fixngo_hmpp_domain_controllers,


### PR DESCRIPTION
## A reference to the issue / Description of it

All hmpp users and shares have been migrated from ad-hmpp-fsx (on 10.20) network to ad-hmpp-fsx-additional (10.27) network. The ad-hmpp-fsx can be safely decommissioned now.

## How does this PR fix the problem?

Deletes the ad-hmpp-fsx FSx resource

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

I've validated there are no open files and no fileshare sessions on the ad-hmpp-fsx share. All users are on the new share.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
