### PR TITLE
Module Update for ec2 image builder logs bucket

### DIFF
--- a/terraform/environments/core-shared-services/bucket.tf
+++ b/terraform/environments/core-shared-services/bucket.tf
@@ -1,6 +1,6 @@
 # tfsec:ignore:aws-s3-enable-versioning tfsec:ignore:aws-s3-encryption-customer-key
 module "imagebuilder_log_bucket" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=479b926"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=9fc34b5c0035480b70dc133aead32af2e1462a33"
 
   providers = {
     aws.bucket-replication = aws.bucket-replication

--- a/terraform/environments/core-shared-services/bucket.tf
+++ b/terraform/environments/core-shared-services/bucket.tf
@@ -1,6 +1,6 @@
 # tfsec:ignore:aws-s3-enable-versioning tfsec:ignore:aws-s3-encryption-customer-key
 module "imagebuilder_log_bucket" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=9fc34b5c0035480b70dc133aead32af2e1462a33"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=479b92623954a75f96a6da8ebb4070a8581c227e"
 
   providers = {
     aws.bucket-replication = aws.bucket-replication

--- a/terraform/environments/core-shared-services/bucket.tf
+++ b/terraform/environments/core-shared-services/bucket.tf
@@ -1,12 +1,13 @@
 # tfsec:ignore:aws-s3-enable-versioning tfsec:ignore:aws-s3-encryption-customer-key
 module "imagebuilder_log_bucket" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=9facf9fc8f8b8e3f93ffbda822028534b9a75399" # v9.0.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=479b926"
 
   providers = {
     aws.bucket-replication = aws.bucket-replication
   }
 
   bucket_prefix       = "ec2-image-builder-logs-"
+  sse_algorithm       = "AES256"
   versioning_enabled  = false
   replication_enabled = false
 


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform-security/issues/102 - Updates the EC2 Image Builder logs S3 bucket to use the stricter encryption defaults [introduced](https://github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket/pull/881) in the `modernisation-platform-terraform-s3-bucket` module.

This bucket is being updated as part of validating the new module behaviour against existing production buckets before releasing v10 of the module.

Testing confirmed that EC2 Image Builder uploads currently rely on bucket default SSE-KMS encryption rather than explicitly sending SSE-KMS request headers.

We are updating our existing buckets first before making a release. Once we are satisfied the changes work correctly with our buckets, we will release v10 and update this bucket to use v10 as well.

---

## How does this PR fix the problem?

This PR upgrades the EC2 Image Builder logs bucket module reference to the latest unreleased commit containing the stricter encryption enforcement changes.

The bucket is explicitly configured to use:

```hcl
sse_algorithm = "AES256"
```

This bucket is treated as an AES256 compatibility case because current uploads do not explicitly provide SSE-KMS request headers.

CloudTrail validation confirmed that uploads currently rely on bucket default encryption behaviour:

- uploads do not send `x-amz-server-side-encryption`
- uploads do not send `x-amz-server-side-encryption-aws-kms-key-id`
- S3 applies encryption automatically using `Default_SSE_KMS`

Strict SSE-KMS enforcement would therefore deny current uploads from EC2 Image Builder and related SSM/SDK upload workflows.

Using `AES256` compatibility mode allows the bucket to safely adopt the updated module changes without interrupting existing uploads.

---

## How has this been tested?

Testing was carried out against the existing EC2 Image Builder logs bucket before applying the module changes.

CloudTrail `PutObject` events for Image Builder uploads were inspected to validate current encryption behaviour.

### Validation performed

- Verified uploads currently rely on bucket default SSE-KMS encryption
- Verified uploads do not explicitly send SSE-KMS request headers
- Verified S3 applies `Default_SSE_KMS`
- Verified uploaded objects are still stored using AWS KMS encryption
- Verified strict SSE-KMS enforcement would likely block existing uploads

CloudWatch Logs Insights queries were used to:

- summarise all `PutObject` encryption behaviour
- inspect request encryption headers
- inspect applied bucket encryption behaviour
- identify whether uploads explicitly use SSE-KMS request headers

Results confirmed that current EC2 Image Builder uploads are not compatible with strict SSE-KMS request-header enforcement.

---

## Deployment Plan / Instructions

### Will this deployment impact the platform and / or services on it?

No expected impact.

This change treats the EC2 Image Builder logs bucket as an AES256 compatibility case while still allowing S3 default SSE-KMS encryption to continue protecting uploaded objects.

---

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

---
