### PR TITLE
fix: correct invalid IAM principal in `testing-test` `MemberInfrastructureAccess` assume role policy

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -586,7 +586,7 @@ data "aws_iam_policy_document" "assume_role_policy" {
       identifiers = ["arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:root",
         "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:user/testing-ci",
         "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/github-actions-testing",
-        "module.github_actions_nuke[0].role",
+        module.github_actions_nuke[0].role,
         one(data.aws_iam_roles.member-sso-admin-access.arns)
       ]
     }


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/actions/runs/24451314890/job/71440716032#step:9:949

## How does this PR fix the problem?

In `terraform/environments/bootstrap/member-bootstrap/iam.tf`, the identifier `module.github_actions_nuke[0].role` was incorrectly wrapped in quotes, making it a static string literal rather than a Terraform expression. AWS IAM rejected the resulting policy document because `"modu..."` is not a valid principal ARN.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
