### PR TITLE
Enforce authorisation for GitHub Actions workflow modifications

### DIFF
--- a/.github/workflows/enforce-workflow-change-authorisation.yml
+++ b/.github/workflows/enforce-workflow-change-authorisation.yml
@@ -10,6 +10,7 @@ jobs:
 
   validate-workflow-change-author:
     runs-on: ubuntu-latest
+    needs: fetch-secrets
     permissions:
       contents: read
       pull-requests: read


### PR DESCRIPTION
Introduce a security control that prevents unauthorised users from modifying GitHub Actions workflow files. Workflow files define CI/CD behaviour, so changes to`.github/workflows` should only be made by trusted maintainers.