### PR TITLE
Add SecretsManager access to github-actions-plan role

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -1458,6 +1458,15 @@ data "aws_iam_policy_document" "oidc_assume_plan_role_member" {
       "s3:PutObject"
     ]
   }
+
+  statement {
+    sid       = "AllowSecretsManagerRead"
+    effect    = "Allow"
+    resources = ["arn:aws:secretsmanager:*:${local.environment_management.account_ids[terraform.workspace]}:secret:*"]
+    actions = [
+      "secretsmanager:GetSecretValue"
+    ]
+  }  
 }
 
 # Role github-actions-apply to support OIDC access from Modernisation-Platform-Environments for:


### PR DESCRIPTION
The `github-actions-plan` role currently has readonly permissions but fails during Terraform plan when attempting to read secrets from Secrets Manager.

This PR adds the `secretsmanager:GetSecretValue` permission, restricted to secrets in this AWS account. [#135](https://github.com/ministryofjustice/modernisation-platform-security/issues/135)