### PR TITLE
feat/ allow execute-api:Invoke on sandbox role

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -428,7 +428,6 @@ data "aws_iam_policy_document" "data_engineering_additional" {
       "dynamodb:GetItem",
       "dynamodb:PutItem",
       "dynamodb:DeleteItem",
-      "execute-api:Invoke",
       "glue:Batch*Partition",
       "glue:BatchDeleteTable",
       "glue:CreateDatabase",


### PR DESCRIPTION
Update the sandbox policy to allow the roles to invoke an API in API gateway. We can test via the "apigateway:POST" permission but a full invocation requires the additional execute-api perm. 

Related JIRA epic - ELM-4520
