### PR TITLE
Remove Glacier transitions and add AWSBackup KMS permissions

### DIFF
--- a/terraform/modernisation-platform-account/s3.tf
+++ b/terraform/modernisation-platform-account/s3.tf
@@ -83,6 +83,19 @@ data "aws_iam_policy_document" "kms_state_bucket" {
       values   = ["${data.aws_organizations_organization.root_account.id}/*/${local.environment_management.modernisation_platform_organisation_unit_id}/*"]
     }
   }
+  statement {
+    sid    = "AllowAWSBackupDecrypt"
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+      "kms:DescribeKey"
+    ]
+    resources = ["*"]
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/AWSBackup"]
+    }
+  }
 }
 
 # State bucket KMS Destination
@@ -129,9 +142,6 @@ module "state-bucket" {
         {
           days          = 90
           storage_class = "STANDARD_IA"
-          }, {
-          days          = 700
-          storage_class = "GLACIER"
         }
       ]
       expiration = {
@@ -141,9 +151,6 @@ module "state-bucket" {
         {
           days          = 90
           storage_class = "STANDARD_IA"
-          }, {
-          days          = 700
-          storage_class = "GLACIER"
         }
       ]
       noncurrent_version_expiration = {


### PR DESCRIPTION
AWS Backup cannot back up objects in Glacier or Glacier Deep Archive storage
classes, causing `'completed with issues'` status on daily backups of the
modernisation-platform-terraform-state bucket.

Changes:
- Remove `GLACIER` lifecycle transitions (at day 700) from state bucket lifecycle
  rule. Objects now transition to `STANDARD_IA` at 90 days and expire at **730** days.
- Add AllowAWSBackupDecrypt statement to kms_state_bucket KMS key policy,
  granting the AWSBackup IAM role `kms:Decrypt` and `kms:DescribeKey` permissions
  so it can read `SSE-KMS` encrypted objects.

Relates to Issue: https://github.com/ministryofjustice/modernisation-platform/issues/12696