### PR TITLE
Bump baselines version to v9.2.0 

### DIFF
--- a/terraform/environments/bootstrap/secure-baselines/main.tf
+++ b/terraform/environments/bootstrap/secure-baselines/main.tf
@@ -6,7 +6,7 @@ data "aws_kms_key" "cloudtrail_key" {
 
 #trivy:ignore:AVD-AWS-0136
 module "baselines" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=fbaa8e2989b3187348f0f9d626bdad9102e9e13f" # v9.1.2
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=79a29a92222824c4e95ec642b54fb11d75e18d23" # v9.2.0
   providers = {
     # Default and replication regions
     aws                    = aws.workspace-eu-west-2

--- a/terraform/modernisation-platform-account/baselines.tf
+++ b/terraform/modernisation-platform-account/baselines.tf
@@ -18,7 +18,7 @@ locals {
 # Secure baselines (GuardDuty, Config, SecurityHub, etc)
 #trivy:ignore:AVD-AWS-0136 trivy:ignore:AVD-AWS-0132
 module "baselines-modernisation-platform" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=35c27b19f923053a9ab0525d45c9301dca743359" # v9.0.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=79a29a92222824c4e95ec642b54fb11d75e18d23" # v9.2.0
   providers = {
     # Default and replication regions
     aws                    = aws.modernisation-platform-eu-west-2


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform-security/issues/92
https://github.com/ministryofjustice/modernisation-platform-security/issues/81

## How does this PR fix the problem?

Updates baselines to `v9.2.0` to deploy changes made to our cloudtrail alarms in the baseline.

## How has this been tested?

These changes were tested running local applies in testing accounts.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
