### PR TITLE
Fix naming for managed file transfer subdomains

### DIFF
--- a/terraform/environments/core-network-services/route53.tf
+++ b/terraform/environments/core-network-services/route53.tf
@@ -300,16 +300,16 @@ module "r53_delegations_integration_hub_mft" {
 
   records = {
     for zone_key in toset([
-      "integration-hub-mft-development",
-      "integration-hub-mft-preproduction",
-      "integration-hub-mft-test",
-      ]) : local.application-zones[zone_key] => {
-      name            = local.application-zones[zone_key]
+      "development",
+      "test",
+      "preproduction",
+      ]) : zone_key => {
+      name            = zone_key
       type            = "NS"
       ttl             = 30
       allow_overwrite = true
 
-      records = aws_route53_zone.application_zones[zone_key].name_servers
+      records = aws_route53_zone.application_zones["integration-hub-mft-${zone_key}"].name_servers
     }
   }
 


### PR DESCRIPTION
## A reference to the issue / Description of it

Route53 module is pulling in the wrong names for the hosted zones under `managed-file-transfer.service.justice.gov.uk` when it writes the NS delegation records

## How does this PR fix the problem?

By truncating the names so that they're correctly prepended.
```
NEW > `development.managed-file-transfer.service.justice.gov.uk`
OLD >`development.managed-file-transfer.service.justice.gov.ukmanaged-file-transfer.service.justice.gov.uk`
```

## How has this been tested?

Tested through CI pipeline

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
