### PR TITLE
Manually bump devcontainer

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -6,9 +6,9 @@
       "integrity": "sha256:e867962c11134137ef6eb267147e2e7e595360a3bef03c26526493eabb1914ce"
     },
     "ghcr.io/ministryofjustice/devcontainer-feature/kubernetes:": {
-      "version": "1.1.0",
-      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/kubernetes@sha256:f58b01629d00cc9105dfda5d54a4ba33dd21e41f9a132e22e2ad12f15bc4f03d",
-      "integrity": "sha256:f58b01629d00cc9105dfda5d54a4ba33dd21e41f9a132e22e2ad12f15bc4f03d"
+      "version": "1.1.1",
+      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/kubernetes@sha256:530ae37a553ff38de71caf0ef74b5b624268f23bf17bcdfe3fb4ba0ab19bfc75",
+      "integrity": "sha256:530ae37a553ff38de71caf0ef74b5b624268f23bf17bcdfe3fb4ba0ab19bfc75"
     },
     "ghcr.io/ministryofjustice/devcontainer-feature/static-analysis:2": {
       "version": "2.0.0",


### PR DESCRIPTION
Dependabot workflow is currently failing, maunally bumping dependancy - https://github.com/ministryofjustice/modernisation-platform/actions/runs/24770103517/job/72474050415