### PR TITLE
Add default tags to all AWS provider configurations in `terraform/modernisation-platform-account`

### DIFF
--- a/terraform/modernisation-platform-account/providers.tf
+++ b/terraform/modernisation-platform-account/providers.tf
@@ -91,12 +91,6 @@ provider "aws" {
 }
 
 provider "aws" {
-  region = "us-east-2"
-  alias  = "modernisation-platform-us-east-2"
-  default_tags { tags = local.tags }
-}
-
-provider "aws" {
   region = "us-west-1"
   alias  = "modernisation-platform-us-west-1"
   default_tags { tags = local.tags }

--- a/terraform/modernisation-platform-account/providers.tf
+++ b/terraform/modernisation-platform-account/providers.tf
@@ -3,86 +3,109 @@
 # Default provider
 provider "aws" {
   region = "eu-west-2"
+  default_tags { tags = local.tags }
 }
 
 provider "aws" {
   region = "ap-northeast-1"
   alias  = "modernisation-platform-ap-northeast-1"
+  default_tags { tags = local.tags }
 }
 
 provider "aws" {
   region = "ap-northeast-2"
   alias  = "modernisation-platform-ap-northeast-2"
+  default_tags { tags = local.tags }
 }
 
 provider "aws" {
   region = "ap-south-1"
   alias  = "modernisation-platform-ap-south-1"
+  default_tags { tags = local.tags }
 }
 
 provider "aws" {
   region = "ap-southeast-1"
   alias  = "modernisation-platform-ap-southeast-1"
+  default_tags { tags = local.tags }
 }
 
 provider "aws" {
   region = "ap-southeast-2"
   alias  = "modernisation-platform-ap-southeast-2"
+  default_tags { tags = local.tags }
 }
 
 provider "aws" {
   region = "ca-central-1"
   alias  = "modernisation-platform-ca-central-1"
+  default_tags { tags = local.tags }
 }
 
 provider "aws" {
   region = "eu-central-1"
   alias  = "modernisation-platform-eu-central-1"
+  default_tags { tags = local.tags }
 }
 
 provider "aws" {
   region = "eu-north-1"
   alias  = "modernisation-platform-eu-north-1"
+  default_tags { tags = local.tags }
 }
 
 provider "aws" {
   region = "eu-west-1"
   alias  = "modernisation-platform-eu-west-1"
+  default_tags { tags = local.tags }
 }
 
 provider "aws" {
   region = "eu-west-2"
   alias  = "modernisation-platform-eu-west-2"
+  default_tags { tags = local.tags }
 }
 
 provider "aws" {
   region = "eu-west-3"
   alias  = "modernisation-platform-eu-west-3"
+  default_tags { tags = local.tags }
 }
 
 provider "aws" {
   region = "sa-east-1"
   alias  = "modernisation-platform-sa-east-1"
+  default_tags { tags = local.tags }
 }
 
 provider "aws" {
   region = "us-east-1"
   alias  = "modernisation-platform-us-east-1"
+  default_tags { tags = local.tags }
 }
 
 provider "aws" {
   region = "us-east-2"
   alias  = "modernisation-platform-us-east-2"
+  default_tags { tags = local.tags }
+}
+
+provider "aws" {
+  region = "us-east-2"
+  alias  = "modernisation-platform-us-east-2"
+  default_tags { tags = local.tags }
 }
 
 provider "aws" {
   region = "us-west-1"
   alias  = "modernisation-platform-us-west-1"
+  default_tags { tags = local.tags }
 }
 
 provider "aws" {
   region = "us-west-2"
   alias  = "modernisation-platform-us-west-2"
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-logging
@@ -92,4 +115,5 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-logging-production"]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/12605

## How does this PR fix the problem?

Ensures tags are supplied to all eligible resources by default by adding to providers in `terraform/modernisation-platform-account`

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
