### PR TITLE
Added Macie2 Permissions to Sandbox Role

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -931,6 +931,7 @@ data "aws_iam_policy_document" "sandbox_additional" {
       "lakeformation:*",
       "lambda:*",
       "logs:*",
+      "macie2:*",
       "mgh:*",
       "mgn:*",
       "organizations:Describe*",


### PR DESCRIPTION
## A reference to the issue / Description of it

Need to create Macie Jobs in electronic-monitoring-data-development but currently blocked on being able to do that due to permissions.

## How does this PR fix the problem?

Allows the sandbox role to have the macie2 perms

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
