### PR TITLE
fix: remove get object perms

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -1902,7 +1902,6 @@ data "aws_iam_policy_document" "data_scientist" {
     sid    = "EMAthenaQueryResultsObjectAccess"
     effect = "Allow"
     actions = [
-      "s3:GetObject",
       "s3:PutObject",
       "s3:AbortMultipartUpload",
       "s3:ListMultipartUploadParts"


### PR DESCRIPTION
## A reference to the issue / Description of it

Dont want to allow users to download csv results.

## How does this PR fix the problem?

Removes s3 get objects.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)
