### PR TITLE
S3 module upgrade for r53 public dns logs bucket

### DIFF
--- a/terraform/environments/core-logging/logs_r53_public_dns_s3.tf
+++ b/terraform/environments/core-logging/logs_r53_public_dns_s3.tf
@@ -1,6 +1,6 @@
 ## S3 Bucket Module for AWS Route 53 Public DNS Query Logs
 module "s3_bucket_r53_public_dns_logs" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=9facf9fc8f8b8e3f93ffbda822028534b9a75399" # v9.0.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=479b926"
 
   providers = {
     aws.bucket-replication = aws.modernisation-platform-eu-west-1
@@ -8,6 +8,7 @@ module "s3_bucket_r53_public_dns_logs" {
   bucket_policy              = [data.aws_iam_policy_document.r53_public_dns_logs_bucket_policy.json]
   bucket_name                = "modernisation-platform-logs-r53-public-dns-logs"
   replication_bucket         = "modernisation-platform-logs-r53-public-dns-logs-replication"
+  sse_algorithm              = "aws:kms"
   suffix_name                = "-r53-public-dns-logs"
   custom_kms_key             = aws_kms_key.r53_public_dns_logs.arn
   custom_replication_kms_key = aws_kms_key.r53_public_dns_logs_replication.arn


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform-security/issues/102 - Updates the Route53 public DNS query logs S3 bucket to use the stricter encryption defaults [introduced](https://github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket/pull/881) in the `modernisation-platform-terraform-s3-bucket` module.

This bucket is being updated as part of validating the new module behaviour against existing production buckets before releasing v10 of the module.

Testing confirmed that Kinesis Firehose is already uploading objects using explicit SSE-KMS request headers with the expected customer-managed KMS key.

We are updating our existing buckets first before making a release. Once we are satisfied the changes work correctly with our buckets, we will release v10 and update this bucket to use v10 as well.

---

## How does this PR fix the problem?

This PR upgrades the Route53 public DNS query logs bucket module reference to the latest unreleased commit containing the stricter SSE-KMS enforcement changes.

The bucket is explicitly configured to use:

```hcl
sse_algorithm = "aws:kms"
```

with the existing customer-managed KMS keys:

- `custom_kms_key = aws_kms_key.r53_public_dns_logs.arn`
- `custom_replication_kms_key = aws_kms_key.r53_public_dns_logs_replication.arn`

CloudTrail validation confirmed that Kinesis Firehose already uploads objects using:

- `x-amz-server-side-encryption = aws:kms`
- the expected `x-amz-server-side-encryption-aws-kms-key-id`

This allows the bucket to safely adopt the stricter SSE-KMS enforcement policies introduced by the updated module.

Replication remains enabled and continues to use customer-managed KMS keys.

---

## How has this been tested?

Testing was carried out against the existing Route53 public DNS query logs bucket before applying the module changes.

CloudTrail `PutObject` events for Firehose uploads were inspected to validate current encryption behaviour.

### Validation performed

- Verified Firehose uploads explicitly use `aws:kms`
- Verified Firehose uploads include the expected customer-managed KMS key ARN
- Verified uploaded objects are stored using the expected KMS key
- Verified no non-compliant uploads were identified
- Verified replication configuration continues to use customer-managed KMS keys

CloudWatch Logs Insights queries were used to:

- summarise all `PutObject` encryption behaviour
- identify uploads using `aws:kms`
- detect uploads missing required KMS request headers
- inspect events with missing `additionalEventData.SSEApplied`

Results confirmed that Firehose uploads are already compliant with the stricter SSE-KMS enforcement requirements.

---

## Deployment Plan / Instructions

### Will this deployment impact the platform and / or services on it?

No expected impact.

This change validates the stricter SSE-KMS enforcement changes against the existing Route53 public DNS query logs bucket, which is already using explicit SSE-KMS uploads with the expected customer-managed KMS key configuration.

---

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

---
