### PR TITLE
Grant laa-workspaces-development member delegation permissions

### DIFF
--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -214,6 +214,12 @@ module "dns_zone_extend_private" {
   vpc_id    = module.vpc[each.key].vpc_id
 }
 
+locals {
+  member_delegation_additional_accounts = {
+    "laa-workspaces-development" = [local.environment_management.account_ids["laa-workspaces-development"]]
+  }
+}
+
 resource "aws_iam_role" "member-delegation" {
   for_each = local.vpcs[terraform.workspace]
 
@@ -226,6 +232,7 @@ resource "aws_iam_role" "member-delegation" {
         Principal = {
           AWS = concat(
             local.expanded_account_numbers_with_keys[each.key],
+            lookup(local.member_delegation_additional_accounts, each.key, []),
             tolist([data.aws_caller_identity.modernisation-platform.account_id])
           )
         }

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -234,7 +234,7 @@ resource "aws_iam_role" "member-delegation" {
         Principal = {
           AWS = concat(
             local.expanded_account_numbers_with_keys[each.key],
-            try(local.member_delegation_additional_accounts[terraform.workspace][each.key], [])
+            try(local.member_delegation_additional_accounts[terraform.workspace][each.key], []),
             tolist([data.aws_caller_identity.modernisation-platform.account_id])
           )
         }

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -234,7 +234,7 @@ resource "aws_iam_role" "member-delegation" {
         Principal = {
           AWS = concat(
             local.expanded_account_numbers_with_keys[each.key],
-            lookup(local.member_delegation_additional_accounts, terraform.workspace, {}),
+            try(local.member_delegation_additional_accounts[terraform.workspace][each.key], [])
             tolist([data.aws_caller_identity.modernisation-platform.account_id])
           )
         }

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -216,7 +216,9 @@ module "dns_zone_extend_private" {
 
 locals {
   member_delegation_additional_accounts = {
-    "laa-workspaces-development" = [local.environment_management.account_ids["laa-workspaces-development"]]
+    "core-vpc-development" = {
+      "laa-development" = [local.environment_management.account_ids["laa-workspaces-development"]]
+    }
   }
 }
 
@@ -232,7 +234,7 @@ resource "aws_iam_role" "member-delegation" {
         Principal = {
           AWS = concat(
             local.expanded_account_numbers_with_keys[each.key],
-            lookup(local.member_delegation_additional_accounts, each.key, []),
+            lookup(local.member_delegation_additional_accounts, terraform.workspace, {}),
             tolist([data.aws_caller_identity.modernisation-platform.account_id])
           )
         }


### PR DESCRIPTION
## A reference to the issue / Description of it
Slack thread: https://mojdt.slack.com/archives/C013RM6MFFW/p1778058372239029

`laa-workspaces-development` has an isolated VPC and they are trying to add r53 records to the
`laa-development.modernisation-platform.service.justice.gov.uk` zone in `core-vpc-development` - but that won't work in TF with the `aws.core-vpc` provider as the only accounts allowed to use the `member-delegation-laa-development` role are those laa accounts that are part of the shared networking setup.

## How does this PR fix the problem?

Adds new `member_delegation_additional_accounts` local with a map of additional accounts to add to the trust policy for the member-delegation role.

This will allow the account to keep its networ isolated but grant access to create records in `laa-development.modernisation-platform.service.justice.gov.uk`

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
