### PR TITLE
Adds ec2:ReplaceRoute to MemberInfrastructureAccess Role

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -207,6 +207,7 @@ data "aws_iam_policy_document" "member-access-compute" {
       "ec2:DeleteSubnet",
       "ec2:CreateRoute",
       "ec2:DeleteRoute",
+      "ec2:ReplaceRoute",
       "ec2:*RouteTable*",
       "ec2:CreateVpcEndpoint",
       "ec2:DeleteVpcEndpoints",


### PR DESCRIPTION

## A reference to the issue / Description of it

Adds ec2:ReplaceRoute to MemberInfrastructureAccess Role following migrations team request re workspaces vpc.

## How does this PR fix the problem?

{Please write here}

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
