### PR TITLE
added additional vpc endpoints to laa test and pre prod

### DIFF
--- a/environments-networks/laa-preproduction.json
+++ b/environments-networks/laa-preproduction.json
@@ -32,7 +32,13 @@
     "additional_endpoints": [
       "com.amazonaws.eu-west-2.xray",
       "com.amazonaws.eu-west-2.secretsmanager",
-      "com.amazonaws.eu-west-2.email-smtp"
+      "com.amazonaws.eu-west-2.email-smtp",
+      "com.amazonaws.eu-west-2.ecs",
+      "com.amazonaws.eu-west-2.ecs-agent",
+      "com.amazonaws.eu-west-2.ecs-telemetry",
+      "com.amazonaws.eu-west-2.ecr.api",
+      "com.amazonaws.eu-west-2.ecr.dkr",
+      "com.amazonaws.eu-west-2.logs"
     ],
     "additional_private_zones": [],
     "additional_vpcs": [],

--- a/environments-networks/laa-test.json
+++ b/environments-networks/laa-test.json
@@ -36,7 +36,13 @@
       "com.amazonaws.eu-west-2.secretsmanager",
       "com.amazonaws.eu-west-2.email-smtp",
       "com.amazonaws.eu-west-2.sns",
-      "com.amazonaws.eu-west-2.sqs"
+      "com.amazonaws.eu-west-2.sqs",
+      "com.amazonaws.eu-west-2.ecs",
+      "com.amazonaws.eu-west-2.ecs-agent",
+      "com.amazonaws.eu-west-2.ecs-telemetry",
+      "com.amazonaws.eu-west-2.ecr.api",
+      "com.amazonaws.eu-west-2.ecr.dkr",
+      "com.amazonaws.eu-west-2.logs"
     ],
     "additional_private_zones": ["aws.prd.legalservices.gov.uk"],
     "additional_vpcs": [],


### PR DESCRIPTION
## A reference to the issue / Description of it

In the process of tightening the security for edrms , requesting for few Additional VPC endpoints for laa test and pre production

## How does this PR fix the problem?

The PR will create Additional VPC endpoints in laa test and pre production , which can be used to direct the services and remove 0.0.0.0/0

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

This is the standard process followed to created Additional VPC endpoints for services and this is being done in test and pre production environment.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [X] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
