### PR TITLE
Update  of core bucketsto latest version on main

### DIFF
--- a/terraform/environments/core-logging/logs_cloudtrail_s3.tf
+++ b/terraform/environments/core-logging/logs_cloudtrail_s3.tf
@@ -1,5 +1,5 @@
 module "s3-bucket-cloudtrail" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=479b92623954a75f96a6da8ebb4070a8581c227e"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=c67758cd6d263bec9c225b99b6f76d6074514159"
   providers = {
     aws.bucket-replication = aws.modernisation-platform-eu-west-1
   }

--- a/terraform/environments/core-logging/logs_config_s3.tf
+++ b/terraform/environments/core-logging/logs_config_s3.tf
@@ -1,6 +1,6 @@
 ## S3 Bucket Module for AWS Config Logs
 module "s3_bucket_config_logs" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=479b92623954a75f96a6da8ebb4070a8581c227e"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=c67758cd6d263bec9c225b99b6f76d6074514159"
 
   providers = {
     aws.bucket-replication = aws.modernisation-platform-eu-west-1

--- a/terraform/environments/core-logging/logs_r53_public_dns_s3.tf
+++ b/terraform/environments/core-logging/logs_r53_public_dns_s3.tf
@@ -1,6 +1,6 @@
 ## S3 Bucket Module for AWS Route 53 Public DNS Query Logs
 module "s3_bucket_r53_public_dns_logs" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=479b926"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=c67758cd6d263bec9c225b99b6f76d6074514159"
 
   providers = {
     aws.bucket-replication = aws.modernisation-platform-eu-west-1

--- a/terraform/environments/core-logging/logs_waf_s3.tf
+++ b/terraform/environments/core-logging/logs_waf_s3.tf
@@ -1,6 +1,6 @@
 # S3 bucket for centralised modernisation platform waf logs
 module "s3-bucket-modernisation-platform-waf-logs" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=479b92623954a75f96a6da8ebb4070a8581c227e"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=c67758cd6d263bec9c225b99b6f76d6074514159"
   providers = {
     aws.bucket-replication = aws.modernisation-platform-eu-west-1
   }


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/orgs/ministryofjustice/projects/17/views/4?pane=issue&itemId=156958371&issue=ministryofjustice%7Cmodernisation-platform-security%7C102 

Follow-up to: https://github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket/pull/890

This PR upgrades the core logging buckets to the latest S3 bucket module version containing the new SSE-KMS compatibility mode support.

We are updating our existing buckets first before making a release. Once we are satisfied the changes work correctly with our buckets, we will release v10 and update this bucket to use v10 as well

---

## How does this PR fix the problem?

This PR updates the core logging S3 buckets to use the latest version of the `modernisation-platform-terraform-s3-bucket` module, which introduces configurable SSE-KMS request-header enforcement.

---

### Updated buckets

The following core logging buckets were updated:

- CloudTrail logs bucket
- AWS Config logs bucket
- Route53 public DNS logs bucket
- WAF logs bucket

---

## How has this been tested?

Tests were completed as part of this [PR](https://github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket/pull/890).

---

## Deployment Plan / Instructions

### Will this deployment impact the platform and / or services on it?

- No

This change is intended to improve compatibility with AWS-managed logging services while maintaining SSE-KMS encryption at rest.

---

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

---

## Additional comments (if any)