### PR TITLE
Add cooldown before version update PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,10 +11,14 @@ updates:
     commit-message:
       prefix: ":dependabot: devcontainers"
       include: "scope"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
     groups:
       action-dependencies:
         patterns:
@@ -24,12 +28,16 @@ updates:
       - "terraform/**/*"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "gomod"
     directories:
       - "scripts/**/*"
       - "terraform/**/*"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
     groups:
       gomod-dependencies:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,14 +11,10 @@ updates:
     commit-message:
       prefix: ":dependabot: devcontainers"
       include: "scope"
-    cooldown:
-      default-days: 7
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
-    cooldown:
-      default-days: 7
     groups:
       action-dependencies:
         patterns:
@@ -28,16 +24,12 @@ updates:
       - "terraform/**/*"
     schedule:
       interval: "daily"
-    cooldown:
-      default-days: 7
   - package-ecosystem: "gomod"
     directories:
       - "scripts/**/*"
       - "terraform/**/*"
     schedule:
       interval: "daily"
-    cooldown:
-      default-days: 7
     groups:
       gomod-dependencies:
         patterns:

--- a/scripts/generate-dependabot-file.sh
+++ b/scripts/generate-dependabot-file.sh
@@ -3,6 +3,15 @@ set -euo pipefail
 
 dependabot_file=".github/dependabot.yml"
 
+# Dependabot cooldown configuration (applies to version updates only)
+# Docs: https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-
+dependabot_cooldown_default_days="${DEPENDABOT_COOLDOWN_DEFAULT_DAYS:-7}"
+
+if ! [[ "$dependabot_cooldown_default_days" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: DEPENDABOT_COOLDOWN_DEFAULT_DAYS must be an integer (days), got: '$dependabot_cooldown_default_days'" >&2
+  exit 1
+fi
+
 # Clear the dependabot file
 > "$dependabot_file"
 
@@ -29,10 +38,14 @@ updates:
     commit-message:
       prefix: ":dependabot: devcontainers"
       include: "scope"
+    cooldown:
+      default-days: ${dependabot_cooldown_default_days}
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: ${dependabot_cooldown_default_days}
     groups:
       action-dependencies:
         patterns:
@@ -52,6 +65,8 @@ if [[ -n "$tf_dirs" ]]; then
   
   echo "    schedule:" >> "$dependabot_file"
   echo "      interval: \"daily\"" >> "$dependabot_file"
+  echo "    cooldown:" >> "$dependabot_file"
+  echo "      default-days: ${dependabot_cooldown_default_days}" >> "$dependabot_file"
 fi
 
 # Add Go module ecosystem entries (dynamically only for top-level directories containing go.mod)
@@ -67,6 +82,8 @@ if [[ -n "$gomod_dirs" ]]; then
 
   echo "    schedule:" >> "$dependabot_file"
   echo "      interval: \"daily\"" >> "$dependabot_file"
+  echo "    cooldown:" >> "$dependabot_file"
+  echo "      default-days: ${dependabot_cooldown_default_days}" >> "$dependabot_file"
   echo "    groups:" >> "$dependabot_file"
   echo "      gomod-dependencies:" >> "$dependabot_file"
   echo "        patterns:" >> "$dependabot_file"

--- a/scripts/generate-dependabot-file.sh
+++ b/scripts/generate-dependabot-file.sh
@@ -12,6 +12,11 @@ if ! [[ "$dependabot_cooldown_default_days" =~ ^[0-9]+$ ]]; then
   exit 1
 fi
 
+if (( dependabot_cooldown_default_days < 1 || dependabot_cooldown_default_days > 90 )); then
+  echo "ERROR: DEPENDABOT_COOLDOWN_DEFAULT_DAYS must be between 1 and 90 (inclusive), got: '$dependabot_cooldown_default_days'" >&2
+  exit 1
+fi
+
 # Clear the dependabot file
 > "$dependabot_file"
 


### PR DESCRIPTION
## A reference to the issue / Description of it

#12036 
## How does this PR fix the problem?

Adds Dependabot cooldown configuration so newly released dependency versions must now wait 7 days by default before 
Dependabot raises a version-update PR (does not affect security updates).

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
