### PR TITLE
Upgrade Image Builder logs bucket for SSE-KMS compatibility mode

### DIFF
--- a/terraform/environments/core-shared-services/bucket.tf
+++ b/terraform/environments/core-shared-services/bucket.tf
@@ -1,15 +1,16 @@
 # tfsec:ignore:aws-s3-enable-versioning tfsec:ignore:aws-s3-encryption-customer-key
 module "imagebuilder_log_bucket" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=479b92623954a75f96a6da8ebb4070a8581c227e"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=c67758cd6d263bec9c225b99b6f76d6074514159"
 
   providers = {
     aws.bucket-replication = aws.bucket-replication
   }
 
-  bucket_prefix       = "ec2-image-builder-logs-"
-  sse_algorithm       = "AES256"
-  versioning_enabled  = false
-  replication_enabled = false
+  bucket_prefix               = "ec2-image-builder-logs-"
+  sse_algorithm               = "aws:kms"
+  enforce_kms_request_headers = false
+  versioning_enabled          = false
+  replication_enabled         = false
 
   lifecycle_rule = [
     {

--- a/terraform/environments/core-shared-services/bucket.tf
+++ b/terraform/environments/core-shared-services/bucket.tf
@@ -50,7 +50,6 @@ module "imagebuilder_log_bucket" {
   tags = local.tags
 }
 
-# Customer-managed KMS key for Image Builder log bucket
 resource "aws_kms_key" "imagebuilder_logs" {
   description             = "KMS key for EC2 Image Builder log bucket"
   deletion_window_in_days = 30
@@ -69,15 +68,16 @@ resource "aws_kms_key" "imagebuilder_logs" {
         Resource = "*"
       },
       {
-        Sid    = "AllowS3UseOfTheKey"
+        Sid    = "AllowImageBuilderRoleToUseKey"
         Effect = "Allow"
         Principal = {
-          Service = "s3.amazonaws.com"
+          AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/ImageBuilder"
         }
         Action = [
-          "kms:Decrypt",
           "kms:Encrypt",
+          "kms:Decrypt",
           "kms:GenerateDataKey",
+          "kms:GenerateDataKeyWithoutPlaintext",
           "kms:DescribeKey"
         ]
         Resource = "*"

--- a/terraform/environments/core-shared-services/bucket.tf
+++ b/terraform/environments/core-shared-services/bucket.tf
@@ -8,6 +8,7 @@ module "imagebuilder_log_bucket" {
 
   bucket_prefix               = "ec2-image-builder-logs-"
   sse_algorithm               = "aws:kms"
+  custom_kms_key              = aws_kms_key.imagebuilder_logs.arn
   enforce_kms_request_headers = false
   versioning_enabled          = false
   replication_enabled         = false
@@ -47,6 +48,49 @@ module "imagebuilder_log_bucket" {
 
 
   tags = local.tags
+}
+
+# Customer-managed KMS key for Image Builder log bucket
+resource "aws_kms_key" "imagebuilder_logs" {
+  description             = "KMS key for EC2 Image Builder log bucket"
+  deletion_window_in_days = 30
+  enable_key_rotation     = true
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "EnableRootPermissions"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+        }
+        Action   = "kms:*"
+        Resource = "*"
+      },
+      {
+        Sid    = "AllowS3UseOfTheKey"
+        Effect = "Allow"
+        Principal = {
+          Service = "s3.amazonaws.com"
+        }
+        Action = [
+          "kms:Decrypt",
+          "kms:Encrypt",
+          "kms:GenerateDataKey",
+          "kms:DescribeKey"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+
+  tags = local.tags
+}
+
+resource "aws_kms_alias" "imagebuilder_logs" {
+  name          = "alias/imagebuilder-log-bucket"
+  target_key_id = aws_kms_key.imagebuilder_logs.key_id
 }
 
 output "imagebuilder_log_bucket_id" {


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/orgs/ministryofjustice/projects/17/views/4?pane=issue&itemId=156958371&issue=ministryofjustice%7Cmodernisation-platform-security%7C102

Follow-up to: https://github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket/pull/890

This PR upgrades the image builder log bucket to the latest S3 bucket module version containing the new SSE-KMS compatibility mode support.

We are updating our existing buckets first before making a release. Once we are satisfied the changes work correctly with our buckets, we will release v10 and update this bucket to use v10 as well.

---

## How does this PR fix the problem?

This PR updates the image builder log S3 bucket to use the latest version of the `modernisation-platform-terraform-s3-bucket` module, which introduces configurable SSE-KMS request-header enforcement.

The bucket is also updated from `AES256` to `aws:kms` encryption while using compatibility mode. In a previous PR, `AES256` was temporarily used to avoid introducing a breaking change for this bucket.

This PR also adds a new customer-managed KMS key for the image builder log bucket. The bucket now uses customer-managed KMS encryption at rest via bucket default encryption, without requiring SSE-KMS request-header enforcement:

```hcl
enforce_kms_request_headers = false
```

This allows uploads that rely on bucket default SSE-KMS encryption to continue working without requiring explicit SSE-KMS request headers.

---

### Updated bucket

- EC2 image builder logs bucket

---

### New KMS key

This PR adds a customer-managed KMS key for the image builder log bucket.

The key is used as the bucket default encryption key and allows the bucket to use `aws:kms` with compatibility mode enabled.

---

## How has this been tested?

Tests were completed as part of this [PR](https://github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket/pull/890).

---

## Deployment Plan / Instructions

### Will this deployment impact the platform and / or services on it?

- No

This change is intended to improve compatibility with AWS-managed logging services while maintaining SSE-KMS encryption at rest.

---

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

---

## Additional comments (if any)
