### PR TITLE
Handle container-platform-octo account naming in member delegation role assumptions

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -1086,8 +1086,8 @@ data "aws_iam_policy_document" "oidc_assume_role_member" {
     sid    = "AllowOIDCToAssumeRoles"
     effect = "Allow"
     resources = compact([
-      # skip for cloud-platform as it uses a different account naming convention and does not need a member-delegation role
-      local.application_name != "cloud-platform" ? format("arn:aws:iam::%s:role/member-delegation-%s-%s", local.environment_management.account_ids[format("core-vpc-%s", local.application_environment)], lower(local.business_unit), local.application_environment) : "",
+      # skip for cloud-platform and container-platform-octo as they use a different account naming convention and do not need a member-delegation role
+      local.application_name != "cloud-platform" && local.application_name != "container-platform-octo" ? format("arn:aws:iam::%s:role/member-delegation-%s-%s", local.environment_management.account_ids[format("core-vpc-%s", local.application_environment)], lower(local.business_unit), local.application_environment) : "",
       format("arn:aws:iam::%s:role/modify-dns-records", local.environment_management.account_ids["core-network-services-production"]),
       format("arn:aws:iam::%s:role/modernisation-account-limited-read-member-access", local.environment_management.modernisation_platform_account_id),
       format("arn:aws:iam::%s:role/ModernisationPlatformSSOReadOnly", local.environment_management.aws_organizations_root_account_id),
@@ -1517,8 +1517,8 @@ data "aws_iam_policy_document" "oidc_assume_nuke_role_member" {
     sid    = "AllowOIDCToAssumeRoles"
     effect = "Allow"
     resources = compact([
-      # skip for cloud-platform as it uses a different account naming convention and does not need a member-delegation role
-      local.application_name != "cloud-platform" ? format("arn:aws:iam::%s:role/member-delegation-%s-%s", local.environment_management.account_ids[format("core-vpc-%s", local.application_environment)], lower(local.business_unit), local.application_environment) : "",
+      # skip for cloud-platform and container-platform-octo as they use a different account naming convention and do not need a member-delegation role
+      local.application_name != "cloud-platform" && local.application_name != "container-platform-octo" ? format("arn:aws:iam::%s:role/member-delegation-%s-%s", local.environment_management.account_ids[format("core-vpc-%s", local.application_environment)], lower(local.business_unit), local.application_environment) : "",
       format("arn:aws:iam::%s:role/modify-dns-records", local.environment_management.account_ids["core-network-services-production"]),
       format("arn:aws:iam::%s:role/modernisation-account-limited-read-member-access", local.environment_management.modernisation_platform_account_id),
       format("arn:aws:iam::%s:role/ModernisationPlatformSSOReadOnly", local.environment_management.aws_organizations_root_account_id),


### PR DESCRIPTION
This PR updates IAM OIDC assume-role policy generation for member bootstrap to treat `container-platform-octo` the same way as `cloud-platform`.

Both accounts use a different naming convention and do not require the `member-delegation-<business-unit>-<environment> role ARN built from core-vpc-<environment>`.
Without this exception, Terraform attempts to index a non-existent `core-vpc-live` key and fails with `Invalid index`.

**Changes made**
- Updated the conditional in oidc_assume_role_member to skip member-delegation role ARN creation for:
   - `cloud-platform`
   - `container-platform-octo`
- Updated the same conditional in `oidc_assume_nuke_role_member` for consistency.

**Why**
Fixes failing workflow/plan for the new `container-platform-octo` account by avoiding invalid account ID map lookup for `core-vpc-live`.

**Impact**
- Prevents Terraform failure for `container-platform-octo`.
- No behavior change for existing standard member accounts.
- Existing `cloud-platform` behavior remains unchanged.
