### PR TITLE
migrate artefact bucket to strict SSE-KMS enforcement

### DIFF
--- a/terraform/environments/core-shared-services/s3.tf
+++ b/terraform/environments/core-shared-services/s3.tf
@@ -15,7 +15,7 @@ module "s3-bucket" {
   force_destroy       = false
   ownership_controls  = "BucketOwnerEnforced"
   sse_algorithm       = "aws:kms"
-  custom_kms_key      = data.aws_kms_alias.general_hmpps.arn
+  custom_kms_key      = data.aws_kms_alias.general_hmpps.target_key_arn
   lifecycle_rule = [
     {
       id      = "main"

--- a/terraform/environments/core-shared-services/s3.tf
+++ b/terraform/environments/core-shared-services/s3.tf
@@ -1,5 +1,9 @@
+data "aws_kms_alias" "general_hmpps" {
+  name = "alias/general-hmpps"
+}
+
 module "s3-bucket" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=9facf9fc8f8b8e3f93ffbda822028534b9a75399" # v9.0.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=c67758cd6d263bec9c225b99b6f76d6074514159"
 
   providers = {
     aws.bucket-replication = aws.bucket-replication
@@ -10,6 +14,8 @@ module "s3-bucket" {
   versioning_enabled  = true
   force_destroy       = false
   ownership_controls  = "BucketOwnerEnforced"
+  sse_algorithm       = "aws:kms"
+  custom_kms_key      = data.aws_kms_alias.general_hmpps.arn
   lifecycle_rule = [
     {
       id      = "main"


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/orgs/ministryofjustice/projects/17/views/4?pane=issue&itemId=156958371&issue=ministryofjustice%7Cmodernisation-platform-security%7C102

Follow-up to: https://github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket/pull/890

This PR upgrades the image artefact bucket to the latest S3 bucket module version containing the new SSE-KMS enforcement behaviour.

We are updating our existing buckets first before making a release. Once we are satisfied the changes work correctly with our buckets, we will release v10 and update remaining buckets to use v10 as well.

---

## How does this PR fix the problem?

This PR updates the image artefact S3 bucket to use the latest version of the `modernisation-platform-terraform-s3-bucket` module.

The bucket is updated to explicitly use customer-managed SSE-KMS encryption:

```hcl
sse_algorithm = "aws:kms"
```

The bucket is configured to use the existing customer-managed KMS key referenced by:

```hcl
data.aws_kms_alias.general_hmpps.target_key_arn
```

CloudTrail validation confirmed uploads already explicitly send:

- `x-amz-server-side-encryption = aws:kms`
- `x-amz-server-side-encryption-aws-kms-key-id = <customer-managed KMS key ARN>`

This bucket is therefore fully compliant with strict SSE-KMS request-header enforcement and does not require compatibility mode.

---

### Updated bucket

- Image artefact bucket

---

## How has this been tested?

- Terraform plan reviewed successfully
- Existing customer-managed KMS configuration verified
- CloudTrail assessment completed for recent bucket activity
- Successful `PutObject` events verified:
  - `request_sse = aws:kms`
  - customer-managed KMS key ID present in request headers
  - `response_sse = aws:kms`
  - `SSEApplied = SSE_KMS`

---

## Deployment Plan / Instructions

### Will this deployment impact the platform and / or services on it?

- No

This change aligns the bucket with the latest S3 module behaviour while enforcing customer-managed SSE-KMS uploads.

---

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

---

## Additional comments (if any)