### PR TITLE
Bump baselines module to v10.0.0 (Phase 2 config bucket cleanup)

### DIFF
--- a/terraform/environments/bootstrap/secure-baselines/main.tf
+++ b/terraform/environments/bootstrap/secure-baselines/main.tf
@@ -6,7 +6,7 @@ data "aws_kms_key" "cloudtrail_key" {
 
 #trivy:ignore:AVD-AWS-0136
 module "baselines" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=0bae32b8835fc5ee327e841e83eac71ebd781f0e" # force-destroy flag
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=385fb13929980e1c283d48713fd37b2829a4a06c" # v10.0.0
   providers = {
     # Default and replication regions
     aws                    = aws.workspace-eu-west-2

--- a/terraform/modernisation-platform-account/baselines.tf
+++ b/terraform/modernisation-platform-account/baselines.tf
@@ -18,7 +18,7 @@ locals {
 # Secure baselines (GuardDuty, Config, SecurityHub, etc)
 #trivy:ignore:AVD-AWS-0136 trivy:ignore:AVD-AWS-0132
 module "baselines-modernisation-platform" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=5c42292e150c9609da5a6e24eb8dc6648ec5f3b7" # v9.5.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=385fb13929980e1c283d48713fd37b2829a4a06c" # v10.0.0
   providers = {
     # Default and replication regions
     aws                    = aws.modernisation-platform-eu-west-2


### PR DESCRIPTION
**What**
This PR updates the baselines module reference to consume Phase 2 from modernisation-platform-terraform-baselines (v10.0.0), pinned by commit SHA.

**Updated in:**
- `main.tf:9`
- `baselines.tf:21`

**Why**
Phase 2 removes legacy AWS Config bucket provisioning from baselines.
Phase 1 has already been applied successfully, so this PR moves us onto the Phase 2 release safely.

**Impact**
Expected infrastructure behavior change from the baselines upgrade (legacy config bucket removal path).
No local module logic changes in this repository beyond updating the module ref.

**Validation**
Terraform plan reviewed for expected Phase 2 behavior.
No unexpected replacements outside the config-bucket decommissioning scope.