### PR TITLE
Allow `github-actions-nuke` role to write to state bucket

### DIFF
--- a/terraform/modernisation-platform-account/s3.tf
+++ b/terraform/modernisation-platform-account/s3.tf
@@ -292,7 +292,7 @@ data "aws_iam_policy_document" "allow-state-access-from-root-account" {
     condition {
       test     = "ForAnyValue:StringLike"
       variable = "aws:PrincipalArn"
-      values   = ["arn:aws:iam::*:role/github-actions-apply", "arn:aws:iam::*:role/github-actions-environments-dev-test"]
+      values   = ["arn:aws:iam::*:role/github-actions-apply", "arn:aws:iam::*:role/github-actions-environments-dev-test", "arn:aws:iam::*:role/github-actions-nuke"]
     }
   }
 


### PR DESCRIPTION
## A reference to the issue / Description of it

#12905 

## How does this PR fix the problem?

The `nuke-redeploy` job requires the ability to write state during `terraform apply`. Without this permission, the workflow fails when attempting to update state.

https://github.com/ministryofjustice/modernisation-platform/actions/runs/24652755106/attempts/1

## How has this been tested?

Manually updated the state bucket policy to allow `github-actions-nuke`, pipeline ran successfully.
https://github.com/ministryofjustice/modernisation-platform/actions/runs/24652755106

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
