### PR TITLE
Add service-area tag with value 'Hosting' to multiple MP-owned json configurations

### DIFF
--- a/environments/cooker.json
+++ b/environments/cooker.json
@@ -37,6 +37,7 @@
   "tags": {
     "application": "modernisation-platform",
     "business-unit": "Platforms",
+    "service-area": "Hosting",
     "infrastructure-support": "modernisation-platform@digital.justice.gov.uk",
     "owner": "Modernisation Platform: modernisation-platform@digital.justice.gov.uk",
     "slack-channel": "modernisation-platform",

--- a/environments/core-logging.json
+++ b/environments/core-logging.json
@@ -18,6 +18,7 @@
   "tags": {
     "application": "modernisation-platform",
     "business-unit": "Platforms",
+    "service-area": "Hosting",
     "infrastructure-support": "modernisation-platform@digital.justice.gov.uk",
     "securityhub-slack-channel": "modernisation-platform",
     "owner": "Modernisation Platform: modernisation-platform@digital.justice.gov.uk",

--- a/environments/core-network-services.json
+++ b/environments/core-network-services.json
@@ -18,6 +18,7 @@
   "tags": {
     "application": "modernisation-platform",
     "business-unit": "Platforms",
+    "service-area": "Hosting",
     "infrastructure-support": "modernisation-platform@digital.justice.gov.uk",
     "securityhub-slack-channel": "modernisation-platform",
     "owner": "Modernisation Platform: modernisation-platform@digital.justice.gov.uk",

--- a/environments/core-sandbox.json
+++ b/environments/core-sandbox.json
@@ -9,6 +9,7 @@
   "tags": {
     "application": "core-sandbox",
     "business-unit": "Platforms",
+    "service-area": "Hosting",
     "infrastructure-support": "modernisation-platform@digital.justice.gov.uk",
     "securityhub-slack-channel": "modernisation-platform",
     "owner": "Modernisation Platform: modernisation-platform@digital.justice.gov.uk",

--- a/environments/core-security.json
+++ b/environments/core-security.json
@@ -22,6 +22,7 @@
   "tags": {
     "application": "modernisation-platform",
     "business-unit": "Platforms",
+    "service-area": "Hosting",
     "infrastructure-support": "modernisation-platform@digital.justice.gov.uk",
     "securityhub-slack-channel": "modernisation-platform",
     "owner": "Modernisation Platform: modernisation-platform@digital.justice.gov.uk",

--- a/environments/core-shared-services.json
+++ b/environments/core-shared-services.json
@@ -35,6 +35,7 @@
   "tags": {
     "application": "modernisation-platform",
     "business-unit": "Platforms",
+    "service-area": "Hosting",
     "infrastructure-support": "modernisation-platform@digital.justice.gov.uk",
     "securityhub-slack-channel": "modernisation-platform",
     "owner": "Modernisation Platform: modernisation-platform@digital.justice.gov.uk",

--- a/environments/core-vpc.json
+++ b/environments/core-vpc.json
@@ -70,6 +70,7 @@
   "tags": {
     "application": "modernisation-platform",
     "business-unit": "Platforms",
+    "service-area": "Hosting",
     "infrastructure-support": "modernisation-platform@digital.justice.gov.uk",
     "securityhub-slack-channel": "modernisation-platform",
     "owner": "Modernisation Platform: modernisation-platform@digital.justice.gov.uk",

--- a/environments/example.json
+++ b/environments/example.json
@@ -26,6 +26,7 @@
   "tags": {
     "application": "example",
     "business-unit": "Platforms",
+    "service-area": "Hosting",
     "infrastructure-support": "modernisation-platform@digital.justice.gov.uk",
     "owner": "Modernisation Platform: modernisation-platform@digital.justice.gov.uk",
     "slack-channel": "modernisation-platform",

--- a/environments/long-term-storage.json
+++ b/environments/long-term-storage.json
@@ -34,6 +34,7 @@
   "tags": {
     "application": "long-term-storage",
     "business-unit": "Platforms",
+    "service-area": "Hosting",
     "infrastructure-support": "modernisation-platform@digital.justice.gov.uk",
     "owner": "hosting-leads@digital.justice.gov.uk",
     "critical-national-infrastructure": false

--- a/environments/sprinkler.json
+++ b/environments/sprinkler.json
@@ -59,6 +59,7 @@
   "tags": {
     "application": "modernisation-platform",
     "business-unit": "Platforms",
+    "service-area": "Hosting",
     "infrastructure-support": "modernisation-platform@digital.justice.gov.uk",
     "owner": "Modernisation Platform : modernisation-platform@digital.justice.gov.uk",
     "slack-channel": "modernisation-platform",

--- a/environments/testing.json
+++ b/environments/testing.json
@@ -22,6 +22,7 @@
   "tags": {
     "application": "testing",
     "business-unit": "Platforms",
+    "service-area": "Hosting",
     "infrastructure-support": "modernisation-platform@digital.justice.gov.uk",
     "owner": "Modernisation Platform: modernisation-platform@digital.justice.gov.uk",
     "critical-national-infrastructure": false


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/12605

## How does this PR fix the problem?

Adds `"service-area": "Hosting"` tag to all MP-owned environment json files.

Most these accounts have already had their various TF local files updated with the tag already e.g. [core-logging](https://github.com/ministryofjustice/modernisation-platform/blob/main/terraform/environments/core-logging/locals.tf#L20), however, adding it to the environment json files makes it easier to identify that our workloads are being tagged with all the mandatory tags at a glance.

I've deliberately avoided any member-owned json files for now as adding that would require some prior warning.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
