### PR TITLE
Fix pip upgrade safe-chain block in IAM hygiene workflow

### DIFF
--- a/.github/workflows/reusable-run-per-account-script.yml
+++ b/.github/workflows/reusable-run-per-account-script.yml
@@ -108,8 +108,15 @@ jobs:
 
       - name: Install GOV.UK Notify client
         run: |
-          python3 -m pip install --upgrade pip
-          pip3 install notifications-python-client
+          set -euo pipefail
+          NOTIFY_VERSION="9.1.0"
+          NOTIFY_SHA256="43b8f738dfa81ae3aa656d91e361dbc51316194f8b9a430706b03347fa7a01bc"
+          WHEEL_DIR="$(mktemp -d)"
+
+          python3 -m pip download --no-deps --only-binary=:all: --dest "$WHEEL_DIR" "notifications-python-client==${NOTIFY_VERSION}"
+          WHEEL_PATH="$(ls "$WHEEL_DIR"/notifications_python_client-"${NOTIFY_VERSION}"-py3-none-any.whl)"
+          echo "${NOTIFY_SHA256}  ${WHEEL_PATH}" | sha256sum -c -
+          python3 -m pip install "$WHEEL_PATH"
 
       - name: Run script in member account
         env:


### PR DESCRIPTION
**Problem**: The Notify client install step upgrades pip before installing, which triggers a safe-chain rejection of newly published pip releases (e.g., pip 26.1.1).

**Solution**: Remove pip upgrade and pin the Notify wheel (notifications-python-client 9.1.0) with SHA256 verification.

**Changes**:
- Updated `reusable-run-per-account-script.yml:109`
- Removed `python3 -m pip install --upgrade pip`
- Added explicit wheel download + SHA256 check before install

**Pinned artifact**:
- notifications-python-client==9.1.0 (sha256: 43b8f738dfa81ae3aa656d91e361dbc51316194f8b9a430706b03347fa7a01bc)
