### PR TITLE
Remove SLSA step

### DIFF
--- a/.github/workflows/access-keys-monitoring.yml
+++ b/.github/workflows/access-keys-monitoring.yml
@@ -31,10 +31,6 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      # ⛓️ SLSA - must run after checkout, before pip install
-      - name: ⛓️ SLSA Supply Chain Security
-        uses: ministryofjustice/devsecops-actions/sca/slsa@2dc8158ef71f7be8c00fda9a71e2ddbc27640a8b # main
-
       # Step 1.1: Decrypt Secrets
       - name: Decrypt Secrets
         uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@d2d07632db53d17c9760c0c2c06f22a37bd3f0a1 # v6.0.1

--- a/.github/workflows/confirm-contacts-for-environments.yml
+++ b/.github/workflows/confirm-contacts-for-environments.yml
@@ -35,10 +35,6 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      # ⛓️ SLSA - must run after checkout, before pip install
-      - name: ⛓️ SLSA Supply Chain Security
-        uses: ministryofjustice/devsecops-actions/sca/slsa@2dc8158ef71f7be8c00fda9a71e2ddbc27640a8b # main
-
       # Step 1.1: Decrypt Secrets  
       - name: Decrypt Secrets
         uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@d2d07632db53d17c9760c0c2c06f22a37bd3f0a1 # v6.0.1

--- a/.github/workflows/generate-dora-metrics.yml
+++ b/.github/workflows/generate-dora-metrics.yml
@@ -41,10 +41,6 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-            # ⛓️ SLSA - must run after checkout, before pip install
-            - name: ⛓️ SLSA Supply Chain Security
-              uses: ministryofjustice/devsecops-actions/sca/slsa@2dc8158ef71f7be8c00fda9a71e2ddbc27640a8b # main
-
             - name: Decrypt Secrets
               uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@d2d07632db53d17c9760c0c2c06f22a37bd3f0a1 # v6.0.1
               with:

--- a/.github/workflows/new-environment.yml
+++ b/.github/workflows/new-environment.yml
@@ -485,10 +485,6 @@ jobs:
         with:
           fetch-depth: 0
           
-        # ⛓️ SLSA - must run after checkout, before pip install
-      - name: ⛓️ SLSA Supply Chain Security
-        uses: ministryofjustice/devsecops-actions/sca/slsa@2dc8158ef71f7be8c00fda9a71e2ddbc27640a8b # main
-
       - name: Decrypt Secrets
         uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@d2d07632db53d17c9760c0c2c06f22a37bd3f0a1 # v6.0.1
         with:

--- a/.github/workflows/reusable-run-per-account-script.yml
+++ b/.github/workflows/reusable-run-per-account-script.yml
@@ -73,10 +73,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      # ⛓️ SLSA - must run after checkout, before pip install
-      - name: ⛓️ SLSA Supply Chain Security
-        uses: ministryofjustice/devsecops-actions/sca/slsa@2dc8158ef71f7be8c00fda9a71e2ddbc27640a8b # main
-
       - name: Decrypt Secrets
         uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@d2d07632db53d17c9760c0c2c06f22a37bd3f0a1
         with:


### PR DESCRIPTION
Removing SLSA steps as devSecOps-Actions is soon to be retired as per https://mojdt.slack.com/archives/C52LPHPK8/p1778673548700149