### PR TITLE
Add missing CP dev routes

### DIFF
--- a/terraform/modules/vpc-inspection/main.tf
+++ b/terraform/modules/vpc-inspection/main.tf
@@ -267,6 +267,20 @@ resource "aws_route" "inspection-10-231-0-0" {
   transit_gateway_id     = var.transit_gateway_id
 }
 
+resource "aws_route" "inspection-10-195-0-0" {
+  for_each               = aws_route_table.inspection
+  destination_cidr_block = "10.195.0.0/16"
+  route_table_id         = each.value.id
+  transit_gateway_id     = var.transit_gateway_id
+}
+
+resource "aws_route" "inspection-10-41-0-0" {
+  for_each               = aws_route_table.inspection
+  destination_cidr_block = "10.41.0.0/16"
+  route_table_id         = each.value.id
+  transit_gateway_id     = var.transit_gateway_id
+}
+
 resource "aws_network_acl" "inspection" {
   vpc_id     = aws_vpc.main.id
   subnet_ids = [for subnet in aws_subnet.inspection : subnet.id]
@@ -361,6 +375,22 @@ resource "aws_route" "public-10-231-0-0" {
   depends_on             = [aws_networkfirewall_firewall.inline_inspection]
   for_each               = aws_route_table.public
   destination_cidr_block = "10.231.0.0/20"
+  route_table_id         = each.value.id
+  vpc_endpoint_id        = local.firewall_endpoint_map[aws_subnet.public[each.key].availability_zone]
+}
+
+resource "aws_route" "public-10-195-0-0" {
+  depends_on             = [aws_networkfirewall_firewall.inline_inspection]
+  for_each               = aws_route_table.public
+  destination_cidr_block = "10.195.0.0/16"
+  route_table_id         = each.value.id
+  vpc_endpoint_id        = local.firewall_endpoint_map[aws_subnet.public[each.key].availability_zone]
+}
+
+resource "aws_route" "public-10-41-0-0" {
+  depends_on             = [aws_networkfirewall_firewall.inline_inspection]
+  for_each               = aws_route_table.public
+  destination_cidr_block = "10.41.0.0/16"
   route_table_id         = each.value.id
   vpc_endpoint_id        = local.firewall_endpoint_map[aws_subnet.public[each.key].availability_zone]
 }


### PR DESCRIPTION
We missed these routes back from the inspection VPC subnets in the initial PR.

