### PR TITLE
Update the collaborator_sandbox_role count so it only enables in member development accounts

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/collaborators.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/collaborators.tf
@@ -75,7 +75,7 @@ data "aws_iam_policy" "developer" {
 module "collaborator_sandbox_role" {
   # checkov:skip=CKV_TF_1:
 
-  count  = (local.account_data.account-type == "member" && (local.application_environment == "development" || terraform.workspace == "youth-justice-app-framework-preproduction")) ? 1 : 0
+  count  = (local.account_data.account-type == "member" && local.application_environment == "development") ? 1 : 0
   source = "github.com/terraform-aws-modules/terraform-aws-iam//modules/iam-assumable-role?ref=de95e21a3bc51cd3a44b3b95a4c2f61000649ebb" # v5.39.1
 
   trusted_role_arns = [


### PR DESCRIPTION
## A reference to the issue / Description of it

Removed preprod workspace from the count as it was only added as a temporary measure. 

## How does this PR fix the problem?

{Please write here}

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
