### PR TITLE
Policy expantion

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -1509,7 +1509,11 @@ data "aws_iam_policy_document" "reporting-operations" {
       "kinesisanalytics:Describe*",
       "kinesisanalytics:DiscoverInputSchema",
       "kinesisanalytics:RollbackApplication",
-      "lambda:InvokeFunction"
+      "lambda:InvokeFunction",
+      "events:PutRule",
+      "events:PutTargets",
+      "events:RemoveTargets",
+      "events:DeleteRule"
     ]
     resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
   }

--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -1512,8 +1512,7 @@ data "aws_iam_policy_document" "reporting-operations" {
       "lambda:InvokeFunction",
       "events:PutRule",
       "events:PutTargets",
-      "events:RemoveTargets",
-      "events:DeleteRule"
+      "events:RemoveTargets"
     ]
     resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
   }


### PR DESCRIPTION
## A reference to the issue / Description of it

From a Member ask channel Request:

Morning, we are trying to setup a scheduled query in redshift but are getting permissions issues, redshift serverless scheduled queries are not supported by terraform at the moment.



Error: arn:aws:sts::225989353474:assumed-role/reporting-operations/thomas.tipler is not authorized to perform: events:PutRule on resource: arn:aws:events:eu-west-2:225989353474:rule/QS2-refresh-materialized-views because no identity-based policy allows the events:PutRule action.


## How does this PR fix the problem?

Added the permissions to the policy as well as some that he might also need

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
