### PR TITLE
TM-2048: csr: allow DB instance access

### DIFF
--- a/environments/corporate-staff-rostering.json
+++ b/environments/corporate-staff-rostering.json
@@ -17,12 +17,20 @@
           "level": "developer"
         },
         {
+          "sso_group_name": "syscon-devs",
+          "level": "instance-access"
+        },
+        {
           "sso_group_name": "azure-aws-sso-digital-studio-operations",
           "level": "developer"
         },
         {
           "sso_group_name": "azure-aws-sso-csr-application-support",
           "level": "developer"
+        },
+        {
+          "sso_group_name": "azure-aws-sso-csr-access",
+          "level": "instance-access"
         }
       ]
     },
@@ -42,12 +50,20 @@
           "level": "developer"
         },
         {
+          "sso_group_name": "syscon-devs",
+          "level": "instance-access"
+        },
+        {
           "sso_group_name": "azure-aws-sso-digital-studio-operations",
           "level": "developer"
         },
         {
           "sso_group_name": "azure-aws-sso-csr-application-support",
           "level": "developer"
+        },
+        {
+          "sso_group_name": "azure-aws-sso-csr-access",
+          "level": "instance-access"
         }
       ]
     }


### PR DESCRIPTION
## A reference to the issue / Description of it

Syscon developers cannot access to CSR database

## How does this PR fix the problem?

Gives instance-access role to the given syscon-devs github team and corresponding EntraId group. This is configured to give read-only access to CSR AWS accounts plus allows SSM port forwarding to the database.

This is consistent with how nomis db access is granted.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

n/a

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

no

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
