### PR TITLE
Module Update for modernisation-platform-laa-shared

### DIFF
--- a/terraform/environments/core-shared-services/s3-laa-shared.tf
+++ b/terraform/environments/core-shared-services/s3-laa-shared.tf
@@ -17,12 +17,13 @@ locals {
 
 
 module "laa-shared-bucket" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=9facf9fc8f8b8e3f93ffbda822028534b9a75399" # v9.0.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=479b92623954a75f96a6da8ebb4070a8581c227e"
 
   providers = {
     aws.bucket-replication = aws.bucket-replication
   }
   bucket_prefix       = "modernisation-platform-laa-shared"
+  sse_algorithm       = "AES256"
   bucket_policy       = [data.aws_iam_policy_document.laa_shared_bucket_policy.json]
   replication_enabled = false
   versioning_enabled  = true


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform-security/issues/102 - Updates the LAA shared S3 bucket to use the stricter encryption defaults [introduced](https://github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket/pull/881) in the `modernisation-platform-terraform-s3-bucket` module.

This bucket is being updated as part of validating the new module behaviour against existing production buckets before releasing v10 of the module.

Testing confirmed that uploads currently rely on bucket default SSE-KMS encryption rather than explicitly sending SSE-KMS request headers.

We are updating our existing buckets first before making a release. Once we are satisfied the changes work correctly with our buckets, we will release v10 and update this bucket to use v10 as well.

---

## How does this PR fix the problem?

This PR upgrades the LAA shared bucket module reference to the latest unreleased commit containing the stricter encryption enforcement changes.

The bucket is explicitly configured to use:

```hcl
sse_algorithm = "AES256"
```

This bucket is treated as an AES256 compatibility case because current uploads do not explicitly provide SSE-KMS request headers.

CloudTrail validation confirmed that uploads currently rely on bucket default encryption behaviour:

- uploads do not send `x-amz-server-side-encryption`
- uploads do not send `x-amz-server-side-encryption-aws-kms-key-id`
- S3 applies encryption automatically using `Default_SSE_KMS`

Strict SSE-KMS enforcement would therefore deny current uploads unless all upload clients are updated to send explicit SSE-KMS headers.

Using `AES256` compatibility mode allows the bucket to safely adopt the updated module changes without interrupting existing uploads.

---

## How has this been tested?

Testing was carried out against the existing LAA shared bucket before applying the module changes.

CloudTrail `PutObject` events were inspected to validate current upload encryption behaviour.

### Validation performed

- Verified existing objects are stored using SSE-KMS
- Verified the bucket default encryption is configured as SSE-KMS
- Verified successful uploads currently rely on `Default_SSE_KMS`
- Verified successful uploads do not explicitly send SSE-KMS request headers
- Verified strict SSE-KMS enforcement would likely block existing upload behaviour

CloudWatch Logs Insights queries were used to:

- inspect historical `PutObject` events
- confirm whether upload requests included SSE-KMS headers
- inspect applied bucket encryption behaviour
- identify failed KMS-related upload attempts

Results confirmed that current uploads are not compatible with strict SSE-KMS request-header enforcement.

---

## Deployment Plan / Instructions

### Will this deployment impact the platform and / or services on it?

No expected impact.

This change treats the LAA shared bucket as an AES256 compatibility case while preserving existing upload behaviour.

---

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

---
