### PR TITLE
Updating Mod Platform buckets to v10

### DIFF
--- a/terraform/environments/core-logging/athena.tf
+++ b/terraform/environments/core-logging/athena.tf
@@ -10,7 +10,7 @@ data "aws_kms_alias" "environment_management" {
 #S3 Bucket for Athena temp SQL queries 
 
 module "s3-bucket-athena" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=c67758cd6d263bec9c225b99b6f76d6074514159"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=f72f8d5bcf3081f6de0ef16d1017b53c81e16457" # v10.0.0
   providers = {
     aws.bucket-replication = aws.modernisation-platform-eu-west-1
   }

--- a/terraform/environments/core-logging/logs_cloudtrail_s3.tf
+++ b/terraform/environments/core-logging/logs_cloudtrail_s3.tf
@@ -1,5 +1,5 @@
 module "s3-bucket-cloudtrail" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=c67758cd6d263bec9c225b99b6f76d6074514159"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=f72f8d5bcf3081f6de0ef16d1017b53c81e16457" # v10.0.0
   providers = {
     aws.bucket-replication = aws.modernisation-platform-eu-west-1
   }

--- a/terraform/environments/core-logging/logs_config_s3.tf
+++ b/terraform/environments/core-logging/logs_config_s3.tf
@@ -1,6 +1,6 @@
 ## S3 Bucket Module for AWS Config Logs
 module "s3_bucket_config_logs" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=c67758cd6d263bec9c225b99b6f76d6074514159"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=f72f8d5bcf3081f6de0ef16d1017b53c81e16457" # v10.0.0
 
   providers = {
     aws.bucket-replication = aws.modernisation-platform-eu-west-1

--- a/terraform/environments/core-logging/logs_r53_public_dns_s3.tf
+++ b/terraform/environments/core-logging/logs_r53_public_dns_s3.tf
@@ -1,6 +1,6 @@
 ## S3 Bucket Module for AWS Route 53 Public DNS Query Logs
 module "s3_bucket_r53_public_dns_logs" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=c67758cd6d263bec9c225b99b6f76d6074514159"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=f72f8d5bcf3081f6de0ef16d1017b53c81e16457" # v10.0.0
 
   providers = {
     aws.bucket-replication = aws.modernisation-platform-eu-west-1

--- a/terraform/environments/core-logging/logs_waf_s3.tf
+++ b/terraform/environments/core-logging/logs_waf_s3.tf
@@ -1,6 +1,6 @@
 # S3 bucket for centralised modernisation platform waf logs
 module "s3-bucket-modernisation-platform-waf-logs" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=c67758cd6d263bec9c225b99b6f76d6074514159"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=f72f8d5bcf3081f6de0ef16d1017b53c81e16457" # v10.0.0
   providers = {
     aws.bucket-replication = aws.modernisation-platform-eu-west-1
   }

--- a/terraform/environments/core-shared-services/bucket.tf
+++ b/terraform/environments/core-shared-services/bucket.tf
@@ -1,6 +1,6 @@
 # tfsec:ignore:aws-s3-enable-versioning tfsec:ignore:aws-s3-encryption-customer-key
 module "imagebuilder_log_bucket" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=c67758cd6d263bec9c225b99b6f76d6074514159"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=f72f8d5bcf3081f6de0ef16d1017b53c81e16457" # v10.0.0
 
   providers = {
     aws.bucket-replication = aws.bucket-replication

--- a/terraform/environments/core-shared-services/s3-laa-shared.tf
+++ b/terraform/environments/core-shared-services/s3-laa-shared.tf
@@ -17,7 +17,7 @@ locals {
 
 
 module "laa-shared-bucket" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=c67758cd6d263bec9c225b99b6f76d6074514159"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=f72f8d5bcf3081f6de0ef16d1017b53c81e16457" # v10.0.0
 
   providers = {
     aws.bucket-replication = aws.bucket-replication

--- a/terraform/environments/core-shared-services/s3.tf
+++ b/terraform/environments/core-shared-services/s3.tf
@@ -3,7 +3,7 @@ data "aws_kms_alias" "general_hmpps" {
 }
 
 module "s3-bucket" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=c67758cd6d263bec9c225b99b6f76d6074514159"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=f72f8d5bcf3081f6de0ef16d1017b53c81e16457" # v10.0.0
 
   providers = {
     aws.bucket-replication = aws.bucket-replication
@@ -84,7 +84,7 @@ data "aws_iam_policy_document" "bucket_policy" {
 }
 
 module "s3-software-bucket" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=c67758cd6d263bec9c225b99b6f76d6074514159"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=f72f8d5bcf3081f6de0ef16d1017b53c81e16457" # v10.0.0
 
   providers = {
     aws.bucket-replication = aws.bucket-replication

--- a/terraform/modernisation-platform-account/s3.tf
+++ b/terraform/modernisation-platform-account/s3.tf
@@ -116,7 +116,7 @@ resource "aws_kms_alias" "s3_state_bucket_eu-west-1_replication" {
 }
 
 module "state-bucket" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=c67758cd6d263bec9c225b99b6f76d6074514159"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=f72f8d5bcf3081f6de0ef16d1017b53c81e16457" # v10.0.0
 
   providers = {
     aws.bucket-replication = aws.modernisation-platform-eu-west-1
@@ -736,7 +736,7 @@ data "aws_iam_policy_document" "allow-state-access-for-root-account-sso-admins" 
 }
 
 module "cost-management-bucket" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=c67758cd6d263bec9c225b99b6f76d6074514159"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=f72f8d5bcf3081f6de0ef16d1017b53c81e16457" # v10.0.0
   providers = {
     aws.bucket-replication = aws.modernisation-platform-eu-west-1
   }
@@ -775,7 +775,7 @@ data "aws_iam_policy_document" "cost_management_bucket_policy" {
 }
 
 module "member_information_bucket" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=c67758cd6d263bec9c225b99b6f76d6074514159"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=f72f8d5bcf3081f6de0ef16d1017b53c81e16457" # v10.0.0
   providers = {
     aws.bucket-replication = aws.modernisation-platform-eu-west-1
   }


### PR DESCRIPTION
## A reference to the issue / Description of it

Follow-up to: https://github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket/pull/890 and https://github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket/pull/881

This PR updates all Terraform S3 bucket references  that are using the  S3 bucket module to `v10.0.0`.

The previous implementation referenced specific commit SHAs while validating the new SSE-KMS compatibility mode changes. Now that validation has been completed, the buckets can move to the official `v10.0.0` release.

---

## How does this PR fix the problem?

This PR replaces direct commit references with the tagged `v10.0.0` release of the `modernisation-platform-terraform-s3-bucket` buckets.

The update standardises usage and ensures all buckets are using the latest released version containing the SSE-KMS compatibility mode support and related fixes.

Example update:

    source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=v10.0.0"

---

### Updated buckets

This PR updates the buckets below:

- athena-cloudtrail-query
- modernisation-platform-logs-config
- modernisation-platform-logs-cloudtrail
- modernisation-platform-logs-r53-public-dns-logs
- modernisation-platform-waf-logs
- ec2-image-builder-logs-20211019134837153100000001
- modernisation-platform-laa-shared20250605080758955300000001
- mod-platform-image-artefact-bucket
- modernisation-platform-software20230224000709766100000001
- modernisation-platform-terraform-state
- mp-cost-explorer-reports
- modernisation-member-information

---

## How has this been tested?

PR's where merged before and tested with cloudwatch

- https://github.com/ministryofjustice/modernisation-platform/pull/13107
- https://github.com/ministryofjustice/modernisation-platform/pull/13108
- https://github.com/ministryofjustice/modernisation-platform/pull/13111
- https://github.com/ministryofjustice/modernisation-platform/pull/13124
- https://github.com/ministryofjustice/modernisation-platform/pull/13119
- https://github.com/ministryofjustice/modernisation-platform/pull/13109
- https://github.com/ministryofjustice/modernisation-platform/pull/13114
- https://github.com/ministryofjustice/modernisation-platform/pull/13132

---

## Deployment Plan / Instructions

### Will this deployment impact the platform and / or services on it?

- No

This change only updates Terraform source references to the released version and does not introduce additional infrastructure changes beyond those already validated.

---

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

---

## Additional comments (if any)

N/A
