### PR TITLE
Add laa-sre-admins sandbox access with github_action_reviewer to maat environments

### DIFF
--- a/environments/maat.json
+++ b/environments/maat.json
@@ -41,7 +41,7 @@
         },
         {
           "sso_group_name": "laa-sre-admins",
-          "level": "sandbox",
+          "level": "developer",
           "github_action_reviewer": "true"
         },
         {

--- a/environments/maat.json
+++ b/environments/maat.json
@@ -65,7 +65,7 @@
         },
         {
           "sso_group_name": "laa-sre-admins",
-          "level": "sandbox",
+          "level": "developer",
           "github_action_reviewer": "true"
         },
         {
@@ -89,7 +89,7 @@
         },
         {
           "sso_group_name": "laa-sre-admins",
-          "level": "sandbox",
+          "level": "developer",
           "github_action_reviewer": "true"
         },
         {

--- a/environments/maat.json
+++ b/environments/maat.json
@@ -15,12 +15,13 @@
           "github_action_reviewer": "true"
         },
         {
-          "sso_group_name": "laa-crime-apps-team",
-          "level": "instance-management"
+          "sso_group_name": "laa-sre-admins",
+          "level": "sandbox",
+          "github_action_reviewer": "true"
         },
         {
-          "sso_group_name": "laa-sre-admins",
-          "level": "sandbox"
+          "sso_group_name": "laa-crime-apps-team",
+          "level": "instance-management"
         }
       ],
       "nuke": "exclude"
@@ -39,12 +40,13 @@
           "github_action_reviewer": "true"
         },
         {
-          "sso_group_name": "laa-crime-apps-team",
-          "level": "instance-management"
+          "sso_group_name": "laa-sre-admins",
+          "level": "sandbox",
+          "github_action_reviewer": "true"
         },
         {
-          "sso_group_name": "laa-sre-admins",
-          "level": "developer"
+          "sso_group_name": "laa-crime-apps-team",
+          "level": "instance-management"
         }
       ]
     },
@@ -62,12 +64,13 @@
           "github_action_reviewer": "true"
         },
         {
-          "sso_group_name": "laa-crime-apps-team",
-          "level": "instance-management"
+          "sso_group_name": "laa-sre-admins",
+          "level": "sandbox",
+          "github_action_reviewer": "true"
         },
         {
-          "sso_group_name": "laa-sre-admins",
-          "level": "developer"
+          "sso_group_name": "laa-crime-apps-team",
+          "level": "instance-management"
         }
       ]
     },
@@ -85,12 +88,13 @@
           "github_action_reviewer": "true"
         },
         {
-          "sso_group_name": "laa-crime-apps-team",
-          "level": "instance-management"
+          "sso_group_name": "laa-sre-admins",
+          "level": "sandbox",
+          "github_action_reviewer": "true"
         },
         {
-          "sso_group_name": "laa-sre-admins",
-          "level": "developer"
+          "sso_group_name": "laa-crime-apps-team",
+          "level": "instance-management"
         },
         {
           "sso_group_name": "octo-cyber-team",

--- a/environments/maat.json
+++ b/environments/maat.json
@@ -45,6 +45,10 @@
           "github_action_reviewer": "true"
         },
         {
+          "sso_group_name": "laa-sre-admins",
+          "level": "instance-management"
+        },
+        {
           "sso_group_name": "laa-crime-apps-team",
           "level": "instance-management"
         }
@@ -69,6 +73,10 @@
           "github_action_reviewer": "true"
         },
         {
+          "sso_group_name": "laa-sre-admins",
+          "level": "instance-management"
+        },
+        {
           "sso_group_name": "laa-crime-apps-team",
           "level": "instance-management"
         }
@@ -91,6 +99,10 @@
           "sso_group_name": "laa-sre-admins",
           "level": "developer",
           "github_action_reviewer": "true"
+        },
+        {
+          "sso_group_name": "laa-sre-admins",
+          "level": "instance-management"
         },
         {
           "sso_group_name": "laa-crime-apps-team",

--- a/environments/maatdb.json
+++ b/environments/maatdb.json
@@ -4,6 +4,7 @@
     "laa-aws-infrastructure",
     "laa-crime-apps-team",
     "laa-maat-migrations",
+    "laa-sre-admins",
     "laa-dba"
   ],
   "environments": [


### PR DESCRIPTION
## Summary

- Added `laa-sre-admins` to `github_teams` in `maatdb.json`
- Updated `laa-sre-admins` permission level to `sandbox` with `github_action_reviewer: true` across all `maat.json` environments (development, test, preproduction, production)
- `laa-crime-apps-team` retains `instance-management` level throughout

## Test plan

- [ ] Verify `laa-sre-admins` has `sandbox` access in all 4 environments
- [ ] Verify `github_action_reviewer: true` is set for `laa-sre-admins` in all environments
- [ ] Verify `laa-crime-apps-team` still has `instance-management` level
- [ ] Confirm JSON is valid in both `maat.json` and `maatdb.json`