### PR TITLE
fix: adding instance management role to sres

### DIFF
--- a/environments/ccms-edrms.json
+++ b/environments/ccms-edrms.json
@@ -32,6 +32,10 @@
           "level": "developer"
         },
         {
+          "sso_group_name": "laa-sre-admins",
+          "level": "instance-management"
+        },
+        {
           "sso_group_name": "laa-ccms-developers",
           "level": "developer"
         },
@@ -47,6 +51,10 @@
         {
           "sso_group_name": "laa-sre-admins",
           "level": "developer"
+        },
+        {
+          "sso_group_name": "laa-sre-admins",
+          "level": "instance-management"
         },
         {
           "sso_group_name": "laa-ccms-developers",
@@ -65,6 +73,10 @@
           "sso_group_name": "laa-sre-admins",
           "level": "developer",
           "github_action_reviewer": "true"
+        },
+        {
+          "sso_group_name": "laa-sre-admins",
+          "level": "instance-management"
         },
         {
           "sso_group_name": "laa-ccms-developers",


### PR DESCRIPTION
## A reference to the issue / Description of it

instance management role for edrms/sres

## How does this PR fix the problem?

allows us to terminate edrms instance in higher environment

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

N/A (Already present in oia, pui and laa-ccms-soa)

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [tbd] All checks have passed
- [n/a] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
