### PR TITLE
Update data-factory-moj.json to remove Data Platform team as github action approvers

### DIFF
--- a/environments/data-factory-moj.json
+++ b/environments/data-factory-moj.json
@@ -21,8 +21,7 @@
         },
         {
           "sso_group_name": "data-platform-engineering",
-          "level": "platform-engineer-admin",
-          "github_action_reviewer": "true"
+          "level": "platform-engineer-admin"
         },
         {
           "sso_group_name": "data-factory-aker-team",


### PR DESCRIPTION
## A reference to the issue / Description of it

Data Platform team are down as github action approvers but this isn't their account

## How does this PR fix the problem?

removes that team as action approvers

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

n/a

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

n/a

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)


