### PR TITLE
feat(ELM-4532): EM dev account cloudtrail permissions update

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -421,6 +421,18 @@ data "aws_iam_policy_document" "member-access-network" {
   }
   statement {
     effect    = "Allow"
+    actions   = ["cloudtrail:DeleteTrail"]
+    resources = ["arn:aws:cloudtrail:*:*:trail/ears_sars_cloudtrail*"]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalAccount"
+      values = [
+        local.environment_management.account_ids["electronic-monitoring-data-development"]
+      ]
+    }
+  }
+  statement {
+    effect    = "Allow"
     actions   = ["s3:DeleteObject"]
     resources = ["arn:aws:s3:::cloudtrail-test*/*"]
     condition {


### PR DESCRIPTION
## A reference to the issue / Description of it

Grant  cloudtrail delete permissions on the electronic monitoring dev account for the ears_sars trail.
Build currently fails in Dev (see https://github.com/ministryofjustice/modernisation-platform-environments/actions/runs/23483378576/job/68332924750) as the resource needs to be destroyed and replaced but there is no permission to do this. 

## How does this PR fix the problem?

Grants cloudtrail:DeleteTrail on the required trail in the EM dev account. 

## How has this been tested?

Permissions need to be updated in Dev for testing.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

Impacts IAM role

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

