### PR TITLE
S3 module update for athena cloudtrail bucket

### DIFF
--- a/terraform/environments/core-logging/athena.tf
+++ b/terraform/environments/core-logging/athena.tf
@@ -10,12 +10,13 @@ data "aws_kms_alias" "environment_management" {
 #S3 Bucket for Athena temp SQL queries 
 
 module "s3-bucket-athena" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=9facf9fc8f8b8e3f93ffbda822028534b9a75399" # v9.0.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=479b926"
   providers = {
     aws.bucket-replication = aws.modernisation-platform-eu-west-1
   }
   bucket_policy       = [data.aws_iam_policy_document.athena_bucket_policy.json]
   bucket_name         = "athena-cloudtrail-query"
+  sse_algorithm       = "aws:kms"
   custom_kms_key      = aws_kms_key.s3_logging_cloudtrail.arn
   replication_enabled = false
   lifecycle_rule = [
@@ -83,7 +84,9 @@ resource "aws_athena_workgroup" "mod-platform" {
     result_configuration {
       output_location = "s3://${module.s3-bucket-athena.bucket.id}/"
       encryption_configuration {
-        encryption_option = "SSE_S3"
+        encryption_option = "SSE_KMS"
+        kms_key_arn       = aws_kms_key.s3_logging_cloudtrail.arn
+
       }
     }
   }


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform-security/issues/102 - Updates the Athena query results S3 bucket to use the stricter encryption defaults [introduced](https://github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket/pull/881) in the `modernisation-platform-terraform-s3-bucket` module.

This also updates the Athena workgroup configuration to explicitly use SSE-KMS for query result encryption.

We are updating our existing buckets first before making a release. Once we are satisfied the changes work correctly with our buckets, we will release v10 and update this bucket to use v10 as well.

---

## How does this PR fix the problem?

This PR upgrades the Athena query results bucket module reference to the latest unreleased commit containing the stricter SSE-KMS enforcement changes.

The bucket is explicitly configured to use `sse_algorithm = "aws:kms"` with the existing customer-managed KMS key:

- `custom_kms_key = aws_kms_key.s3_logging_cloudtrail.arn`

The Athena workgroup configuration has also been updated from:

```hcl
encryption_option = "SSE_S3"
```

to:

```hcl
encryption_option = "SSE_KMS"
kms_key_arn       = aws_kms_key.s3_logging_cloudtrail.arn
```

This ensures Athena explicitly sends SSE-KMS encryption headers when writing query result objects, allowing compatibility with the stricter bucket policies enforcing:

- `x-amz-server-side-encryption = aws:kms`
- the expected customer-managed KMS key ARN

---

## How has this been tested?

Testing was carried out against the existing Athena query results bucket before applying the module changes.

CloudTrail `PutObject` events for Athena query result uploads were inspected to validate current encryption behaviour.

### Validation performed

Before the Athena workgroup update:

- Verified Athena query result objects were stored using the expected KMS key
- Verified Athena uploads did not explicitly send SSE-KMS request headers
- Confirmed Athena relied on bucket default encryption rather than explicit SSE-KMS request configuration

After the Athena workgroup update:

- Verified Athena query result uploads explicitly use `aws:kms`
- Verified Athena uploads use the expected customer-managed KMS key ARN
- Verified uploaded Athena result objects continue to be stored using the expected KMS key
- Verified no AccessDenied or KMS permission failures occurred during Athena query execution

CloudTrail `PutObject` events were validated to confirm Athena uploads now include:

- `x-amz-server-side-encryption = aws:kms`
- the expected `x-amz-server-side-encryption-aws-kms-key-id`

---

## Deployment Plan / Instructions

### Will this deployment impact the platform and / or services on it?

No expected impact.

This change validates the stricter SSE-KMS enforcement changes against the existing Athena query results bucket and updates Athena to explicitly use SSE-KMS for query result uploads.

---

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

---