### PR TITLE
Revert CNI tag for AP and Data Platform

### DIFF
--- a/environments/analytical-platform-common.json
+++ b/environments/analytical-platform-common.json
@@ -33,8 +33,7 @@
     "application": "analytical-platform-common",
     "business-unit": "Platforms",
     "infrastructure-support": "analytical_platform@digital.justice.gov.uk",
-    "owner": "Analytical Platform: analytical_platform@digital.justice.gov.uk",
-    "critical-national-infrastructure": false
+    "owner": "Analytical Platform: analytical_platform@digital.justice.gov.uk"
   },
   "github-oidc-team-repositories": [""]
 }

--- a/environments/analytical-platform-compute.json
+++ b/environments/analytical-platform-compute.json
@@ -147,8 +147,7 @@
     "application": "analytical-platform-compute",
     "business-unit": "Platforms",
     "infrastructure-support": "analytical-platform@digital.justice.gov.uk",
-    "owner": "Analytical Platform: analytical-platform@digital.justice.gov.uk",
-    "critical-national-infrastructure": false
+    "owner": "Analytical Platform: analytical-platform@digital.justice.gov.uk"
   },
   "github-oidc-team-repositories": [""],
   "go-live-date": ""

--- a/environments/analytical-platform-data-engineering.json
+++ b/environments/analytical-platform-data-engineering.json
@@ -64,8 +64,7 @@
     "application": "analytical-platform-data-engineering",
     "business-unit": "Platforms",
     "infrastructure-support": "analytical_platform@digital.justice.gov.uk",
-    "owner": "Analytical Platform: analytical_platform@digital.justice.gov.uk",
-    "critical-national-infrastructure": false
+    "owner": "Analytical Platform: analytical_platform@digital.justice.gov.uk"
   },
   "github-oidc-team-repositories": [""]
 }

--- a/environments/analytical-platform-data.json
+++ b/environments/analytical-platform-data.json
@@ -56,8 +56,7 @@
     "application": "analytical-platform-data",
     "business-unit": "Platforms",
     "infrastructure-support": "analytical_platform@digital.justice.gov.uk",
-    "owner": "Analytical Platform: analytical_platform@digital.justice.gov.uk",
-    "critical-national-infrastructure": false
+    "owner": "Analytical Platform: analytical_platform@digital.justice.gov.uk"
   },
   "github-oidc-team-repositories": [""]
 }

--- a/environments/analytical-platform-ingestion.json
+++ b/environments/analytical-platform-ingestion.json
@@ -68,8 +68,7 @@
     "application": "analytical-platform-ingestion",
     "business-unit": "Platforms",
     "infrastructure-support": "analytical-platform@digital.justice.gov.uk",
-    "owner": "Analytical Platform",
-    "critical-national-infrastructure": false
+    "owner": "Analytical Platform"
   },
   "github-oidc-team-repositories": [
     "ministryofjustice/analytical-platform-ingestion-notify",

--- a/environments/analytical-platform-landing.json
+++ b/environments/analytical-platform-landing.json
@@ -23,8 +23,7 @@
     "application": "analytical-platform-landing",
     "business-unit": "Platforms",
     "infrastructure-support": "analytical_platform@digital.justice.gov.uk",
-    "owner": "Analytical Platform: analytical_platform@digital.justice.gov.uk",
-    "critical-national-infrastructure": false
+    "owner": "Analytical Platform: analytical_platform@digital.justice.gov.uk"
   },
   "github-oidc-team-repositories": [""]
 }

--- a/environments/analytical-platform-management.json
+++ b/environments/analytical-platform-management.json
@@ -23,8 +23,7 @@
     "application": "analytical-platform-management",
     "business-unit": "Platforms",
     "infrastructure-support": "analytical_platform@digital.justice.gov.uk",
-    "owner": "Analytical Platform: analytical_platform@digital.justice.gov.uk",
-    "critical-national-infrastructure": false
+    "owner": "Analytical Platform: analytical_platform@digital.justice.gov.uk"
   },
   "github-oidc-team-repositories": [""]
 }

--- a/environments/analytical-platform.json
+++ b/environments/analytical-platform.json
@@ -44,8 +44,7 @@
     "application": "analytical-platform",
     "business-unit": "Platforms",
     "infrastructure-support": "analytical_platform@digital.justice.gov.uk",
-    "owner": "Analytical Platform: analytical_platform@digital.justice.gov.uk",
-    "critical-national-infrastructure": false
+    "owner": "Analytical Platform: analytical_platform@digital.justice.gov.uk"
   },
   "github-oidc-team-repositories": [""]
 }

--- a/environments/data-platform.json
+++ b/environments/data-platform.json
@@ -68,8 +68,7 @@
     "application": "data-platform",
     "business-unit": "Platforms",
     "infrastructure-support": "dataplatform@digital.justice.gov.uk",
-    "owner": "dataplatform@digital.justice.gov.uk",
-    "critical-national-infrastructure": false
+    "owner": "dataplatform@digital.justice.gov.uk"
   },
   "github-oidc-team-repositories": ["ministryofjustice/data-platform"]
 }

--- a/policies/environments/environment-definitions.rego
+++ b/policies/environments/environment-definitions.rego
@@ -148,11 +148,15 @@ deny contains msg if {
 }
 
 deny contains msg if {
+  not startswith(input.filename, "environments/analytical-platform")
+  not startswith(input.filename, "environments/data-platform")
   not has_field(input.tags, "critical-national-infrastructure")
   msg := sprintf("`%v` is missing the `critical-national-infrastructure` field", [input.filename])
 }
 
 deny contains msg if {
+  not startswith(input.filename, "environments/analytical-platform")
+  not startswith(input.filename, "environments/data-platform")
   not is_boolean(input.tags["critical-national-infrastructure"])
   msg := sprintf("`%v` has invalid `critical-national-infrastructure` value: got `%v`, expected a boolean (true or false)", [input.filename, input.tags["critical-national-infrastructure"]])
 }


### PR DESCRIPTION
Reverting `critical-national-infrastructure` tag and adding temporary bypass of CNI OPA check for AP and Data environments. 