### PR TITLE
Checkout `modernisation-platform-environments` for nuke redeploy workflow

### DIFF
--- a/.github/workflows/nuke-redeploy.yml
+++ b/.github/workflows/nuke-redeploy.yml
@@ -75,8 +75,11 @@ jobs:
     needs: [setup-matrix,fetch-secrets]
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Repository
+      - name: Checkout modernisation-platform-environments repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: 'ministryofjustice/modernisation-platform-environments'
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Decrypt Secrets
         uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@5b44b387694dfa249cfa2dcf289ca871abe9e3e2 # v5.0.1
         with:


### PR DESCRIPTION
`terraform apply` steps operate on Terraform code that lives in `modernisation-platform-environments`, not in this repo. Without this change, the workflow was referencing `terraform/environments/` and `scripts/` paths that don't exist in 
`modernisation-platform`, causing the steps to fail.