### PR TITLE
Prepare Terraform state KMS backend permissions

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -1266,6 +1266,31 @@ data "aws_iam_policy_document" "oidc_assume_role_dev_test" {
   }
 
   statement {
+    sid    = "AllowTerraformStateKMSBackend"
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+      "kms:DescribeKey",
+      "kms:Encrypt",
+      "kms:GenerateDataKey*",
+      "kms:ReEncrypt*"
+    ]
+    resources = ["arn:aws:kms:eu-west-2:${local.environment_management.modernisation_platform_account_id}:key/*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "kms:ViaService"
+      values   = ["s3.eu-west-2.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "kms:EncryptionContext:aws:s3:arn"
+      values   = ["arn:aws:s3:::modernisation-platform-terraform-state/environments/accounts/*"]
+    }
+  }
+
+  statement {
     sid    = "AllowOIDCReadState"
     effect = "Allow"
     resources = [
@@ -1607,6 +1632,31 @@ data "aws_iam_policy_document" "oidc_assume_nuke_role_member" {
     effect    = "Allow"
     resources = ["*"]
     actions   = ["kms:Decrypt"]
+  }
+
+  statement {
+    sid    = "AllowTerraformStateKMSBackend"
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+      "kms:DescribeKey",
+      "kms:Encrypt",
+      "kms:GenerateDataKey*",
+      "kms:ReEncrypt*"
+    ]
+    resources = ["arn:aws:kms:eu-west-2:${local.environment_management.modernisation_platform_account_id}:key/*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "kms:ViaService"
+      values   = ["s3.eu-west-2.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "kms:EncryptionContext:aws:s3:arn"
+      values   = ["arn:aws:s3:::modernisation-platform-terraform-state/environments/members/*"]
+    }
   }
 
   statement {

--- a/terraform/environments/sprinkler/iam.tf
+++ b/terraform/environments/sprinkler/iam.tf
@@ -21,6 +21,34 @@ data "aws_iam_policy_document" "oidc_deny_specific_actions" {
   }
 
   statement {
+    sid    = "AllowTerraformStateKMSBackend"
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+      "kms:DescribeKey",
+      "kms:Encrypt",
+      "kms:GenerateDataKey*",
+      "kms:ReEncrypt*"
+    ]
+    resources = ["arn:aws:kms:eu-west-2:${data.aws_ssm_parameter.modernisation_platform_account_id.value}:key/*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "kms:ViaService"
+      values   = ["s3.eu-west-2.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "kms:EncryptionContext:aws:s3:arn"
+      values = [
+        "arn:aws:s3:::modernisation-platform-terraform-state/single-sign-on/*",
+        "arn:aws:s3:::modernisation-platform-terraform-state/environments/bootstrap/*/sprinkler-development/*"
+      ]
+    }
+  }
+
+  statement {
     sid       = "AllowOIDCReadState"
     effect    = "Allow"
     resources = ["arn:aws:s3:::modernisation-platform-terraform-state/*", "arn:aws:s3:::modernisation-platform-terraform-state/"]
@@ -77,6 +105,31 @@ data "aws_iam_policy_document" "github_actions_environments_read_only" {
   }
 
   statement {
+    sid    = "AllowTerraformStateKMSBackend"
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+      "kms:DescribeKey",
+      "kms:Encrypt",
+      "kms:GenerateDataKey*",
+      "kms:ReEncrypt*"
+    ]
+    resources = ["arn:aws:kms:eu-west-2:${data.aws_ssm_parameter.modernisation_platform_account_id.value}:key/*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "kms:ViaService"
+      values   = ["s3.eu-west-2.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "kms:EncryptionContext:aws:s3:arn"
+      values   = ["arn:aws:s3:::modernisation-platform-terraform-state/environments/members/sprinkler/*"]
+    }
+  }
+
+  statement {
     sid    = "AllowAssumeRoles"
     effect = "Allow"
     actions = [
@@ -129,6 +182,35 @@ data "aws_iam_policy_document" "github_actions_environments_dev_test" {
     effect    = "Allow"
     resources = ["*"]
     actions   = ["kms:Decrypt"]
+  }
+
+  statement {
+    sid    = "AllowTerraformStateKMSBackend"
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+      "kms:DescribeKey",
+      "kms:Encrypt",
+      "kms:GenerateDataKey*",
+      "kms:ReEncrypt*"
+    ]
+    resources = ["arn:aws:kms:eu-west-2:${data.aws_ssm_parameter.modernisation_platform_account_id.value}:key/*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "kms:ViaService"
+      values   = ["s3.eu-west-2.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "kms:EncryptionContext:aws:s3:arn"
+      values = [
+        "arn:aws:s3:::modernisation-platform-terraform-state/single-sign-on/*",
+        "arn:aws:s3:::modernisation-platform-terraform-state/environments/bootstrap/*/sprinkler-development/*",
+        "arn:aws:s3:::modernisation-platform-terraform-state/environments/members/sprinkler/sprinkler-development/*"
+      ]
+    }
   }
 
   statement {

--- a/terraform/modernisation-platform-account/s3.tf
+++ b/terraform/modernisation-platform-account/s3.tf
@@ -131,8 +131,11 @@ data "aws_iam_policy_document" "kms_state_bucket" {
     resources = ["*"]
 
     principals {
-      type        = "AWS"
-      identifiers = ["arn:aws:iam::${local.environment_management.account_ids["sprinkler-development"]}:role/github-actions", "arn:aws:iam::${local.environment_management.account_ids["sprinkler-development"]}:role/github-actions-environments-dev-test"]
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${local.environment_management.account_ids["sprinkler-development"]}:role/github-actions",
+        "arn:aws:iam::${local.environment_management.account_ids["sprinkler-development"]}:role/github-actions-environments-dev-test"
+      ]
     }
 
     condition {
@@ -148,6 +151,69 @@ data "aws_iam_policy_document" "kms_state_bucket" {
         "arn:aws:s3:::modernisation-platform-terraform-state/single-sign-on/*",
         "arn:aws:s3:::modernisation-platform-terraform-state/environments/bootstrap/*/sprinkler-development/*"
       ]
+    }
+  }
+
+  statement {
+    sid    = "AllowSprinklerAccountTerraformStateBucketUse"
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+      "kms:DescribeKey",
+      "kms:Encrypt",
+      "kms:GenerateDataKey*",
+      "kms:ReEncrypt*"
+    ]
+    resources = ["*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${local.environment_management.account_ids["sprinkler-development"]}:role/github-actions-dev-test"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "kms:ViaService"
+      values   = ["s3.eu-west-2.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "kms:EncryptionContext:aws:s3:arn"
+      values   = ["arn:aws:s3:::modernisation-platform-terraform-state/environments/accounts/sprinkler/*"]
+    }
+  }
+
+  statement {
+    sid    = "AllowSprinklerMemberTerraformStateBucketUse"
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+      "kms:DescribeKey",
+      "kms:Encrypt",
+      "kms:GenerateDataKey*",
+      "kms:ReEncrypt*"
+    ]
+    resources = ["*"]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${local.environment_management.account_ids["sprinkler-development"]}:role/github-actions-environments-dev-test",
+        "arn:aws:iam::${local.environment_management.account_ids["sprinkler-development"]}:role/github-actions-environments-read-only"
+      ]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "kms:ViaService"
+      values   = ["s3.eu-west-2.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "kms:EncryptionContext:aws:s3:arn"
+      values   = ["arn:aws:s3:::modernisation-platform-terraform-state/environments/members/sprinkler/*"]
     }
   }
   statement {


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/orgs/ministryofjustice/projects/17/views/4?pane=issue&itemId=187213756&issue=ministryofjustice%7Cmodernisation-platform%7C13136&reload=1

This PR prepares the Terraform state bucket KMS permissions before reintroducing any Terraform backend initialisation changes.

## How does this PR fix the problem?

This PR adds the missing KMS permissions needed for Terraform state and lock writes when the backend later sends `kms_key_id`.

It updates identity-side IAM permissions for roles that already write Terraform state, and updates the state bucket KMS key policy for explicit sprinkler roles not covered by the member OU condition.

The new KMS access is restricted to S3 in `eu-west-2` and the relevant `modernisation-platform-terraform-state` encryption context paths.

## How has this been tested?
 See runs below

## Deployment Plan / Instructions


## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

This PR intentionally does not change `enforce_kms_request_headers` or Terraform init behaviour. It is the permissions-first step to avoid breaking workflows when the backend init change is reintroduced.