### PR TITLE
Configuring Athena results to use explicit SSE-KMS encryption

### DIFF
--- a/terraform/environments/core-logging/athena.tf
+++ b/terraform/environments/core-logging/athena.tf
@@ -144,6 +144,8 @@ resource "aws_iam_policy" "athena_lambda_policy" {
       {
         Action = [
           "kms:Decrypt*",
+          "kms:DescribeKey",
+          "kms:Encrypt",
           "kms:GenerateDataKey"
         ]
         Effect = "Allow"
@@ -279,7 +281,8 @@ resource "aws_lambda_function" "athena_table_update" {
   kms_key_arn                    = aws_kms_key.athena_logging.arn
   environment {
     variables = {
-      mod_account = data.aws_caller_identity.mod-platform.account_id
+      mod_account        = data.aws_caller_identity.mod-platform.account_id
+      ATHENA_KMS_KEY_ARN = aws_kms_key.s3_logging_cloudtrail.arn
     }
   }
 }

--- a/terraform/environments/core-logging/lambda/index.py
+++ b/terraform/environments/core-logging/lambda/index.py
@@ -2,6 +2,7 @@
 import base64
 from botocore.exceptions import ClientError
 import json
+import os
 
 athena_client = boto3.client('athena', region_name='eu-west-2')
 sts_client = boto3.client('sts')
@@ -9,6 +10,14 @@ ssm_client = boto3.client('ssm', region_name='eu-west-2')
 query_location='s3://athena-cloudtrail-query'
 athena_db="mod_cloudtrail_logs"
 athena_table="cloudtrail_logs"
+athena_kms_key_arn = os.environ["ATHENA_KMS_KEY_ARN"]
+athena_result_configuration = {
+    "OutputLocation": query_location,
+    "EncryptionConfiguration": {
+        "EncryptionOption": "SSE_KMS",
+        "KmsKey": athena_kms_key_arn,
+    },
+}
 
 #Get account numbers from modernsation platform account
 def get_accounts():
@@ -84,7 +93,7 @@ def create_athena_database():
            
         QueryString='CREATE DATABASE IF NOT EXISTS %s' % athena_db,
         
-        ResultConfiguration={'OutputLocation': query_location})
+        ResultConfiguration=athena_result_configuration)
         
     except ClientError as e:
         print("Unexpected error: %s" % e)     
@@ -103,7 +112,7 @@ def drop_athena_table():
                 'Database': athena_db
          },
          
-        ResultConfiguration={'OutputLocation': query_location})
+        ResultConfiguration=athena_result_configuration)
         
     except ClientError as e:
         
@@ -191,9 +200,7 @@ def create_athena_table(list_accounts):
             QueryExecutionContext={
                 'Database': athena_db
          },
-            ResultConfiguration={
-                'OutputLocation': query_location,
-            }
+            ResultConfiguration=athena_result_configuration
         )
         print(response)
         return response


### PR DESCRIPTION
## A reference to the issue / Description of it

#13136

This PR addresses `athena-cloudtrail-query`, which is KMS encrypted at rest but still in SSE-KMS compatibility mode because Athena result uploads were not sending explicit SSE-KMS request headers.

## How does this PR fix the problem?

The `athena_table_update` Lambda now passes explicit SSE-KMS result encryption to Athena `StartQueryExecution` calls.

It sets:

- `EncryptionOption = SSE_KMS`
- `KmsKey = aws_kms_key.s3_logging_cloudtrail.arn`

The Lambda receives the key through `ATHENA_KMS_KEY_ARN`, and its IAM policy now includes the KMS permissions needed for explicit SSE-KMS result writes.

This PR intentionally keeps `enforce_kms_request_headers = false` until the production uploader behaviour is validated in CloudTrail.

## How has this been tested?

Tested in the `cooker` environment with temporary S3, Athena, and Lambda resources.

- Athena without explicit `SSE_KMS` wrote to a compatibility bucket and the result object was KMS encrypted at rest.
- Athena with explicit `SSE_KMS` wrote successfully to a strict bucket.
- A temporary Lambda using the same explicit Athena `ResultConfiguration` pattern wrote successfully to the strict bucket via the `primary` workgroup.
- Result object in strict bucket confirmed `ServerSideEncryption = aws:kms`


## Deployment Plan / Instructions

Deploy through the normal core-logging Terraform pipeline.

Expected impact is low. The change only affects Athena result encryption configuration for the scheduled `athena_table_update` Lambda.

After deployment:

1. Wait for the scheduled Lambda run, or invoke it manually if appropriate.
2. Check CloudTrail S3 `PutObject` events for `athena-cloudtrail-query`.
3. Confirm result uploads include:
   - `requestParameters.x-amz-server-side-encryption = aws:kms`
   - `requestParameters.x-amz-server-side-encryption-aws-kms-key-id = <customer-managed KMS key>`

Once confirmed, raise a follow-up PR to remove `enforce_kms_request_headers = false`.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

This is the uploader remediation step only. The bucket remains in compatibility mode until production CloudTrail confirms explicit SSE-KMS request headers.
