### PR TITLE
Add default tags to AWS provider configurations in secure-baselines and single-sign-on

### DIFF
--- a/terraform/environments/bootstrap/secure-baselines/providers.tf
+++ b/terraform/environments/bootstrap/secure-baselines/providers.tf
@@ -1,6 +1,7 @@
 # AWS provider (default): the Modernisation Platform account, which this Terraform configuration should be called using.
 provider "aws" {
   region = "eu-west-2"
+  default_tags { tags = local.environments }
 }
 
 # AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
@@ -19,6 +20,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.environments }
 }
 
 # Region specific providers for the workspace. Required for bootstrapping resources in enabled regions.
@@ -30,6 +32,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.environments }
 }
 
 provider "aws" {
@@ -40,6 +43,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.environments }
 }
 
 provider "aws" {
@@ -50,6 +54,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.environments }
 }
 
 provider "aws" {
@@ -60,6 +65,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.environments }
 }
 
 provider "aws" {
@@ -70,6 +76,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.environments }
 }
 
 # AWS provider for core-logging
@@ -79,4 +86,5 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-logging-production"]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.environments }
 }

--- a/terraform/environments/bootstrap/single-sign-on/locals.tf
+++ b/terraform/environments/bootstrap/single-sign-on/locals.tf
@@ -19,4 +19,12 @@ locals {
 
     if(data.name == local.env_name)
   }
+
+  tags = {
+    business-unit = "Platforms"
+    service-area  = "Hosting"
+    application   = "Modernisation Platform"
+    is-production = true
+    owner         = "Modernisation Platform: modernisation-platform@digital.justice.gov.uk"
+  }
 }

--- a/terraform/environments/bootstrap/single-sign-on/providers.tf
+++ b/terraform/environments/bootstrap/single-sign-on/providers.tf
@@ -1,6 +1,7 @@
 # AWS provider (default)
 provider "aws" {
   region = "eu-west-2"
+  default_tags { tags = local.tags }
 }
 
 # AWS provider (AWS root account for AWS SSO management)
@@ -10,6 +11,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.aws_organizations_root_account_id}:role/ModernisationPlatformSSOAdministrator"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets
@@ -28,6 +30,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for the Modernisation Platform, to get things from there if required


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/12605

## How does this PR fix the problem?

Ensures tags are supplied to all eligible resources by default by adding to providers in `terraform/environments/bootstrap/single-sign-on` and `terraform/environments/bootstrap/secure-baselines`

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
