### PR TITLE
Allow electronic-monitoring-data-gdpr repo to push images to ecr

### DIFF
--- a/environments/electronic-monitoring-data.json
+++ b/environments/electronic-monitoring-data.json
@@ -72,7 +72,8 @@
   },
   "github-oidc-team-repositories": [
     "ministryofjustice/electronic-monitoring-data-lambda-functions",
-    "ministryofjustice/electronic-monitoring-ear-sars"
+    "ministryofjustice/electronic-monitoring-ear-sars",
+    "ministryofjustice/electronic-monitoring-data-gdpr"
   ],
   "go-live-date": ""
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

Currently not allowed to push images in this repo - https://github.com/ministryofjustice/electronic-monitoring-data-gdpr

<img width="825" height="315" alt="image" src="https://github.com/user-attachments/assets/466c84f3-6c8a-41b2-814c-d3018068c69b" />


## How does this PR fix the problem?

adds our repo to the allowed list of repos to assume the role - https://github.com/ministryofjustice/electronic-monitoring-data-gdpr

