### PR TITLE
updated athena bucket

### DIFF
--- a/terraform/environments/core-logging/athena.tf
+++ b/terraform/environments/core-logging/athena.tf
@@ -10,14 +10,16 @@ data "aws_kms_alias" "environment_management" {
 #S3 Bucket for Athena temp SQL queries 
 
 module "s3-bucket-athena" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=9facf9fc8f8b8e3f93ffbda822028534b9a75399" # v9.0.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=c67758cd6d263bec9c225b99b6f76d6074514159"
   providers = {
     aws.bucket-replication = aws.modernisation-platform-eu-west-1
   }
-  bucket_policy       = [data.aws_iam_policy_document.athena_bucket_policy.json]
-  bucket_name         = "athena-cloudtrail-query"
-  custom_kms_key      = aws_kms_key.s3_logging_cloudtrail.arn
-  replication_enabled = false
+  bucket_policy               = [data.aws_iam_policy_document.athena_bucket_policy.json]
+  bucket_name                 = "athena-cloudtrail-query"
+  custom_kms_key              = aws_kms_key.s3_logging_cloudtrail.arn
+  sse_algorithm               = "aws:kms"
+  enforce_kms_request_headers = false
+  replication_enabled         = false
   lifecycle_rule = [
     {
       id      = "main"


### PR DESCRIPTION
## A reference to the issue / Description of it

Migrate the Athena CloudTrail query results bucket to the updated S3 bucket module SSE-KMS configuration.

---

## How does this PR fix the problem?

This PR upgrades the `athena-cloudtrail-query` bucket to the latest S3 bucket module version and aligns the bucket configuration with the new v10 SSE-KMS defaults.

Changes include:

- upgrade to the latest `modernisation-platform-terraform-s3-bucket` module version
- explicitly configure:
  - `sse_algorithm = "aws:kms"`
  - `custom_kms_key = aws_kms_key.s3_logging_cloudtrail.arn`
- enable compatibility mode with:
  - `enforce_kms_request_headers = false`

Compatibility mode was chosen because Athena query result uploads rely on bucket default SSE-KMS encryption and do not consistently send explicit SSE-KMS request headers.

This keeps the bucket encrypted with the existing customer-managed KMS key while avoiding upload failures caused by strict request-header enforcement.

---

## How has this been tested?

- Terraform plan review
- CloudTrail analysis of Athena query result uploads
- Verified uploads use bucket default SSE-KMS encryption (`Default_SSE_KMS`)

---

## Deployment Plan / Instructions

### Will this deployment impact the platform and / or services on it?

- No expected impact

The bucket will continue using SSE-KMS encryption with the existing customer-managed KMS key.

Compatibility mode avoids breaking Athena uploads that rely on bucket default encryption behaviour.

---

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation

---

## Additional comments (if any)
