### PR TITLE
Module update mp-cost-explorer-reports

### DIFF
--- a/terraform/modernisation-platform-account/s3.tf
+++ b/terraform/modernisation-platform-account/s3.tf
@@ -734,14 +734,16 @@ data "aws_iam_policy_document" "allow-state-access-for-root-account-sso-admins" 
 }
 
 module "cost-management-bucket" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=9facf9fc8f8b8e3f93ffbda822028534b9a75399" # v9.0.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=c67758cd6d263bec9c225b99b6f76d6074514159"
   providers = {
     aws.bucket-replication = aws.modernisation-platform-eu-west-1
   }
-  bucket_policy       = [data.aws_iam_policy_document.cost_management_bucket_policy.json]
-  bucket_name         = "mp-cost-explorer-reports"
-  custom_kms_key      = aws_kms_key.s3_state_bucket_multi_region.arn
-  replication_enabled = false
+  bucket_policy               = [data.aws_iam_policy_document.cost_management_bucket_policy.json]
+  bucket_name                 = "mp-cost-explorer-reports"
+  custom_kms_key              = aws_kms_key.s3_state_bucket_multi_region.arn
+  sse_algorithm               = "aws:kms"
+  enforce_kms_request_headers = false
+  replication_enabled         = false
   lifecycle_rule = [
     {
       id      = "main"

--- a/terraform/modernisation-platform-account/s3.tf
+++ b/terraform/modernisation-platform-account/s3.tf
@@ -773,14 +773,16 @@ data "aws_iam_policy_document" "cost_management_bucket_policy" {
 }
 
 module "member_information_bucket" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=9facf9fc8f8b8e3f93ffbda822028534b9a75399" # v9.0.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=c67758cd6d263bec9c225b99b6f76d6074514159"
   providers = {
     aws.bucket-replication = aws.modernisation-platform-eu-west-1
   }
-  bucket_policy       = [data.aws_iam_policy_document.member_information_bucket_policy.json]
-  bucket_name         = "modernisation-member-information"
-  custom_kms_key      = aws_kms_key.s3_state_bucket_multi_region.arn
-  replication_enabled = false
+  bucket_policy               = [data.aws_iam_policy_document.member_information_bucket_policy.json]
+  bucket_name                 = "modernisation-member-information"
+  custom_kms_key              = aws_kms_key.s3_state_bucket_multi_region.arn
+  sse_algorithm               = "aws:kms"
+  enforce_kms_request_headers = false
+  replication_enabled         = false
   lifecycle_rule = [
     {
       id      = "main"


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/orgs/ministryofjustice/projects/17/views/4?pane=issue&itemId=156958371&issue=ministryofjustice%7Cmodernisation-platform-security%7C102

Follow-up to: https://github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket/pull/890

This PR upgrades the Cost Explorer reports bucket and member information bucket to the latest S3 bucket module version containing the new SSE-KMS compatibility mode support.

We are updating our existing buckets first before making a release. Once we are satisfied the changes work correctly with our buckets, we will release v10 and update remaining buckets to use v10 as well.

---

## How does this PR fix the problem?

This PR updates the following S3 buckets to use the latest version of the `modernisation-platform-terraform-s3-bucket` module:

- `mp-cost-explorer-reports`
- `modernisation-member-information`

Both buckets already use customer-managed KMS encryption at rest via bucket default encryption using:

```hcl
custom_kms_key = aws_kms_key.s3_state_bucket_multi_region.arn
```

Both buckets are now explicitly configured to use:

```hcl
sse_algorithm = "aws:kms"
```

Compatibility mode has also enabled:

```hcl
enforce_kms_request_headers = false
```

CloudTrail assessment confirmed that upload activity for both buckets is not request-header compliant.

For `modernisation-member-information`, uploads are performed via aws-cli / GitHub Actions role without explicit SSE-KMS request headers, so S3 applies `Default_SSE_KMS` bucket encryption automatically.

For `mp-cost-explorer-reports`, the bucket is encrypted at rest using customer-managed SSE-KMS bucket default encryption, but upload activity does not explicitly send SSE-KMS request headers.

Compatibility mode allows uploads to continue working without requiring explicit SSE-KMS request headers while still maintaining customer-managed KMS encryption at rest.

---

### Updated buckets

- Cost Explorer reports bucket
- Member information bucket

---

## How has this been tested?

- Terraform plan reviewed successfully
- Existing customer-managed KMS configuration verified
- Bucket encryption configuration verified
- CloudTrail assessment completed for recent bucket activity
- KMS key ownership verified using `aws kms describe-key`
- Upload behaviour verified against CloudTrail events
- Behaviour was also tested in example account as part of this [PR](https://github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket/pull/890).

---

## Deployment Plan / Instructions

### Will this deployment impact the platform and / or services on it?

- No

This change improves encryption defaults while preserving compatibility with existing upload behaviour.

---

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

---

## Additional comments (if any)