### PR TITLE
access for delius-core teams

### DIFF
--- a/environments/delius-core.json
+++ b/environments/delius-core.json
@@ -69,6 +69,11 @@
           "sso_group_name": "octo-data-architecture",
           "level": "developer",
           "github_action_reviewer": "false"
+        },
+        {
+          "sso_group_name": "delius-core-development",
+          "level": "developer",
+          "github_action_reviewer": "false"
         }
       ],
       "nuke": "exclude"
@@ -135,6 +140,11 @@
         },
         {
           "sso_group_name": "octo-data-architecture",
+          "level": "developer",
+          "github_action_reviewer": "false"
+        },
+        {
+          "sso_group_name": "delius-core-test",
           "level": "developer",
           "github_action_reviewer": "false"
         }
@@ -235,6 +245,11 @@
         {
           "sso_group_name": "octo-cyber-team",
           "level": "security-audit"
+        },
+        {
+          "sso_group_name": "delius-core-production",
+          "level": "developer",
+          "github_action_reviewer": "false"
         }
       ]
     }


### PR DESCRIPTION
## A reference to the issue / Description of it

Adding teams for developer access into the delius-core accounts

## How does this PR fix the problem?

It adds team access

## How has this been tested?

Just the PR checks.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No, it will only add user access.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)