### PR TITLE
Add default tags to AWS providers across multiple environments

### DIFF
--- a/terraform/environments/analytical-platform-common/providers.tf
+++ b/terraform/environments/analytical-platform-common/providers.tf
@@ -4,12 +4,14 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
   alias  = "modernisation-platform"
   region = "eu-west-2"
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
@@ -20,6 +22,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-network-services-production, to share VPCs into this account
@@ -30,6 +33,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets

--- a/terraform/environments/analytical-platform-compute/providers.tf
+++ b/terraform/environments/analytical-platform-compute/providers.tf
@@ -4,12 +4,14 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
   alias  = "modernisation-platform"
   region = "eu-west-2"
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
@@ -20,6 +22,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-network-services-production, to share VPCs into this account
@@ -30,6 +33,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets

--- a/terraform/environments/analytical-platform-data-engineering/providers.tf
+++ b/terraform/environments/analytical-platform-data-engineering/providers.tf
@@ -4,12 +4,14 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
   alias  = "modernisation-platform"
   region = "eu-west-2"
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
@@ -20,6 +22,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-network-services-production, to share VPCs into this account
@@ -30,6 +33,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets

--- a/terraform/environments/analytical-platform-ingestion/providers.tf
+++ b/terraform/environments/analytical-platform-ingestion/providers.tf
@@ -4,12 +4,14 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
   alias  = "modernisation-platform"
   region = "eu-west-2"
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
@@ -20,6 +22,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-network-services-production, to share VPCs into this account
@@ -30,6 +33,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets

--- a/terraform/environments/analytical-platform-landing/providers.tf
+++ b/terraform/environments/analytical-platform-landing/providers.tf
@@ -4,12 +4,14 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
   alias  = "modernisation-platform"
   region = "eu-west-2"
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
@@ -20,6 +22,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-network-services-production, to share VPCs into this account
@@ -30,6 +33,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets

--- a/terraform/environments/analytical-platform-management/providers.tf
+++ b/terraform/environments/analytical-platform-management/providers.tf
@@ -4,12 +4,14 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
   alias  = "modernisation-platform"
   region = "eu-west-2"
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
@@ -20,6 +22,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-network-services-production, to share VPCs into this account
@@ -30,6 +33,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets

--- a/terraform/environments/analytical-platform-next-poc-hub/providers.tf
+++ b/terraform/environments/analytical-platform-next-poc-hub/providers.tf
@@ -4,12 +4,14 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
   alias  = "modernisation-platform"
   region = "eu-west-2"
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
@@ -20,6 +22,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-network-services-production, to share VPCs into this account
@@ -30,6 +33,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets

--- a/terraform/environments/analytical-platform-next-poc-producer/providers.tf
+++ b/terraform/environments/analytical-platform-next-poc-producer/providers.tf
@@ -4,12 +4,14 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
   alias  = "modernisation-platform"
   region = "eu-west-2"
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
@@ -20,6 +22,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-network-services-production, to share VPCs into this account
@@ -30,6 +33,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets

--- a/terraform/environments/apex/providers.tf
+++ b/terraform/environments/apex/providers.tf
@@ -4,12 +4,14 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
   alias  = "modernisation-platform"
   region = "eu-west-2"
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
@@ -20,6 +22,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-network-services-production, to share VPCs into this account
@@ -30,6 +33,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets

--- a/terraform/environments/bichard7/providers.tf
+++ b/terraform/environments/bichard7/providers.tf
@@ -4,12 +4,14 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
   alias  = "modernisation-platform"
   region = "eu-west-2"
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
@@ -20,6 +22,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-network-services-production, to share VPCs into this account
@@ -30,6 +33,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets

--- a/terraform/environments/ccms-edrms/providers.tf
+++ b/terraform/environments/ccms-edrms/providers.tf
@@ -4,12 +4,14 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
   alias  = "modernisation-platform"
   region = "eu-west-2"
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
@@ -20,6 +22,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-network-services-production, to share VPCs into this account
@@ -30,6 +33,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets

--- a/terraform/environments/ccms-oia/providers.tf
+++ b/terraform/environments/ccms-oia/providers.tf
@@ -4,12 +4,14 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
   alias  = "modernisation-platform"
   region = "eu-west-2"
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
@@ -20,6 +22,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-network-services-production, to share VPCs into this account
@@ -30,6 +33,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets

--- a/terraform/environments/ccms-pui-internal/providers.tf
+++ b/terraform/environments/ccms-pui-internal/providers.tf
@@ -4,12 +4,14 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
   alias  = "modernisation-platform"
   region = "eu-west-2"
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
@@ -20,6 +22,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-network-services-production, to share VPCs into this account
@@ -30,6 +33,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets

