### PR TITLE
Propagate CP attachments into centralised_endpoints TGW route table

### DIFF
--- a/terraform/environments/core-network-services/container_platform_tgw_connections.tf
+++ b/terraform/environments/core-network-services/container_platform_tgw_connections.tf
@@ -57,6 +57,12 @@ resource "aws_ec2_transit_gateway_route_table_propagation" "propagate_cp_attachm
   transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.route-tables["non_live_data"].id
 }
 
+resource "aws_ec2_transit_gateway_route_table_propagation" "propagate_cp_attachments_nonlive_centralised_endpoints" {
+  for_each                       = local.container-platform-nonlive-attachments
+  transit_gateway_attachment_id  = each.value.attachment_id
+  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.centralised_endpoints.id
+}
+
 # Live
 resource "aws_ec2_transit_gateway_route_table_association" "cp_live_association" {
   for_each                       = local.container-platform-live-attachments
@@ -68,4 +74,10 @@ resource "aws_ec2_transit_gateway_route_table_propagation" "propagate_cp_attachm
   for_each                       = local.container-platform-live-attachments
   transit_gateway_attachment_id  = each.value.attachment_id
   transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.route-tables["live_data"].id
+}
+
+resource "aws_ec2_transit_gateway_route_table_propagation" "propagate_cp_attachments_live_centralised_endpoints" {
+  for_each                       = local.container-platform-live-attachments
+  transit_gateway_attachment_id  = each.value.attachment_id
+  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.centralised_endpoints.id
 }


### PR DESCRIPTION
## What
Adds missing TGW route table propagations so cloud-platform/container-platform attachments are also propagated into the `centralised_endpoints` TGW route table.

## Why
CP confirmed DNS resolution to centralised endpoint ENI IPs (10.20.244/245/246.x) but TCP connections timed out. This indicates request path exists but return path from the endpoint hub cannot resolve consumer CIDRs.

In current MP config, these attachments are associated/propagated into `live_data` and `non_live_data`, but not explicitly into `centralised_endpoints`.

## Change
In `terraform/environments/core-network-services/container_platform_tgw_connections.tf`:
- Add `aws_ec2_transit_gateway_route_table_propagation.propagate_cp_attachments_nonlive_centralised_endpoints`
- Add `aws_ec2_transit_gateway_route_table_propagation.propagate_cp_attachments_live_centralised_endpoints`

Both propagate existing CP/cloud-platform attachment IDs into `aws_ec2_transit_gateway_route_table.centralised_endpoints.id`.

## Expected outcome
Once applied, return traffic from centralised endpoint ENIs should be routable back to CP/Cloud Platform CIDRs, resolving the observed TLS timeout.
