### PR TITLE
Add service-area tag to all environment locals for consistency

### DIFF
--- a/terraform/environments/analytical-platform-common/locals.tf
+++ b/terraform/environments/analytical-platform-common/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/analytical-platform-compute/locals.tf
+++ b/terraform/environments/analytical-platform-compute/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/analytical-platform-data-engineering/locals.tf
+++ b/terraform/environments/analytical-platform-data-engineering/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/analytical-platform-data/locals.tf
+++ b/terraform/environments/analytical-platform-data/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/analytical-platform-ingestion/locals.tf
+++ b/terraform/environments/analytical-platform-ingestion/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/analytical-platform-landing/locals.tf
+++ b/terraform/environments/analytical-platform-landing/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/analytical-platform-management/locals.tf
+++ b/terraform/environments/analytical-platform-management/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/analytical-platform-next-poc-hub/locals.tf
+++ b/terraform/environments/analytical-platform-next-poc-hub/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/analytical-platform-next-poc-producer/locals.tf
+++ b/terraform/environments/analytical-platform-next-poc-producer/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/analytical-platform/locals.tf
+++ b/terraform/environments/analytical-platform/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/apex/locals.tf
+++ b/terraform/environments/apex/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/bichard7/locals.tf
+++ b/terraform/environments/bichard7/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/ccms-ebs-upgrade/locals.tf
+++ b/terraform/environments/ccms-ebs-upgrade/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/ccms-ebs/locals.tf
+++ b/terraform/environments/ccms-ebs/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/ccms-edrms/locals.tf
+++ b/terraform/environments/ccms-edrms/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/ccms-oia/locals.tf
+++ b/terraform/environments/ccms-oia/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/ccms-pui-internal/locals.tf
+++ b/terraform/environments/ccms-pui-internal/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/ccms-pui/locals.tf
+++ b/terraform/environments/ccms-pui/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/cdpt-chaps/locals.tf
+++ b/terraform/environments/cdpt-chaps/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/cdpt-ifs/locals.tf
+++ b/terraform/environments/cdpt-ifs/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/cica-copilot/locals.tf
+++ b/terraform/environments/cica-copilot/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/cica-data-extraction/locals.tf
+++ b/terraform/environments/cica-data-extraction/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/cica-sandbox/locals.tf
+++ b/terraform/environments/cica-sandbox/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/cica-tariff/locals.tf
+++ b/terraform/environments/cica-tariff/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/cloud-platform-live/locals.tf
+++ b/terraform/environments/cloud-platform-live/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/cloud-platform-non-live/locals.tf
+++ b/terraform/environments/cloud-platform-non-live/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/cloud-platform/locals.tf
+++ b/terraform/environments/cloud-platform/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/coat/locals.tf
+++ b/terraform/environments/coat/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/contract-work-administration/locals.tf
+++ b/terraform/environments/contract-work-administration/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/cooker/locals.tf
+++ b/terraform/environments/cooker/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/corporate-staff-rostering/locals.tf
+++ b/terraform/environments/corporate-staff-rostering/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/dacp/locals.tf
+++ b/terraform/environments/dacp/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/data-factory-corporate/locals.tf
+++ b/terraform/environments/data-factory-corporate/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/data-factory-laa/locals.tf
+++ b/terraform/environments/data-factory-laa/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/data-factory-moj/locals.tf
+++ b/terraform/environments/data-factory-moj/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/data-platform-governance/locals.tf
+++ b/terraform/environments/data-platform-governance/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/data-platform/locals.tf
+++ b/terraform/environments/data-platform/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/delete-account/locals.tf
+++ b/terraform/environments/delete-account/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/delius-alfresco/locals.tf
+++ b/terraform/environments/delius-alfresco/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/delius-core-training/locals.tf
+++ b/terraform/environments/delius-core-training/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/delius-core/locals.tf
+++ b/terraform/environments/delius-core/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/delius-iaps/locals.tf
+++ b/terraform/environments/delius-iaps/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/delius-jitbit/locals.tf
+++ b/terraform/environments/delius-jitbit/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/delius-mis/locals.tf
+++ b/terraform/environments/delius-mis/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/digital-prison-reporting/locals.tf
+++ b/terraform/environments/digital-prison-reporting/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/edw-19c/locals.tf
+++ b/terraform/environments/edw-19c/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/electronic-monitoring-data/locals.tf
+++ b/terraform/environments/electronic-monitoring-data/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/equip/locals.tf
+++ b/terraform/environments/equip/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/eucs-appstream/locals.tf
+++ b/terraform/environments/eucs-appstream/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/example/locals.tf
+++ b/terraform/environments/example/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/genesys-call-centre-data/locals.tf
+++ b/terraform/environments/genesys-call-centre-data/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/hmcts-claude-provider/locals.tf
+++ b/terraform/environments/hmcts-claude-provider/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/hmpps-court-data-ingestion-api/locals.tf
+++ b/terraform/environments/hmpps-court-data-ingestion-api/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/hmpps-domain-services/locals.tf
+++ b/terraform/environments/hmpps-domain-services/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/hmpps-esupervision/locals.tf
+++ b/terraform/environments/hmpps-esupervision/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/hmpps-oem/locals.tf
+++ b/terraform/environments/hmpps-oem/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/integration-hub/locals.tf
+++ b/terraform/environments/integration-hub/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/laa-ccms-soa/locals.tf
+++ b/terraform/environments/laa-ccms-soa/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/laa-cis/locals.tf
+++ b/terraform/environments/laa-cis/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/laa-cst-security-dashboard/locals.tf
+++ b/terraform/environments/laa-cst-security-dashboard/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/laa-enterprise-service-bus/locals.tf
+++ b/terraform/environments/laa-enterprise-service-bus/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/laa-mail-relay/locals.tf
+++ b/terraform/environments/laa-mail-relay/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/laa-oem/locals.tf
+++ b/terraform/environments/laa-oem/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/laa-pui-secure-browser/locals.tf
+++ b/terraform/environments/laa-pui-secure-browser/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/laa-stabilisation-cdc-poc/locals.tf
+++ b/terraform/environments/laa-stabilisation-cdc-poc/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/laa-workspaces/locals.tf
+++ b/terraform/environments/laa-workspaces/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/long-term-storage/locals.tf
+++ b/terraform/environments/long-term-storage/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/maat/locals.tf
+++ b/terraform/environments/maat/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/maatdb/locals.tf
+++ b/terraform/environments/maatdb/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/mlra/locals.tf
+++ b/terraform/environments/mlra/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/moj-network-operations-centre/locals.tf
+++ b/terraform/environments/moj-network-operations-centre/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/mojfin/locals.tf
+++ b/terraform/environments/mojfin/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/ncas/locals.tf
+++ b/terraform/environments/ncas/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/nomis-combined-reporting/locals.tf
+++ b/terraform/environments/nomis-combined-reporting/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/nomis-data-hub/locals.tf
+++ b/terraform/environments/nomis-data-hub/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/nomis/locals.tf
+++ b/terraform/environments/nomis/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/oas/locals.tf
+++ b/terraform/environments/oas/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/oasys-national-reporting/locals.tf
+++ b/terraform/environments/oasys-national-reporting/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/oasys/locals.tf
+++ b/terraform/environments/oasys/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/observability-platform/locals.tf
+++ b/terraform/environments/observability-platform/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/octo/locals.tf
+++ b/terraform/environments/octo/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/opg-lpa-data-store/locals.tf
+++ b/terraform/environments/opg-lpa-data-store/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/panda-cyber-appsec-lab/locals.tf
+++ b/terraform/environments/panda-cyber-appsec-lab/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/performance-hub/locals.tf
+++ b/terraform/environments/performance-hub/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/planetfm/locals.tf
+++ b/terraform/environments/planetfm/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/portal/locals.tf
+++ b/terraform/environments/portal/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/ppud/locals.tf
+++ b/terraform/environments/ppud/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/pra-register/locals.tf
+++ b/terraform/environments/pra-register/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/prison-retail/locals.tf
+++ b/terraform/environments/prison-retail/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/property-cafm-data-migration/locals.tf
+++ b/terraform/environments/property-cafm-data-migration/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/refer-monitor/locals.tf
+++ b/terraform/environments/refer-monitor/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/sprinkler/locals.tf
+++ b/terraform/environments/sprinkler/locals.tf
@@ -23,6 +23,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
 
   )

