### PR TITLE
Allow testing-test more IAM permissions for iam-superadmins module testing

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -469,24 +469,17 @@ data "aws_iam_policy_document" "member-access-network" {
   statement {
     effect = "Deny"
     actions = [
-      "iam:AddUserToGroup",
-      "iam:AttachGroupPolicy",
       "iam:CreateAccountAlias",
-      "iam:CreateGroup",
       "iam:CreateLoginProfile",
       "iam:CreateSAMLProvider",
       "iam:CreateVirtualMFADevice",
       "iam:DeactivateMFADevice",
       "iam:DeleteAccountAlias",
       "iam:DeleteAccountPasswordPolicy",
-      "iam:DeleteGroup",
-      "iam:DeleteGroupPolicy",
       "iam:DeleteSAMLProvider",
       "iam:DeleteUserPermissionsBoundary",
       "iam:DeleteVirtualMFADevice",
-      "iam:DetachGroupPolicy",
       "iam:EnableMFADevice",
-      "iam:RemoveUserFromGroup",
       "iam:ResyncMFADevice",
       "iam:UpdateAccountPasswordPolicy",
       "iam:UpdateGroup",
@@ -497,10 +490,19 @@ data "aws_iam_policy_document" "member-access-network" {
     resources = ["*"]
   }
 
-  # Deny iam:DeleteLoginProfile for all accounts except testing-test, which needs it for unit testing terraform-iam-superadmins module
+  # Deny group/login management actions for all accounts except testing-test, which needs them for IAM user/group lifecycle testing in the terraform-iam-superadmins module
   statement {
-    effect    = "Deny"
-    actions   = ["iam:DeleteLoginProfile"]
+    effect = "Deny"
+    actions = [
+      "iam:AddUserToGroup",
+      "iam:AttachGroupPolicy",
+      "iam:CreateGroup",
+      "iam:DeleteGroup",
+      "iam:DeleteGroupPolicy",
+      "iam:DeleteLoginProfile",
+      "iam:DetachGroupPolicy",
+      "iam:RemoveUserFromGroup",
+    ]
     resources = ["*"]
     condition {
       test     = "StringNotEquals"
@@ -1483,8 +1485,8 @@ data "aws_iam_policy_document" "oidc_assume_plan_role_member" {
   }
 
   statement {
-    sid    = "AllowOAMListTagsForResource"
-    effect = "Allow"
+    sid       = "AllowOAMListTagsForResource"
+    effect    = "Allow"
     resources = ["arn:aws:oam:*:${local.environment_management.account_ids[terraform.workspace]}:*"]
     actions = [
       "oam:ListTagsForResource"


### PR DESCRIPTION
## A reference to the issue / Description of it

This is a follow on from the issue in https://github.com/ministryofjustice/modernisation-platform/pull/12810

We need to add more exceptions for the testing-test account so that the `MemberInfrastructureAccess` role can perform the unit tests in the [modernisation-platform-terraform-iam-superadmins](https://github.com/ministryofjustice/modernisation-platform-terraform-iam-superadmins) module.

## How does this PR fix the problem?

Added more exceptions for the testing-test account only....

```
    actions = [
      "iam:AddUserToGroup",
      "iam:AttachGroupPolicy",
      "iam:CreateGroup",
      "iam:DeleteGroup",
      "iam:DeleteGroupPolicy",
      "iam:DeleteLoginProfile",
      "iam:DetachGroupPolicy",
      "iam:RemoveUserFromGroup",
    ]
```

In all other accounts these actions will still be denied.

## How has this been tested?

I had to update the role manually in testing-test to tune the policy appropriately.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
