### PR TITLE
Adds depends_on statements for policy attachments to MemberInfrastructureAccess

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -139,18 +139,21 @@ module "member-access-sprinkler" {
 
 resource "aws_iam_role_policy_attachment" "member_infrastructure_access_sprinkler_role_compute" {
   count      = (terraform.workspace == "sprinkler-development") ? 1 : 0
+  depends_on = [module.member-access-sprinkler]
   role       = "MemberInfrastructureAccess"
   policy_arn = aws_iam_policy.member-access-compute[0].arn
 }
 
 resource "aws_iam_role_policy_attachment" "member_infrastructure_access_sprinkler_role_data" {
   count      = (terraform.workspace == "sprinkler-development") ? 1 : 0
+  depends_on = [module.member-access-sprinkler]
   role       = "MemberInfrastructureAccess"
   policy_arn = aws_iam_policy.member-access-data[0].arn
 }
 
 resource "aws_iam_role_policy_attachment" "member_infrastructure_access_sprinkler_role_network" {
   count      = (terraform.workspace == "sprinkler-development") ? 1 : 0
+  depends_on = [module.member-access-sprinkler]
   role       = "MemberInfrastructureAccess"
   policy_arn = aws_iam_policy.member-access-network[0].arn
 }

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -110,18 +110,21 @@ module "member-access" {
 
 resource "aws_iam_role_policy_attachment" "member_infrastructure_access_role_compute" {
   count      = (local.account_data.account-type == "member" && terraform.workspace != "testing-test" && terraform.workspace != "sprinkler-development") ? 1 : 0
+  depends_on = [module.member-access]
   role       = "MemberInfrastructureAccess"
   policy_arn = aws_iam_policy.member-access-compute[0].arn
 }
 
 resource "aws_iam_role_policy_attachment" "member_infrastructure_access_role_data" {
   count      = (local.account_data.account-type == "member" && terraform.workspace != "testing-test" && terraform.workspace != "sprinkler-development") ? 1 : 0
+  depends_on = [module.member-access]
   role       = "MemberInfrastructureAccess"
   policy_arn = aws_iam_policy.member-access-data[0].arn
 }
 
 resource "aws_iam_role_policy_attachment" "member_infrastructure_access_role_network" {
   count      = (local.account_data.account-type == "member" && terraform.workspace != "testing-test" && terraform.workspace != "sprinkler-development") ? 1 : 0
+  depends_on = [module.member-access]
   role       = "MemberInfrastructureAccess"
   policy_arn = aws_iam_policy.member-access-network[0].arn
 }


### PR DESCRIPTION

## A reference to the issue / Description of it

Adds depends_on statements for policy attachments to MemberInfrastructureAccess as this is causing issues during account creation where the module has not completed the role creation when the attachment runs.

## How does this PR fix the problem?

In the policy attachment the role is referenced as a string and not a resource id, so we need a depends_on as a hint to terraform to wait for the module resources to complete.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
