### PR TITLE
add team for delius-core-preproduction

### DIFF
--- a/environments/delius-core.json
+++ b/environments/delius-core.json
@@ -186,6 +186,11 @@
           "sso_group_name": "hmpps-manage-people-on-probation-dev",
           "level": "developer",
           "github_action_reviewer": "false"
+        },
+        {
+          "sso_group_name": "delius-core-preproduction",
+          "level": "developer",
+          "github_action_reviewer": "false"
         }
       ],
       "instance_scheduler_skip": ["true"]


### PR DESCRIPTION
## A reference to the issue / Description of it

Added a team for developer access into the delius-core-preproduction account.

## How does this PR fix the problem?

It adds the team.

## How has this been tested?

Just the PR checks.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No, it will only add user access.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)
