### PR TITLE
Fix core-logging CloudTrail S3 backup expiry with dedicated extended-window plan

### DIFF
--- a/terraform/environments/core-logging/backup_cloudtrail_s3.tf
+++ b/terraform/environments/core-logging/backup_cloudtrail_s3.tf
@@ -1,0 +1,29 @@
+resource "aws_backup_plan" "cloudtrail_s3_extended_window" {
+  name = "cloudtrail-s3-extended-window"
+
+  rule {
+    rule_name         = "backup-daily-retain-30-days-cloudtrail-s3"
+    target_vault_name = "everything"
+
+    # Backup every day at 00:30am
+    schedule = "cron(30 0 * * ? *)"
+
+    # Keep the same 1-hour start window but allow up to 180 hours to complete
+    # the initial full scan for this very large bucket.
+    start_window      = 60
+    completion_window = 10800
+
+    lifecycle {
+      delete_after = 30
+    }
+  }
+
+  tags = local.tags
+}
+
+resource "aws_backup_selection" "cloudtrail_s3_extended_window" {
+  name         = "cloudtrail-s3-extended-window"
+  iam_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/AWSBackup"
+  plan_id      = aws_backup_plan.cloudtrail_s3_extended_window.id
+  resources    = [module.s3-bucket-cloudtrail.bucket.arn]
+}

--- a/terraform/environments/core-logging/logs_cloudtrail_s3.tf
+++ b/terraform/environments/core-logging/logs_cloudtrail_s3.tf
@@ -19,7 +19,9 @@ module "s3-bucket-cloudtrail" {
     "log_bucket_policy" : module.s3-bucket-cloudtrail-logging.bucket_policy.policy,
   })
   log_prefix = ""
-  tags       = local.tags
+  tags = merge(local.tags, {
+    backup = "false"
+  })
 }
 
 data "aws_iam_policy_document" "cloudtrail_bucket_policy" {


### PR DESCRIPTION
**Summary**
This change fixes recurring AWS Backup Expired jobs for the large CloudTrail bucket in core-logging by moving it out of the default short-window backup selection and into a dedicated backup plan with a much longer completion window.

**Context**
AWS Support identified that backup jobs for modernisation-platform-logs-cloudtrail were expiring because the default completion window was too short for the bucket size and object count.

**Changes**
1. Exclude CloudTrail bucket from baseline tag-selected backups
- Updated tags on the CloudTrail bucket module to set backup=false in [logs_cloudtrail_s3.tf](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).
2. Add a dedicated CloudTrail backup plan and selection
- Added `backup_cloudtrail_s3.tf` with:
- Daily schedule at 00:30
- start_window = 60 minutes
- completion_window = 10800 minutes (180 hours)
- delete_after = 30 days
- Explicit resource selection for the CloudTrail bucket ARN

**Why this approach**
1. Limits blast radius: only the CloudTrail bucket gets the long completion window.
2. Keeps default backup behavior unchanged for the rest of the estate.
3. Avoids duplicate backup attempts by excluding this bucket from the default tag-based selection.

**Notes**
- This change addresses Expired backup jobs.
- Completed with issues can still occur for objects already in Glacier storage classes due to AWS Backup S3 limitations.