### PR TITLE
handle container-platform member-delegation skips in bootstrap IAM

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -1100,8 +1100,8 @@ data "aws_iam_policy_document" "oidc_assume_role_member" {
     sid    = "AllowOIDCToAssumeRoles"
     effect = "Allow"
     resources = compact([
-      # skip for cloud-platform and container-platform-octo as they use a different account naming convention and do not need a member-delegation role
-      local.application_name != "cloud-platform" && local.application_name != "container-platform-octo" ? format("arn:aws:iam::%s:role/member-delegation-%s-%s", local.environment_management.account_ids[format("core-vpc-%s", local.application_environment)], lower(local.business_unit), local.application_environment) : "",
+      # skip for cloud-platform and container-platform-* as they use a different account naming convention and do not need a member-delegation role
+      local.application_name != "cloud-platform" && !startswith(local.application_name, "container-platform-") && contains(keys(local.environment_management.account_ids), format("core-vpc-%s", local.application_environment)) ? format("arn:aws:iam::%s:role/member-delegation-%s-%s", local.environment_management.account_ids[format("core-vpc-%s", local.application_environment)], lower(local.business_unit), local.application_environment) : "",
       format("arn:aws:iam::%s:role/modify-dns-records", local.environment_management.account_ids["core-network-services-production"]),
       format("arn:aws:iam::%s:role/modernisation-account-limited-read-member-access", local.environment_management.modernisation_platform_account_id),
       format("arn:aws:iam::%s:role/ModernisationPlatformSSOReadOnly", local.environment_management.aws_organizations_root_account_id),
@@ -1616,8 +1616,8 @@ data "aws_iam_policy_document" "oidc_assume_nuke_role_member" {
     sid    = "AllowOIDCToAssumeRoles"
     effect = "Allow"
     resources = compact([
-      # skip for cloud-platform and container-platform-octo as they use a different account naming convention and do not need a member-delegation role
-      local.application_name != "cloud-platform" && local.application_name != "container-platform-octo" ? format("arn:aws:iam::%s:role/member-delegation-%s-%s", local.environment_management.account_ids[format("core-vpc-%s", local.application_environment)], lower(local.business_unit), local.application_environment) : "",
+      # skip for cloud-platform and container-platform-* as they use a different account naming convention and do not need a member-delegation role
+      local.application_name != "cloud-platform" && !startswith(local.application_name, "container-platform-") && contains(keys(local.environment_management.account_ids), format("core-vpc-%s", local.application_environment)) ? format("arn:aws:iam::%s:role/member-delegation-%s-%s", local.environment_management.account_ids[format("core-vpc-%s", local.application_environment)], lower(local.business_unit), local.application_environment) : "",
       format("arn:aws:iam::%s:role/modify-dns-records", local.environment_management.account_ids["core-network-services-production"]),
       format("arn:aws:iam::%s:role/modernisation-account-limited-read-member-access", local.environment_management.modernisation_platform_account_id),
       format("arn:aws:iam::%s:role/ModernisationPlatformSSOReadOnly", local.environment_management.aws_organizations_root_account_id),

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -1102,7 +1102,7 @@ data "aws_iam_policy_document" "oidc_assume_role_member" {
     effect = "Allow"
     resources = compact([
       # skip for cloud-platform and container-platform-* as they use a different account naming convention and do not need a member-delegation role
-      local.application_name != "cloud-platform" && !startswith(local.application_name, "container-platform-") && contains(keys(local.environment_management.account_ids), format("core-vpc-%s", local.application_environment)) ? format("arn:aws:iam::%s:role/member-delegation-%s-%s", local.environment_management.account_ids[format("core-vpc-%s", local.application_environment)], lower(local.business_unit), local.application_environment) : "",
+      local.application_name != "cloud-platform" && !startswith(local.application_name, "container-platform-") ? format("arn:aws:iam::%s:role/member-delegation-%s-%s", local.environment_management.account_ids[format("core-vpc-%s", local.application_environment)], lower(local.business_unit), local.application_environment) : "",
       format("arn:aws:iam::%s:role/modify-dns-records", local.environment_management.account_ids["core-network-services-production"]),
       format("arn:aws:iam::%s:role/modernisation-account-limited-read-member-access", local.environment_management.modernisation_platform_account_id),
       format("arn:aws:iam::%s:role/ModernisationPlatformSSOReadOnly", local.environment_management.aws_organizations_root_account_id),
@@ -1618,7 +1618,7 @@ data "aws_iam_policy_document" "oidc_assume_nuke_role_member" {
     effect = "Allow"
     resources = compact([
       # skip for cloud-platform and container-platform-* as they use a different account naming convention and do not need a member-delegation role
-      local.application_name != "cloud-platform" && !startswith(local.application_name, "container-platform-") && contains(keys(local.environment_management.account_ids), format("core-vpc-%s", local.application_environment)) ? format("arn:aws:iam::%s:role/member-delegation-%s-%s", local.environment_management.account_ids[format("core-vpc-%s", local.application_environment)], lower(local.business_unit), local.application_environment) : "",
+      local.application_name != "cloud-platform" && !startswith(local.application_name, "container-platform-") ? format("arn:aws:iam::%s:role/member-delegation-%s-%s", local.environment_management.account_ids[format("core-vpc-%s", local.application_environment)], lower(local.business_unit), local.application_environment) : "",
       format("arn:aws:iam::%s:role/modify-dns-records", local.environment_management.account_ids["core-network-services-production"]),
       format("arn:aws:iam::%s:role/modernisation-account-limited-read-member-access", local.environment_management.modernisation_platform_account_id),
       format("arn:aws:iam::%s:role/ModernisationPlatformSSOReadOnly", local.environment_management.aws_organizations_root_account_id),


### PR DESCRIPTION
**What**
This updates the bootstrap IAM OIDC assume-role policies to treat `container-platform-*` accounts the same way as the existing `container-platform-octo` exception.

**Why**
New container platform accounts such as `container-platform-hmpps` do not follow the standard `core-vpc-*` member-delegation lookup path. Without a skip, Terraform attempts to index a non-existent `core-vpc-live` entry and fails with an `Invalid index error`.

**Changes**
- replace the hard-coded `container-platform-octo` check with a `container-platform-*` prefix check
- apply the change in both member OIDC policy documents:
  - apply role policy
  - nuke role policy
- keep the defensive `account_ids` key existence check around the `core-vpc-*` lookup

**Outcome**
This allows creation of new `container-platform-*` accounts without breaking bootstrap IAM policy generation, while preserving the existing behaviour for `cloud-platform` and the already-created `container-platform-octo`.