### PR TITLE
#13159 - FW Egress Rules for hmpps-production to DHL CIDRs.

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/inline_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/inline_rules.json
@@ -131,5 +131,19 @@
     "destination_ip": "0.0.0.0/0",
     "destination_port": "587",
     "protocol": "TCP"
+  },
+  "hmpps-production_to_internet_dhl_qa_sftp": {
+    "action": "PASS",
+    "source_ip": "${hmpps-production}",
+    "destination_ip": "165.72.0.0/16",
+    "destination_port": "22",
+    "protocol": "TCP"
+  },
+  "hmpps-production_to_internet_dhl_sftp": {
+    "action": "PASS",
+    "source_ip": "${hmpps-production}",
+    "destination_ip": "199.40.0.0/16",
+    "destination_port": "22",
+    "protocol": "TCP"
   }
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

#13159 

## How does this PR fix the problem?

Adds egress inline rules for hmpps-production to DHL FTP sites. Note that the egress port is 22, domain-based egress rules are not sufficient.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
