### PR TITLE
Fix centralised VPC endpoint hub: remove unsupported RAM sharing and correct hub VPC routing

### DIFF
--- a/terraform/environments/core-network-services/output.tf
+++ b/terraform/environments/core-network-services/output.tf
@@ -101,9 +101,6 @@ output "centralised_endpoint_route53_profile_arn" {
   value = aws_route53profiles_profile.centralised_endpoint_dns_profile.arn
 }
 
-output "centralised_vpc_endpoint_ram_share_arn" {
-  value = aws_ram_resource_share.centralised_vpc_endpoints.arn
-}
 
 output "centralised_route53_profile_ram_share_arn" {
   value = aws_ram_resource_share.centralised_endpoint_dns_profile.arn

--- a/terraform/environments/core-network-services/transit-gateway.tf
+++ b/terraform/environments/core-network-services/transit-gateway.tf
@@ -61,3 +61,35 @@ resource "aws_ec2_transit_gateway_route" "inspection_route" {
   transit_gateway_attachment_id  = module.vpc_inspection[each.key].transit_gateway_attachment_id
   transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.route-tables[each.key].id
 }
+
+######################################
+# Centralised endpoints VPC attachment
+######################################
+# TGW attachment for the centralised endpoint hub VPC.
+# Disables default route table association/propagation — managed explicitly below
+# and in transit_gateway_connections.tf.
+resource "aws_ec2_transit_gateway_vpc_attachment" "centralised_endpoints" {
+  transit_gateway_id                              = aws_ec2_transit_gateway.transit-gateway.id
+  vpc_id                                          = module.vpc_centralised_endpoints.vpc_id
+  subnet_ids                                      = module.vpc_centralised_endpoints.tgw_subnet_ids
+  transit_gateway_default_route_table_association = false
+  transit_gateway_default_route_table_propagation = false
+
+  tags = merge(
+    local.tags,
+    { Name = "centralised-endpoints-attachment" }
+  )
+}
+
+# Dedicated TGW route table for the hub attachment.
+resource "aws_ec2_transit_gateway_route_table" "centralised_endpoints" {
+  transit_gateway_id = aws_ec2_transit_gateway.transit-gateway.id
+
+  tags = merge(local.tags, { Name = "centralised_endpoints" })
+}
+
+# Associate the hub attachment with its dedicated TGW route table.
+resource "aws_ec2_transit_gateway_route_table_association" "centralised_endpoints" {
+  transit_gateway_attachment_id  = aws_ec2_transit_gateway_vpc_attachment.centralised_endpoints.id
+  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.centralised_endpoints.id
+}

--- a/terraform/environments/core-network-services/transit_gateway_connections.tf
+++ b/terraform/environments/core-network-services/transit_gateway_connections.tf
@@ -224,3 +224,36 @@ resource "aws_ec2_transit_gateway_route" "inspection_static_routes_ecp_safedb" {
   transit_gateway_attachment_id  = data.aws_ec2_transit_gateway_peering_attachment.ecp_tgw.id
   transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.external_inspection_out.id
 }
+
+######################################
+# Centralised endpoints TGW routing
+######################################
+# Propagate live and non-live consumer VPC attachments into the hub's TGW route
+# table so return traffic from endpoint ENIs can find its way back to consumer VPCs.
+resource "aws_ec2_transit_gateway_route_table_propagation" "centralised_endpoints_from_live" {
+  for_each = local.tgw_live_data_attachments
+
+  transit_gateway_attachment_id  = each.key
+  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.centralised_endpoints.id
+}
+
+resource "aws_ec2_transit_gateway_route_table_propagation" "centralised_endpoints_from_non_live" {
+  for_each = local.tgw_non_live_data_attachments
+
+  transit_gateway_attachment_id  = each.key
+  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.centralised_endpoints.id
+}
+
+# Static routes for the hub VPC CIDR in the live_data and non_live_data TGW
+# route tables so consumer VPCs can initiate connections to the endpoint ENIs.
+resource "aws_ec2_transit_gateway_route" "centralised_endpoints_live_data" {
+  destination_cidr_block         = local.centralised_endpoint_vpc_cidr
+  transit_gateway_attachment_id  = aws_ec2_transit_gateway_vpc_attachment.centralised_endpoints.id
+  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.route-tables["live_data"].id
+}
+
+resource "aws_ec2_transit_gateway_route" "centralised_endpoints_non_live_data" {
+  destination_cidr_block         = local.centralised_endpoint_vpc_cidr
+  transit_gateway_attachment_id  = aws_ec2_transit_gateway_vpc_attachment.centralised_endpoints.id
+  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.route-tables["non_live_data"].id
+}

--- a/terraform/environments/core-network-services/vpc-endpoints.tf
+++ b/terraform/environments/core-network-services/vpc-endpoints.tf
@@ -48,25 +48,11 @@ module "vpc_centralised_endpoints" {
   tags_prefix = "centralised-endpoints"
 }
 
-# TGW attachment for the centralised endpoint hub VPC.
-# Disables default route table association/propagation — we manage these explicitly.
-resource "aws_ec2_transit_gateway_vpc_attachment" "centralised_endpoints" {
-  transit_gateway_id                              = aws_ec2_transit_gateway.transit-gateway.id
-  vpc_id                                          = module.vpc_centralised_endpoints.vpc_id
-  subnet_ids                                      = module.vpc_centralised_endpoints.tgw_subnet_ids
-  transit_gateway_default_route_table_association = false
-  transit_gateway_default_route_table_propagation = false
-
-  tags = merge(
-    local.tags,
-    { Name = "centralised-endpoints-attachment" }
-  )
-}
-
-# Return-path default routes (0.0.0.0/0 → TGW) on all private and data route
-# tables in the hub VPC. Referencing the attachment's transit_gateway_id
-# attribute creates an implicit Terraform dependency, ensuring the attachment
-# exists before these routes are applied.
+# Return-path default routes (0.0.0.0/0 → TGW) on all hub VPC route tables.
+# Referencing the attachment's transit_gateway_id attribute creates an implicit
+# Terraform dependency, ensuring the attachment exists before these routes are
+# applied. TGW attachment and route table resources live in transit-gateway.tf
+# and transit_gateway_connections.tf.
 resource "aws_route" "centralised_endpoints_private_tgw" {
   for_each = module.vpc_centralised_endpoints.private_route_tables_map["private"]
 
@@ -89,50 +75,6 @@ resource "aws_route" "centralised_endpoints_transit_gateway_tgw" {
   route_table_id         = each.value
   destination_cidr_block = "0.0.0.0/0"
   transit_gateway_id     = aws_ec2_transit_gateway_vpc_attachment.centralised_endpoints.transit_gateway_id
-}
-
-# Dedicated TGW route table for the hub attachment.
-resource "aws_ec2_transit_gateway_route_table" "centralised_endpoints" {
-  transit_gateway_id = aws_ec2_transit_gateway.transit-gateway.id
-
-  tags = merge(local.tags, { Name = "centralised_endpoints" })
-}
-
-# Associate the hub attachment with its dedicated TGW route table.
-resource "aws_ec2_transit_gateway_route_table_association" "centralised_endpoints" {
-  transit_gateway_attachment_id  = aws_ec2_transit_gateway_vpc_attachment.centralised_endpoints.id
-  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.centralised_endpoints.id
-}
-
-# Propagate live and non-live MP consumer VPC attachments into the hub's TGW
-# route table so return traffic from endpoint ENIs can reach consumer VPCs.
-resource "aws_ec2_transit_gateway_route_table_propagation" "centralised_endpoints_from_live" {
-  for_each = local.tgw_live_data_attachments
-
-  transit_gateway_attachment_id  = each.key
-  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.centralised_endpoints.id
-}
-
-resource "aws_ec2_transit_gateway_route_table_propagation" "centralised_endpoints_from_non_live" {
-  for_each = local.tgw_non_live_data_attachments
-
-  transit_gateway_attachment_id  = each.key
-  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.centralised_endpoints.id
-}
-
-# Static routes in live_data and non_live_data TGW route tables pointing the
-# hub VPC CIDR to the centralised endpoints attachment. This enables consumer
-# VPCs to reach the endpoint ENIs.
-resource "aws_ec2_transit_gateway_route" "centralised_endpoints_live_data" {
-  destination_cidr_block         = local.centralised_endpoint_vpc_cidr
-  transit_gateway_attachment_id  = aws_ec2_transit_gateway_vpc_attachment.centralised_endpoints.id
-  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.route-tables["live_data"].id
-}
-
-resource "aws_ec2_transit_gateway_route" "centralised_endpoints_non_live_data" {
-  destination_cidr_block         = local.centralised_endpoint_vpc_cidr
-  transit_gateway_attachment_id  = aws_ec2_transit_gateway_vpc_attachment.centralised_endpoints.id
-  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.route-tables["non_live_data"].id
 }
 
 resource "aws_security_group" "centralised_endpoint_interface" {

--- a/terraform/environments/core-network-services/vpc-endpoints.tf
+++ b/terraform/environments/core-network-services/vpc-endpoints.tf
@@ -28,12 +28,12 @@ module "vpc_centralised_endpoints" {
   # CIDRs
   vpc_cidr = local.centralised_endpoint_vpc_cidr
 
-  # private gateway type
-  #   nat = Nat Gateway
-  #   transit = Transit Gateway
-  #   none = no gateway for internal traffic
-  # Interface endpoints do not need outbound routing via TGW; inbound traffic
-  # arrives from consumer VPCs via TGW attachments to the endpoint ENIs directly.
+  # gateway = "none" to avoid a circular Terraform dependency: the vpc-hub
+  # module does not create a TGW attachment, so setting gateway = "transit"
+  # causes route creation to fail (AWS requires the attachment to exist first).
+  # Return-path routes (0.0.0.0/0 → TGW) are created explicitly below, after
+  # the TGW attachment is provisioned, using the attachment ID as an implicit
+  # dependency signal to Terraform.
   gateway = "none"
 
   # VPC Flow Logs
@@ -46,6 +46,93 @@ module "vpc_centralised_endpoints" {
   # Tags
   tags_common = local.tags
   tags_prefix = "centralised-endpoints"
+}
+
+# TGW attachment for the centralised endpoint hub VPC.
+# Disables default route table association/propagation — we manage these explicitly.
+resource "aws_ec2_transit_gateway_vpc_attachment" "centralised_endpoints" {
+  transit_gateway_id                              = aws_ec2_transit_gateway.transit-gateway.id
+  vpc_id                                          = module.vpc_centralised_endpoints.vpc_id
+  subnet_ids                                      = module.vpc_centralised_endpoints.tgw_subnet_ids
+  transit_gateway_default_route_table_association = false
+  transit_gateway_default_route_table_propagation = false
+
+  tags = merge(
+    local.tags,
+    { Name = "centralised-endpoints-attachment" }
+  )
+}
+
+# Return-path default routes (0.0.0.0/0 → TGW) on all private and data route
+# tables in the hub VPC. Referencing the attachment's transit_gateway_id
+# attribute creates an implicit Terraform dependency, ensuring the attachment
+# exists before these routes are applied.
+resource "aws_route" "centralised_endpoints_private_tgw" {
+  for_each = module.vpc_centralised_endpoints.private_route_tables_map["private"]
+
+  route_table_id         = each.value
+  destination_cidr_block = "0.0.0.0/0"
+  transit_gateway_id     = aws_ec2_transit_gateway_vpc_attachment.centralised_endpoints.transit_gateway_id
+}
+
+resource "aws_route" "centralised_endpoints_data_tgw" {
+  for_each = module.vpc_centralised_endpoints.private_route_tables_map["data"]
+
+  route_table_id         = each.value
+  destination_cidr_block = "0.0.0.0/0"
+  transit_gateway_id     = aws_ec2_transit_gateway_vpc_attachment.centralised_endpoints.transit_gateway_id
+}
+
+resource "aws_route" "centralised_endpoints_transit_gateway_tgw" {
+  for_each = module.vpc_centralised_endpoints.private_route_tables_map["transit_gateway"]
+
+  route_table_id         = each.value
+  destination_cidr_block = "0.0.0.0/0"
+  transit_gateway_id     = aws_ec2_transit_gateway_vpc_attachment.centralised_endpoints.transit_gateway_id
+}
+
+# Dedicated TGW route table for the hub attachment.
+resource "aws_ec2_transit_gateway_route_table" "centralised_endpoints" {
+  transit_gateway_id = aws_ec2_transit_gateway.transit-gateway.id
+
+  tags = merge(local.tags, { Name = "centralised_endpoints" })
+}
+
+# Associate the hub attachment with its dedicated TGW route table.
+resource "aws_ec2_transit_gateway_route_table_association" "centralised_endpoints" {
+  transit_gateway_attachment_id  = aws_ec2_transit_gateway_vpc_attachment.centralised_endpoints.id
+  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.centralised_endpoints.id
+}
+
+# Propagate live and non-live MP consumer VPC attachments into the hub's TGW
+# route table so return traffic from endpoint ENIs can reach consumer VPCs.
+resource "aws_ec2_transit_gateway_route_table_propagation" "centralised_endpoints_from_live" {
+  for_each = local.tgw_live_data_attachments
+
+  transit_gateway_attachment_id  = each.key
+  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.centralised_endpoints.id
+}
+
+resource "aws_ec2_transit_gateway_route_table_propagation" "centralised_endpoints_from_non_live" {
+  for_each = local.tgw_non_live_data_attachments
+
+  transit_gateway_attachment_id  = each.key
+  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.centralised_endpoints.id
+}
+
+# Static routes in live_data and non_live_data TGW route tables pointing the
+# hub VPC CIDR to the centralised endpoints attachment. This enables consumer
+# VPCs to reach the endpoint ENIs.
+resource "aws_ec2_transit_gateway_route" "centralised_endpoints_live_data" {
+  destination_cidr_block         = local.centralised_endpoint_vpc_cidr
+  transit_gateway_attachment_id  = aws_ec2_transit_gateway_vpc_attachment.centralised_endpoints.id
+  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.route-tables["live_data"].id
+}
+
+resource "aws_ec2_transit_gateway_route" "centralised_endpoints_non_live_data" {
+  destination_cidr_block         = local.centralised_endpoint_vpc_cidr
+  transit_gateway_attachment_id  = aws_ec2_transit_gateway_vpc_attachment.centralised_endpoints.id
+  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.route-tables["non_live_data"].id
 }
 
 resource "aws_security_group" "centralised_endpoint_interface" {

--- a/terraform/environments/core-network-services/vpc-endpoints.tf
+++ b/terraform/environments/core-network-services/vpc-endpoints.tf
@@ -32,7 +32,9 @@ module "vpc_centralised_endpoints" {
   #   nat = Nat Gateway
   #   transit = Transit Gateway
   #   none = no gateway for internal traffic
-  gateway = "transit"
+  # Interface endpoints do not need outbound routing via TGW; inbound traffic
+  # arrives from consumer VPCs via TGW attachments to the endpoint ENIs directly.
+  gateway = "none"
 
   # VPC Flow Logs
   vpc_flow_log_iam_role       = aws_iam_role.vpc_flow_log.arn
@@ -85,27 +87,6 @@ resource "aws_vpc_endpoint" "centralised_interface_endpoints" {
       Name = "${local.application_name}-${each.key}-centralised-endpoint"
     }
   )
-}
-
-resource "aws_ram_resource_share" "centralised_vpc_endpoints" {
-  name                      = "centralised-vpc-endpoints"
-  allow_external_principals = false
-
-  tags = local.tags
-}
-
-resource "aws_ram_resource_association" "centralised_vpc_endpoints" {
-  for_each = aws_vpc_endpoint.centralised_interface_endpoints
-
-  resource_arn       = each.value.arn
-  resource_share_arn = aws_ram_resource_share.centralised_vpc_endpoints.arn
-}
-
-resource "aws_ram_principal_association" "centralised_vpc_endpoints" {
-  for_each = local.centralised_endpoint_consumer_accounts
-
-  principal          = each.value
-  resource_share_arn = aws_ram_resource_share.centralised_vpc_endpoints.arn
 }
 
 resource "aws_route53_zone" "centralised_endpoint_private_zones" {


### PR DESCRIPTION
## What
Fixes apply errors introduced by the centralised VPC endpoints deployment and corrects the hub VPC routing architecture.

Related to [#13221](https://github.com/ministryofjustice/modernisation-platform/issues/13221) / follow-up to [#13403](https://github.com/ministryofjustice/modernisation-platform/pull/13403)

## Fixes

### 1. Remove VPC endpoint RAM sharing
AWS does not support sharing VPC interface endpoints via RAM (`MalformedArnException: You cannot share the selected resource type`).

Removed:
- `aws_ram_resource_share.centralised_vpc_endpoints`
- `aws_ram_resource_association.centralised_vpc_endpoints`
- `aws_ram_principal_association.centralised_vpc_endpoints`
- `output.centralised_vpc_endpoint_ram_share_arn`

Consumer VPCs reach the central endpoints by routing traffic via the Transit Gateway into the hub VPC. The Route53 Profile RAM share remains and handles DNS distribution correctly.

### 2. Add explicit TGW attachment and correct hub VPC routing
The original fix set `gateway = "none"` on the hub VPC module to avoid `InvalidTransitGatewayID.NotFound` errors. However this was architecturally incorrect — without return-path routes, TCP connections cannot complete (no route for SYN-ACK back to consumer VPCs).

The root cause was that the `vpc-hub` module does not create a TGW VPC attachment itself. Setting `gateway = "transit"` caused routes to be created before the VPC was attached to the TGW, which AWS rejects. The fix is to keep `gateway = "none"` and manage the attachment and routes explicitly outside the module, giving Terraform correct dependency ordering.

Added:
- `aws_ec2_transit_gateway_vpc_attachment.centralised_endpoints` — attaches hub VPC to TGW
- `aws_route.centralised_endpoints_{private,data,transit_gateway}_tgw` — `0.0.0.0/0 → TGW` on all hub VPC route tables, created after the attachment (implicit dependency via attachment ID reference)
- `aws_ec2_transit_gateway_route_table.centralised_endpoints` — dedicated TGW route table for the hub
- `aws_ec2_transit_gateway_route_table_association.centralised_endpoints` — associates hub attachment with its route table
- `aws_ec2_transit_gateway_route_table_propagation.centralised_endpoints_from_{live,non_live}` — propagates consumer VPC attachments into hub's TGW route table so return traffic resolves correctly
- `aws_ec2_transit_gateway_route.centralised_endpoints_{live,non_live}_data` — static routes for `10.20.240.0/20` in `live_data`/`non_live_data` TGW route tables so consumer VPCs can reach endpoint ENIs

### 3. Refactor TGW resources into conventional files
Moved TGW-related resources out of `vpc-endpoints.tf` into the files where TGW config conventionally lives:
- `transit-gateway.tf` — attachment, route table, route table association
- `transit_gateway_connections.tf` — propagations, static routes into `live_data`/`non_live_data` TGW route tables

VPC route table entries (`aws_route.*`) remain in `vpc-endpoints.tf` as they are internal to the hub VPC rather than TGW infrastructure. No functional change.

## Traffic flow
Consumer VPC → TGW (live/non_live route table) → Hub VPC endpoint ENI → AWS service
AWS service → Hub VPC endpoint ENI → TGW (hub route table, propagated consumer routes) → Consumer VPC


## Plan summary
- **62 to add** — TGW attachment, routes, route table, propagations
- **0 to change**
- **6 to destroy** — the unsupported endpoint RAM share resources

## Notes for reviewers
- No existing infrastructure is modified — all changes are additive except removing the 6 invalid RAM share resources
- The Route53 Profile sharing is unaffected
- The `propagate_firewall` addition in the plan is pre-existing data-driven behaviour picking up a recently added attachment — not introduced by this PR