### PR TITLE
Added relevant batch and cloudwatch policies to data_engineering_additional

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -271,6 +271,7 @@ data "aws_iam_policy_document" "member-access-data" {
     effect = "Allow"
     actions = [
       "athena:*",
+      "batch:*",
       "datasync:*",
       "dbqms:*",
       "dlm:*",

--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -420,6 +420,12 @@ data "aws_iam_policy_document" "data_engineering_additional" {
       "athena:StartQueryExecution",
       "athena:StopQueryExecution",
       "apigateway:POST",
+      "batch:CancelJob",
+      "batch:Describe*",
+      "batch:List*",
+      "batch:SubmitJob",
+      "batch:TerminateJob",
+      "batch:UpdateJobQueue",
       "bedrock:PutUseCaseForModelAccess",
       "ce:CreateReport",
       "dms:StartReplicationTask",
@@ -468,6 +474,10 @@ data "aws_iam_policy_document" "data_engineering_additional" {
       "lakeformation:RemoveLFTagsFromResource",
       "lakeformation:GetDataAccess",
       "lambda:PutRuntimeManagementConfig",
+      "logs:GetLogEvents",
+      "logs:FilterLogEvents",
+      "logs:DescribeLogStreams",
+      "logs:DescribeLogGroups"
       "macie2:ListManagedDataIdentifiers",
       "macie2:ListCustomDataIdentifiers",
       "macie2:GetFindings",
@@ -516,7 +526,11 @@ data "aws_iam_policy_document" "data_engineering_additional" {
       "arn:aws:iam::${local.environment_management.account_ids["electronic-monitoring-data-production"]}:role/glue-notebook-role-tf",
       "arn:aws:iam::${local.environment_management.account_ids["electronic-monitoring-data-test"]}:role/AWSS3BucketReplication*",
       "arn:aws:iam::${local.environment_management.account_ids["electronic-monitoring-data-preproduction"]}:role/AWSS3BucketReplication*",
-      "arn:aws:iam::${local.environment_management.account_ids["electronic-monitoring-data-production"]}:role/AWSS3BucketReplication*"
+      "arn:aws:iam::${local.environment_management.account_ids["electronic-monitoring-data-production"]}:role/AWSS3BucketReplication*",
+      "arn:aws:iam::${local.environment_management.account_ids["electronic-monitoring-data-development"]}:role/emds-gdpr-*",
+      "arn:aws:iam::${local.environment_management.account_ids["electronic-monitoring-data-preproduction"]}:role/emds-gdpr-*",
+      "arn:aws:iam::${local.environment_management.account_ids["electronic-monitoring-data-production"]}:role/emds-gdpr-*",
+      "arn:aws:iam::${local.environment_management.account_ids["electronic-monitoring-data-test"]}:role/emds-gdpr-*"
     ]
   }
 

--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -474,10 +474,6 @@ data "aws_iam_policy_document" "data_engineering_additional" {
       "lakeformation:RemoveLFTagsFromResource",
       "lakeformation:GetDataAccess",
       "lambda:PutRuntimeManagementConfig",
-      "logs:GetLogEvents",
-      "logs:FilterLogEvents",
-      "logs:DescribeLogStreams",
-      "logs:DescribeLogGroups"
       "macie2:ListManagedDataIdentifiers",
       "macie2:ListCustomDataIdentifiers",
       "macie2:GetFindings",


### PR DESCRIPTION
## A reference to the issue / Description of it
[ELM-4309](https://dsdmoj.atlassian.net/browse/ELM-4309)

## How does this PR fix the problem?
Currently unable to submit Batch jobs via CLI or Console across environments as a user for testing or manual running of batch jobs.

## How has this been tested?
Attempted the following in our development environment 
```bash
aws batch submit-job \
    --job-name "gdpr-shredder-manual-test-01" \
    --job-queue "shred-unstructured-from-zip-processing-queue" \
    --job-definition "shred-unstructured-from-zip-job" \
    --container-overrides '{
        "environment": [
            {"name": "S3_FILE_URI", "value": "s3://emds-dev-data-20240917144025201600000001/g4s/dev_access/2024-02-16/SyntheticAtriumStructuredData.zip"},
            {"name": "DELETE_PATTERN", "value": "Synthetic Atrium Data/0000000-0009999/0000000-0000999/0000000-0000099/0000001/*"}
        ]
    }'
```

Which returned:
`An error occurred (AccessDeniedException) when calling the SubmitJob operation: User: arn:aws:sts::800964199911:assumed-role/AWSReservedSSO_modernisation-platform-sandbox_83094e3f92a3fdb1/luke-a-williams@digital.justice.gov.uk is not authorized to perform: batch:SubmitJob on resource: arn:aws:batch:eu-west-2:800964199911:job-definition/shred-unstructured-from-zip-job because no identity-based policy allows the batch:SubmitJob action`

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

Well, it's a change so yes?

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

Happy to negotiate on the batch permissions, or be corrected on the need for log permissions if they exist somewhere else as I'm not familiar with how all of the policies come together.

I also noticed that development seemed to be missing from our Iam:PassRole list, so added it in for anything GDPR we are doing for cross environment testing. Happy to be corrected here too if a better solution exists.


[ELM-4309]: https://dsdmoj.atlassian.net/browse/ELM-4309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