### PR TITLE
Updates baselines refs to v10.0.2

### DIFF
--- a/terraform/environments/bootstrap/secure-baselines/main.tf
+++ b/terraform/environments/bootstrap/secure-baselines/main.tf
@@ -6,7 +6,7 @@ data "aws_kms_key" "cloudtrail_key" {
 
 #trivy:ignore:AVD-AWS-0136
 module "baselines" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=a9276e4322f82be9f7dd24a68876044dd796d807" # v10.0.1
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=e47822c473db5999c28b62ccb5c47f37748074d9" # v10.0.2
   providers = {
     # Default and replication regions
     aws                    = aws.workspace-eu-west-2

--- a/terraform/modernisation-platform-account/baselines.tf
+++ b/terraform/modernisation-platform-account/baselines.tf
@@ -18,7 +18,7 @@ locals {
 # Secure baselines (GuardDuty, Config, SecurityHub, etc)
 #trivy:ignore:AVD-AWS-0136 trivy:ignore:AVD-AWS-0132
 module "baselines-modernisation-platform" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=a9276e4322f82be9f7dd24a68876044dd796d807" # v10.0.1
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=e47822c473db5999c28b62ccb5c47f37748074d9" # v10.0.2
   providers = {
     # Default and replication regions
     aws                    = aws.modernisation-platform-eu-west-2


### PR DESCRIPTION
## A reference to the issue / Description of it

Updated baselines refs for release v10.0.2:

- Changes following experience of alerts outputting to high-priority channel
- Excludes replication events from s3 delete object/s alerts.
- Excludes MP-owned sandbox environments from s3 delete object/s alerts & ensures deployment to testing-test.

## How does this PR fix the problem?

{Please write here}

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
