### PR TITLE
Migrate nuke and redeploy workflows to modernisation-platform repo

### DIFF
--- a/.github/nuke-redeploy.yml
+++ b/.github/nuke-redeploy.yml
@@ -1,0 +1,133 @@
+name: Redeploy after nuke
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/nuke-redeploy.yml'
+  pull_request:
+    branches:
+      - main
+    types: [opened, edited, reopened, synchronize]
+    paths:
+      - '.github/workflows/nuke-redeploy.yml'
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    # trigger every monday at 6:00am
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "Nuke mode"
+        required: true
+        type: choice
+        default: nuke-dry-run
+        options:
+          - nuke-dry-run
+          - nuke-no-dry-run
+env:
+  AWS_REGION: "eu-west-2"
+  MODERNISATION_PLATFORM_ACCOUNT_ID: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_ID }}
+  PASSPHRASE: ${{ secrets.PASSPHRASE }}
+  TF_IN_AUTOMATION: true
+
+permissions: {}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  fetch-secrets:
+    uses: ministryofjustice/modernisation-platform-github-actions/.github/workflows/aws-secrets-management.yml@5b44b387694dfa249cfa2dcf289ca871abe9e3e2 # v5.0.1
+    permissions:
+      id-token: write
+      contents: read
+    secrets:
+        MODERNISATION_PLATFORM_ACCOUNT_NUMBER: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_ID }}
+        PASSPHRASE: ${{ secrets.PASSPHRASE }}
+        
+  setup-matrix:
+    runs-on: ubuntu-latest
+    needs: fetch-secrets
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Decrypt Secrets
+        uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@5b44b387694dfa249cfa2dcf289ca871abe9e3e2 # v5.0.1
+        with:
+          nuke_rebuild_account_ids: ${{ needs.fetch-secrets.outputs.nuke_rebuild_account_ids }}
+          PASSPHRASE: ${{ secrets.PASSPHRASE }}
+      - id: set-matrix
+        run: echo "matrix=$(jq -c '.rebuild_accounts | sort' <<< $NUKE_REBUILD_ACCOUNT_IDS)" >> $GITHUB_OUTPUT
+
+  redeploy-after-nuke:
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read # This is required for actions/checkout
+    strategy:
+      fail-fast: false
+      matrix:
+        nuke_accts: ${{ fromJSON(needs.setup-matrix.outputs.matrix) }}
+    name: Redeploy after nuke
+    needs: [setup-matrix,fetch-secrets]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Decrypt Secrets
+        uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@5b44b387694dfa249cfa2dcf289ca871abe9e3e2 # v5.0.1
+        with:
+          environment_management: ${{ needs.fetch-secrets.outputs.environment_management }}
+          slack_webhook_url: ${{ needs.fetch-secrets.outputs.slack_webhook_url }}
+          PASSPHRASE: ${{ secrets.PASSPHRASE }}
+
+      - name: Set Account Number
+        run: |
+          ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${ACCOUNT_NAME}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)
+          echo "::add-mask::$ACCOUNT_NUMBER"
+          echo "ACCOUNT_NUMBER=${ACCOUNT_NUMBER}" >> $GITHUB_ENV
+
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions-nuke"
+          role-session-name: githubactionsnukerolesession
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Load and Configure Terraform
+        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
+        with:
+          terraform_version: "~1"
+          terraform_wrapper: false
+
+      - name: Plan after nuke - ${{ matrix.nuke_accts }}
+        run: |
+          terraform --version
+          echo "Terraform Plan - ${ACCOUNT_NAME%-development}" # removes the -development suffix in order to get the directory name
+          bash scripts/terraform-init.sh terraform/environments/${ACCOUNT_NAME%-development}
+          terraform -chdir="terraform/environments/${ACCOUNT_NAME%-development}" workspace select "${ACCOUNT_NAME}"
+          bash scripts/terraform-plan.sh terraform/environments/${ACCOUNT_NAME%-development}
+
+      - name: Apply after nuke - ${{ matrix.nuke_accts }}
+        if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && inputs.mode == 'nuke-no-dry-run') }}
+        run: |
+          terraform --version
+          echo "Terraform apply - ${ACCOUNT_NAME%-development}" # removes the -development suffix in order to get the directory name
+          bash scripts/terraform-init.sh terraform/environments/${ACCOUNT_NAME%-development}
+          terraform -chdir="terraform/environments/${ACCOUNT_NAME%-development}" workspace select "${ACCOUNT_NAME}"
+          bash scripts/terraform-apply.sh terraform/environments/${ACCOUNT_NAME%-development}
+
+      - name: Slack failure notification
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
+        with:
+          webhook-type: incoming-webhook
+          payload: |
+            {"blocks":[{"type": "section","text": {"type": "mrkdwn","text": ":no_entry: Failed GitHub Action:"}},{"type": "section","fields":[{"type": "mrkdwn","text": "*Workflow:*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>"},{"type": "mrkdwn","text": "*Job:*\n${{ github.job }}"},{"type": "mrkdwn","text": "*Repo:*\n${{ github.repository }}"}]}]}
+        env:
+          SLACK_WEBHOOK_URL: ${{ env.SLACK_WEBHOOK_URL }}
+        if: ${{ failure() }}
+
+    env:
+      ACCOUNT_NAME: ${{ matrix.nuke_accts }}

