### PR TITLE
Module update for mod-platform-image-artefact-bucket

### DIFF
--- a/terraform/environments/core-shared-services/s3.tf
+++ b/terraform/environments/core-shared-services/s3.tf
@@ -1,10 +1,11 @@
 module "s3-bucket" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=9facf9fc8f8b8e3f93ffbda822028534b9a75399" # v9.0.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=479b92623954a75f96a6da8ebb4070a8581c227e"
 
   providers = {
     aws.bucket-replication = aws.bucket-replication
   }
   bucket_prefix       = "mod-platform-image-artefact-bucket"
+  sse_algorithm       = "AES256"
   bucket_policy       = [data.aws_iam_policy_document.bucket_policy.json]
   replication_enabled = false
   versioning_enabled  = true


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform-security/issues/102 - Updates the image artefact bucket to use the stricter encryption defaults [introduced](https://github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket/pull/881) in the `modernisation-platform-terraform-s3-bucket` module.

This bucket is being updated as part of validating the new module behaviour against existing production buckets before releasing v10 of the module.

Testing confirmed that the bucket currently receives a mixture of uploads:
- some uploads explicitly send SSE-KMS headers
- some uploads rely on bucket default SSE-KMS encryption

We are updating our existing buckets first before making a release. Once we are satisfied the changes work correctly with our buckets, we will release v10 and update this bucket to use v10 as well.

---

## How does this PR fix the problem?

This PR upgrades the image artefact bucket module reference to the latest unreleased commit containing the stricter encryption enforcement changes.

The bucket is explicitly configured to use:

```hcl
sse_algorithm = "AES256"
```

This bucket is treated as an AES256 compatibility case because current upload behaviour is mixed.

CloudTrail validation confirmed:
- some uploads explicitly send SSE-KMS request headers
- some uploads do not send SSE-KMS request headers
- some uploads rely on `Default_SSE_KMS`

Strict SSE-KMS enforcement would therefore likely break existing upload workflows that currently rely on bucket default encryption behaviour.

Using `AES256` compatibility mode allows the bucket to safely adopt the updated module changes without interrupting existing uploads.

---

## How has this been tested?

Testing was carried out against the existing image artefact bucket before applying the module changes.

CloudTrail `PutObject` events were inspected to validate current upload encryption behaviour.

### Validation performed

- Verified active `PutObject` traffic against the bucket
- Verified uploads are currently encrypted using SSE-KMS
- Verified some upload clients explicitly send SSE-KMS headers
- Verified some upload clients rely on `Default_SSE_KMS`
- Verified the bucket currently has mixed client encryption behaviour
- Verified strict SSE-KMS enforcement would likely break some existing uploads

CloudWatch Logs Insights queries were used to:
- inspect historical `PutObject` events
- inspect upload request encryption headers
- inspect applied bucket encryption behaviour
- identify compatibility risks with strict SSE-KMS enforcement

Results confirmed that the bucket is not yet fully compatible with strict SSE-KMS request-header enforcement.

---

## Deployment Plan / Instructions

### Will this deployment impact the platform and / or services on it?

No expected impact.

This change treats the image artefact bucket as an AES256 compatibility case while preserving existing upload behaviour.

---

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

---
