### PR TITLE
Amend business unit tag for COAT environments

### DIFF
--- a/environments/coat.json
+++ b/environments/coat.json
@@ -23,7 +23,7 @@
   ],
   "tags": {
     "application": "coat",
-    "business-unit": "Platforms",
+    "business-unit": "OCTO",
     "infrastructure-support": "CloudOptimisationAndAccountability@justice.gov.uk",
     "owner": "CloudOptimisationAndAccountability@justice.gov.uk",
     "critical-national-infrastructure": false


### PR DESCRIPTION
The COAT team has deployed an SCP from the root account to enforce mandatory tags in COAT environments - https://github.com/ministryofjustice/aws-root-account/blob/main/management-account/terraform/organizations-policy-service-control.tf#L512

This SCP enforces valid values for the business-unit tag. "Platforms" is a legacy value for the business unit tag, which is no longer valid. Instead, the "OCTO" business unit should be used.

This PR updates the business unit tag for COAT environments, enabling resource deployment into COAT environments, without being blocked by the new SCP.