### PR TITLE
Cooker credential testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ config.txt
 execution_log.txt
 .lycheecache
 megalinter-reports
+lambda/credential_responder.zip
+

--- a/terraform/environments/cooker/iam-credential-alerting.tf
+++ b/terraform/environments/cooker/iam-credential-alerting.tf
@@ -1,0 +1,28 @@
+# tfsec:ignore:aws-sns-enable-topic-encryption
+resource "aws_sns_topic" "iam_credential_alert" {
+  #checkov:skip=CKV_AWS_26:"encrypted topics do not work with pagerduty subscription"
+  name = "iam-credential-exposed-alert"
+}
+
+data "aws_secretsmanager_secret" "pagerduty_integration_keys" {
+  provider = aws.modernisation-platform
+  name     = "pagerduty_integration_keys"
+}
+
+data "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {
+  provider  = aws.modernisation-platform
+  secret_id = data.aws_secretsmanager_secret.pagerduty_integration_keys.id
+}
+
+locals {
+  pagerduty_integration_keys = jsondecode(data.aws_secretsmanager_secret_version.pagerduty_integration_keys.secret_string)
+}
+
+module "pagerduty_iam_credential_alert" {
+  depends_on = [
+    aws_sns_topic.iam_credential_alert
+  ]
+  source                    = "github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration?ref=d88bd90d490268896670a898edfaba24bba2f8ab" # v3.0.0
+  sns_topics                = [aws_sns_topic.iam_credential_alert.name]
+  pagerduty_integration_key = local.pagerduty_integration_keys["core_alerts_high_priority_cloudwatch"]
+}

--- a/terraform/environments/cooker/iam-credential-alerting.tf
+++ b/terraform/environments/cooker/iam-credential-alerting.tf
@@ -5,12 +5,12 @@ resource "aws_sns_topic" "iam_credential_alert" {
 }
 
 data "aws_secretsmanager_secret" "pagerduty_integration_keys" {
-  provider = aws.modernisation-platform
+  provider = aws.modernisation-secrets-read
   name     = "pagerduty_integration_keys"
 }
 
 data "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {
-  provider  = aws.modernisation-platform
+  provider  = aws.modernisation-secrets-read
   secret_id = data.aws_secretsmanager_secret.pagerduty_integration_keys.id
 }
 

--- a/terraform/environments/cooker/iam-credential-response.tf
+++ b/terraform/environments/cooker/iam-credential-response.tf
@@ -1,0 +1,105 @@
+# EventBridge rule — fires when AWS Health detects an exposed IAM key
+resource "aws_cloudwatch_event_rule" "iam_credential_exposed" {
+  name        = "iam-credential-exposed"
+  description = "Triggers on AWS_RISK_CREDENTIALS_EXPOSED Health events"
+
+  event_pattern = jsonencode({
+    source      = ["aws.health"]
+    detail-type = ["AWS Health Event"]
+    detail = {
+      service       = ["IAM"]
+      eventTypeCode = ["AWS_RISK_CREDENTIALS_EXPOSED"]
+    }
+  })
+}
+
+resource "aws_cloudwatch_event_target" "iam_credential_exposed_lambda" {
+  rule      = aws_cloudwatch_event_rule.iam_credential_exposed.name
+  target_id = "credential-responder-lambda"
+  arn       = aws_lambda_function.credential_responder.arn
+}
+
+# Allow EventBridge to invoke the Lambda
+resource "aws_lambda_permission" "allow_eventbridge" {
+  statement_id  = "AllowEventBridgeInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.credential_responder.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.iam_credential_exposed.arn
+}
+
+# IAM role for the Lambda
+resource "aws_iam_role" "credential_responder" {
+  name = "credential-responder-lambda"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "lambda.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "credential_responder" {
+  name = "credential-responder-policy"
+  role = aws_iam_role.credential_responder.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "DisableAndQuarantineIAM"
+        Effect = "Allow"
+        Action = [
+          "iam:UpdateAccessKey",
+          "iam:PutUserPolicy",
+          "iam:ListUsers",
+          "iam:ListAccessKeys"
+        ]
+        Resource = "*"
+      },
+      {
+        Sid      = "PublishToSNS"
+        Effect   = "Allow"
+        Action   = "sns:Publish"
+        Resource = aws_sns_topic.iam_credential_alert.arn
+      },
+      {
+        Sid    = "BasicLambdaLogs"
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ]
+        Resource = "arn:aws:logs:*:*:*"
+      }
+    ]
+  })
+}
+
+# Lambda function
+resource "aws_lambda_function" "credential_responder" {
+  function_name    = "iam-credential-responder"
+  description      = "Disables exposed IAM keys, quarantines users, and raises alerts via SNS"
+  role             = aws_iam_role.credential_responder.arn
+  handler          = "credential_responder.handler"
+  runtime          = "python3.12"
+  filename         = data.archive_file.credential_responder.output_path
+  source_code_hash = data.archive_file.credential_responder.output_base64sha256
+  timeout          = 60
+
+  environment {
+    variables = {
+      CREDENTIAL_ALERT_SNS_ARN = aws_sns_topic.iam_credential_alert.arn
+    }
+  }
+}
+
+data "archive_file" "credential_responder" {
+  type        = "zip"
+  source_file = "${path.module}/lambda/credential_responder.py"
+  output_path = "${path.module}/lambda/credential_responder.zip"
+}