--- a/.github/nuke-redeploy.yml
+++ b/.github/nuke-redeploy.yml
@@ -28,7 +28,7 @@ on:
           - nuke-no-dry-run
 env:
   AWS_REGION: "eu-west-2"
-  MODERNISATION_PLATFORM_ACCOUNT_ID: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_ID }}
+  MODERNISATION_PLATFORM_ACCOUNT_ID: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_NUMBER }}
   PASSPHRASE: ${{ secrets.PASSPHRASE }}
   TF_IN_AUTOMATION: true
 
@@ -45,7 +45,7 @@ jobs:
       id-token: write
       contents: read
     secrets:
-        MODERNISATION_PLATFORM_ACCOUNT_NUMBER: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_ID }}
+        MODERNISATION_PLATFORM_ACCOUNT_NUMBER: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_NUMBER }}
         PASSPHRASE: ${{ secrets.PASSPHRASE }}
         
   setup-matrix:

--- a/.github/nuke-redeploy.yml
+++ b/.github/nuke-redeploy.yml
@@ -71,6 +71,7 @@ jobs:
       matrix:
         nuke_accts: ${{ fromJSON(needs.setup-matrix.outputs.matrix) }}
     name: Redeploy after nuke
+    if: github.ref == 'refs/heads/main'
     needs: [setup-matrix,fetch-secrets]
     runs-on: ubuntu-latest
     steps:
@@ -90,6 +91,7 @@ jobs:
           echo "ACCOUNT_NUMBER=${ACCOUNT_NUMBER}" >> $GITHUB_ENV
 
       - name: configure aws credentials
+        if: github.ref == 'refs/heads/main'
         uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions-nuke"

--- a/.github/workflows/awsnuke.yml
+++ b/.github/workflows/awsnuke.yml
@@ -30,7 +30,7 @@ on:
 env:
   AWS_REGION: "eu-west-2"
   TF_IN_AUTOMATION: true
-  MODERNISATION_PLATFORM_ACCOUNT_ID: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_ID }}
+  MODERNISATION_PLATFORM_ACCOUNT_NUMBER: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_NUMBER }}
   PASSPHRASE: ${{ secrets.PASSPHRASE }}
 
 permissions: {}
@@ -47,7 +47,7 @@ jobs:
       id-token: write
       contents: read
     secrets:
-        MODERNISATION_PLATFORM_ACCOUNT_NUMBER: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_ID }}
+        MODERNISATION_PLATFORM_ACCOUNT_NUMBER: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_NUMBER }}
         PASSPHRASE: ${{ secrets.PASSPHRASE }}
   setup-prerequisites:
     runs-on: ubuntu-latest
@@ -145,6 +145,7 @@ jobs:
           AWS_NUKE_VERSION: v3.51.1
 
       - name: Nuke Plan (Dry Run)
+        if: ${{ inputs.mode == 'nuke-dry-run' }}
         run: |
           aws sts assume-role \
             --role-arn "arn:aws:iam::${ACCOUNT_NUMBER}:role/MemberInfrastructureAccess" \

