### PR TITLE
Enforce SSE-KMS request headers on modernisation-platform-software bucket

### DIFF
--- a/terraform/environments/core-shared-services/s3.tf
+++ b/terraform/environments/core-shared-services/s3.tf
@@ -94,7 +94,7 @@ module "s3-software-bucket" {
   bucket_policy               = [data.aws_iam_policy_document.software_bucket_policy.json]
   sse_algorithm               = "aws:kms"
   custom_kms_key              = aws_kms_key.software_bucket.arn
-  enforce_kms_request_headers = false
+  enforce_kms_request_headers = true
   replication_enabled         = false
   versioning_enabled          = true
   force_destroy               = false


### PR DESCRIPTION
## A reference to the issue / Description of it

#13136

This PR updates the `modernisation-platform-software` S3 bucket to move it from SSE-KMS compatibility mode to strict SSE-KMS request-header enforcement.

## How does this PR fix the problem?

The bucket already uses a customer-managed KMS key:

- `aws_kms_key.software_bucket`
- alias: `alias/modernisation-platform-software-bucket`

This PR changes:

```hcl
enforce_kms_request_headers = false
```

to:

```hcl
enforce_kms_request_headers = true
```

This means future uploads must explicitly send SSE-KMS request headers instead of relying only on the bucket default encryption.

## How has this been tested?

See checks below

## Deployment Plan / Instructions

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)
I wont merge PR until Delius have confirmed that that are aware of new changes. I have sent emails and waiting for replies