--- a/terraform/environments/cooker/lambda/credential_responder.py
+++ b/terraform/environments/cooker/lambda/credential_responder.py
@@ -1,0 +1,72 @@
+import boto3
+import json
+import os
+from datetime import datetime, timezone
+
+iam = boto3.client("iam")
+sns = boto3.client("sns")
+
+DENY_ALL = json.dumps({
+    "Version": "2012-10-17",
+    "Statement": [{"Effect": "Deny", "Action": "*", "Resource": "*"}]
+})
+
+def get_username_for_key(key_id):
+    paginator = iam.get_paginator("list_users")
+    for page in paginator.paginate():
+        for user in page["Users"]:
+            keys = iam.list_access_keys(UserName=user["UserName"])["AccessKeyMetadata"]
+            if any(k["AccessKeyId"] == key_id for k in keys):
+                return user["UserName"]
+    return None
+
+def handler(event, context):
+    detail   = event.get("detail", {})
+    entities = detail.get("affectedEntities", [])
+
+    for entity in entities:
+        key_id   = entity["entityValue"]
+        username = get_username_for_key(key_id)
+
+        if not username:
+            print(f"Could not find a user for key {key_id} — may already be deleted")
+            continue
+
+        # 1. Disable the exposed key
+        iam.update_access_key(
+            UserName=username,
+            AccessKeyId=key_id,
+            Status="Inactive"
+        )
+        print(f"Disabled key {key_id} for user {username}")
+
+        # 2. Attach deny-all quarantine policy
+        iam.put_user_policy(
+            UserName=username,
+            PolicyName="EmergencyQuarantine",
+            PolicyDocument=DENY_ALL
+        )
+        print(f"Quarantine policy applied to {username}")
+
+        # 3. Publish to SNS → PagerDuty
+        sns.publish(
+            TopicArn=os.environ["CREDENTIAL_ALERT_SNS_ARN"],
+            Subject="ALARM: IAM_CREDENTIAL_EXPOSED",
+            Message=json.dumps({
+                "AlarmName":        "IAM_CREDENTIAL_EXPOSED",
+                "AlarmDescription": f"Exposed IAM key {key_id} detected for user {username}",
+                "AWSAccountId":     event.get("account", "unknown"),
+                "NewStateValue":    "ALARM",
+                "NewStateReason":   f"Exposed key {key_id} for user {username}. Key disabled and quarantine policy applied automatically.",
+                "NewStateReasonData": "",
+                "OldStateValue":    "OK",
+                "StateChangeTime":  datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z"),
+                "Region":           "EU (London)",
+                "Trigger": {
+                    "MetricName": "IAM_CREDENTIAL_EXPOSED",
+                    "Namespace":  "Security",
+                    "Dimensions": []
+                }
+            })
+        )
+        print(f"SNS alert published for {key_id}")


### PR DESCRIPTION
This pull request introduces an automated response system for exposed IAM credentials in the `cooker` environment. It sets up infrastructure to detect, respond to, and alert on AWS Health events indicating exposed IAM keys. The changes include new Terraform resources for event detection, a Lambda function to remediate incidents, and integration with SNS and PagerDuty for alerting.

**Automated IAM credential exposure response:**

* Added an EventBridge rule (`aws_cloudwatch_event_rule.iam_credential_exposed`) to detect AWS Health events for exposed IAM credentials and trigger a Lambda function for automated response.
* Created a Lambda function (`lambda/credential_responder.py`) that disables exposed IAM keys, applies a deny-all quarantine policy to the affected user, and publishes an alert to SNS. [[1]](diffhunk://#diff-e6a17e5bf4216154c31b0936c37990cd5a36832f6ecd5add61df36e5653c95f8R1-R72) [[2]](diffhunk://#diff-dc847b430aa8a2873b34600f2a3fba7bba506cc24c11035d8ea83f9af3e60f0aR1-R105)
* Defined necessary IAM roles and permissions for the Lambda to manage IAM users and publish to SNS.

**Alerting integration:**

* Provisioned an SNS topic (`aws_sns_topic.iam_credential_alert`) for credential exposure alerts, and integrated it with PagerDuty using a dedicated Terraform module and secrets from AWS Secrets Manager.
* Updated Lambda environment variables and permissions to enable publishing alerts to the SNS topic, ensuring incidents are escalated via PagerDuty. [[1]](diffhunk://#diff-dc847b430aa8a2873b34600f2a3fba7bba506cc24c11035d8ea83f9af3e60f0aR1-R105) [[2]](diffhunk://#diff-f17099973279e2846f75a8f73ea4155ef919f75b967113919754f3573604729bR1-R28)## A reference to the issue / Description of it
