### PR TITLE
Add glue connection read permissions

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -1492,6 +1492,17 @@ data "aws_iam_policy_document" "oidc_assume_plan_role_member" {
       "oam:ListTagsForResource"
     ]
   }
+
+  statement {
+    sid       = "AllowGlueConnectionRead"
+    effect    = "Allow"
+    resources = [
+      "arn:aws:glue:*:${local.environment_management.account_ids[terraform.workspace]}:*"
+    ]
+    actions = [
+      "glue:GetConnection"
+    ]
+  }
 }
 
 # Role github-actions-apply to support OIDC access from Modernisation-Platform-Environments for:


### PR DESCRIPTION
## A reference to the issue / Description of it

Discussed in https://mojdt.slack.com/archives/C01A7QK5VM1/p1774946398276949

```
User: arn:aws:sts::***:assumed-role/github-actions-plan/githubactionsplanrolesession is not authorized to perform: glue:GetConnection
```

## How does this PR fix the problem?

Allows the `github-actions-plan` role to have glue permissions: `glue:GetConnection`

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
