### PR TITLE
[CC-4517] Fix maatdb github-oidc-team-repositories empty string entry

### DIFF
--- a/environments/maatdb.json
+++ b/environments/maatdb.json
@@ -176,5 +176,5 @@
     "owner": "LAACrimeApps-Core@justice.gov.uk",
     "critical-national-infrastructure": true
   },
-  "github-oidc-team-repositories": [""]
+  "github-oidc-team-repositories": []
 }


### PR DESCRIPTION
## Summary
- Fixes `maatdb.json` `github-oidc-team-repositories` value from `[""]` (empty string in array) to `[]` (empty array)
- This was causing Terraform plan evaluation to detect unexpected changes requiring approval from @ministryofjustice/modernisation-platform

## Test plan
- [ ] Verify Terraform plan for maatdb no longer triggers the protected resource approval check