### PR TITLE
adding batch to data engineer role

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -421,6 +421,7 @@ data "aws_iam_policy_document" "data_engineering_additional" {
       "athena:StartQueryExecution",
       "athena:StopQueryExecution",
       "apigateway:POST",
+      "batch:*",
       "bedrock:PutUseCaseForModelAccess",
       "ce:CreateReport",
       "dms:StartReplicationTask",


### PR DESCRIPTION
## A reference to the issue / Description of it

as part of user request

Luke Williams  [11:26 AM]
Morning Mod Plat!
Following on from my previous request: https://mojdt.slack.com/archives/C01A7QK5VM1/p1775559986377039
We need the permissions for Batch in our preproduction / production environments which is seperate from the development sandbox permissions where they currently exist. Can we have the permissions replicated there?
See thread for example error I'm getting :thread:

## How does this PR fix the problem?

added Batch * to data engineer role

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
