### PR TITLE
property dev account - sandbox level access

### DIFF
--- a/environments/property-cafm-data-migration.json
+++ b/environments/property-cafm-data-migration.json
@@ -7,7 +7,7 @@
       "access": [
         {
           "sso_group_name": "property-datahub",
-          "level": "data-engineer"
+          "level": "sandbox"
         }
       ]
     },


### PR DESCRIPTION
## A reference to the issue / Description of it

Allow Sandbox level access to the  Property dev account

## How does this PR fix the problem?

Analytical Platform Sandbox account was used for some Property account related development work. This work will now take place in the property dev account.

## How has this been tested?
N/A - Role change


## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)
