### PR TITLE
Pass KMS key for Terraform state backend

### DIFF
--- a/scripts/terraform-init.sh
+++ b/scripts/terraform-init.sh
@@ -6,9 +6,40 @@ set -e
 # You need to pass through a Terraform directory as an argument, e.g.
 # sh terraform-init.sh terraform/environments
 
+state_kms_key_id() {
+  if [ -n "${TERRAFORM_STATE_KMS_KEY_ID:-}" ]; then
+    echo "${TERRAFORM_STATE_KMS_KEY_ID}"
+    return
+  fi
+
+  local account_id="${MODERNISATION_PLATFORM_ACCOUNT_ID:-${MODERNISATION_PLATFORM_ACCOUNT_NUMBER:-}}"
+
+  if [ -z "${account_id}" ] && [ -n "${ENVIRONMENT_MANAGEMENT:-}" ] && command -v jq >/dev/null 2>&1; then
+    account_id=$(jq -r -e '.modernisation_platform_account_id // empty' <<< "${ENVIRONMENT_MANAGEMENT}" 2>/dev/null || true)
+  fi
+
+  if [ -z "${account_id}" ] && command -v aws >/dev/null 2>&1; then
+    account_id=$(aws ssm get-parameter \
+      --name modernisation_platform_account_id \
+      --with-decryption \
+      --region eu-west-2 \
+      --query Parameter.Value \
+      --output text 2>/dev/null || true)
+  fi
+
+  if [ -z "${account_id}" ] || ! [[ "${account_id}" =~ ^[0-9]{12}$ ]]; then
+    echo "Unable to resolve Modernisation Platform account ID for Terraform state KMS backend config." >&2
+    echo "Set TERRAFORM_STATE_KMS_KEY_ID, MODERNISATION_PLATFORM_ACCOUNT_ID, MODERNISATION_PLATFORM_ACCOUNT_NUMBER, or ENVIRONMENT_MANAGEMENT." >&2
+    exit 1
+  fi
+
+  echo "arn:aws:kms:eu-west-2:${account_id}:alias/s3-state-bucket"
+}
+
 if [ -z "$1" ]; then
   echo "Unsure where to run terraform, exiting"
   exit 1
 else
-  terraform -chdir="$1" init -input=false -no-color
+  kms_key_id="$(state_kms_key_id)"
+  terraform -chdir="$1" init -input=false -no-color -backend-config="kms_key_id=${kms_key_id}"
 fi


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/orgs/ministryofjustice/projects/17/views/4?pane=issue&itemId=187213756&issue=ministryofjustice%7Cmodernisation-platform%7C13136&reload=1

This PR reintroduces Terraform backend initialisation with the Modernisation Platform state bucket KMS key.

The permissions required for this were added separately first, so this PR only changes init behaviour.

## How does this PR fix the problem?

This PR updates `scripts/terraform-init.sh` so Terraform init passes the state bucket KMS key via backend config:

`kms_key_id = arn:aws:kms:eu-west-2:<modernisation-platform-account-id>:alias/s3-state-bucket`

The script resolves the Modernisation Platform account ID from, in order:

- `TERRAFORM_STATE_KMS_KEY_ID`
- `MODERNISATION_PLATFORM_ACCOUNT_ID`
- `MODERNISATION_PLATFORM_ACCOUNT_NUMBER`
- `ENVIRONMENT_MANAGEMENT`
- SSM parameter `modernisation_platform_account_id`

If the key cannot be resolved, the script fails clearly rather than silently falling back to the old init behaviour.

## How has this been tested?

Static checks passed locally:

A local smoke test using a fake Terraform binary confirmed the script passes:

`-backend-config=kms_key_id=arn:aws:kms:eu-west-2:946070829339:alias/s3-state-bucket`

PR checks should confirm bootstrap and member workflows can initialise successfully with the KMS backend config.

## Deployment Plan / Instructions


## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

This PR does not change IAM/KMS permissions or strict request-header enforcement. Any `kms:GenerateDataKey` failure after this change should be treated as evidence of a missing permission/path and should pause rollout.