### PR TITLE
updated

### DIFF
--- a/terraform/environments/core-shared-services/s3-laa-shared.tf
+++ b/terraform/environments/core-shared-services/s3-laa-shared.tf
@@ -17,19 +17,20 @@ locals {
 
 
 module "laa-shared-bucket" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=479b92623954a75f96a6da8ebb4070a8581c227e"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=c67758cd6d263bec9c225b99b6f76d6074514159"
 
   providers = {
     aws.bucket-replication = aws.bucket-replication
   }
   bucket_prefix       = "modernisation-platform-laa-shared"
-  sse_algorithm       = "AES256"
   bucket_policy       = [data.aws_iam_policy_document.laa_shared_bucket_policy.json]
   replication_enabled = false
   versioning_enabled  = true
   force_destroy       = false
   ownership_controls  = "BucketOwnerEnforced"
+  sse_algorithm       = "aws:kms"
   custom_kms_key      = local.laa_general_kms_arn
+  enforce_kms_request_headers = false
 
   lifecycle_rule = [
     {


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/orgs/ministryofjustice/projects/17/views/4?pane=issue&itemId=156958371&issue=ministryofjustice%7Cmodernisation-platform-security%7C102

Follow-up to: https://github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket/pull/890

This PR upgrades the LAA shared bucket to the latest S3 bucket module version containing the new SSE-KMS compatibility mode support.

We are updating our existing buckets first before making a release. Once we are satisfied the changes work correctly with our buckets, we will release v10 and update remaining buckets to use v10 as well.

---

## How does this PR fix the problem?

This PR updates the LAA shared S3 bucket to use the latest version of the `modernisation-platform-terraform-s3-bucket` module.

The bucket is also updated from AES256 to aws:kms encryption while using compatibility mode. In a previous PR, AES256 was temporarily used to avoid introducing a breaking change for this bucket.

This bucket already uses a customer-managed KMS key:

```hcl
custom_kms_key = local.laa_general_kms_arn
```

Compatibility mode has been enabled:

```hcl
enforce_kms_request_headers = false
```

This allows uploads that rely on bucket default SSE-KMS encryption to continue working without requiring explicit SSE-KMS request headers.

During assessment, no successful object write activity was observed for this bucket, so strict SSE-KMS request-header compliance could not yet be verified safely.

---

### Updated bucket

- LAA shared bucket

---

## How has this been tested?

- Terraform plan reviewed successfully
- Existing customer-managed KMS configuration verified
- CloudTrail assessment completed for recent bucket activity

---

## Deployment Plan / Instructions

### Will this deployment impact the platform and / or services on it?

- No

This change improves encryption defaults while preserving compatibility with existing upload behaviour.

---

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

---

## Additional comments (if any)
