### PR TITLE
Add default tags to AWS provider configurations in SSO

### DIFF
--- a/terraform/single-sign-on/locals.tf
+++ b/terraform/single-sign-on/locals.tf
@@ -3,4 +3,13 @@ locals {
   sso_identity_store_id  = coalesce(data.aws_ssoadmin_instances.default.identity_store_ids...)
   sso_admin_instance_arn = coalesce(data.aws_ssoadmin_instances.default.arns...)
   environment_management = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
+
+  tags = {
+    business-unit = "Platforms"
+    service-area  = "Hosting"
+    application   = "Modernisation Platform"
+    is-production = true
+    owner         = "Modernisation Platform: modernisation-platform@digital.justice.gov.uk"
+  }
+
 }

--- a/terraform/single-sign-on/providers.tf
+++ b/terraform/single-sign-on/providers.tf
@@ -1,6 +1,7 @@
 # AWS provider (default)
 provider "aws" {
   region = "eu-west-2"
+  default_tags { tags = local.tags }
 }
 
 # AWS provider (AWS root account for AWS SSO management)
@@ -10,4 +11,5 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.aws_organizations_root_account_id}:role/ModernisationPlatformSSOAdministrator"
   }
+  default_tags { tags = local.tags }
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/12605

## How does this PR fix the problem?

Ensures tags are supplied to all eligible resources by default by adding to providers in `terraform/single-sign-on`

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
