### PR TITLE
remove octo option for the moment

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-environment.yml
+++ b/.github/ISSUE_TEMPLATE/new-environment.yml
@@ -193,7 +193,6 @@ body:
     - CICA
     - Platforms
     - Technology Services
-    - OCTO
   validations:
     required: true
 - type: input


### PR DESCRIPTION
## A reference to the issue / Description of it

after speaking with the team we have no VPC options for OCTO at the moment as this need to be changed from the current platforms octo

## How does this PR fix the problem?

removes octo

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
