### PR TITLE
Add `instance-access` for `laa-cyber-security-team` in OAS preproduction

### DIFF
--- a/environments/oas.json
+++ b/environments/oas.json
@@ -56,7 +56,7 @@
         },
         {
           "sso_group_name": "laa-cyber-security-team",
-          "level": "instance_access"
+          "level": "instance-access"
         }
       ]
     },


### PR DESCRIPTION
## A reference to the issue / Description of it
Issue raised in Slack https://mojdt.slack.com/archives/C01A7QK5VM1/p1773223600557669

## How does this PR fix the problem?

Adding `instance-access` for `laa-cyber-security-team` in OAS preproduction