--- a/.github/workflows/awsnuke.yml
+++ b/.github/workflows/awsnuke.yml
@@ -1,0 +1,204 @@
+---
+name: awsnuke
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/awsnuke.yml'
+  pull_request:
+    branches:
+      - main
+    types: [opened, edited, reopened, synchronize]
+    paths:
+      - '.github/workflows/awsnuke.yml'
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    # trigger every friday at 9:00pm
+    - cron: '0 21 * * 5'
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "Nuke mode"
+        required: true
+        type: choice
+        default: nuke-dry-run
+        options:
+          - nuke-dry-run
+          - nuke-no-dry-run
+
+env:
+  AWS_REGION: "eu-west-2"
+  TF_IN_AUTOMATION: true
+  MODERNISATION_PLATFORM_ACCOUNT_ID: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_ID }}
+  PASSPHRASE: ${{ secrets.PASSPHRASE }}
+
+permissions: {}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+
+  fetch-secrets:
+    uses: ministryofjustice/modernisation-platform-github-actions/.github/workflows/aws-secrets-management.yml@5b44b387694dfa249cfa2dcf289ca871abe9e3e2 # v5.0.1
+    permissions:
+      id-token: write
+      contents: read
+    secrets:
+        MODERNISATION_PLATFORM_ACCOUNT_NUMBER: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_ID }}
+        PASSPHRASE: ${{ secrets.PASSPHRASE }}
+  setup-prerequisites:
+    runs-on: ubuntu-latest
+    needs: fetch-secrets
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+      account_blocklist_str: ${{ steps.set-blocklist-string.outputs.account_blocklist_str }}
+    steps:
+      - name: Decrypt Secrets
+        uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@5b44b387694dfa249cfa2dcf289ca871abe9e3e2 # v5.0.1
+        with:
+          environment_management: ${{ needs.fetch-secrets.outputs.environment_management }}
+          nuke_account_ids: ${{ needs.fetch-secrets.outputs.nuke_account_ids }} 
+          nuke_account_blocklist: ${{ needs.fetch-secrets.outputs.nuke_account_blocklist }}
+          PASSPHRASE: ${{ secrets.PASSPHRASE }}
+      - id: set-matrix
+        name: Set Up Matrix
+        run: |
+          echo "matrix=$(jq -c '.nuke_accounts | sort' <<< $NUKE_ACCOUNT_IDS)" >> $GITHUB_OUTPUT
+
+      - id: set-blocklist-string
+        name: Set Up Blocklist
+        run: |
+          account_blocklist_str=""
+          while read -r account_alias _; do
+          account_number=$(jq -r -e --arg account_name "$account_alias" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)
+          account_blocklist_str+="  - \"${account_number}\" # ${account_alias}"
+          account_blocklist_str+=$'\n'
+          done <<< "$(jq -c -r '.blocklist[]' <<< $NUKE_ACCOUNT_BLOCKLIST)" # Taking this approach as piping (|) to a read opens a subshell and passes the variables to it by value
+          # Encoding and passing blocklist string as an output
+          echo "account_blocklist_str=$(echo -n "${account_blocklist_str}" | base64 -w 0)" >> $GITHUB_OUTPUT
+
+  nuke:
+    strategy:
+      fail-fast: false
+      matrix:
+        nuke_accts: ${{ fromJSON(needs.setup-prerequisites.outputs.matrix) }}
+    name: Sandbox Nuke
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read # This is required for actions/checkout
+    runs-on: ubuntu-latest
+    needs: [setup-prerequisites, fetch-secrets]
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      
+      - name: Decrypt Secrets
+        uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@5b44b387694dfa249cfa2dcf289ca871abe9e3e2 # v5.0.1
+        with:
+          environment_management: ${{ needs.fetch-secrets.outputs.environment_management }}
+          slack_webhook_url: ${{ needs.fetch-secrets.outputs.slack_webhook_url }}
+          PASSPHRASE: ${{ secrets.PASSPHRASE }}
+
+      - name: Set Account Number
+        run: |
+          ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${ACCOUNT_NAME}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)
+          echo "::add-mask::$ACCOUNT_NUMBER"
+          echo "ACCOUNT_NUMBER=${ACCOUNT_NUMBER}" >> $GITHUB_ENV
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions-nuke"
+          role-session-name: githubactionsnukerolesession
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Setup Nuke Account String
+        run: |
+          accounts_str=''
+          accounts_str+="  \"${ACCOUNT_NUMBER}\": # ${ACCOUNT_NAME}"
+          accounts_str+=$'\n'
+          accounts_str+="    presets:"
+          accounts_str+=$'\n'
+          accounts_str+="      - \"common\""
+          accounts_str+=$'\n'
+          echo "$accounts_str"
+          echo "ACCOUNTS_STR<<EOF" >> $GITHUB_ENV
+          echo "$accounts_str" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+
+      - name: Setup Nuke Config
+        run: |
+          export accounts_str="$ACCOUNTS_STR"
+          export account_blocklist_str=$(echo "${{ needs.setup-prerequisites.outputs.account_blocklist_str }}" | base64 --decode)
+          cat scripts/nuke-config-template.txt | envsubst > nuke-config.yml
+
+      - name: Install AWS Nuke
+        run: |
+          echo "BEGIN: Install AWS Nuke"
+          mkdir -p $HOME/bin
+          wget -c "https://github.com/ekristen/aws-nuke/releases/download/${AWS_NUKE_VERSION}/aws-nuke-${AWS_NUKE_VERSION}-linux-amd64.tar.gz" -O - | tar -xz -C $HOME/bin
+          chmod +x $HOME/bin/aws-nuke
+          echo "END: Install AWS Nuke"
+        env:
+          AWS_NUKE_VERSION: v3.51.1
+
+      - name: Nuke Plan (Dry Run)
+        run: |
+          aws sts assume-role \
+            --role-arn "arn:aws:iam::${ACCOUNT_NUMBER}:role/MemberInfrastructureAccess" \
+            --role-session-name githubactionsgotestrolesession > creds.json || {
+              echo "Failed to assume role"
+              exit 1
+          }
+          export AWS_ACCESS_KEY_ID=$(jq -r '.Credentials.AccessKeyId' creds.json)
+          export AWS_SECRET_ACCESS_KEY=$(jq -r '.Credentials.SecretAccessKey' creds.json)
+          export AWS_SESSION_TOKEN=$(jq -r '.Credentials.SessionToken' creds.json)
+
+          echo "Verifying identity..."
+          aws sts get-caller-identity || {
+            echo "Invalid credentials"
+            exit 1
+          }
+          echo "Running AWS Nuke (dry run)..."
+          $HOME/bin/aws-nuke run \
+            --config nuke-config.yml \
+            --no-prompt
+
+      - name: Nuke Apply (Destructive)
+        if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && inputs.mode == 'nuke-no-dry-run') }}
+        run: |
+          # The environment gets reset between steps, so the role needs to be re-assumed.
+          aws sts assume-role \
+            --role-arn "arn:aws:iam::${ACCOUNT_NUMBER}:role/MemberInfrastructureAccess" \
+            --role-session-name githubactionsgoliveapply > creds.json || {
+              echo "Failed to assume role"
+              exit 1
+          }
+          export AWS_ACCESS_KEY_ID=$(jq -r '.Credentials.AccessKeyId' creds.json)
+          export AWS_SECRET_ACCESS_KEY=$(jq -r '.Credentials.SecretAccessKey' creds.json)
+          export AWS_SESSION_TOKEN=$(jq -r '.Credentials.SessionToken' creds.json)
+
+          echo "Verifying identity..."
+          aws sts get-caller-identity || {
+            echo "Invalid credentials"
+            exit 1
+          }
+          echo "Running AWS Nuke (full apply)..."
+           $HOME/bin/aws-nuke run \
+            --config nuke-config.yml \
+            --no-prompt \
+            --no-dry-run
+
+      - name: Slack failure notification
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
+        with:
+          webhook-type: incoming-webhook
+          payload: |
+            {"blocks":[{"type": "section","text": {"type": "mrkdwn","text": ":no_entry: Failed GitHub Action:"}},{"type": "section","fields":[{"type": "mrkdwn","text": "*Workflow:*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>"},{"type": "mrkdwn","text": "*Job:*\n${{ github.job }}"},{"type": "mrkdwn","text": "*Repo:*\n${{ github.repository }}"}]}]}
+        env:
+          SLACK_WEBHOOK_URL: ${{ env.SLACK_WEBHOOK_URL }}
+        if: ${{ failure() }}
+    env:
+      ACCOUNT_NAME: ${{ matrix.nuke_accts }}

