### PR TITLE
🪣 Give Data Platform Engineering access to Data Platform Governance state

### DIFF
--- a/terraform/modernisation-platform-account/s3.tf
+++ b/terraform/modernisation-platform-account/s3.tf
@@ -575,6 +575,10 @@ data "aws_iam_policy_document" "allow-state-access-from-root-account" {
         local.environment_management.account_ids["data-platform-preproduction"],
         local.environment_management.account_ids["data-platform-production"],
         local.environment_management.account_ids["data-platform-test"],
+        local.environment_management.account_ids["data-platform-governance-development"],
+        local.environment_management.account_ids["data-platform-governance-preproduction"],
+        local.environment_management.account_ids["data-platform-governance-production"],
+        local.environment_management.account_ids["data-platform-governance-test"],
       ]
     }
   }
@@ -607,6 +611,10 @@ data "aws_iam_policy_document" "allow-state-access-from-root-account" {
         local.environment_management.account_ids["data-platform-preproduction"],
         local.environment_management.account_ids["data-platform-production"],
         local.environment_management.account_ids["data-platform-test"],
+        local.environment_management.account_ids["data-platform-governance-development"],
+        local.environment_management.account_ids["data-platform-governance-preproduction"],
+        local.environment_management.account_ids["data-platform-governance-production"],
+        local.environment_management.account_ids["data-platform-governance-test"],
       ]
     }
   }


### PR DESCRIPTION
## A reference to the issue / Description of it

I cannot apply locally

```
│ Error: Failed to save state
│ 
│ Error saving state: failed to upload state: operation error S3: PutObject, https response error StatusCode: 403, RequestID: 95H88W1NS6NBR3GG, HostID: lZc/aorXNa2g9INNpVcbfQKw4bcQCChXaTsNf/lVqrO14AzWWHYD9bV5xaG2L4ug9KrL5/4+rz4=, api error AccessDenied: User:
│ arn:aws:sts::883644721336:assumed-role/AWSReservedSSO_platform-engineer-admin_257f8c4deb3e79ef/jacobwoffenden@digital.justice.gov.uk is not authorized to perform: s3:PutObject on resource:
│ "arn:aws:s3:::modernisation-platform-terraform-state/environments/members/data-platform-governance/lakeformation/data-platform-governance-development/terraform.tfstate" because no resource-based policy allows the s3:PutObject action
╵
╷
│ Error: Failed to persist state to backend
│ 
│ The error shown above has prevented Terraform from writing the updated state to the configured backend. To allow for recovery, the state has been written to the file "errored.tfstate" in the current working directory.
│ 
│ Running "terraform apply" again at this point will create a forked state, making it harder to recover.
│ 
│ To retry writing this state, use the following command:
│     terraform state push errored.tfstate
```

## How does this PR fix the problem?

Provides the same access we have for Data Platform

## How has this been tested?

It hasn't, but it's additive

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
