### PR TITLE
fix: Add repository-projects:write permission to biannual-incident

### DIFF
--- a/.github/workflows/biannual-incident-ncsc-recovery-test.yml
+++ b/.github/workflows/biannual-incident-ncsc-recovery-test.yml
@@ -9,6 +9,7 @@ on:
 
 permissions: 
     issues: write 
+    repository-projects: write 
 
 jobs:
   create-and-track-issue:

--- a/.github/workflows/biannual-incident-simulation.yml
+++ b/.github/workflows/biannual-incident-simulation.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   issues: write
+  repository-projects: write
 
 jobs:
   create-and-track-issue:

--- a/.github/workflows/biannual-network-revocation-drill.yml
+++ b/.github/workflows/biannual-network-revocation-drill.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   issues: write
+  repository-projects: write
 
 jobs:
   create-and-track-issue:


### PR DESCRIPTION
The workflow was failing to add created issues to the GitHub Project V2 due to insufficient permissions. The GraphQL mutation `addProjectV2ItemById` requires the `repository-projects:write` permission, but the workflow only had `issues:write` granted.

Added `repository-projects: write` to the permissions block to enable the workflow to successfully add issues to the project.

Resolves: Resource not accessible by integration error