### PR TITLE
Remove references to testing CI user in IAM policies

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/iam.tf
+++ b/terraform/environments/bootstrap/delegate-access/iam.tf
@@ -10,7 +10,7 @@ module "cross-account-access" {
     [
       "arn:aws:iam::${local.environment_management.account_ids["sprinkler-development"]}:role/github-actions"
     ],
-    terraform.workspace == "testing-test" ? ["arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:user/testing-ci", "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/github-actions-testing"] : [],
+    terraform.workspace == "testing-test" ? ["arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/github-actions-testing"] : [],
     terraform.workspace == "core-vpc-sandbox" ? [
       "arn:aws:iam::${local.environment_management.account_ids["sprinkler-development"]}:role/github-actions-dev-test",
       "arn:aws:iam::${local.environment_management.account_ids["cooker-development"]}:role/github-actions-dev-test"

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -584,7 +584,6 @@ data "aws_iam_policy_document" "assume_role_policy" {
     principals {
       type = "AWS"
       identifiers = concat(["arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:root",
-        "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:user/testing-ci",
         "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/github-actions-testing",
         one(data.aws_iam_roles.member-sso-admin-access.arns)
         ],

--- a/terraform/environments/core-network-services/iam.tf
+++ b/terraform/environments/core-network-services/iam.tf
@@ -73,14 +73,6 @@ resource "aws_iam_role" "dns" {
         {
           "Effect" : "Allow",
           "Principal" : {
-            "AWS" : "arn:aws:iam::${local.environment_management.account_ids["testing-test"]}:user/testing-ci"
-          },
-          "Action" : "sts:AssumeRole",
-          "Condition" : {}
-        },
-        {
-          "Effect" : "Allow",
-          "Principal" : {
             "AWS" : "*"
           },
           "Action" : "sts:AssumeRole",

--- a/terraform/modernisation-platform-account/s3.tf
+++ b/terraform/modernisation-platform-account/s3.tf
@@ -256,21 +256,6 @@ data "aws_iam_policy_document" "allow-state-access-from-root-account" {
   }
 
   statement {
-    sid     = "AllowTestingCIUser"
-    effect  = "Allow"
-    actions = ["s3:PutObject"]
-    resources = [
-      "${module.state-bucket.bucket.arn}/environments/members/testing/testing-test/terraform.tfstate",
-      "${module.state-bucket.bucket.arn}/environments/members/testing/testing-test/*.tflock",
-    ]
-
-    principals {
-      type        = "AWS"
-      identifiers = ["arn:aws:iam::${local.environment_management.account_ids["testing-test"]}:user/testing-ci"]
-    }
-  }
-
-  statement {
     sid     = "AllowGithubActionsRole"
     effect  = "Allow"
     actions = ["s3:PutObject"]


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform-security/issues/99

I've deleted the testing-ci user but it is referenced in a few IAM policies which now fail e.g. https://github.com/ministryofjustice/modernisation-platform/actions/runs/24835835093/job/72695842172#step:21:1519

## How does this PR fix the problem?

Removes testing-ci refernces from IAM policies as it has now been deleted.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
