### PR TITLE
deligated access for production

### DIFF
--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -222,7 +222,12 @@ locals {
         local.environment_management.account_ids["laa-workspaces-development"],
         local.environment_management.account_ids["laa-new-workspaces-development"],
       ]
-    }
+    },
+    "core-vpc-production" = {
+      "laa-production" = [
+        local.environment_management.account_ids["laa-new-workspaces-production"],
+      ]
+    },
   }
 }
 


### PR DESCRIPTION
## A reference to the issue / Description of it

The LAA workspace team have reported that they have got the stack building out correctly in dev and want to move to production but we need to add deligated access permission

## How does this PR fix the problem?

adds in a block for production for the new laa workspaces

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