--- a/terraform/environments/ccms-pui/providers.tf
+++ b/terraform/environments/ccms-pui/providers.tf
@@ -4,12 +4,14 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
   alias  = "modernisation-platform"
   region = "eu-west-2"
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
@@ -20,6 +22,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-network-services-production, to share VPCs into this account
@@ -30,6 +33,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets

--- a/terraform/environments/cica-sandbox/providers.tf
+++ b/terraform/environments/cica-sandbox/providers.tf
@@ -4,12 +4,14 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
   alias  = "modernisation-platform"
   region = "eu-west-2"
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
@@ -20,6 +22,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-network-services-production, to share VPCs into this account
@@ -30,6 +33,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets

--- a/terraform/environments/coat/providers.tf
+++ b/terraform/environments/coat/providers.tf
@@ -4,12 +4,14 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
   alias  = "modernisation-platform"
   region = "eu-west-2"
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
@@ -20,6 +22,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-network-services-production, to share VPCs into this account
@@ -30,6 +33,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets

--- a/terraform/environments/corporate-staff-rostering/providers.tf
+++ b/terraform/environments/corporate-staff-rostering/providers.tf
@@ -4,12 +4,14 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
   alias  = "modernisation-platform"
   region = "eu-west-2"
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
@@ -20,6 +22,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-network-services-production, to share VPCs into this account
@@ -30,6 +33,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets

--- a/terraform/environments/delete-account/providers.tf
+++ b/terraform/environments/delete-account/providers.tf
@@ -4,12 +4,14 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
   alias  = "modernisation-platform"
   region = "eu-west-2"
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
@@ -20,6 +22,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-network-services-production, to share VPCs into this account
@@ -30,6 +33,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets

--- a/terraform/environments/delius-core-training/providers.tf
+++ b/terraform/environments/delius-core-training/providers.tf
@@ -4,12 +4,14 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
   alias  = "modernisation-platform"
   region = "eu-west-2"
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
@@ -20,6 +22,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-network-services-production, to share VPCs into this account
@@ -30,6 +33,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets

--- a/terraform/environments/hmpps-esupervision/providers.tf
+++ b/terraform/environments/hmpps-esupervision/providers.tf
@@ -4,12 +4,14 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
   alias  = "modernisation-platform"
   region = "eu-west-2"
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
@@ -20,6 +22,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-network-services-production, to share VPCs into this account
@@ -30,6 +33,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets

--- a/terraform/environments/laa-ccms-soa/providers.tf
+++ b/terraform/environments/laa-ccms-soa/providers.tf
@@ -4,12 +4,14 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
   alias  = "modernisation-platform"
   region = "eu-west-2"
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
@@ -20,6 +22,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-network-services-production, to share VPCs into this account
@@ -30,6 +33,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets

--- a/terraform/environments/laa-enterprise-service-bus/providers.tf
+++ b/terraform/environments/laa-enterprise-service-bus/providers.tf
@@ -4,12 +4,14 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
   alias  = "modernisation-platform"
   region = "eu-west-2"
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
@@ -20,6 +22,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-network-services-production, to share VPCs into this account
@@ -30,6 +33,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets

--- a/terraform/environments/property-cafm-data-migration/providers.tf
+++ b/terraform/environments/property-cafm-data-migration/providers.tf
@@ -4,12 +4,14 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
   alias  = "modernisation-platform"
   region = "eu-west-2"
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
@@ -20,6 +22,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-network-services-production, to share VPCs into this account
@@ -30,6 +33,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets

--- a/terraform/environments/vcms/providers.tf
+++ b/terraform/environments/vcms/providers.tf
@@ -4,12 +4,14 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
   alias  = "modernisation-platform"
   region = "eu-west-2"
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
@@ -20,6 +22,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-network-services-production, to share VPCs into this account
@@ -30,6 +33,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets

--- a/terraform/environments/youth-justice-networking/providers.tf
+++ b/terraform/environments/youth-justice-networking/providers.tf
@@ -4,12 +4,14 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
   alias  = "modernisation-platform"
   region = "eu-west-2"
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
@@ -20,6 +22,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-network-services-production, to share VPCs into this account
@@ -30,6 +33,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider (modernisation-secrets-read): Required for assuming a role into modernisation platform account to read secrets


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/12605

## How does this PR fix the problem?

Ensures default tags block is supplied to provider block for apps in `terraform/environments/app/*`

The [file templates](https://github.com/ministryofjustice/modernisation-platform/blob/main/terraform/templates/modernisation-platform/providers.tf) now include the default tag blocks but it is still missing from some apps/directories.

Though these dirs don't tend to contain any taggble infra, in the main, it's worth having for consistency. 

This doesn't affect any tagging of infra in the apps associated `terraform-platform-environments` infrastructure.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
