### PR TITLE
fix: update access level for laa-cyber-security-team in oas.json

### DIFF
--- a/environments/oas.json
+++ b/environments/oas.json
@@ -56,7 +56,7 @@
         },
         {
           "sso_group_name": "laa-cyber-security-team",
-          "level": "instance-access"
+          "level": "instance-management"
         }
       ]
     },


### PR DESCRIPTION
## A reference to the issue / Description of it

As per Slack thread https://mojdt.slack.com/archives/C01A7QK5VM1/p1773223600557669

LAA security team need ability to SSM to a Kali instance in OAS Pre-Prod

They are getting error:

```
$ aws ssm start-session --target i-xxx

An error occurred (AccessDeniedException) when calling the StartSession operation: User: arn:aws:sts::xxx:assumed-role/AWSReservedSSO_mp-instance-access_e6373bcf464a69b6/krupalb-dev@digital.justice.gov.uk is not authorized to perform: ssm:StartSession on resource: arn:aws:ssm:eu-west-2:xxx:document/SSM-SessionManagerRunShell because no identity-based policy allows the ssm:StartSession action
```

## How does this PR fix the problem?

Updated access level for laa-cyber-security-team in oas.json to instance-management

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
