### PR TITLE
protect AWSBackupSelection resources from aws-nuke

### DIFF
--- a/scripts/nuke-config-template.txt
+++ b/scripts/nuke-config-template.txt
@@ -18,6 +18,7 @@ resource-types:
   # don't nuke IAM users
   excludes:
     - ACMCertificate
+    - AWSBackupSelection
     - CloudTrailTrail
     - CloudWatchAlarm
     - CloudWatchLogsLogGroup


### PR DESCRIPTION
`aws_backup_selection` resources created by the [modernisation-platform-terraform-baselines](https://github.com/ministryofjustice/modernisation-platform-terraform-baselines) module are not protected by the existing `secure-baselines` tag filters in the nuke config presets.

This is because `aws_backup_selection` **does not support tagging** as a resource attribute in Terraform, making tag-based filtering in the preset impossible for this resource type.

Without this change, running aws-nuke on a member account risks deleting the platform-managed backup selections, which would break the backup strategy for non-production workloads.
#12217 
