### PR TITLE
[STB-4268] share MoJ Transit Gateway to laa-new-workspaces via RAM small change

### DIFF
--- a/terraform/environments/laa-new-workspaces/transit-gateway-attachment.tf
+++ b/terraform/environments/laa-new-workspaces/transit-gateway-attachment.tf
@@ -1,0 +1,21 @@
+data "aws_ec2_transit_gateway" "transit-gateway" {
+  provider = aws.core-network-services
+  filter {
+    name   = "options.amazon-side-asn"
+    values = ["64589"]
+  }
+}
+
+data "aws_ram_resource_share" "transit-gateway-shared" {
+  provider = aws.core-network-services
+
+  name           = "transit-gateway"
+  resource_owner = "SELF"
+}
+
+resource "aws_ram_principal_association" "transit_gateway_association" {
+  provider = aws.core-network-services
+
+  principal          = data.aws_caller_identity.current.account_id
+  resource_share_arn = data.aws_ram_resource_share.transit-gateway-shared.arn
+}


### PR DESCRIPTION
## A reference to the issue / Description of it

The laa-new-workspaces account creates its own dedicated VPC and attaches it directly to the MoJ Transit Gateway. The TGW is managed in core-network-services-production and shared via a named RAM resource share. Without an explicit aws_ram_principal_association, the TGW is not visible in the member account, causing terraform plan in modernisation-platform-environments/workspace-components to fail with: Error: no matching EC2 Transit Gateway found.

## How does this PR fix the problem?

Adds a transit-gateway-attachment.tf to the laa-new-workspaces core platform environment that creates an aws_ram_principal_association, sharing the transit-gateway RAM resource share from core-network-services-production to the laa-new-workspaces account. This follows the same pattern as laa-pui-secure-browser. Once applied, the TGW becomes visible in the member account and the workspace-components VPC attachment can be created.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

The change has been validated by reviewing the equivalent working implementation in laa-pui-secure-browser/transit-gateway-attachment.tf, which uses the same resource types and provider configuration. A terraform plan against the laa-new-workspaces workspace in modernisation-platform has been run to confirm no errors. The workspace-components plan in modernisation-platform-environments will be re-run after this is applied to verify the TGW data source resolves correctly.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No. This adds a RAM principal association to an existing resource share — it grants the laa-new-workspaces account visibility of the Transit Gateway but does not modify the TGW, its route tables, or any existing attachments. No other accounts or services are affected. The change is additive and isolated to the new account.

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
