### PR TITLE
Add a missing permission to manage AWS Transfer Family Web Apps

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -395,6 +395,7 @@ data "aws_iam_policy_document" "member-access-network" {
       "sso:PutApplicationAssignmentConfiguration",
       "sso:PutApplicationAuthenticationMethod",
       "sso:PutApplicationGrant",
+      "sso:UpdateApplication",
       "sso-directory:DescribeUser",
       "sso-directory:DescribeGroup",
       "states:*",


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform-environments/actions/runs/26645556497/job/78530325806

## How does this PR fix the problem?

Adds the missing permission

## How has this been tested?

Tested through CI

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
