### PR TITLE
RAM share for integration-hub accounts

### DIFF
--- a/environments-networks/platforms-development.json
+++ b/environments-networks/platforms-development.json
@@ -14,6 +14,7 @@
           "data-platform-development",
           "data-platform-governance-development",
           "example-development",
+          "integration-hub-development",
           "observability-platform-development",
           "octo-development",
           "panda-cyber-appsec-lab-development"

--- a/environments-networks/platforms-preproduction.json
+++ b/environments-networks/platforms-preproduction.json
@@ -5,7 +5,8 @@
         "cidr": "10.27.104.0/21",
         "accounts": [
           "data-platform-preproduction",
-          "data-platform-governance-preproduction"
+          "data-platform-governance-preproduction",
+          "integration-hub-preproduction"
         ]
       }
     }

--- a/environments-networks/platforms-production.json
+++ b/environments-networks/platforms-production.json
@@ -10,6 +10,7 @@
           "coat-production",
           "data-platform-production",
           "data-platform-governance-production",
+          "integration-hub-production",
           "long-term-storage-production",
           "observability-platform-production"
         ]

--- a/environments-networks/platforms-test.json
+++ b/environments-networks/platforms-test.json
@@ -9,6 +9,7 @@
           "data-factory-moj-test",
           "data-platform-test",
           "data-platform-governance-test",
+          "integration-hub-test",
           "testing-test"
         ]
       }

--- a/policies/.regal/config.yaml
+++ b/policies/.regal/config.yaml
@@ -9,7 +9,7 @@ rules:
   # https://docs.styra.com/regal/category/style
   style:
     file-length:
-      
+      level: ignore
     line-length:
       level: ignore
     opa-fmt:

--- a/policies/.regal/config.yaml
+++ b/policies/.regal/config.yaml
@@ -8,6 +8,8 @@ rules:
   # so certainly optional
   # https://docs.styra.com/regal/category/style
   style:
+    file-length:
+      
     line-length:
       level: ignore
     opa-fmt:

--- a/policies/networking/expected.rego
+++ b/policies/networking/expected.rego
@@ -424,6 +424,7 @@ expected :=
           "data-platform-development",
           "data-platform-governance-development",
           "example-development",
+          "integration-hub-development",
           "observability-platform-development",
           "octo-development",
           "panda-cyber-appsec-lab-development"
@@ -438,6 +439,7 @@ expected :=
           "data-factory-moj-test",
           "data-platform-test",
           "data-platform-governance-test",
+          "integration-hub-test",
           "testing-test"
         ]
       }
@@ -447,7 +449,8 @@ expected :=
         "cidr": "10.27.104.0/21",
         "accounts": [
           "data-platform-preproduction",
-          "data-platform-governance-preproduction"
+          "data-platform-governance-preproduction",
+          "integration-hub-preproduction"
         ]
       }
     },
@@ -460,6 +463,7 @@ expected :=
           "coat-production",
           "data-platform-production",
           "data-platform-governance-production",
+          "integration-hub-production",
           "long-term-storage-production",
           "observability-platform-production"
         ]


### PR DESCRIPTION
#13008 (Adds RAM share for integration-hub accounts)

Also Ignore Regal `file-length` rule in `.regal/config.yaml`.

`policies/networking/expected.rego` exceeds the recommended line limit as it holds static account definitions for all environments, growing with each onboarding.