### PR TITLE
S3 object lock waf replication

### DIFF
--- a/terraform/environments/core-logging/logs_waf_s3.tf
+++ b/terraform/environments/core-logging/logs_waf_s3.tf
@@ -1,6 +1,6 @@
 # S3 bucket for centralised modernisation platform waf logs
 module "s3-bucket-modernisation-platform-waf-logs" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=76321e50b20f5c0d918cd45bdcf0b62049f5baf1" # v10.1.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=355197b5695fcce014ad838c7b586b95f9eb4988"
   providers = {
     aws.bucket-replication = aws.modernisation-platform-eu-west-1
   }
@@ -12,9 +12,10 @@ module "s3-bucket-modernisation-platform-waf-logs" {
   custom_kms_key             = aws_kms_key.s3_modernisation_platform_waf_logs.arn
   custom_replication_kms_key = aws_kms_key.s3_modernisation_platform_waf_logs_eu_west_1_replication.arn
 
-  replication_enabled = true
-  replication_region  = "eu-west-1"
-  versioning_enabled  = true
+  replication_enabled          = true
+  replication_object_lock_days = 1
+  replication_region           = "eu-west-1"
+  versioning_enabled           = true
 
   lifecycle_rule = [
     {

--- a/terraform/environments/core-logging/logs_waf_s3.tf
+++ b/terraform/environments/core-logging/logs_waf_s3.tf
@@ -1,6 +1,6 @@
 # S3 bucket for centralised modernisation platform waf logs
 module "s3-bucket-modernisation-platform-waf-logs" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=355197b5695fcce014ad838c7b586b95f9eb4988"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=355197b5695fcce014ad838c7b586b95f9eb4988" # v10.2.0
   providers = {
     aws.bucket-replication = aws.modernisation-platform-eu-west-1
   }


### PR DESCRIPTION
## A reference to the issue / Description of it

#13105 
## How does this PR fix the problem?

It enables Object Lock on WAF logs replication bucket first so we can review the Terraform plan and confirm the impact before applying the same pattern more widely.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
