### PR TITLE
:wrench: Update new-collaborator.yml to use email instead of slack

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-collaborator.yml
+++ b/.github/ISSUE_TEMPLATE/new-collaborator.yml
@@ -19,11 +19,11 @@ body:
   validations:
     required: true
 - type: input
-  id: requestor-slack
+  id: requestor-email
   attributes:
-    label: Requestor Slack handle
-    description: The Slack handle of the person making this request.
-    placeholder: e.g., @bilbo-baggins
+    label: Requestor email address
+    description: The email address of the person making this request.
+    placeholder: e.g., user@justice.gov.uk
   validations:
     required: true
 - type: markdown


### PR DESCRIPTION
## A reference to the issue / Description of it

The collaborator form asks for slack handle in format `@username`

However when interpreted in the resulting GitHub issue the username may not be right as GitHub users also use the `@` symbol and essentially someone raised an issue and it looked like someone else had raised it.

## How does this PR fix the problem?

I've switched the field to email instead as this is truly unique and identifies the user. 
