### PR TITLE
Adds readonly permissions from github-actions-plan to github-actions-…

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -1531,6 +1531,32 @@ data "aws_iam_policy_document" "oidc_assume_nuke_role_member" {
     actions = ["sts:AssumeRole"]
   }
 
+  # Additional read permissions to align with scope of those assigned to github-actions-plan
+  statement {
+    sid    = "AllowAccountRestrictedAccess"
+    effect = "Allow"
+    actions = [
+      "airflow:Get*",
+      "airflow:List*",
+      "glue:GetConnection",
+      "lakeformation:GetLFTag",
+      "lakeformation:ListLFTags",
+      "oam:ListTagsForResource",
+      "quicksight:Describe*",
+      "quicksight:ListTagsForResource",
+      "redshift-data:Describe*",
+      "secretsmanager:GetSecretValue",
+      "workspaces-web:Get*",
+      "workspaces-web:List*"
+    ]
+    resources = ["*"]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalAccount"
+      values   = [local.environment_management.account_ids[terraform.workspace]]
+    }
+  }
+
   # checkov:skip=CKV_AWS_111: "Cannot restrict by KMS alias so leaving open"
   # checkov:skip=CKV_AWS_356: "Cannot restrict by KMS alias so leaving open"
   statement {


### PR DESCRIPTION

## A reference to the issue / Description of it

Adds readonly permissions from github-actions-plan to github-actions-nuke to fix nuke rebuild failures.

## How does this PR fix the problem?

The terraform plan phase of nuke rebuild will fail when some resources are read such as secrets.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
