### PR TITLE
Add role_name to GitHub Actions OIDC Provider module for testing

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -621,6 +621,7 @@ module "github_actions_testing_oidc_provider" {
   count                  = terraform.workspace == "testing-test" ? 1 : 0
   source                 = "github.com/ministryofjustice/modernisation-platform-github-oidc-provider?ref=5dc9bc211d10c58de4247fa751c318a3985fc87b" # v4.0.0
   additional_permissions = data.aws_iam_policy_document.oidc_deny_specific_actions.json
+  role_name              = "github-actions-provider-role"
   github_repositories = [
     "ministryofjustice/modernisation-platform:*"
   ]


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/pull/12898 failed to deploy with error:
https://github.com/ministryofjustice/modernisation-platform/actions/runs/24248172012/job/70800149847#step:9:1030

```
EntityAlreadyExists: Role with name github-actions already exists.
```

## How does this PR fix the problem?
I've added a unique name `github-actions-provider-role` to the default role created by the provider module.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
