### PR TITLE
Typo in access level

### DIFF
--- a/environments/data-factory-laa.json
+++ b/environments/data-factory-laa.json
@@ -6,7 +6,7 @@
       "access": [
         {
           "sso_group_name": "laa-data-factory-engineering",
-          "level": "data-engineering"
+          "level": "sandbox"
         }
       ],
       "nuke": "rebuild"


### PR DESCRIPTION
## A reference to the issue / Description of it

The recently created data-factory-laa account has access level set to `data-engineering`. The list defined in [definitions.rego](https://github.com/ministryofjustice/modernisation-platform/blob/main/policies/environments/environment-definitions.rego#L16) contains `data-engineer` (without the `ing`)

**Update: This account will actually have the sandbox level access for data engineers**

## How does this PR fix the problem?

Fixes the access level to match the value in definitions.rego

## How has this been tested?

Not tested. Currently the account does not appear in the access portal

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No. It should just affect access for SSO users.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)
