### PR TITLE
Add `id-token` write permission to workflow

### DIFF
--- a/.github/workflows/enforce-workflow-change-authorisation.yml
+++ b/.github/workflows/enforce-workflow-change-authorisation.yml
@@ -1,6 +1,10 @@
 name: Enforce Workflow Change Authorisation
 on:
   pull_request_target:
+permissions:
+  contents: read
+  pull-requests: read
+  id-token: write
 jobs:
   fetch-secrets:
     uses: ministryofjustice/modernisation-platform-github-actions/.github/workflows/aws-secrets-management.yml@5c713c93eea694829b1bd3f410d0b235053318ce # v4.0.0
@@ -11,9 +15,6 @@ jobs:
   validate-workflow-change-author:
     runs-on: ubuntu-latest
     needs: fetch-secrets
-    permissions:
-      contents: read
-      pull-requests: read
     steps:
       - name: Decrypt Secrets
         uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@5c713c93eea694829b1bd3f410d0b235053318ce # v4.0.0


### PR DESCRIPTION
Added `id-token: write` permission to GitHub Actions workflow to enable OIDC authentication