### PR TITLE
Adding security-audit permissions for octo cyber to delius-iaps-production

### DIFF
--- a/environments/delius-iaps.json
+++ b/environments/delius-iaps.json
@@ -37,6 +37,10 @@
         {
           "sso_group_name": "hmpps-accredited-programmes-manage-and-deliver-devs",
           "level": "instance-management"
+        },
+        {
+          "sso_group_name": "octo-cyber-team",
+          "level": "security-audit"
         }
       ]
     },


### PR DESCRIPTION
Adding permissions so that the cyber team can run the AWS ITHC check.