### PR TITLE
chore: add sns permission in us-east-1 region

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -657,6 +657,7 @@ data "aws_iam_policy_document" "member-access-us-east" {
       "iam:ListRoles",
       "lambda:*",
       "logs:*",
+      "sns:*",
       "waf:*",
       "wafv2:*",
       "cur:PutReportDefinition",
@@ -721,7 +722,7 @@ data "aws_iam_policy_document" "member-access-us-east" {
     condition {
       test     = "StringEquals"
       variable = "iam:PassedToService"
-      values   = ["lambda.amazonaws.com"]
+      values   = ["lambda.amazonaws.com", "events.amazonaws.com"]
     }
   }
 


### PR DESCRIPTION
## A reference to the issue / Description of it

{Please write here}

We are going to set up EventBridge rules in `us-east-1` to monitor IAM events (`CreateUser`) via CloudTrail and currently there is no permission for sns.

## How does this PR fix the problem?

{Please write here}
This will add the permission `sns:*` for the module `member-access-us-east`.
## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
