### PR TITLE
Encrypt AWS Config log bucket with SSE-KMS

### DIFF
--- a/terraform/environments/core-logging/iam_cortex.tf
+++ b/terraform/environments/core-logging/iam_cortex.tf
@@ -62,7 +62,10 @@ data "aws_iam_policy_document" "cortex_user_policy" {
       "kms:Decrypt",
       "kms:DescribeKey"
     ]
-    resources = [for key in aws_kms_key.logging : key.arn]
+    resources = concat(
+      [for key in aws_kms_key.logging : key.arn],
+      [aws_kms_key.config_logs.arn]
+    )
   }
 }
 
@@ -87,4 +90,3 @@ data "aws_iam_policy_document" "cortex_trust_policy" {
     }
   }
 }
-

--- a/terraform/environments/core-logging/logs_config_s3.tf
+++ b/terraform/environments/core-logging/logs_config_s3.tf
@@ -5,17 +5,16 @@ module "s3_bucket_config_logs" {
   providers = {
     aws.bucket-replication = aws.modernisation-platform-eu-west-1
   }
-  bucket_policy               = [data.aws_iam_policy_document.config_bucket_policy.json]
-  bucket_name                 = "modernisation-platform-logs-config"
-  replication_bucket          = "modernisation-platform-logs-config-replication"
-  suffix_name                 = "-config"
-  custom_kms_key              = aws_kms_key.config_logs.arn
-  custom_replication_kms_key  = aws_kms_key.config_logs_replication.arn
-  sse_algorithm               = "aws:kms"
-  enforce_kms_request_headers = false
-  replication_enabled         = true
-  replication_region          = "eu-west-1"
-  versioning_enabled          = true
+  bucket_policy              = [data.aws_iam_policy_document.config_bucket_policy.json]
+  bucket_name                = "modernisation-platform-logs-config"
+  replication_bucket         = "modernisation-platform-logs-config-replication"
+  suffix_name                = "-config"
+  custom_kms_key             = aws_kms_key.config_logs.arn
+  custom_replication_kms_key = aws_kms_key.config_logs_replication.arn
+  sse_algorithm              = "AES256"
+  replication_enabled        = true
+  replication_region         = "eu-west-1"
+  versioning_enabled         = true
 
   lifecycle_rule = [
     {

--- a/terraform/environments/core-logging/logs_config_s3.tf
+++ b/terraform/environments/core-logging/logs_config_s3.tf
@@ -5,16 +5,17 @@ module "s3_bucket_config_logs" {
   providers = {
     aws.bucket-replication = aws.modernisation-platform-eu-west-1
   }
-  bucket_policy              = [data.aws_iam_policy_document.config_bucket_policy.json]
-  bucket_name                = "modernisation-platform-logs-config"
-  replication_bucket         = "modernisation-platform-logs-config-replication"
-  suffix_name                = "-config"
-  custom_kms_key             = aws_kms_key.config_logs.arn
-  custom_replication_kms_key = aws_kms_key.config_logs_replication.arn
-  sse_algorithm              = "AES256"
-  replication_enabled        = true
-  replication_region         = "eu-west-1"
-  versioning_enabled         = true
+  bucket_policy               = [data.aws_iam_policy_document.config_bucket_policy.json]
+  bucket_name                 = "modernisation-platform-logs-config"
+  replication_bucket          = "modernisation-platform-logs-config-replication"
+  suffix_name                 = "-config"
+  custom_kms_key              = aws_kms_key.config_logs.arn
+  custom_replication_kms_key  = aws_kms_key.config_logs_replication.arn
+  sse_algorithm               = "aws:kms"
+  enforce_kms_request_headers = false
+  replication_enabled         = true
+  replication_region          = "eu-west-1"
+  versioning_enabled          = true
 
   lifecycle_rule = [
     {


### PR DESCRIPTION
## A reference to the issue / Description of it

Updates the `modernisation-platform-logs-config` S3 bucket so new AWS Config log objects are encrypted using SSE-KMS instead of SSE-S3/AES256.

## How does this PR fix the problem?

This PR changes the AWS Config logs bucket default encryption from `AES256` to `aws:kms`, using the existing Config logs KMS keys.

It also sets `enforce_kms_request_headers = false`, so AWS Config does not need to send explicit KMS headers when uploading objects. S3 will apply the bucket default encryption.

Cortex XSIAM read permissions are updated to include decrypt access to the Config logs KMS key, so it can continue reading new KMS-encrypted Config log objects.

The Terraform plan shows the expected changes for this PR:
- `modernisation-platform-logs-config` default encryption changes from `AES256` to `aws:kms`.
- `modernisation-platform-logs-config-replication` default encryption changes from `AES256` to `aws:kms`.
- S3 replication is updated to replicate SSE-KMS encrypted objects using the existing replication KMS key.
- The replication IAM policy condition changes from `AES256` to `aws:kms`.
- The Cortex XSIAM IAM policy gains access to the Config logs KMS key.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Created tests in the cooker development environment to prove S3 bucket default KMS encryption is applied even when the object upload does not specify explicit SSE/KMS headers.

The test uploaded an object without setting explicit SSE/KMS options. The object was stored with:

`ServerSideEncryption = aws:kms`

This confirms that S3 bucket default KMS encryption is applied without requiring the uploader to send KMS headers.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No expected service impact.

New objects written to `modernisation-platform-logs-config` will be encrypted using SSE-KMS. Existing AES256-encrypted objects will not be re-encrypted.

After deployment, verify that AWS Config continues delivering objects and that new objects show `ServerSideEncryption = aws:kms`.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

The shared baselines module has not been changed in this PR. Config delivery-channel `s3_kms_key_arn` support can be considered separately after this bucket-default KMS change is proven safe.