### PR TITLE
S3 module update for Configs Logs bucket

### DIFF
--- a/terraform/environments/core-logging/logs_config_s3.tf
+++ b/terraform/environments/core-logging/logs_config_s3.tf
@@ -1,6 +1,6 @@
 ## S3 Bucket Module for AWS Config Logs
 module "s3_bucket_config_logs" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=9facf9fc8f8b8e3f93ffbda822028534b9a75399" # v9.0.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=479b926"
 
   providers = {
     aws.bucket-replication = aws.modernisation-platform-eu-west-1
@@ -11,6 +11,7 @@ module "s3_bucket_config_logs" {
   suffix_name                = "-config"
   custom_kms_key             = aws_kms_key.config_logs.arn
   custom_replication_kms_key = aws_kms_key.config_logs_replication.arn
+  sse_algorithm              = "AES256"
   replication_enabled        = true
   replication_region         = "eu-west-1"
   versioning_enabled         = true


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform-security/issues/102 - Updates the AWS Config logs S3 bucket to use the stricter encryption defaults [introduced](https://github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket/pull/881) in the `modernisation-platform-terraform-s3-bucket` module.

This bucket is being updated as part of validating the new module behaviour against existing production buckets before releasing v10 of the module.

Testing confirmed that AWS Config currently uploads objects using `AES256` (`SSE_S3`) rather than explicit SSE-KMS request headers.

As a result, this bucket is being configured as an explicit AES256 compatibility case.

We are updating our existing buckets first before making a release. Once we are satisfied the changes work correctly with our buckets, we will release v10 and update this bucket to use v10 as well.

---

## How does this PR fix the problem?

This PR upgrades the AWS Config logs bucket module reference to the latest unreleased commit containing the stricter SSE-KMS enforcement changes.

The bucket is explicitly configured to use:

```hcl
sse_algorithm = "AES256"
```

rather than the default strict `aws:kms` enforcement mode.

This preserves compatibility with AWS Config delivery behaviour, which currently uploads objects with:

```text
x-amz-server-side-encryption = AES256
```

CloudTrail validation confirmed AWS Config is not currently sending:

- `x-amz-server-side-encryption = aws:kms`
- `x-amz-server-side-encryption-aws-kms-key-id`

Using strict `aws:kms` enforcement for this bucket would therefore deny AWS Config uploads.

Replication remains enabled, but KMS-specific replication encryption configuration is not applied in AES256 mode.

---

## How has this been tested?

Testing was carried out against the existing AWS Config logs bucket before applying the module changes.

CloudTrail `PutObject` events for AWS Config uploads were inspected to validate current encryption behaviour.

### Validation performed

- Verified AWS Config uploads explicitly use `AES256`
- Verified AWS Config uploads do not use `aws:kms`
- Verified no AWS Config uploads were observed using KMS request headers
- Verified AWS Config uploads include:
  - `x-amz-server-side-encryption = AES256`
- Verified AWS Config uploads continue to succeed using SSE-S3 encryption
- Verified failed/throttled events also used `AES256`
- Verified no existing uploads would be compatible with strict `aws:kms` enforcement

CloudWatch Logs Insights queries were used to:

- summarise all AWS Config `PutObject` encryption behaviour
- identify any uploads using `aws:kms`
- inspect failed upload events with missing response encryption fields

Results confirmed the bucket currently operates as an AES256/SSE-S3 bucket.

---

## Deployment Plan / Instructions

### Will this deployment impact the platform and / or services on it?

No expected impact.

This change preserves the current AWS Config upload encryption behaviour while validating compatibility with the updated S3 bucket module changes.

The bucket is intentionally configured as an AES256 compatibility case because AWS Config currently uploads using SSE-S3 rather than explicit SSE-KMS request headers.

---

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

---