### PR TITLE
Add new tgw attachments from container platform to route tables

### DIFF
--- a/terraform/environments/core-network-services/container_platform_tgw_connections.tf
+++ b/terraform/environments/core-network-services/container_platform_tgw_connections.tf
@@ -12,6 +12,12 @@ locals {
     container-platform-octo-nonlive = {
       attachment_id = "tgw-attach-0e373debb35a1ecbd"
     }
+    container-platform-laa-nonlive = {
+      attachment_id = "tgw-attach-04e0dc1082bbe9826"
+    }
+    container-platform-hmpps-nonlive = {
+      attachment_id = "tgw-attach-0147624fb2cebdbe4"
+    }
   }
 
   container-platform-live-attachments = {
@@ -20,6 +26,12 @@ locals {
     },
     container-platform-octo-live = {
       attachment_id = "tgw-attach-05031a46f7a0d42ba"
+    }
+    container-platform-laa-live = {
+      attachment_id = "tgw-attach-032e6e3bf761b91f4"
+    }
+    container-platform-hmpps-live = {
+      attachment_id = "tgw-attach-032e9a7da06ed4b63"
     }
   }
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

Add new tgw attachments from container platform to route tables

## How does this PR fix the problem?

Adds the new attachment ids to the locals

## How has this been tested?

Previous bu attachments

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
