### PR TITLE
Add HMPPS and LAA accounts to centralised endpoint DNS share

### DIFF
--- a/terraform/environments/core-network-services/vpc-endpoints.tf
+++ b/terraform/environments/core-network-services/vpc-endpoints.tf
@@ -2,11 +2,15 @@ locals {
   centralised_endpoint_vpc_cidr = "10.20.240.0/20"
 
   centralised_endpoint_consumer_accounts = {
-    cloud-platform-development      = local.environment_management.account_ids["cloud-platform-development"]
-    cloud-platform-preproduction    = local.environment_management.account_ids["cloud-platform-preproduction"]
-    cloud-platform-live             = local.environment_management.account_ids["cloud-platform-live"]
-    container-platform-octo-nonlive = local.environment_management.account_ids["container-platform-octo-nonlive"]
-    container-platform-octo-live    = local.environment_management.account_ids["container-platform-octo-live"]
+    cloud-platform-development       = local.environment_management.account_ids["cloud-platform-development"]
+    cloud-platform-preproduction     = local.environment_management.account_ids["cloud-platform-preproduction"]
+    cloud-platform-live              = local.environment_management.account_ids["cloud-platform-live"]
+    container-platform-hmpps-live    = local.environment_management.account_ids["container-platform-hmpps-live"]
+    container-platform-hmpps-nonlive = local.environment_management.account_ids["container-platform-hmpps-nonlive"]
+    container-platform-laa-live      = local.environment_management.account_ids["container-platform-laa-live"]
+    container-platform-laa-nonlive   = local.environment_management.account_ids["container-platform-laa-nonlive"]
+    container-platform-octo-nonlive  = local.environment_management.account_ids["container-platform-octo-nonlive"]
+    container-platform-octo-live     = local.environment_management.account_ids["container-platform-octo-live"]
   }
 
   centralised_endpoint_configuration = jsondecode(file("${path.module}/centralised-vpc-endpoints.json"))


### PR DESCRIPTION
## What
Adds the HMPPS and LAA container-platform live/non-live accounts to the Route53 Profile RAM share for the centralised VPC endpoints DNS profile.

## Why
Ky requested that these additional container platform accounts receive the shared Route53 Profile so they can associate it with their VPCs and use the centralised interface endpoints.

Accounts added:
- container-platform-hmpps-nonlive
- container-platform-hmpps-live
- container-platform-laa-nonlive
- container-platform-laa-live

## Change
Updates `centralised_endpoint_consumer_accounts` in `terraform/environments/core-network-services/vpc-endpoints.tf` to include the four additional account IDs.

## Notes
This only expands the Route53 Profile RAM share principals; it does not change endpoint configuration or TGW routing.
