### PR TITLE
Adds shared S3 server access logs bucket and enables s3 server access logging

### DIFF
--- a/terraform/environments/core-logging/logs_cloudtrail_s3_kms.tf
+++ b/terraform/environments/core-logging/logs_cloudtrail_s3_kms.tf
@@ -185,3 +185,156 @@ data "aws_iam_policy_document" "kms_logging_cloudtrail_replication" {
     }
   }
 }
+
+# KMS key pair for shared S3 server access logs bucket
+resource "aws_kms_key" "s3_server_access_logs" {
+  description             = "s3-server-access-logs"
+  policy                  = data.aws_iam_policy_document.kms_s3_server_access_logs.json
+  enable_key_rotation     = true
+  deletion_window_in_days = 30
+  tags                    = local.tags
+}
+
+resource "aws_kms_alias" "s3_server_access_logs" {
+  name          = "alias/s3-server-access-logs"
+  target_key_id = aws_kms_key.s3_server_access_logs.id
+}
+
+data "aws_iam_policy_document" "kms_s3_server_access_logs" {
+  # checkov:skip=CKV_AWS_111: "policy is directly related to the resource"
+  # checkov:skip=CKV_AWS_356: "policy is directly related to the resource"
+  # checkov:skip=CKV_AWS_109: "role is resticted by limited actions in member account"
+
+  statement {
+    sid    = "Allow management access of the key to the logging account"
+    effect = "Allow"
+    actions = [
+      "kms:*"
+    ]
+    resources = [
+      "*"
+    ]
+    principals {
+      type = "AWS"
+      identifiers = [
+        data.aws_caller_identity.current.account_id
+      ]
+    }
+  }
+
+  statement {
+    sid    = "Allow use of the key including encryption"
+    effect = "Allow"
+    actions = [
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:Encrypt*",
+      "kms:Describe*",
+      "kms:Decrypt*"
+    ]
+    resources = ["*"]
+    principals {
+      type        = "Service"
+      identifiers = ["logging.s3.amazonaws.com"]
+    }
+  }
+
+  statement {
+    sid    = "Allow use of the key by the ModernisationPlatformAccess role in all MP accounts"
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+    actions = [
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:Encrypt*",
+      "kms:Describe*",
+      "kms:Decrypt*"
+    ]
+    resources = ["*"]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalOrgID"
+      values   = [data.aws_organizations_organization.moj_root_account.id]
+    }
+    condition {
+      test     = "StringLike"
+      variable = "aws:PrincipalArn"
+      values   = ["arn:aws:iam::*:role/ModernisationPlatformAccess"]
+    }
+  }
+
+  statement {
+    sid    = "Allow key decryption to STS bucket replication roles"
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt*"
+    ]
+    resources = ["*"]
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:sts::${data.aws_caller_identity.current.account_id}:assumed-role/AWSS3BucketReplication-s3-server-access-logs/s3-replication",
+      ]
+    }
+  }
+}
+
+resource "aws_kms_key" "s3_server_access_logs_eu-west-1_replication" {
+  provider = aws.modernisation-platform-eu-west-1
+
+  description             = "s3-server-access-logs-eu-west-1-replication"
+  policy                  = data.aws_iam_policy_document.kms_s3_server_access_logs_replication.json
+  enable_key_rotation     = true
+  deletion_window_in_days = 30
+  tags                    = local.tags
+}
+
+resource "aws_kms_alias" "s3_server_access_logs_eu-west-1_replication" {
+  provider = aws.modernisation-platform-eu-west-1
+
+  name          = "alias/s3-server-access-logs-eu-west-1-replication"
+  target_key_id = aws_kms_key.s3_server_access_logs_eu-west-1_replication.id
+}
+
+data "aws_iam_policy_document" "kms_s3_server_access_logs_replication" {
+  # checkov:skip=CKV_AWS_111: "policy is directly related to the resource"
+  # checkov:skip=CKV_AWS_356: "policy is directly related to the resource"
+  # checkov:skip=CKV_AWS_109: "role is resticted by limited actions in member account"
+
+  statement {
+    sid    = "Allow management access of the key to the logging account"
+    effect = "Allow"
+    actions = [
+      "kms:*"
+    ]
+    resources = [
+      "*"
+    ]
+    principals {
+      type = "AWS"
+      identifiers = [
+        data.aws_caller_identity.current.account_id
+      ]
+    }
+  }
+
+  statement {
+    sid    = "Allow key use to STS bucket replication roles"
+    effect = "Allow"
+    actions = [
+      "kms:ReEncrypt*",
+      "kms:Encrypt*",
+      "kms:Describe*"
+    ]
+    resources = ["*"]
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:sts::${data.aws_caller_identity.current.account_id}:assumed-role/AWSS3BucketReplication-s3-server-access-logs/s3-replication",
+      ]
+    }
+  }
+}

