### PR TITLE
update devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,9 +2,9 @@
   "name": "modernisation-platform",
   "image": "ghcr.io/ministryofjustice/devcontainer-base:latest",
   "features": {
-    "ghcr.io/ministryofjustice/devcontainer-feature/aws:": {},
-    "ghcr.io/ministryofjustice/devcontainer-feature/kubernetes:": {},
+    "ghcr.io/ministryofjustice/devcontainer-feature/aws:1": {},
+    "ghcr.io/ministryofjustice/devcontainer-feature/kubernetes:1": {},
     "ghcr.io/ministryofjustice/devcontainer-feature/static-analysis:2": {},
-    "ghcr.io/ministryofjustice/devcontainer-feature/terraform:": {}
+    "ghcr.io/ministryofjustice/devcontainer-feature/terraform:1": {}
   }
 }


### PR DESCRIPTION
**Summary**
This PR updates the devcontainer feature references in modernisation-platform/.devcontainer/devcontainer.json to pin major versions instead of using unbounded latest tags.

**Changes**
Pin AWS feature to major 1
Pin Kubernetes feature to major 1
Keep Static Analysis on major 2 (already pinned)
Pin Terraform feature to major 1

**Why**
Dependabot devcontainer updates have intermittently failed on the Kubernetes feature with an unknown updater error.
Constraining feature references to major streams reduces exposure to breaking upstream publishes while still allowing patch and minor updates.

**Testing**
Validated modernisation-platform/.devcontainer/devcontainer.json is valid JSON.
No runtime code changes; configuration-only update.

**Risk**
Low. Change is limited to devcontainer dependency resolution behaviour.