### PR TITLE
vcms allow dso team

### DIFF
--- a/environments/vcms.json
+++ b/environments/vcms.json
@@ -9,6 +9,10 @@
           "level": "sandbox"
         },
         {
+          "sso_group_name": "azure-aws-sso-digital-studio-operations",
+          "level": "sandbox"
+        },
+        {
           "sso_group_name": "hmpps-vcms-write-team",
           "level": "developer"
         }
@@ -23,6 +27,10 @@
           "level": "developer"
         },
         {
+          "sso_group_name": "azure-aws-sso-digital-studio-operations",
+          "level": "developer"
+        },
+        {
           "sso_group_name": "hmpps-vcms-write-team",
           "level": "developer"
         }
@@ -34,6 +42,10 @@
         {
           "sso_group_name": "hosting-migrations",
           "level": "developer"
+        },
+        {
+          "sso_group_name": "azure-aws-sso-digital-studio-operations",
+          "level": "developer"
         }
       ]
     },
@@ -42,6 +54,10 @@
       "access": [
         {
           "sso_group_name": "hosting-migrations",
+          "level": "developer"
+        },
+        {
+          "sso_group_name": "azure-aws-sso-digital-studio-operations",
           "level": "developer"
         }
       ]


### PR DESCRIPTION
## A reference to the issue / Description of it

dso team is a subset of the hosting migrations. However hosting migrations is the github accounts, the added group is the justice accounts of the dso team 

## How does this PR fix the problem?

{Please write here}

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
