### PR TITLE
Grant AdministratorAccess to GitHub Actions nuke role

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -1511,6 +1511,7 @@ module "github_actions_nuke" {
   source              = "github.com/ministryofjustice/modernisation-platform-github-oidc-role?ref=b40748ec162b446f8f8d282f767a85b6501fd192" # v4.0.0
   github_repositories = ["ministryofjustice/modernisation-platform"]
   role_name           = "github-actions-nuke"
+  policy_arns         = ["arn:aws:iam::aws:policy/AdministratorAccess"]
   policy_jsons        = [data.aws_iam_policy_document.oidc_assume_nuke_role_member[0].json]
   subject_claim       = "ref:refs/heads/main"
   tags                = { "Name" = "github-actions-nuke" }
@@ -1540,32 +1541,6 @@ data "aws_iam_policy_document" "oidc_assume_nuke_role_member" {
       values   = [data.aws_organizations_organization.root_account.id]
     }
     actions = ["sts:AssumeRole"]
-  }
-
-  # Additional read permissions to align with scope of those assigned to github-actions-plan
-  statement {
-    sid    = "AllowAccountRestrictedAccess"
-    effect = "Allow"
-    actions = [
-      "airflow:Get*",
-      "airflow:List*",
-      "glue:GetConnection",
-      "lakeformation:GetLFTag",
-      "lakeformation:ListLFTags",
-      "oam:ListTagsForResource",
-      "quicksight:Describe*",
-      "quicksight:ListTagsForResource",
-      "redshift-data:Describe*",
-      "secretsmanager:GetSecretValue",
-      "workspaces-web:Get*",
-      "workspaces-web:List*"
-    ]
-    resources = ["*"]
-    condition {
-      test     = "StringEquals"
-      variable = "aws:PrincipalAccount"
-      values   = [local.environment_management.account_ids[terraform.workspace]]
-    }
   }
 
   # checkov:skip=CKV_AWS_111: "Cannot restrict by KMS alias so leaving open"


### PR DESCRIPTION
## A reference to the issue / Description of it

Add AdministratorAccess permissions to the GitHub Actions nuke IAM role to allow environment cleanup workflows to complete successfully in development accounts. #13292 

## How does this PR fix the problem?

The nuke workflow currently fails when removing resources due to insufficient IAM permissions. Granting AdministratorAccess to this dedicated role allows the cleanup process to remove all managed resources without permission-related failures.

The role remains restricted by the existing GitHub OIDC trust policy:

- Only the `modernisation-platform` repository can assume the role
- Only the `main` branch is permitted

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
