### PR TITLE
Refactor AWS Nuke workflow to remove redundant role assumption

### DIFF
--- a/.github/workflows/awsnuke.yml
+++ b/.github/workflows/awsnuke.yml
@@ -148,16 +148,6 @@ jobs:
       - name: Nuke Plan (Dry Run)
         if: ${{ inputs.mode == 'nuke-dry-run' }}
         run: |
-          aws sts assume-role \
-            --role-arn "arn:aws:iam::${ACCOUNT_NUMBER}:role/MemberInfrastructureAccess" \
-            --role-session-name githubactionsgotestrolesession > creds.json || {
-              echo "Failed to assume role"
-              exit 1
-          }
-          export AWS_ACCESS_KEY_ID=$(jq -r '.Credentials.AccessKeyId' creds.json)
-          export AWS_SECRET_ACCESS_KEY=$(jq -r '.Credentials.SecretAccessKey' creds.json)
-          export AWS_SESSION_TOKEN=$(jq -r '.Credentials.SessionToken' creds.json)
-
           echo "Verifying identity..."
           aws sts get-caller-identity || {
             echo "Invalid credentials"
@@ -171,17 +161,6 @@ jobs:
       - name: Nuke Apply (Destructive)
         if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && inputs.mode == 'nuke-no-dry-run') }}
         run: |
-          # The environment gets reset between steps, so the role needs to be re-assumed.
-          aws sts assume-role \
-            --role-arn "arn:aws:iam::${ACCOUNT_NUMBER}:role/MemberInfrastructureAccess" \
-            --role-session-name githubactionsgoliveapply > creds.json || {
-              echo "Failed to assume role"
-              exit 1
-          }
-          export AWS_ACCESS_KEY_ID=$(jq -r '.Credentials.AccessKeyId' creds.json)
-          export AWS_SECRET_ACCESS_KEY=$(jq -r '.Credentials.SecretAccessKey' creds.json)
-          export AWS_SESSION_TOKEN=$(jq -r '.Credentials.SessionToken' creds.json)
-
           echo "Verifying identity..."
           aws sts get-caller-identity || {
             echo "Invalid credentials"


### PR DESCRIPTION
`github-actions-nuke` already has an `AdministratorAccess` policy attached, so assuming `MemberInfrastructureAccess` is unnecessary.

This change:
1. removes redundant credential handling
2. simplifies the authentication flow
3. eliminates temporary credential export logic
4. fixes the current AWS Nuke job failures

#12905 