### PR TITLE
Add default tags to AWS provider configurations in `terraform/pagerduty`

### DIFF
--- a/terraform/pagerduty/locals.tf
+++ b/terraform/pagerduty/locals.tf
@@ -68,6 +68,7 @@ locals {
 
   tags = {
     business-unit = "Platforms"
+    service-area  = "Hosting"
     application   = "Modernisation Platform"
     is-production = true
     owner         = "Modernisation Platform: modernisation-platform@digital.justice.gov.uk"

--- a/terraform/pagerduty/providers.tf
+++ b/terraform/pagerduty/providers.tf
@@ -4,6 +4,7 @@ provider "pagerduty" {
 }
 provider "aws" {
   region = "eu-west-2"
+  default_tags { tags = local.tags }
 }
 
 
@@ -11,4 +12,5 @@ provider "aws" {
 provider "aws" {
   alias  = "modernisation-platform-eu-west-1"
   region = "eu-west-1"
+  default_tags { tags = local.tags }
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/12605

## How does this PR fix the problem?

Ensures tags are supplied to all eligible resources by default by adding to providers in `terraform/pagerduty`

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
