### PR TITLE
Enforce kms headers cost explorer reports

### DIFF
--- a/.github/workflows/upload-cost-explorer-to-s3.yml
+++ b/.github/workflows/upload-cost-explorer-to-s3.yml
@@ -4,18 +4,8 @@ on:
     # Runs on the second day of every month at 6:30 AM
     - cron: '30 6 2 * *'
   workflow_dispatch:
-    inputs:
-      upload_target:
-        description: "Upload target"
-        required: true
-        default: "production"
-        type: choice
-        options:
-          - "production"
-          - "example-canary"
 env:
   AWS_REGION: "eu-west-2"
-  COST_EXPLORER_UPLOAD_TARGET: ${{ github.event_name == 'workflow_dispatch' && inputs.upload_target || 'production' }}
 permissions:
   id-token: write # This is required for requesting the JWT
   contents: read # This is required for actions/checkout
@@ -45,17 +35,6 @@ jobs:
           ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< $ENVIRONMENT_MANAGEMENT)
           echo "::add-mask::$ACCOUNT_NUMBER"
           echo ACCOUNT_NUMBER=$ACCOUNT_NUMBER >> $GITHUB_ENV
-
-      - name: Set Cost Explorer upload target
-        run: |
-          if [ "$COST_EXPLORER_UPLOAD_TARGET" = "example-canary" ]; then
-            EXAMPLE_ACCOUNT_NUMBER=$(jq -r -e '.account_ids["example-development"]' <<< "$ENVIRONMENT_MANAGEMENT")
-            echo "COST_EXPLORER_BUCKET_NAME=mp-example-development-cost-explorer-upload-test" >> "$GITHUB_ENV"
-            echo "COST_EXPLORER_KMS_KEY_ID=arn:aws:kms:${AWS_REGION}:${EXAMPLE_ACCOUNT_NUMBER}:alias/example-cost-explorer-upload-test" >> "$GITHUB_ENV"
-          else
-            echo "COST_EXPLORER_BUCKET_NAME=mp-cost-explorer-reports" >> "$GITHUB_ENV"
-            echo "COST_EXPLORER_KMS_KEY_ID=alias/s3-state-bucket-multi-region" >> "$GITHUB_ENV"
-          fi
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0

--- a/scripts/upload_cost_explorer_to_s3.sh
+++ b/scripts/upload_cost_explorer_to_s3.sh
@@ -12,8 +12,8 @@ previous_month_name=$(date -d "${current_month}/01 -1 month" +%B)
 previous_month_year="$previous_month_name $current_year"
 
 # S3 bucket and file details
-bucket_name="${COST_EXPLORER_BUCKET_NAME:-mp-cost-explorer-reports}"
-kms_key_id="${COST_EXPLORER_KMS_KEY_ID:-alias/s3-state-bucket-multi-region}"
+bucket_name="mp-cost-explorer-reports"
+kms_key_id="alias/s3-state-bucket-multi-region"
 csv_file="cost_explorer.csv"
 s3_file_path="s3://$bucket_name/$csv_file"
 

--- a/terraform/modernisation-platform-account/s3.tf
+++ b/terraform/modernisation-platform-account/s3.tf
@@ -969,7 +969,7 @@ module "cost-management-bucket" {
   bucket_name                 = "mp-cost-explorer-reports"
   custom_kms_key              = aws_kms_key.s3_state_bucket_multi_region.arn
   sse_algorithm               = "aws:kms"
-  enforce_kms_request_headers = true
+  enforce_kms_request_headers = false
   replication_enabled         = false
   lifecycle_rule = [
     {

--- a/terraform/modernisation-platform-account/s3.tf
+++ b/terraform/modernisation-platform-account/s3.tf
@@ -969,7 +969,7 @@ module "cost-management-bucket" {
   bucket_name                 = "mp-cost-explorer-reports"
   custom_kms_key              = aws_kms_key.s3_state_bucket_multi_region.arn
   sse_algorithm               = "aws:kms"
-  enforce_kms_request_headers = false
+  enforce_kms_request_headers = true
   replication_enabled         = false
   lifecycle_rule = [
     {


### PR DESCRIPTION
## A reference to the issue / Description of it

#13136

## How does this PR fix the problem?

This removes the temporary Cost Explorer `example-canary` workflow target now that the canary validation has completed.

The production Cost Explorer upload script continues to send explicit SSE-KMS headers when uploading to `mp-cost-explorer-reports`:

- `--sse aws:kms`
- `--sse-kms-key-id alias/s3-state-bucket-multi-region`

This PR intentionally leaves `enforce_kms_request_headers = false` on the production bucket. Strict enforcement will be enabled in a follow-up PR after the production workflow has been run and validated with the canary code removed.

## How has this been tested?

Runtime validation completed before this PR:

https://github.com/ministryofjustice/modernisation-platform/pull/13411


- The workflow ran successfully against the strict `example-development` canary bucket.
- CloudTrail for the canary upload showed:
  - `requestParameters.x-amz-server-side-encryption = aws:kms`
  - `requestParameters.x-amz-server-side-encryption-aws-kms-key-id` populated
  - `additionalEventData.SSEApplied = SSE_KMS`
  - no upload `AccessDenied`
- The workflow also ran successfully against the production bucket while strict mode remained disabled.
- CloudTrail for the production upload showed:
  - bucket `mp-cost-explorer-reports`
  - key `cost_explorer.csv`
  - writer `github-actions-apply`
  - `requestParameters.x-amz-server-side-encryption = aws:kms`
  - `requestParameters.x-amz-server-side-encryption-aws-kms-key-id = alias/s3-state-bucket-multi-region`
  - `additionalEventData.SSEApplied = SSE_KMS`

## Deployment Plan / Instructions

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)