### PR TITLE
Enable Object Lock for  replication buckets

### DIFF
--- a/terraform/environments/core-logging/logs_cloudtrail_s3.tf
+++ b/terraform/environments/core-logging/logs_cloudtrail_s3.tf
@@ -1,19 +1,20 @@
 module "s3-bucket-cloudtrail" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=76321e50b20f5c0d918cd45bdcf0b62049f5baf1" # v10.1.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=355197b5695fcce014ad838c7b586b95f9eb4988" # v10.2.0
   providers = {
     aws.bucket-replication = aws.modernisation-platform-eu-west-1
   }
-  bucket_policy              = [data.aws_iam_policy_document.cloudtrail_bucket_policy.json]
-  bucket_name                = "modernisation-platform-logs-cloudtrail"
-  replication_bucket         = "modernisation-platform-logs-cloudtrail-replication"
-  sse_algorithm              = "aws:kms"
-  suffix_name                = "-cloudtrail"
-  custom_kms_key             = aws_kms_key.s3_logging_cloudtrail.arn
-  custom_replication_kms_key = aws_kms_key.s3_logging_cloudtrail_eu-west-1_replication.arn
-  replication_enabled        = true
-  replication_region         = "eu-west-1"
-  ownership_controls         = "BucketOwnerEnforced"
-  log_bucket                 = module.s3-bucket-cloudtrail-logging.bucket.id
+  bucket_policy                = [data.aws_iam_policy_document.cloudtrail_bucket_policy.json]
+  bucket_name                  = "modernisation-platform-logs-cloudtrail"
+  replication_bucket           = "modernisation-platform-logs-cloudtrail-replication"
+  sse_algorithm                = "aws:kms"
+  suffix_name                  = "-cloudtrail"
+  custom_kms_key               = aws_kms_key.s3_logging_cloudtrail.arn
+  custom_replication_kms_key   = aws_kms_key.s3_logging_cloudtrail_eu-west-1_replication.arn
+  replication_enabled          = true
+  replication_object_lock_days = 1
+  replication_region           = "eu-west-1"
+  ownership_controls           = "BucketOwnerEnforced"
+  log_bucket                   = module.s3-bucket-cloudtrail-logging.bucket.id
   log_buckets = tomap({
     "log_bucket_name" : module.s3-bucket-cloudtrail-logging.bucket.id,
     "log_bucket_arn" : module.s3-bucket-cloudtrail-logging.bucket.arn,

--- a/terraform/environments/core-logging/logs_cloudtrail_s3_access_logs.tf
+++ b/terraform/environments/core-logging/logs_cloudtrail_s3_access_logs.tf
@@ -1,5 +1,5 @@
 module "s3-bucket-cloudtrail-logging" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=9facf9fc8f8b8e3f93ffbda822028534b9a75399" # v9.0.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=355197b5695fcce014ad838c7b586b95f9eb4988" # v10.2.0
   providers = {
     aws.bucket-replication = aws.modernisation-platform-eu-west-1
   }
@@ -12,8 +12,9 @@ module "s3-bucket-cloudtrail-logging" {
   custom_replication_kms_key = aws_kms_key.s3_logging_cloudtrail_eu-west-1_replication.arn
   ownership_controls         = "BucketOwnerEnforced"
 
-  replication_enabled = true
-  replication_region  = "eu-west-1"
+  replication_enabled          = true
+  replication_object_lock_days = 1
+  replication_region           = "eu-west-1"
 
   tags = local.tags
 }

--- a/terraform/environments/core-logging/logs_config_s3.tf
+++ b/terraform/environments/core-logging/logs_config_s3.tf
@@ -1,21 +1,22 @@
 ## S3 Bucket Module for AWS Config Logs
 module "s3_bucket_config_logs" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=76321e50b20f5c0d918cd45bdcf0b62049f5baf1" # v10.1.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=355197b5695fcce014ad838c7b586b95f9eb4988" # v10.2.0
 
   providers = {
     aws.bucket-replication = aws.modernisation-platform-eu-west-1
   }
-  bucket_policy               = [data.aws_iam_policy_document.config_bucket_policy.json]
-  bucket_name                 = "modernisation-platform-logs-config"
-  replication_bucket          = "modernisation-platform-logs-config-replication"
-  suffix_name                 = "-config"
-  custom_kms_key              = aws_kms_key.config_logs.arn
-  custom_replication_kms_key  = aws_kms_key.config_logs_replication.arn
-  sse_algorithm               = "aws:kms"
-  enforce_kms_request_headers = false
-  replication_enabled         = true
-  replication_region          = "eu-west-1"
-  versioning_enabled          = true
+  bucket_policy                = [data.aws_iam_policy_document.config_bucket_policy.json]
+  bucket_name                  = "modernisation-platform-logs-config"
+  replication_bucket           = "modernisation-platform-logs-config-replication"
+  suffix_name                  = "-config"
+  custom_kms_key               = aws_kms_key.config_logs.arn
+  custom_replication_kms_key   = aws_kms_key.config_logs_replication.arn
+  sse_algorithm                = "aws:kms"
+  enforce_kms_request_headers  = false
+  replication_enabled          = true
+  replication_object_lock_days = 1
+  replication_region           = "eu-west-1"
+  versioning_enabled           = true
 
   lifecycle_rule = [
     {

--- a/terraform/environments/core-logging/logs_r53_public_dns_s3.tf
+++ b/terraform/environments/core-logging/logs_r53_public_dns_s3.tf
@@ -1,20 +1,21 @@
 ## S3 Bucket Module for AWS Route 53 Public DNS Query Logs
 module "s3_bucket_r53_public_dns_logs" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=76321e50b20f5c0d918cd45bdcf0b62049f5baf1" # v10.1.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=355197b5695fcce014ad838c7b586b95f9eb4988" # v10.2.0
 
   providers = {
     aws.bucket-replication = aws.modernisation-platform-eu-west-1
   }
-  bucket_policy              = [data.aws_iam_policy_document.r53_public_dns_logs_bucket_policy.json]
-  bucket_name                = "modernisation-platform-logs-r53-public-dns-logs"
-  replication_bucket         = "modernisation-platform-logs-r53-public-dns-logs-replication"
-  sse_algorithm              = "aws:kms"
-  suffix_name                = "-r53-public-dns-logs"
-  custom_kms_key             = aws_kms_key.r53_public_dns_logs.arn
-  custom_replication_kms_key = aws_kms_key.r53_public_dns_logs_replication.arn
-  replication_enabled        = true
-  replication_region         = "eu-west-1"
-  versioning_enabled         = true
+  bucket_policy                = [data.aws_iam_policy_document.r53_public_dns_logs_bucket_policy.json]
+  bucket_name                  = "modernisation-platform-logs-r53-public-dns-logs"
+  replication_bucket           = "modernisation-platform-logs-r53-public-dns-logs-replication"
+  sse_algorithm                = "aws:kms"
+  suffix_name                  = "-r53-public-dns-logs"
+  custom_kms_key               = aws_kms_key.r53_public_dns_logs.arn
+  custom_replication_kms_key   = aws_kms_key.r53_public_dns_logs_replication.arn
+  replication_enabled          = true
+  replication_object_lock_days = 1
+  replication_region           = "eu-west-1"
+  versioning_enabled           = true
 
   lifecycle_rule = [
     {

--- a/terraform/modernisation-platform-account/s3.tf
+++ b/terraform/modernisation-platform-account/s3.tf
@@ -341,23 +341,24 @@ resource "aws_kms_alias" "s3_state_bucket_eu-west-1_replication" {
 }
 
 module "state-bucket" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=76321e50b20f5c0d918cd45bdcf0b62049f5baf1" # v10.1.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=355197b5695fcce014ad838c7b586b95f9eb4988" # v10.2.0
 
   providers = {
     aws.bucket-replication = aws.modernisation-platform-eu-west-1
   }
-  bucket_policy               = [data.aws_iam_policy_document.allow-state-access-from-root-account.json, data.aws_iam_policy_document.allow-state-access-for-root-account-sso-admins.json]
-  bucket_name                 = "modernisation-platform-terraform-state"
-  replication_bucket          = "modernisation-platform-terraform-state-replication"
-  suffix_name                 = "-terraform-state"
-  sse_algorithm               = "aws:kms"
-  enforce_kms_request_headers = false
-  replication_enabled         = true
-  replication_region          = "eu-west-1"
-  custom_kms_key              = aws_kms_key.s3_state_bucket_multi_region.arn
-  custom_replication_kms_key  = aws_kms_replica_key.s3_state_bucket_multi_region_replica.arn
-  ownership_controls          = "BucketOwnerEnforced"
-  tags                        = local.tags
+  bucket_policy                = [data.aws_iam_policy_document.allow-state-access-from-root-account.json, data.aws_iam_policy_document.allow-state-access-for-root-account-sso-admins.json]
+  bucket_name                  = "modernisation-platform-terraform-state"
+  replication_bucket           = "modernisation-platform-terraform-state-replication"
+  suffix_name                  = "-terraform-state"
+  sse_algorithm                = "aws:kms"
+  enforce_kms_request_headers  = false
+  replication_enabled          = true
+  replication_object_lock_days = 1
+  replication_region           = "eu-west-1"
+  custom_kms_key               = aws_kms_key.s3_state_bucket_multi_region.arn
+  custom_replication_kms_key   = aws_kms_replica_key.s3_state_bucket_multi_region_replica.arn
+  ownership_controls           = "BucketOwnerEnforced"
+  tags                         = local.tags
 
   lifecycle_rule = [
     {


### PR DESCRIPTION
## A reference to the issue / Description of it

#13105 
## How does this PR fix the problem?

Adding object lock to replication buckets with 1 day retention to test impact.
Cloudtrail logging bucket required a module upgrade from v9.0.0 to v10.2.0, so the plan includes expected module-version alignment changes in addition to Object Lock.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
