### PR TITLE
Add `github-actions-nuke` trust to `MemberInfrastructureAccess` for `sprinkler` and `testing-test`

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -130,7 +130,7 @@ module "member-access-sprinkler" {
   count                  = (terraform.workspace == "sprinkler-development") ? 1 : 0
   source                 = "github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access?ref=321b0bcb8699b952a2a66f60c6242876048480d5" #v4.0.0
   account_id             = data.aws_ssm_parameter.modernisation_platform_account_id.value
-  additional_trust_roles = [data.aws_iam_role.sprinkler_oidc[0].arn, data.aws_iam_role.sprinkler_environments_read_only[0].arn, data.aws_iam_role.sprinkler_environments_dev_test[0].arn, one(data.aws_iam_roles.member-sso-admin-access.arns)]
+  additional_trust_roles = [data.aws_iam_role.sprinkler_oidc[0].arn, data.aws_iam_role.sprinkler_environments_read_only[0].arn, data.aws_iam_role.sprinkler_environments_dev_test[0].arn, module.github_actions_nuke[0].role, one(data.aws_iam_roles.member-sso-admin-access.arns)]
   role_name              = "MemberInfrastructureAccess"
 }
 
@@ -586,6 +586,7 @@ data "aws_iam_policy_document" "assume_role_policy" {
       identifiers = ["arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:root",
         "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:user/testing-ci",
         "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/github-actions-testing",
+        "module.github_actions_nuke[0].role",
         one(data.aws_iam_roles.member-sso-admin-access.arns)
       ]
     }


### PR DESCRIPTION
## A reference to the issue / Description of it

#12905 

## How does this PR fix the problem?

Add `github-actions-nuke` role to the `MemberInfrastructureAccess` trust  relationship for `sprinkler-development` and `testing-test` accounts.

These two accounts have separate role definitions and were missing the trust, causing the awsnuke workflow to fail when assuming `MemberInfrastructureAccess`. Regular member accounts already have this trust in place.

## How has this been tested?

Deployed to sprinkler

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
