### PR TITLE
CC-4626: Update apex owner and infrastructure-support tags

### DIFF
--- a/environments/apex.json
+++ b/environments/apex.json
@@ -79,8 +79,8 @@
   "tags": {
     "application": "apex",
     "business-unit": "LAA",
-    "infrastructure-support": "laa_ops@digital.justice.gov.uk",
-    "owner": "laa_ops@digital.justice.gov.uk",
+    "infrastructure-support": "ApplicationOperations@justice.gov.uk",
+    "owner": "ApplicationOperations@justice.gov.uk",
     "critical-national-infrastructure": false
   },
   "github-oidc-team-repositories": ["ministryofjustice/laa-apex"],


### PR DESCRIPTION
## Summary

- Updates `owner` and `infrastructure-support` tags in `environments/apex.json` from `laa_ops@digital.justice.gov.uk` to `ApplicationOperations@justice.gov.uk`, consistent with the ccms-ebs environment

## Test plan

- [ ] Dev plan — verify tags reflect new values in Terraform plan output
- [ ] Dev apply — confirm tag updates applied to resources
- [ ] Promote to prod