### PR TITLE
Add GitHub Actions OIDC Provider for testing-test account

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -616,6 +616,29 @@ resource "aws_iam_role_policy_attachment" "testing_member_infrastructure_access_
   policy_arn = aws_iam_policy.member-access-network[0].arn
 }
 
+# Bootstrap a GH Actions OIDC Provider for the testing-test account only
+module "github_actions_testing_oidc_provider" {
+  count                  = terraform.workspace == "testing-test" ? 1 : 0
+  source                 = "github.com/ministryofjustice/modernisation-platform-github-oidc-provider?ref=5dc9bc211d10c58de4247fa751c318a3985fc87b" # v4.0.0
+  additional_permissions = data.aws_iam_policy_document.oidc_deny_specific_actions.json
+  github_repositories = [
+    "ministryofjustice/modernisation-platform:*"
+  ]
+  tags_common = { "Name" = format("%s-oidc", terraform.workspace) }
+  tags_prefix = ""
+}
+
+data "aws_iam_policy_document" "oidc_deny_specific_actions" {
+  statement {
+    effect = "Deny"
+    actions = [
+      "iam:ChangePassword",
+      "iam:CreateLoginProfile"
+    ]
+    resources = ["*"]
+  }
+}
+
 # MemberInfrastructureAccessUSEast
 module "member-access-us-east" {
   count      = (local.account_data.account-type == "member" && terraform.workspace != "testing-test" && terraform.workspace != "sprinkler-development") ? 1 : 0


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform-security/issues/99

## How does this PR fix the problem?

Adds an GH Actions OIDC provider in the `testing-test` account.

In a subsequent PR I will add a dedicated testing-test OIDC role in the `/terraform/environments/testing` folder which will allow all of our terraform module repos to assume the role for their testing workflows.

This needs to be added first as no GH actions provider exists yet in testing-test. When I tried adding this code in the .. directory I got an error...
https://github.com/ministryofjustice/modernisation-platform/actions/runs/24244549927/job/70787367150?pr=12896#step:5:26
```
Error: Could not assume role with OIDC: No OpenIDConnect provider found in your account for https://token.actions.githubusercontent.com
```

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
