### PR TITLE
TM: delius-prod: add oracle db connectivity to legacy

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/production_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/production_rules.json
@@ -280,6 +280,34 @@
     "destination_port": "5721",
     "protocol": "UDP"
   },
+  "hmpps_production_to_delius_prod_oracledb_1521": {
+    "action": "PASS",
+    "source_ip": "${hmpps-production}",
+    "destination_ip": "${delius-prod}",
+    "destination_port": "1521",
+    "protocol": "TCP"
+  },
+  "hmpps_production_to_delius_prod_oracledb_1522": {
+    "action": "PASS",
+    "source_ip": "${hmpps-production}",
+    "destination_ip": "${delius-prod}",
+    "destination_port": "1522",
+    "protocol": "TCP"
+  },
+  "delius_prod_to_hmpps_production_oracledb_1521": {
+    "action": "PASS",
+    "source_ip": "${delius-prod}",
+    "destination_ip": "${hmpps-production}",
+    "destination_port": "1521",
+    "protocol": "TCP"
+  },
+  "delius_prod_to_hmpps_production_oracledb_1522": {
+    "action": "PASS",
+    "source_ip": "${delius-prod}",
+    "destination_ip": "${hmpps-production}",
+    "destination_port": "1522",
+    "protocol": "TCP"
+  },
   "hmpps_production_to_delius_eng_prod_oracledb": {
     "action": "PASS",
     "source_ip": "${hmpps-production}",


### PR DESCRIPTION
## A reference to the issue / Description of it

To allow migration of delius prod MIS dbs on Saturday

## How does this PR fix the problem?

Allows oracle traffic between legacy and MP

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Similar rules already applied in preprod

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
