### PR TITLE
add data architects to delius core

### DIFF
--- a/environments/delius-core.json
+++ b/environments/delius-core.json
@@ -64,6 +64,11 @@
           "sso_group_name": "hmpps-manage-people-on-probation-dev",
           "level": "developer",
           "github_action_reviewer": "false"
+        },
+        {
+          "sso_group_name": "octo-data-architecture",
+          "level": "developer",
+          "github_action_reviewer": "false"
         }
       ],
       "nuke": "exclude"
@@ -125,6 +130,11 @@
         },
         {
           "sso_group_name": "hmpps-manage-people-on-probation-dev",
+          "level": "developer",
+          "github_action_reviewer": "false"
+        },
+        {
+          "sso_group_name": "octo-data-architecture",
           "level": "developer",
           "github_action_reviewer": "false"
         }


### PR DESCRIPTION
## A reference to the issue / Description of it

Office of the CTO Data Architecture team needs access to delius core dev and test

## How does this PR fix the problem?

It adds their access

## How has this been tested?

Just the PR checks.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No, it is only adding user access.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

N/A
