### PR TITLE
Add new cp octo business unit to TGW

### DIFF
--- a/terraform/environments/core-network-services/container_platform_tgw_connections.tf
+++ b/terraform/environments/core-network-services/container_platform_tgw_connections.tf
@@ -8,12 +8,18 @@ locals {
     },
     cloud-platform-preproduction = {
       attachment_id = "tgw-attach-0dafba0c55531888f"
+    },
+    container-platform-octo-nonlive = {
+      attachment_id = "tgw-attach-0e373debb35a1ecbd"
     }
   }
 
   container-platform-live-attachments = {
     cloud-platform-live = {
       attachment_id = "tgw-attach-04105db6caaa49915"
+    },
+    container-platform-octo-live = {
+      attachment_id = "tgw-attach-05031a46f7a0d42ba"
     }
   }
 }


### PR DESCRIPTION

## A reference to the issue / Description of it
As per guidance here - https://runbooks.cloud-platform.service.justice.gov.uk/cp30/adding-a-new-business-unit.html#8-add-new-accounts-to-tgw-routes

Adding routing for the new BU.


## How does this PR fix the problem?

Adds in the routes

## How has this been tested?

Tested with previous BUs

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
