### PR TITLE
Add ec2:DetachVolume permission to developer role

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -228,6 +228,7 @@ data "aws_iam_policy_document" "developer_additional" {
       "ec2:DescribeInstanceTypes",
       "ec2:DescribeSnapshots",
       "ec2:DescribeVolumes",
+      "ec2:DetachVolume",
       "ec2:ImportImage",
       "ec2:ImportSnapshot",
       "ec2:RegisterImage",


### PR DESCRIPTION
This PR adds the `ec2:DetachVolume` permission to the developer role as per Slack request https://mojdt.slack.com/archives/C01A7QK5VM1/p1778668424913079