### PR TITLE
minor permissions upgrade

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -1169,6 +1169,13 @@ data "aws_iam_policy_document" "oidc_assume_role_member" {
   }
 
   statement {
+    sid       = "AllowOIDCReadStateBucketEncryption"
+    effect    = "Allow"
+    resources = ["arn:aws:s3:::modernisation-platform-terraform-state"]
+    actions   = ["s3:GetEncryptionConfiguration"]
+  }
+
+  statement {
     sid       = "AllowOIDCWriteState"
     effect    = "Allow"
     resources = ["arn:aws:s3:::modernisation-platform-terraform-state/environments/members/*"]
@@ -1529,6 +1536,13 @@ data "aws_iam_policy_document" "oidc_assume_plan_role_member" {
       "s3:Get*",
       "s3:List*"
     ]
+  }
+
+  statement {
+    sid       = "AllowOIDCReadStateBucketEncryption"
+    effect    = "Allow"
+    resources = ["arn:aws:s3:::modernisation-platform-terraform-state"]
+    actions   = ["s3:GetEncryptionConfiguration"]
   }
 
   statement {

--- a/terraform/modernisation-platform-account/s3.tf
+++ b/terraform/modernisation-platform-account/s3.tf
@@ -516,6 +516,33 @@ data "aws_iam_policy_document" "allow-state-access-from-root-account" {
   }
 
   statement {
+    sid       = "AllowGithubActionsReadStateBucketEncryption"
+    effect    = "Allow"
+    actions   = ["s3:GetEncryptionConfiguration"]
+    resources = [module.state-bucket.bucket.arn]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    condition {
+      test     = "ForAnyValue:StringLike"
+      variable = "aws:PrincipalOrgPaths"
+      values   = ["${data.aws_organizations_organization.root_account.id}/*/${local.environment_management.modernisation_platform_organisation_unit_id}/*"]
+    }
+
+    condition {
+      test     = "ForAnyValue:StringLike"
+      variable = "aws:PrincipalArn"
+      values = [
+        "arn:aws:iam::*:role/github-actions-plan",
+        "arn:aws:iam::*:role/github-actions-apply"
+      ]
+    }
+  }
+
+  statement {
     sid     = "AllowGithubActionsTerraformReadOnlyPutLock"
     effect  = "Allow"
     actions = ["s3:PutObject"]


### PR DESCRIPTION
## A reference to the issue / Description of it

Follow-on work for validating SSE-KMS Terraform backend writes to the `modernisation-platform-terraform-state` bucket.

The cooker canary now dynamically resolves the state bucket KMS key from the bucket encryption configuration before passing it to Terraform backend init. The latest canary run showed the member `github-actions-plan` role cannot read that bucket encryption configuration.

https://github.com/ministryofjustice/modernisation-platform-environments/actions/runs/28187952459/job/83494853238?pr=17213#step:11:42

## How does this PR fix the problem?

This PR allows member GitHub Actions Terraform roles to read the state bucket encryption configuration.

It adds `s3:GetEncryptionConfiguration` for the `modernisation-platform-terraform-state` bucket to:

- the platform state bucket policy for member `github-actions-plan` and `github-actions-apply` roles
- the member bootstrap IAM policies for `github-actions-plan` and `github-actions-apply`

This is limited to reading the encryption configuration only. It does not change KMS permissions, Terraform init behaviour, or strict request-header enforcement.

## How has this been tested?

Tested in Cooker and it worked

## Deployment Plan / Instructions


## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)
