### PR TITLE
S3 Module upgrade - MP Waf Logs 

### DIFF
--- a/terraform/environments/core-logging/logs_cloudtrail_s3.tf
+++ b/terraform/environments/core-logging/logs_cloudtrail_s3.tf
@@ -1,5 +1,5 @@
 module "s3-bucket-cloudtrail" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=479b926"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=479b92623954a75f96a6da8ebb4070a8581c227e"
   providers = {
     aws.bucket-replication = aws.modernisation-platform-eu-west-1
   }

--- a/terraform/environments/core-logging/logs_config_s3.tf
+++ b/terraform/environments/core-logging/logs_config_s3.tf
@@ -1,6 +1,6 @@
 ## S3 Bucket Module for AWS Config Logs
 module "s3_bucket_config_logs" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=479b926"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=479b92623954a75f96a6da8ebb4070a8581c227e"
 
   providers = {
     aws.bucket-replication = aws.modernisation-platform-eu-west-1

--- a/terraform/environments/core-logging/logs_waf_s3.tf
+++ b/terraform/environments/core-logging/logs_waf_s3.tf
@@ -1,6 +1,6 @@
 # S3 bucket for centralised modernisation platform waf logs
 module "s3-bucket-modernisation-platform-waf-logs" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=479b926"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=479b92623954a75f96a6da8ebb4070a8581c227e"
   providers = {
     aws.bucket-replication = aws.modernisation-platform-eu-west-1
   }

--- a/terraform/environments/core-logging/logs_waf_s3.tf
+++ b/terraform/environments/core-logging/logs_waf_s3.tf
@@ -1,11 +1,12 @@
 # S3 bucket for centralised modernisation platform waf logs
 module "s3-bucket-modernisation-platform-waf-logs" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=9facf9fc8f8b8e3f93ffbda822028534b9a75399" # v9.0.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=479b926"
   providers = {
     aws.bucket-replication = aws.modernisation-platform-eu-west-1
   }
 
   bucket_name                = "modernisation-platform-waf-logs"
+  sse_algorithm              = "aws:kms"
   replication_bucket         = "modernisation-platform-waf-logs-replication"
   suffix_name                = "-waf-logs"
   custom_kms_key             = aws_kms_key.s3_modernisation_platform_waf_logs.arn


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform-security/issues/102 - Updates the Modernisation Platform WAF logs S3 bucket to use the stricter encryption defaults [introduced](https://github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket/pull/881) in the `modernisation-platform-terraform-s3-bucket` module.

This bucket is being updated as part of validating the new module behaviour against existing production buckets before releasing v10 of the module.

Testing confirmed that Kinesis Firehose is already uploading WAF log objects using explicit SSE-KMS request headers.

We are updating our existing buckets first before making a release. Once we are satisfied the changes work correctly with our buckets, we will release v10 and update this bucket to use v10 as well.

---

## How does this PR fix the problem?

This PR upgrades the WAF logs bucket module reference to the latest unreleased commit containing the stricter SSE-KMS enforcement changes.

The bucket is explicitly configured to use:

```hcl
sse_algorithm = "aws:kms"
```

with the existing customer-managed KMS keys:

- `custom_kms_key = aws_kms_key.s3_modernisation_platform_waf_logs.arn`
- `custom_replication_kms_key = aws_kms_key.s3_modernisation_platform_waf_logs_eu_west_1_replication.arn`

CloudTrail validation confirmed that Kinesis Firehose already uploads objects using:

- `x-amz-server-side-encryption = aws:kms`

This allows the bucket to safely adopt the stricter SSE-KMS enforcement policies introduced by the updated module.

Replication remains enabled and continues to use customer-managed KMS keys.

---

## How has this been tested?

Testing was carried out against the existing WAF logs bucket before applying the module changes.

CloudTrail `PutObject` events for Firehose uploads were inspected to validate current encryption behaviour.

### Validation performed

- Verified Firehose uploads use SSE-KMS
- Verified no uploads were found missing `x-amz-server-side-encryption = aws:kms`
- Verified uploaded objects are stored using SSE-KMS
- Verified replication remains configured with customer-managed KMS keys

CloudWatch Logs Insights queries were used to:

- summarise all `PutObject` encryption behaviour
- confirm Firehose uploads are using SSE-KMS
- detect uploads missing required KMS request headers

Results confirmed that Firehose uploads are already compliant with the stricter SSE-KMS enforcement requirements.

---

## Deployment Plan / Instructions

### Will this deployment impact the platform and / or services on it?

No expected impact.

This change validates the stricter SSE-KMS enforcement changes against the existing WAF logs bucket, which is already receiving SSE-KMS uploads from Kinesis Firehose.

---

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

---
