### PR TITLE
Add SSE-KMS headers to member information upload

### DIFF
--- a/scripts/internal/modernisation-member-information.sh
+++ b/scripts/internal/modernisation-member-information.sh
@@ -13,6 +13,7 @@ README_REPO_DIR="./modernisation-platform-environments/terraform/environments"
 bucket_name="$1"
 csv_file="$2"
 s3_file_path="s3://$bucket_name/data/$csv_file"
+kms_key_id="alias/s3-state-bucket-multi-region"
 
 # Function to extract member readme info
 extract_member_readme_info() {
@@ -143,5 +144,5 @@ for json_file in "$JSON_DIR"/*.json; do
 done
 
 # Upload $csv_file to the S3 bucket
-aws s3 cp $csv_file $s3_file_path
+aws s3 cp "$csv_file" "$s3_file_path" --sse aws:kms --sse-kms-key-id "$kms_key_id"
 rm $csv_file


### PR DESCRIPTION
## A reference to the issue / Description of it

This PR is part of the work to make the `modernisation-member-information` S3 bucket compatible with strict SSE-KMS request-header enforcement.

CloudTrail baseline checks showed that `data/member_information.csv` is written by the `github-actions-apply` role, and the upload succeeds, but it relies on the bucket’s default SSE-KMS encryption rather than sending explicit SSE-KMS request headers.

## How does this PR fix the problem?

This updates `scripts/internal/modernisation-member-information.sh` so the `aws s3 cp` upload sends explicit SSE-KMS headers:

- `--sse aws:kms`
- `--sse-kms-key-id alias/s3-state-bucket-multi-region`

The bucket already uses this KMS key by default in Terraform. This PR does not enable `enforce_kms_request_headers`; it only makes the data upload path compliant first.

## How has this been tested?


## Deployment Plan / Instructions


## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

This PR only covers the `/data/member_information.csv` writer path.

Athena query results and historical `route53-inventory/*` writes use the same bucket and should be assessed separately before setting `enforce_kms_request_headers = true` on the bucket.
```