### PR TITLE
Revert "Add internal-airflow component to analytical-platform-compute"

### DIFF
--- a/environments/analytical-platform-compute.json
+++ b/environments/analytical-platform-compute.json
@@ -33,9 +33,6 @@
     },
     {
       "name": "next"
-    },
-    {
-      "name": "internal-airflow"
     }
   ],
   "codeowners": ["analytical-platform-engineers"],


### PR DESCRIPTION
Reverts ministryofjustice/modernisation-platform#12660

Reverting as this duplicate component is no longer required.