### PR TITLE
Deny `iam:DeleteLoginProfile` for all accounts except testing-test for unit testing

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -480,7 +480,6 @@ data "aws_iam_policy_document" "member-access-network" {
       "iam:DeleteAccountPasswordPolicy",
       "iam:DeleteGroup",
       "iam:DeleteGroupPolicy",
-      "iam:DeleteLoginProfile",
       "iam:DeleteSAMLProvider",
       "iam:DeleteUserPermissionsBoundary",
       "iam:DeleteVirtualMFADevice",
@@ -495,6 +494,18 @@ data "aws_iam_policy_document" "member-access-network" {
       "iam:UpdateUser"
     ]
     resources = ["*"]
+  }
+
+  # Deny iam:DeleteLoginProfile for all accounts except testing-test, which needs it for unit testing terraform-iam-superadmins module
+  statement {
+    effect    = "Deny"
+    actions   = ["iam:DeleteLoginProfile"]
+    resources = ["*"]
+    condition {
+      test     = "StringNotEquals"
+      variable = "aws:PrincipalAccount"
+      values   = [local.environment_management.account_ids["testing-test"]]
+    }
   }
 
   statement {
@@ -1465,17 +1476,6 @@ data "aws_iam_policy_document" "oidc_assume_plan_role_member" {
     resources = ["arn:aws:secretsmanager:*:${local.environment_management.account_ids[terraform.workspace]}:secret:*"]
     actions = [
       "secretsmanager:GetSecretValue"
-    ]
-  }
-
-  statement {
-    sid       = "AllowGlueConnectionRead"
-    effect    = "Allow"
-    resources = [
-      "arn:aws:glue:*:${local.environment_management.account_ids[terraform.workspace]}:*"
-    ]
-    actions = [
-      "glue:GetConnection"
     ]
   }
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

The unit test in the terraform-iam-superadmins module is currently using a role called `TestingTestMemberInfrastructureAccess` which  will cause a high priority alert as we are not filtering out that role in our cw alarms metric filters (only `MemberInfrastructureAccess`).

Rather than update the baseline again I propose to stop using the `TestingTestMemberInfrastructureAccess` as it's not widely used and not in our module template. We should make it use the standard role `MemberInfrastructureAccess` and look to remove the `TestingTestMemberInfrastructureAccess` altogether.

However, the unit tests in this module require the ability to use `iam:DeleteLoginProfile` and it fails to work when using the `MemberInfrastructureAccess` role currently....
See: https://github.com/ministryofjustice/modernisation-platform-terraform-iam-superadmins/actions/runs/23639179290/job/68855348789?pr=773#step:7:1238

## How does this PR fix the problem?

Updates `MemberInfrastructureAccess` role so that **for testing-test only** `iam:DeleteLoginProfile` is permitted

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
