### PR TITLE
Adds access for collaborators to assume the member-shared-services role in core-shared-services-production.

### DIFF
--- a/terraform/modernisation-platform-account/iam.tf
+++ b/terraform/modernisation-platform-account/iam.tf
@@ -50,6 +50,7 @@ data "aws_iam_policy_document" "collaborator_local_plan" {
       "arn:aws:iam::${local.environment_management.account_ids["core-vpc-preproduction"]}:role/member-delegation-read-only",
       "arn:aws:iam::${local.environment_management.account_ids["core-vpc-production"]}:role/member-delegation-read-only",
       "arn:aws:iam::${local.environment_management.account_ids["core-vpc-sandbox"]}:role/member-delegation-read-only",
+      "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/member-shared-services",
       "arn:aws:iam::${data.aws_caller_identity.current.id}:role/modernisation-account-limited-read-member-access"
     ]
     condition {


### PR DESCRIPTION
## A reference to the issue / Description of it

An issue has been raised on the #ask-modernisation-platform channel by Thomas Tipler who is unable to access the core-shared-services-production account as a collaborator using the published guidance (https://user-guide.modernisation-platform.service.justice.gov.uk/user-guide/member-read-only-core-accounts.html#viewing-core-account-resources-as-a-member-account-developer).

## How does this PR fix the problem?

This PR adds access to that account via that role.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

See plan output.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