--- a/terraform/environments/core-logging/logs_r53_public_dns_s3.tf
+++ b/terraform/environments/core-logging/logs_r53_public_dns_s3.tf
@@ -15,6 +15,9 @@ module "s3_bucket_r53_public_dns_logs" {
   replication_region         = "eu-west-1"
   versioning_enabled         = true
 
+  log_bucket = module.s3-bucket-core-logging-s3-server-access-logs.bucket.id
+  log_prefix = "s3-access/modernisation-platform-logs-r53-public-dns-logs/"
+
   lifecycle_rule = [
     {
       id      = "main"

--- a/terraform/environments/core-logging/logs_s3.tf
+++ b/terraform/environments/core-logging/logs_s3.tf
@@ -188,3 +188,11 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "logging" {
     bucket_key_enabled = true
   }
 }
+
+resource "aws_s3_bucket_logging" "vpc_and_r53_resolver" {
+  for_each = toset(["vpc-flow-logs", "r53-resolver-logs"])
+
+  bucket        = aws_s3_bucket.logging[each.key].id
+  target_bucket = module.s3-bucket-core-logging-s3-server-access-logs.bucket.id
+  target_prefix = "s3-access/${aws_s3_bucket.logging[each.key].bucket}/"
+}

--- a/terraform/environments/core-logging/logs_s3_server_access_logging_enable.tf
+++ b/terraform/environments/core-logging/logs_s3_server_access_logging_enable.tf
@@ -1,0 +1,7 @@
+resource "aws_s3_bucket_logging" "vpc_and_r53_resolver" {
+  for_each = toset(["vpc-flow-logs", "r53-resolver-logs"])
+
+  bucket        = aws_s3_bucket.logging[each.key].id
+  target_bucket = module.s3-bucket-core-logging-s3-server-access-logs.bucket.id
+  target_prefix = "s3-access/${aws_s3_bucket.logging[each.key].bucket}/"
+}

--- a/terraform/environments/core-logging/logs_s3_server_access_logging_enable.tf
+++ b/terraform/environments/core-logging/logs_s3_server_access_logging_enable.tf
@@ -1,7 +1,0 @@
-resource "aws_s3_bucket_logging" "vpc_and_r53_resolver" {
-  for_each = toset(["vpc-flow-logs", "r53-resolver-logs"])
-
-  bucket        = aws_s3_bucket.logging[each.key].id
-  target_bucket = module.s3-bucket-core-logging-s3-server-access-logs.bucket.id
-  target_prefix = "s3-access/${aws_s3_bucket.logging[each.key].bucket}/"
-}

--- a/terraform/environments/core-logging/logs_s3_server_access_logs.tf
+++ b/terraform/environments/core-logging/logs_s3_server_access_logs.tf
@@ -1,0 +1,62 @@
+module "s3-bucket-core-logging-s3-server-access-logs" {
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=9facf9fc8f8b8e3f93ffbda822028534b9a75399" # v9.0.0
+  providers = {
+    aws.bucket-replication = aws.modernisation-platform-eu-west-1
+  }
+
+  bucket_policy      = [data.aws_iam_policy_document.core_logging_s3_server_access_logs_bucket_policy.json]
+  bucket_name        = "modernisation-platform-logs-s3-server-access-logs"
+  replication_bucket = "modernisation-platform-logs-s3-server-access-logs-replication"
+  suffix_name        = "-s3-server-access-logs"
+
+  # Reuse an existing KMS key if you prefer; otherwise create a new one.
+  # This is an example using the same key as cloudtrail logging.
+  custom_kms_key             = aws_kms_key.s3_logging_cloudtrail.arn
+  custom_replication_kms_key = aws_kms_key.s3_logging_cloudtrail_eu-west-1_replication.arn
+
+  ownership_controls  = "BucketOwnerEnforced"
+  replication_enabled = true
+  replication_region  = "eu-west-1"
+
+  tags = local.tags
+}
+
+data "aws_iam_policy_document" "core_logging_s3_server_access_logs_bucket_policy" {
+  statement {
+    sid       = "AllowS3ServerAccessLoggingPutObjectFromSourceBucketsWithinAccount"
+    effect    = "Allow"
+    actions   = ["s3:PutObject"]
+    resources = ["${module.s3-bucket-core-logging-s3-server-access-logs.bucket.arn}/*"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["logging.s3.amazonaws.com"]
+    }
+
+    # Allow writes only from our account
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
+
+    # Allow only from the specific source buckets we’re enabling logging on
+    condition {
+      test     = "ArnEquals"
+      variable = "aws:SourceArn"
+      values = [
+        # WAF bucket (module-based)
+        module.s3-bucket-modernisation-platform-waf-logs.bucket.arn,
+
+        # R53 public DNS bucket (module-based)
+        module.s3_bucket_r53_public_dns_logs.bucket.arn,
+
+        # VPC flow logs bucket (raw aws_s3_bucket in logs_s3.tf)
+        aws_s3_bucket.logging["vpc-flow-logs"].arn,
+
+        # R53 resolver logs bucket (raw aws_s3_bucket in logs_s3.tf)
+        aws_s3_bucket.logging["r53-resolver-logs"].arn,
+      ]
+    }
+  }
+}

--- a/terraform/environments/core-logging/logs_s3_server_access_logs.tf
+++ b/terraform/environments/core-logging/logs_s3_server_access_logs.tf
@@ -9,10 +9,8 @@ module "s3-bucket-core-logging-s3-server-access-logs" {
   replication_bucket = "modernisation-platform-logs-s3-server-access-logs-replication"
   suffix_name        = "-s3-server-access-logs"
 
-  # Reuse an existing KMS key if you prefer; otherwise create a new one.
-  # This is an example using the same key as cloudtrail logging.
-  custom_kms_key             = aws_kms_key.s3_logging_cloudtrail.arn
-  custom_replication_kms_key = aws_kms_key.s3_logging_cloudtrail_eu-west-1_replication.arn
+  custom_kms_key             = aws_kms_key.s3_server_access_logs.arn
+  custom_replication_kms_key = aws_kms_key.s3_server_access_logs_eu-west-1_replication.arn
 
   ownership_controls  = "BucketOwnerEnforced"
   replication_enabled = true
@@ -45,16 +43,9 @@ data "aws_iam_policy_document" "core_logging_s3_server_access_logs_bucket_policy
       test     = "ArnEquals"
       variable = "aws:SourceArn"
       values = [
-        # WAF bucket (module-based)
         module.s3-bucket-modernisation-platform-waf-logs.bucket.arn,
-
-        # R53 public DNS bucket (module-based)
         module.s3_bucket_r53_public_dns_logs.bucket.arn,
-
-        # VPC flow logs bucket (raw aws_s3_bucket in logs_s3.tf)
         aws_s3_bucket.logging["vpc-flow-logs"].arn,
-
-        # R53 resolver logs bucket (raw aws_s3_bucket in logs_s3.tf)
         aws_s3_bucket.logging["r53-resolver-logs"].arn,
       ]
     }

--- a/terraform/environments/core-logging/logs_waf_s3.tf
+++ b/terraform/environments/core-logging/logs_waf_s3.tf
@@ -11,6 +11,9 @@ module "s3-bucket-modernisation-platform-waf-logs" {
   custom_kms_key             = aws_kms_key.s3_modernisation_platform_waf_logs.arn
   custom_replication_kms_key = aws_kms_key.s3_modernisation_platform_waf_logs_eu_west_1_replication.arn
 
+  log_bucket = module.s3-bucket-core-logging-s3-server-access-logs.bucket.id
+  log_prefix = "s3-access/modernisation-platform-waf-logs/"
+
   replication_enabled = true
   replication_region  = "eu-west-1"
   versioning_enabled  = true


### PR DESCRIPTION
## A reference to the issue / Description of it

This change adds a single shared S3 Server Access Logs bucket in core-logging and enables S3 server access logging for selected source buckets WAF, Route 53 Public DNS logs, VPC flow logs, and Route 53 resolver logs.

## How does this PR fix the problem?

Creates a new shared target bucket (with replication + encryption) and a restrictive bucket policy allowing writes only from the source buckets.
Enables server access logging on WAF + R53 public DNS,VPC flow logs + R53 resolver logs buckets. 

S3 access log files for each enabled source bucket will start appearing in the shared bucket under the set bucket’s prefix, without changing how the source buckets store their existing objects.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