--- a/terraform/environments/testing/locals.tf
+++ b/terraform/environments/testing/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/tipstaff/locals.tf
+++ b/terraform/environments/tipstaff/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/tribunals/locals.tf
+++ b/terraform/environments/tribunals/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/vcms/locals.tf
+++ b/terraform/environments/vcms/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/wardship/locals.tf
+++ b/terraform/environments/wardship/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/xhibit-portal/locals.tf
+++ b/terraform/environments/xhibit-portal/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/youth-justice-app-framework/locals.tf
+++ b/terraform/environments/youth-justice-app-framework/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 

--- a/terraform/environments/youth-justice-networking/locals.tf
+++ b/terraform/environments/youth-justice-networking/locals.tf
@@ -16,6 +16,7 @@ locals {
     jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
+    { "service-area" = "Hosting" },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
   )
 


### PR DESCRIPTION
## A reference to the issue / Description of it
https://github.com/ministryofjustice/modernisation-platform/issues/12605

## How does this PR fix the problem?
This PR adds a new local variable "service-area" with the value "Hosting" to the locals.tf files across multiple environments.

This ensures that all infra built by the Mod Platform team in accounts is compliant with the mandatory tagging strategy.

In future, members can add their own `service-area` tag to their relevent `environments/*.json` files which will apply only to the infra they build into their accounts and will not conflict with our definition in these local files.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
