### PR TITLE
fix: add Grafana service account permissions to GitHub Actions OIDC roles

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -1133,25 +1133,25 @@ data "aws_iam_policy_document" "oidc_assume_role_member" {
     ]
   }
 
-  dynamic "statement" {
-    for_each = can(regex("^observability-platform-", terraform.workspace)) ? [1] : []
-    content {
-      sid    = "AllowAccountRestrictedGrafana"
-      effect = "Allow"
-      actions = [
-        "grafana:ListWorkspaceServiceAccounts",
-        "grafana:ListWorkspaceServiceAccountTokens",
-        "grafana:CreateWorkspaceServiceAccount",
-        "grafana:DeleteWorkspaceServiceAccount",
-        "grafana:CreateWorkspaceServiceAccountToken",
-        "grafana:DeleteWorkspaceServiceAccountToken"
+  statement {
+    sid    = "AllowAccountRestrictedGrafana"
+    effect = "Allow"
+    actions = [
+      "grafana:ListWorkspaceServiceAccounts",
+      "grafana:ListWorkspaceServiceAccountTokens",
+      "grafana:CreateWorkspaceServiceAccount",
+      "grafana:DeleteWorkspaceServiceAccount",
+      "grafana:CreateWorkspaceServiceAccountToken",
+      "grafana:DeleteWorkspaceServiceAccountToken"
+    ]
+    resources = ["*"]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalAccount"
+      values = [
+        local.environment_management.account_ids["observability-platform-development"],
+        local.environment_management.account_ids["observability-platform-production"],
       ]
-      resources = ["*"]
-      condition {
-        test     = "StringEquals"
-        variable = "aws:PrincipalAccount"
-        values   = [local.environment_management.account_ids[terraform.workspace]]
-      }
     }
   }
 }
@@ -1452,21 +1452,21 @@ data "aws_iam_policy_document" "oidc_assume_plan_role_member" {
     }
   }
 
-  dynamic "statement" {
-    for_each = can(regex("^observability-platform-", terraform.workspace)) ? [1] : []
-    content {
-      sid    = "AllowAccountRestrictedGrafana"
-      effect = "Allow"
-      actions = [
-        "grafana:ListWorkspaceServiceAccounts",
-        "grafana:ListWorkspaceServiceAccountTokens"
+  statement {
+    sid    = "AllowAccountRestrictedGrafana"
+    effect = "Allow"
+    actions = [
+      "grafana:ListWorkspaceServiceAccounts",
+      "grafana:ListWorkspaceServiceAccountTokens"
+    ]
+    resources = ["*"]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalAccount"
+      values = [
+        local.environment_management.account_ids["observability-platform-development"],
+        local.environment_management.account_ids["observability-platform-production"],
       ]
-      resources = ["*"]
-      condition {
-        test     = "StringEquals"
-        variable = "aws:PrincipalAccount"
-        values   = [local.environment_management.account_ids[terraform.workspace]]
-      }
     }
   }
 }

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -1132,6 +1132,28 @@ data "aws_iam_policy_document" "oidc_assume_role_member" {
       "s3:DeleteObject"
     ]
   }
+
+  dynamic "statement" {
+    for_each = can(regex("^observability-platform-", terraform.workspace)) ? [1] : []
+    content {
+      sid    = "AllowAccountRestrictedGrafana"
+      effect = "Allow"
+      actions = [
+        "grafana:ListWorkspaceServiceAccounts",
+        "grafana:ListWorkspaceServiceAccountTokens",
+        "grafana:CreateWorkspaceServiceAccount",
+        "grafana:DeleteWorkspaceServiceAccount",
+        "grafana:CreateWorkspaceServiceAccountToken",
+        "grafana:DeleteWorkspaceServiceAccountToken"
+      ]
+      resources = ["*"]
+      condition {
+        test     = "StringEquals"
+        variable = "aws:PrincipalAccount"
+        values   = [local.environment_management.account_ids[terraform.workspace]]
+      }
+    }
+  }
 }
 
 # AWS Shield Advanced SRT (Shield Response Team) support role
@@ -1427,6 +1449,24 @@ data "aws_iam_policy_document" "oidc_assume_plan_role_member" {
       test     = "StringEquals"
       variable = "aws:PrincipalAccount"
       values   = [local.environment_management.account_ids[terraform.workspace]]
+    }
+  }
+
+  dynamic "statement" {
+    for_each = can(regex("^observability-platform-", terraform.workspace)) ? [1] : []
+    content {
+      sid    = "AllowAccountRestrictedGrafana"
+      effect = "Allow"
+      actions = [
+        "grafana:ListWorkspaceServiceAccounts",
+        "grafana:ListWorkspaceServiceAccountTokens"
+      ]
+      resources = ["*"]
+      condition {
+        test     = "StringEquals"
+        variable = "aws:PrincipalAccount"
+        values   = [local.environment_management.account_ids[terraform.workspace]]
+      }
     }
   }
 }


### PR DESCRIPTION
**Problem**

Terraform plan and apply for the `observability-platform` environments were failing with a 403 AccessDeniedException when reading the aws_grafana_workspace_service_account resource:
> grafana:ListWorkspaceServiceAccounts is not authorized to perform onresource: arn:aws:grafana:eu-west-2:***:/workspaces/g-e937f84aea

**Changes**

`modernisation-platform — member-bootstrap/iam.tf:`
- Added `AllowAccountRestrictedGrafana` statement to `oidc_assume_plan_role_member` (plan role) with read-only Grafana service account actions (`ListWorkspaceServiceAccounts, ListWorkspaceServiceAccountTokens`)
- Added `AllowAccountRestrictedGrafana` statement to `oidc_assume_role_member` (apply role) with full service account lifecycle actions (`Create*, Delete*`)
- Both statements are scoped via `aws:PrincipalAccount` condition to `observability-platform-development` and `observability-platform-production` only