--- a/.github/workflows/awsnuke.yml
+++ b/.github/workflows/awsnuke.yml
@@ -86,6 +86,7 @@ jobs:
       matrix:
         nuke_accts: ${{ fromJSON(needs.setup-prerequisites.outputs.matrix) }}
     name: Sandbox Nuke
+    if: github.ref == 'refs/heads/main'
     permissions:
       id-token: write # This is required for requesting the JWT
       contents: read # This is required for actions/checkout

--- a/scripts/nuke-config-template.txt
+++ b/scripts/nuke-config-template.txt
@@ -1,0 +1,130 @@
+---
+# This file is consumed by the awsnuke.yml workflow
+settings:
+  disable-deletion-protection:
+    RDSInstance: true
+    EC2Instance: true
+    CloudformationStack: true
+    force-delete-lightsail-addons:
+    enabled: true
+
+regions:
+  - "eu-west-2"
+
+blocklist:
+$account_blocklist_str
+
+resource-types:
+  # don't nuke IAM users
+  excludes:
+    - ACMCertificate
+    - CloudTrailTrail
+    - CloudWatchAlarm
+    - CloudWatchLogsLogGroup
+    - ConfigServiceConfigRule
+    - ConfigServiceConfigurationRecorder
+    - ConfigServiceDeliveryChannel
+    - EC2DHCPOption
+    - EC2InternetGateway
+    - EC2InternetGatewayAttachment
+    - EC2NetworkACL
+    - EC2RouteTable
+    - EC2Subnet
+    - EC2VPC
+    - GuardDutyDetector
+    - IAMGroup
+    - IAMGroupPolicy
+    - IAMGroupPolicyAttachment
+    - IAMInstanceProfile
+    - IAMInstanceProfileRole
+    - IAMLoginProfile
+    - IAMOpenIDConnectProvider
+    - IAMPolicy
+    - IAMRole
+    - IAMRolePolicy
+    - IAMRolePolicyAttachment
+    - IAMSAMLProvider
+    - IAMServerCertificate
+    - IAMServiceSpecificCredential
+    - IAMSigningCertificate
+    - IAMUser
+    - IAMUserAccessKey
+    - IAMUserGroupAttachment
+    - IAMUserPolicy
+    - IAMUserPolicyAttachment
+    - IAMUserSSHPublicKey
+    - IAMVirtualMFADevice
+    - Inspector2
+    - KMSAlias
+    - KMSKey
+    - OSPackage
+    - QuickSightSubscription
+    - QuickSightUser
+    - S3AccessPoint
+    - S3Bucket
+    - S3MultipartUpload
+    - S3Object
+    - SecretsManagerSecret
+    - SecurityHub
+    - SSMResourceDataSync
+    - Transfer
+    - WAFv2WebACL
+    - WAFv2IPSet
+
+accounts:
+$accounts_str
+
+presets:
+  common:
+    filters:
+      AccessAnalyzer:
+        - property: tag:component
+          value: "secure-baselines"
+      AWSBackupPlan:
+        - property: tag:component
+          value: "secure-baselines"
+      AWSBackupVault:
+        - property: tag:component
+          value: "secure-baselines"
+      ConfigServiceConfigRule:
+        - type: glob
+          value: "securityhub-*"
+        - type: glob
+          value: "FMManagedShieldConfigRule*"
+      EC2DHCPOption:
+        - property: tag:component
+          value: "secure-baselines"
+      EC2InternetGatewayAttachment:
+        - property: tag:vpc:component
+          value: "secure-baselines"
+      EC2NetworkACL:
+        - property: tag:component
+          value: "secure-baselines"
+      EC2RouteTable:
+        - property: tag:component
+          value: "secure-baselines"
+      EC2SecurityGroup:
+        - property: tag:component
+          value: "secure-baselines"
+      EC2VPC:
+        - property: tag:component
+          value: "secure-baselines"
+      KMSKey:
+        - property: tag:component
+          value: "secure-baselines"
+      RDSClusterSnapshot:
+        - property: SnapshotType
+          value: "shared"
+        - property: SnapshotType
+          value: "automated"
+      S3Bucket:
+        - property: tag:component
+          value: "secure-baselines"
+      SSMParameter:
+        - property: tag:component
+          value: "delegate-access"
+        - property: tag:component
+          value: "member-bootstrap"
+      SNSTopic:
+        - property: tag:component
+          value: "secure-baselines"

