### PR TITLE
Enforce SSE-KMS request headers for LAA shared S3 bucket

### DIFF
--- a/terraform/environments/core-shared-services/s3-laa-shared.tf
+++ b/terraform/environments/core-shared-services/s3-laa-shared.tf
@@ -30,7 +30,7 @@ module "laa-shared-bucket" {
   ownership_controls          = "BucketOwnerEnforced"
   sse_algorithm               = "aws:kms"
   custom_kms_key              = local.laa_general_kms_arn
-  enforce_kms_request_headers = false
+  enforce_kms_request_headers = true
 
   lifecycle_rule = [
     {


### PR DESCRIPTION
## A reference to the issue / Description of it

#13136 

This PR updates the `modernisation-platform-laa-shared` S3 bucket as part of the review of buckets that were left in SSE-KMS compatibility mode during the S3 bucket module v10 rollout.

## How does this PR fix the problem?

The bucket is already encrypted at rest using customer-managed KMS via `alias/general-laa`, but strict SSE-KMS request-header enforcement was disabled.

This PR enables strict request-header enforcement for the LAA shared bucket by setting:

`enforce_kms_request_headers = true`

This means future uploads must explicitly include SSE-KMS headers, for example:

`--sse aws:kms`
`--sse-kms-key-id alias/general-laa`

## How has this been tested?

Tests were already done as part of v10 rollout

## Deployment Plan / Instructions


## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

I have contacted LAA and they are aware of the change