### PR TITLE
Add Cloud Platform CIDR routes to inspection VPC

### DIFF
--- a/terraform/modules/vpc-inspection/main.tf
+++ b/terraform/modules/vpc-inspection/main.tf
@@ -267,6 +267,13 @@ resource "aws_route" "inspection-10-231-0-0" {
   transit_gateway_id     = var.transit_gateway_id
 }
 
+resource "aws_route" "inspection-10-195-0-0" {
+  for_each               = aws_route_table.inspection
+  destination_cidr_block = "10.195.0.0/16"
+  route_table_id         = each.value.id
+  transit_gateway_id     = var.transit_gateway_id
+}
+
 resource "aws_network_acl" "inspection" {
   vpc_id     = aws_vpc.main.id
   subnet_ids = [for subnet in aws_subnet.inspection : subnet.id]
@@ -361,6 +368,14 @@ resource "aws_route" "public-10-231-0-0" {
   depends_on             = [aws_networkfirewall_firewall.inline_inspection]
   for_each               = aws_route_table.public
   destination_cidr_block = "10.231.0.0/20"
+  route_table_id         = each.value.id
+  vpc_endpoint_id        = local.firewall_endpoint_map[aws_subnet.public[each.key].availability_zone]
+}
+
+resource "aws_route" "public-10-195-0-0" {
+  depends_on             = [aws_networkfirewall_firewall.inline_inspection]
+  for_each               = aws_route_table.public
+  destination_cidr_block = "10.195.0.0/16"
   route_table_id         = each.value.id
   vpc_endpoint_id        = local.firewall_endpoint_map[aws_subnet.public[each.key].availability_zone]
 }


### PR DESCRIPTION
### Problem
During connectivity testing between the Cloud Platform and the central Transit Gateway, traffic was successfully flowing outbound (CP → Internet) but return traffic from external sources could not reach CP VPCs. The inspection VPC route tables had return routes for Modernisation Platform CIDRs but were missing routes for Cloud Platform CIDRs.

### Solution
Added `10.195.0.0/16` routes (covering all CP environments: development, preproduction, and live) to both the inspection and public route tables in the vpc-inspection module, routing traffic back through the Transit Gateway.

### Changes
- Added `aws_route "inspection-10-195-0-0"` to route CP CIDRs through transit gateway
- Added `aws_route "public-10-195-0-0"` to route CP CIDRs through firewall endpoint