### PR TITLE
:bug: Pin AWS Provider below 6.45.0 

### DIFF
--- a/terraform/environments/bootstrap/delegate-access/versions.tf
+++ b/terraform/environments/bootstrap/delegate-access/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 6.0"
+      version = ">= 6.0, < 6.45.0"
       source  = "hashicorp/aws"
     }
     tls = {

--- a/terraform/environments/bootstrap/member-bootstrap/versions.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 6.0"
+      version = ">= 6.0, < 6.45.0"
       source  = "hashicorp/aws"
     }
     tls = {

--- a/terraform/environments/bootstrap/secure-baselines/versions.tf
+++ b/terraform/environments/bootstrap/secure-baselines/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 6.0"
+      version = ">= 6.0, < 6.45.0"
       source  = "hashicorp/aws"
     }
   }

--- a/terraform/environments/bootstrap/single-sign-on/versions.tf
+++ b/terraform/environments/bootstrap/single-sign-on/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 6.0"
+      version = ">= 6.0, < 6.45.0"
       source  = "hashicorp/aws"
     }
   }

--- a/terraform/environments/versions.tf
+++ b/terraform/environments/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 6.0"
+      version = ">= 6.0, < 6.45.0"
       source  = "hashicorp/aws"
     }
     github = {


### PR DESCRIPTION
**Summary**
Temporarily pins the AWS Terraform provider below `6.45.0` for the new environment provisioning workflow paths to avoid a known upstream regression in `aws_secretsmanager_secret_version` (HashiCorp issue #47907).

**Context**
New environment provisioning started failing in GitHub Actions due to a provider bug introduced in `6.45.0`, where apply can fail with:
- `Provider produced inconsistent final plan`
- planned action changing from `Update` to `DeleteThenCreate`
This is an upstream regression and not a configuration error in this repo.

**What Changed**
Updated `hashicorp/aws` constraints from `~> 6.0` to `>= 6.0, < 6.45.0` in Terraform roots used by [new-environment.yml]

**Why This Approach**
- Narrowly scoped to the workflow paths that failed
- Avoids broad repo-wide provider churn
- Prevents accidental upgrades into the known-bad range while keeping compatibility with stable `6.44.x`

**Validation**
- Confirmed the new-environment workflow executes Terraform init from the above roots
- Confirmed constraints now exclude `6.45.0+` in those paths

**Follow-up**
- Track upstream fix: https://github.com/hashicorp/terraform-provider-aws/issues/47907
- Once a fix is released and verified, relax constraints to allow newer versions again.