### PR TITLE
Add SLSA supply chain step to workflows

### DIFF
--- a/.github/workflows/reusable-run-per-account-script.yml
+++ b/.github/workflows/reusable-run-per-account-script.yml
@@ -73,6 +73,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
+      # ⛓️ SLSA - must run after checkout, before any dependency installation
+      - name: ⛓️ SLSA Supply Chain Security
+        uses: ministryofjustice/devsecops-actions/sca/slsa@3e9410cef31dd9cec64ad567efc959afd88a591c
+
       - name: Decrypt Secrets
         uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@5b44b387694dfa249cfa2dcf289ca871abe9e3e2
         with:

--- a/.github/workflows/terraform-static-analysis.yml
+++ b/.github/workflows/terraform-static-analysis.yml
@@ -32,6 +32,9 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+      # ⛓️ SLSA - must run after checkout, before any dependency installation
+      - name: ⛓️ SLSA Supply Chain Security
+        uses: ministryofjustice/devsecops-actions/sca/slsa@3e9410cef31dd9cec64ad567efc959afd88a591c
       - name: Run Analysis
         uses: ministryofjustice/modernisation-platform-github-actions/terraform-static-analysis@5b44b387694dfa249cfa2dcf289ca871abe9e3e2 # v5.0.1
         env:
@@ -60,6 +63,9 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+      # ⛓️ SLSA - must run after checkout, before any dependency installation
+      - name: ⛓️ SLSA Supply Chain Security
+        uses: ministryofjustice/devsecops-actions/sca/slsa@3e9410cef31dd9cec64ad567efc959afd88a591c
       - name: Run Analysis
         uses: ministryofjustice/modernisation-platform-github-actions/terraform-static-analysis@5b44b387694dfa249cfa2dcf289ca871abe9e3e2 # v5.0.1
         env:
@@ -86,6 +92,9 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+      # ⛓️ SLSA - must run after checkout, before any dependency installation
+      - name: ⛓️ SLSA Supply Chain Security
+        uses: ministryofjustice/devsecops-actions/sca/slsa@3e9410cef31dd9cec64ad567efc959afd88a591c
       - name: Decrypt Secrets
         uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@5b44b387694dfa249cfa2dcf289ca871abe9e3e2 # v5.0.1
         with:


### PR DESCRIPTION
## Issue

https://github.com/ministryofjustice/modernisation-platform-security/issues/146


## Changes

- adds the SLSA Supply Chain Security step immediately after checkout in reusable and terraform static analysis workflows
- apply this consistently after  all checkout points in the updated workflows
