### PR TITLE
Allow state KMS bucket key encryption context

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -1144,7 +1144,10 @@ data "aws_iam_policy_document" "oidc_assume_role_member" {
     condition {
       test     = "StringLike"
       variable = "kms:EncryptionContext:aws:s3:arn"
-      values   = ["arn:aws:s3:::modernisation-platform-terraform-state/*"]
+      values = [
+        "arn:aws:s3:::modernisation-platform-terraform-state",
+        "arn:aws:s3:::modernisation-platform-terraform-state/*"
+      ]
     }
   }
 
@@ -1286,7 +1289,10 @@ data "aws_iam_policy_document" "oidc_assume_role_dev_test" {
     condition {
       test     = "StringLike"
       variable = "kms:EncryptionContext:aws:s3:arn"
-      values   = ["arn:aws:s3:::modernisation-platform-terraform-state/environments/accounts/*"]
+      values = [
+        "arn:aws:s3:::modernisation-platform-terraform-state",
+        "arn:aws:s3:::modernisation-platform-terraform-state/environments/accounts/*"
+      ]
     }
   }
 
@@ -1501,7 +1507,10 @@ data "aws_iam_policy_document" "oidc_assume_plan_role_member" {
     condition {
       test     = "StringLike"
       variable = "kms:EncryptionContext:aws:s3:arn"
-      values   = ["arn:aws:s3:::modernisation-platform-terraform-state/*"]
+      values = [
+        "arn:aws:s3:::modernisation-platform-terraform-state",
+        "arn:aws:s3:::modernisation-platform-terraform-state/*"
+      ]
     }
   }
 
@@ -1655,7 +1664,10 @@ data "aws_iam_policy_document" "oidc_assume_nuke_role_member" {
     condition {
       test     = "StringLike"
       variable = "kms:EncryptionContext:aws:s3:arn"
-      values   = ["arn:aws:s3:::modernisation-platform-terraform-state/environments/members/*"]
+      values = [
+        "arn:aws:s3:::modernisation-platform-terraform-state",
+        "arn:aws:s3:::modernisation-platform-terraform-state/environments/members/*"
+      ]
     }
   }
 

--- a/terraform/modernisation-platform-account/s3.tf
+++ b/terraform/modernisation-platform-account/s3.tf
@@ -115,7 +115,10 @@ data "aws_iam_policy_document" "kms_state_bucket" {
     condition {
       test     = "StringLike"
       variable = "kms:EncryptionContext:aws:s3:arn"
-      values   = ["arn:aws:s3:::modernisation-platform-terraform-state/*"]
+      values = [
+        "arn:aws:s3:::modernisation-platform-terraform-state",
+        "arn:aws:s3:::modernisation-platform-terraform-state/*"
+      ]
     }
   }
   statement {
@@ -161,7 +164,10 @@ data "aws_iam_policy_document" "kms_state_bucket" {
     condition {
       test     = "StringLike"
       variable = "kms:EncryptionContext:aws:s3:arn"
-      values   = ["arn:aws:s3:::modernisation-platform-terraform-state/environments/members/*"]
+      values = [
+        "arn:aws:s3:::modernisation-platform-terraform-state",
+        "arn:aws:s3:::modernisation-platform-terraform-state/environments/members/*"
+      ]
     }
   }
   statement {
@@ -191,7 +197,10 @@ data "aws_iam_policy_document" "kms_state_bucket" {
     condition {
       test     = "StringLike"
       variable = "kms:EncryptionContext:aws:s3:arn"
-      values   = ["arn:aws:s3:::modernisation-platform-terraform-state/environments/members/*"]
+      values = [
+        "arn:aws:s3:::modernisation-platform-terraform-state",
+        "arn:aws:s3:::modernisation-platform-terraform-state/environments/members/*"
+      ]
     }
   }
   statement {
@@ -224,6 +233,7 @@ data "aws_iam_policy_document" "kms_state_bucket" {
       test     = "StringLike"
       variable = "kms:EncryptionContext:aws:s3:arn"
       values = [
+        "arn:aws:s3:::modernisation-platform-terraform-state",
         "arn:aws:s3:::modernisation-platform-terraform-state/single-sign-on/*",
         "arn:aws:s3:::modernisation-platform-terraform-state/environments/bootstrap/*/sprinkler-development/*"
       ]
@@ -256,7 +266,10 @@ data "aws_iam_policy_document" "kms_state_bucket" {
     condition {
       test     = "StringLike"
       variable = "kms:EncryptionContext:aws:s3:arn"
-      values   = ["arn:aws:s3:::modernisation-platform-terraform-state/environments/accounts/sprinkler/*"]
+      values = [
+        "arn:aws:s3:::modernisation-platform-terraform-state",
+        "arn:aws:s3:::modernisation-platform-terraform-state/environments/accounts/sprinkler/*"
+      ]
     }
   }
 
@@ -289,7 +302,10 @@ data "aws_iam_policy_document" "kms_state_bucket" {
     condition {
       test     = "StringLike"
       variable = "kms:EncryptionContext:aws:s3:arn"
-      values   = ["arn:aws:s3:::modernisation-platform-terraform-state/environments/members/sprinkler/*"]
+      values = [
+        "arn:aws:s3:::modernisation-platform-terraform-state",
+        "arn:aws:s3:::modernisation-platform-terraform-state/environments/members/sprinkler/*"
+      ]
     }
   }
   statement {


### PR DESCRIPTION
## A reference to the issue / Description of it

Follow-up fix for the Terraform state SSE-KMS backend work.

The cooker canary still failed with `kms:GenerateDataKey` after the member KMS permissions were applied. Further investigation showed the state bucket has S3 Bucket Keys enabled.

## How does this PR fix the problem?

This PR updates the KMS encryption context conditions to allow the bucket ARN:

`arn:aws:s3:::modernisation-platform-terraform-state`

as well as the existing object path ARNs.

This is needed because S3 Bucket Keys use the bucket ARN in the KMS encryption context, rather than the individual state object ARN.

The change updates both:

- the platform state bucket KMS key policy
- the member workflow role KMS identity policies

## How has this been tested?

Confirmed the live state bucket encryption config has:

`BucketKeyEnabled = true`

Confirmed the cooker canary was passing the KMS key ARN during `terraform init`, but still failed on:

`kms:GenerateDataKey`

Local checks passed:

```text
terraform fmt -check terraform/modernisation-platform-account/s3.tf terraform/environments/bootstrap/member-bootstrap/iam.tf
git diff --check
```

## Deployment Plan / Instructions


## Checklist

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments

This is a bucket-key compatibility fix. It does not remove the existing object-path restrictions; it adds the bucket ARN context required when S3 Bucket Keys are enabled.