### PR TITLE
updated permissions

### DIFF
--- a/terraform/modernisation-platform-account/s3.tf
+++ b/terraform/modernisation-platform-account/s3.tf
@@ -165,6 +165,36 @@ data "aws_iam_policy_document" "kms_state_bucket" {
     }
   }
   statement {
+    sid    = "AllowMemberTerraformStateBucketUseFromMemberAccounts"
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+      "kms:DescribeKey",
+      "kms:Encrypt",
+      "kms:GenerateDataKey*",
+      "kms:ReEncrypt*"
+    ]
+    resources = ["*"]
+
+    # Cross-account KMS permissions are delegated to member accounts here; member IAM policies restrict the actual roles.
+    principals {
+      type        = "AWS"
+      identifiers = [for account_id in sort(values(local.environment_management.account_ids)) : "arn:aws:iam::${account_id}:root"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "kms:ViaService"
+      values   = ["s3.eu-west-2.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "kms:EncryptionContext:aws:s3:arn"
+      values   = ["arn:aws:s3:::modernisation-platform-terraform-state/environments/members/*"]
+    }
+  }
+  statement {
     sid    = "AllowSprinklerTerraformStateBucketUse"
     effect = "Allow"
     actions = [


### PR DESCRIPTION
## A reference to the issue / Description of it

Follow-up fix for the Terraform state SSE-KMS backend work.

The cooker canary is correctly testing real member behaviour, but still failed when `github-actions-plan` tried to write the Terraform `.tflock` object using SSE-KMS.

## How does this PR fix the problem?

This PR adds an additional KMS key policy statement for the platform Terraform state bucket key.

It delegates KMS use to Modernisation Platform member accounts, while still restricting usage to:

- S3 via `kms:ViaService = s3.eu-west-2.amazonaws.com`
- Terraform member state paths under `modernisation-platform-terraform-state/environments/members/*`

The member account IAM policies still control which roles can use the key. This avoids a cooker-only exception and supports the real member workflow model.

## How has this been tested?

The cooker canary failed with:

```text
github-actions-plan is not authorized to perform kms:GenerateDataKey
```

We confirmed:

- the MP KMS key policy update was live
- the cooker `github-actions-plan` role had identity-side KMS permissions
- using the key ARN instead of alias did not fix the issue

This points to the KMS resource policy needing standard cross-account delegation to member accounts.

## Deployment Plan / Instructions

1. Review and apply this MP KMS key policy change.
2. Re-run the cooker `state-kms-backend-canary` workflow.
3. Confirm the canary can acquire the `.tflock` and complete Terraform plan/apply.
4. Verify the state object metadata shows `ServerSideEncryption = aws:kms`.

`enforce_kms_request_headers = false` remains unchanged.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments

This is an additive key policy change. It does not widen use beyond the Terraform member state path and still relies on member IAM policies to restrict the actual writer roles.