--- a/source/concepts/environments/auto-nuke.html.md.erb
+++ b/source/concepts/environments/auto-nuke.html.md.erb
@@ -11,10 +11,10 @@ review_in: 6 months
 
 This feature automatically destroys all resources in development environments on a weekly basis, and provides a utitily to recreate resources in these environments. This is useful for environments with the sandbox permission, which allow users to provision resources directly through the AWS web console alongside infrastructure as code (IaC). In such cases, the auto-nuke will make ensure the manually created resources will be regularly removed. If requested, resources defined in terraform can then be recreated.
 
-Every Sunday:
 
-- At 22:00 the [awsnuke.yml workflow](https://github.com/ministryofjustice/modernisation-platform-environments/blob/main/.github/workflows/awsnuke.yml) is triggered. This workflow nukes all the configured development environments using the [AWS Nuke tool](https://github.com/ekristen/aws-nuke).
-- At 12:00 the [nuke-redeploy.yml workflow](https://github.com/ministryofjustice/modernisation-platform-environments/blob/main/.github/workflows/nuke-redeploy.yml) is triggered. If requested, this workflow redeploys IaC into the nuked environment using `terraform apply`.
+
+- Every Friday at 21:00 the [awsnuke.yml workflow](https://github.com/ministryofjustice/modernisation-platform/blob/main/.github/workflows/awsnuke.yml) is triggered. This workflow nukes all the configured development environments using the [AWS Nuke tool](https://github.com/ekristen/aws-nuke).
+- Every Monday at 06:00 the [nuke-redeploy.yml workflow](https://github.com/ministryofjustice/modernisation-platform/blob/main/.github/workflows/nuke-redeploy.yml) is triggered. If requested, this workflow redeploys IaC into the nuked environment using `terraform apply`.
 
 An outline of the 'nuke' algorithm is as follows:
 
@@ -33,7 +33,7 @@ Auto-nuke consumes the following dynamically generated Github secrets stored in 
 
 - `MODERNISATION_PLATFORM_AUTONUKE_REBUILD`: Accounts to be rebuilt after auto-nuke runs. This secret is consumed by the `nuke-redeploy.yml` workflow.
 
-The [`nuke-config-template.txt`](https://github.com/ministryofjustice/modernisation-platform-environments/blob/main/scripts/nuke-config-template.txt) is populated with account and blocklist information during the runtime of the `awsnuke.yml` workflow, to produce a valid aws-nuke configuration file.
+The [`nuke-config-template.txt`](https://github.com/ministryofjustice/modernisation-platform/blob/main/scripts/nuke-config-template.txt) is populated with account and blocklist information during the runtime of the `awsnuke.yml` workflow, to produce a valid aws-nuke configuration file.
 
 ### When new sandbox development environment is onboarded
 


### PR DESCRIPTION
## A reference to the issue / Description of it

#12905 

## How does this PR fix the problem?

### New workflows added
- `.github/workflows/awsnuke.yml` — migrated from the environments repo, now using the `github-actions-nuke` OIDC role
- `.github/workflows/nuke-redeploy.yml` — migrated from the environments repo, now using the `github-actions-nuke` OIDC role

### Removed
- `nuke-testing-test` job - previously used long-lived static credentials (`testing-ci` IAM user keys) as a workaround because the `testing-test` account was not OIDC-enabled. Now that OIDC is deployed to support this account, the special-case job is no longer needed and has been removed.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
