### PR TITLE
Allow member workflow roles to use state KMS key

### DIFF
--- a/terraform/modernisation-platform-account/s3.tf
+++ b/terraform/modernisation-platform-account/s3.tf
@@ -119,6 +119,52 @@ data "aws_iam_policy_document" "kms_state_bucket" {
     }
   }
   statement {
+    sid    = "AllowMemberTerraformStateBucketUseFromGithubActions"
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+      "kms:DescribeKey",
+      "kms:Encrypt",
+      "kms:GenerateDataKey*",
+      "kms:ReEncrypt*"
+    ]
+    resources = ["*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalOrgID"
+      values   = [data.aws_organizations_organization.root_account.id]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "kms:ViaService"
+      values   = ["s3.eu-west-2.amazonaws.com"]
+    }
+
+    condition {
+      test     = "ArnLike"
+      variable = "aws:PrincipalArn"
+      values = [
+        "arn:aws:iam::*:role/github-actions-plan",
+        "arn:aws:iam::*:role/github-actions-apply",
+        "arn:aws:sts::*:assumed-role/github-actions-plan/*",
+        "arn:aws:sts::*:assumed-role/github-actions-apply/*"
+      ]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "kms:EncryptionContext:aws:s3:arn"
+      values   = ["arn:aws:s3:::modernisation-platform-terraform-state/environments/members/*"]
+    }
+  }
+  statement {
     sid    = "AllowSprinklerTerraformStateBucketUse"
     effect = "Allow"
     actions = [


### PR DESCRIPTION
## A reference to the issue / Description of it

Follow-up to the Terraform state SSE-KMS backend remediation work.

The cooker canary is testing the real member workflow path and is failing when `github-actions-plan` tries to write the Terraform state lock using the platform state bucket KMS key.

## How does this PR fix the problem?

This PR adds an additional KMS key-policy statement for member GitHub Actions workflow roles using the shared Terraform state bucket.

Access is restricted to:

- principals in the MoJ AWS Organization
- `github-actions-plan` and `github-actions-apply` role patterns
- S3 via `kms:ViaService = s3.eu-west-2.amazonaws.com`
- member state paths under `environments/members/*`

The existing Modernisation Platform OU KMS statement is left unchanged.

## How has this been tested?

## Deployment Plan / Instructions

## Checklist

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments

This PR does not change Terraform init behaviour. It adds the missing member workflow KMS key-policy path needed before the init-script PR can be safely merged.