### PR TITLE
S3 module update for modernisation platform logs cloudtrail bucket

### DIFF
--- a/terraform/environments/core-logging/logs_cloudtrail_s3.tf
+++ b/terraform/environments/core-logging/logs_cloudtrail_s3.tf
@@ -1,11 +1,12 @@
 module "s3-bucket-cloudtrail" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=9facf9fc8f8b8e3f93ffbda822028534b9a75399" # v9.0.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=479b926"
   providers = {
     aws.bucket-replication = aws.modernisation-platform-eu-west-1
   }
   bucket_policy              = [data.aws_iam_policy_document.cloudtrail_bucket_policy.json]
   bucket_name                = "modernisation-platform-logs-cloudtrail"
   replication_bucket         = "modernisation-platform-logs-cloudtrail-replication"
+  sse_algorithm              = "aws:kms"
   suffix_name                = "-cloudtrail"
   custom_kms_key             = aws_kms_key.s3_logging_cloudtrail.arn
   custom_replication_kms_key = aws_kms_key.s3_logging_cloudtrail_eu-west-1_replication.arn


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform-security/issues/102 - Updates the CloudTrail S3 bucket to use the stricter encryption defaults [introduced](https://github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket/pull/881) in the `modernisation-platform-terraform-s3-bucket` module.

We are updating our existing buckets first before making a release. Once we are satisfied the changes work correctly with our buckets, we will release v10 and update this bucket to use v10 as well.

---

## How does this PR fix the problem?

This PR upgrades the CloudTrail bucket module reference to the latest unreleased commit containing the stricter SSE-KMS enforcement changes.

The bucket is explicitly configured to use `sse_algorithm = "aws:kms"` with the existing customer-managed KMS keys:

- `custom_kms_key = aws_kms_key.s3_logging_cloudtrail.arn`
- `custom_replication_kms_key = aws_kms_key.s3_logging_cloudtrail_eu-west-1_replication.arn`

This validates that existing CloudTrail delivery continues to work correctly under the new stricter bucket policies enforcing:

- `x-amz-server-side-encryption = aws:kms`
- the expected customer-managed KMS key ARN

---

## How has this been tested?

Testing was carried out against the existing CloudTrail logging bucket before applying the module changes.

The existing bucket was checked to confirm that current CloudTrail `PutObject` requests already send the required SSE-KMS headers expected by the new module policy.

### Validation performed

- Verified existing CloudTrail uploads include `x-amz-server-side-encryption = aws:kms`
- Verified existing CloudTrail uploads include the expected customer-managed KMS key ARN
- Verified S3 stores uploaded CloudTrail objects using the expected KMS key
- Verified no non-compliant CloudTrail uploads exist in the queried events

---

## Deployment Plan / Instructions

### Will this deployment impact the platform and / or services on it?

No expected impact.

This change validates the stricter SSE-KMS enforcement changes against an existing CloudTrail bucket that is already using the expected customer-managed KMS key configuration.

---

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

---

## Additional comments (if any)

This PR intentionally references an unreleased module commit while validating the stricter encryption enforcement changes against existing buckets prior to the v10 release.