### PR TITLE
Add PagerDuty Integration for Delius Oracle Production Alarms

### DIFF
--- a/terraform/pagerduty/aws.tf
+++ b/terraform/pagerduty/aws.tf
@@ -57,6 +57,7 @@ resource "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {
     delius_core_nonprod_alarms           = pagerduty_service_integration.delius_core_nonprod_cloudwatch.integration_key
     delius_core_prod_alarms              = pagerduty_service_integration.delius_core_prod_cloudwatch.integration_key
     delius_oracle_nonprod_alarms         = pagerduty_service_integration.delius_oracle_nonprod_cloudwatch.integration_key
+    delius_oracle_prod_alarms            = pagerduty_service_integration.delius_oracle_prod_cloudwatch.integration_key
     laa_cwa_nonprod_alarms               = pagerduty_service_integration.cwa_non_prod.integration_key
     laa_cwa_prod_alarms                  = pagerduty_service_integration.cwa_prod.integration_key
     hub2_non_prod_alarms                 = pagerduty_service_integration.hub2_non_prod.integration_key

--- a/terraform/pagerduty/member-services-integrations.tf
+++ b/terraform/pagerduty/member-services-integrations.tf
@@ -2466,6 +2466,58 @@ resource "pagerduty_slack_connection" "cis_non_prod" {
   }
 }
 
+
+# Slack channel: #delius-aws-oracle-prod-alerts
+
+resource "pagerduty_service" "delius_oracle_prod" {
+  name                    = "Delius Oracle Prod"
+  description             = "Delius Oracle Prod Alarms"
+  auto_resolve_timeout    = "null"
+  acknowledgement_timeout = "null"
+  escalation_policy       = pagerduty_escalation_policy.member_policy.id
+  alert_creation          = "create_alerts_and_incidents"
+}
+
+resource "pagerduty_service_integration" "delius_oracle_prod_cloudwatch" {
+  name    = data.pagerduty_vendor.cloudwatch.name
+  service = pagerduty_service.delius_oracle_prod.id
+  vendor  = data.pagerduty_vendor.cloudwatch.id
+}
+
+resource "pagerduty_slack_connection" "delius_oracle_prod_connection" {
+  source_id         = pagerduty_service.delius_oracle_prod.id
+  source_type       = "service_reference"
+  workspace_id      = local.slack_workspace_id
+  channel_id        = "CRECAHXT4"
+  notification_type = "responder"
+  lifecycle {
+    ignore_changes = [
+      config,
+    ]
+  }
+  config {
+    events = [
+      "incident.triggered",
+      "incident.acknowledged",
+      "incident.escalated",
+      "incident.resolved",
+      "incident.reassigned",
+      "incident.annotated",
+      "incident.unacknowledged",
+      "incident.delegated",
+      "incident.priority_updated",
+      "incident.action_invocation.created",
+      "incident.action_invocation.terminated",
+      "incident.action_invocation.updated",
+      "incident.responder.added",
+      "incident.responder.replied",
+      "incident.status_update_published",
+      "incident.reopened"
+    ]
+    priorities = ["*"]
+  }
+}
+
 # # Slack channel: #mp-laa-alerts-cis-nonprod
 
 # Performance Hub --------------


### PR DESCRIPTION
## A reference to the issue / Description of it

Requirement for PagerDuty Integration for Delius Oracle Production Alarms similar to existing Non-Production Integration

## How does this PR fix the problem?

Add PagerDuty Integration for Delius Oracle Production Alarms

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Following guidance here:  https://user-guide.modernisation-platform.service.justice.gov.uk/user-guide/integrating-alarms-with-pagerduty-with-slack.html#integrating-cloudwatch-alarms-with-pagerduty-and-slack

No testing done until integrated.

## Deployment Plan / Instructions

Slack Alerts should be available for Alarms

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

n/a