### PR TITLE
Fix Config logs S3 replication KMS permissions

### DIFF
--- a/terraform/environments/core-logging/logs_config_s3_kms.tf
+++ b/terraform/environments/core-logging/logs_config_s3_kms.tf
@@ -51,9 +51,15 @@ data "aws_iam_policy_document" "kms_config_logs" {
   }
 
   statement {
-    sid       = "AllowReplicationAccess"
-    effect    = "Allow"
-    actions   = ["kms:Decrypt"]
+    sid    = "AllowReplicationAccess"
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+      "kms:Encrypt",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:DescribeKey"
+    ]
     resources = ["*"]
     principals {
       type = "AWS"


### PR DESCRIPTION
## A reference to the issue / Description of it

The `modernisation-platform-logs-config` bucket was failing replication to `modernisation-platform-logs-config-replication` bucket. Other core logging buckets, such as CloudTrail and Route53 public DNS logs, already allow the replication role the wider set of KMS actions needed for encrypted replication.

## How does this PR fix the problem?

This PR updates the Config logs source KMS key policy so the S3 replication role can use the same KMS action set as the working replicated logging buckets.

The policy now allows the replication role to use:

- `kms:Decrypt`
- `kms:Encrypt`
- `kms:ReEncrypt*`
- `kms:GenerateDataKey*`
- `kms:DescribeKey`

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Tested in Example account. 

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
