### PR TITLE
Fix: conditionally include github_actions_nuke role in assume_role_policy for testing-test

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -583,12 +583,13 @@ data "aws_iam_policy_document" "assume_role_policy" {
 
     principals {
       type = "AWS"
-      identifiers = ["arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:root",
+      identifiers = concat(["arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:root",
         "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:user/testing-ci",
         "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/github-actions-testing",
-        module.github_actions_nuke[0].role,
         one(data.aws_iam_roles.member-sso-admin-access.arns)
-      ]
+        ],
+        terraform.workspace == "testing-test" ? [module.github_actions_nuke[0].role] : []
+      )
     }
   }
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/actions/runs/24452727304

## How does this PR fix the problem?

Conditionally include `module.github_actions_nuke[0].role` in the `assume_role_policy` identifiers only when workspace is `testing-test`.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
