### PR TITLE
Adds ingress for tcp 443 (https) from laa-workspaces VPC to laa-general-private subnets.

### DIFF
--- a/terraform/modules/vpc-nacls/locals.tf
+++ b/terraform/modules/vpc-nacls/locals.tf
@@ -81,6 +81,110 @@ locals {
   laa_custom_tcp_rules_to_apply = local.apply_laa_custom_tcp_rules ? local.laa_custom_egress_tcp_acl_rules : {}
 
 
+ # LAA ingress rules from Workspaces. Add/change these as required.
+ # Note - only rule numbers between 2200 and 2219
+
+  laa_workspaces_ingress_rule_list = [
+    {
+      laa_vpc_name    = "laa-development"
+      rule_number     = 2200
+      from_port       = 443
+      to_port         = 443
+      workspaces_cidr = "10.26.130.0/23"
+      subnet_name     = "general-private"
+    },
+    {
+      laa_vpc_name    = "laa-test"
+      rule_number     = 2200
+      from_port       = 443
+      to_port         = 443
+      workspaces_cidr = "10.26.130.0/23"
+      subnet_name     = "general-private"
+    },
+    {
+      laa_vpc_name    = "laa-preproduction"
+      rule_number     = 2200
+      from_port       = 443
+      to_port         = 443
+      workspaces_cidr = "10.27.130.0/23"
+      subnet_name     = "general-private"
+    },
+    {
+      laa_vpc_name    = "laa-production"
+      rule_number     = 2200
+      from_port       = 443
+      to_port         = 443
+      workspaces_cidr = "10.27.130.0/23"
+      subnet_name     = "general-private"
+    }
+  ]
+
+ # LAA egress rules for Workspaces traffic. These are typically stable ephemeral ranges.
+  laa_workspaces_egress_rule_list = [
+    {
+      laa_vpc_name    = "laa-development"
+      rule_number     = 2200
+      from_port       = 1024
+      to_port         = 65535
+      workspaces_cidr = "10.26.130.0/23"
+      subnet_name     = "general-private"
+    },
+    {
+      laa_vpc_name    = "laa-test"
+      rule_number     = 2200
+      from_port       = 1024
+      to_port         = 65535
+      workspaces_cidr = "10.26.130.0/23"
+      subnet_name     = "general-private"
+    },
+    {
+      laa_vpc_name    = "laa-preproduction"
+      rule_number     = 2200
+      from_port       = 1024
+      to_port         = 65535
+      workspaces_cidr = "10.27.130.0/23"
+      subnet_name     = "general-private"
+    },
+    {
+      laa_vpc_name    = "laa-production"
+      rule_number     = 2200
+      from_port       = 1024
+      to_port         = 65535
+      workspaces_cidr = "10.27.130.0/23"
+      subnet_name     = "general-private"
+    }
+  ]
+
+  laa_workspaces_ingress_rules_to_apply = {
+    for idx, rule in local.laa_workspaces_ingress_rule_list :
+    format("laa_workspaces_ingress_%s_%d_%d_%03d", rule.subnet_name, rule.from_port, rule.to_port, idx) => {
+      cidr_block  = rule.workspaces_cidr
+      egress      = false
+      from_port   = rule.from_port
+      to_port     = rule.to_port
+      protocol    = "tcp"
+      rule_action = "allow"
+      rule_number = rule.rule_number
+      subnet_name = rule.subnet_name
+    } if rule.laa_vpc_name == var.vpc_name
+  }
+
+  laa_workspaces_egress_rules_to_apply = {
+    for idx, rule in local.laa_workspaces_egress_rule_list :
+    format("laa_workspaces_egress_%s_%d_%d_%03d", rule.subnet_name, rule.from_port, rule.to_port, idx) => {
+      cidr_block  = rule.workspaces_cidr
+      egress      = true
+      from_port   = rule.from_port
+      to_port     = rule.to_port
+      protocol    = "tcp"
+      rule_action = "allow"
+      rule_number = rule.rule_number
+      subnet_name = rule.subnet_name
+    } if rule.laa_vpc_name == var.vpc_name
+  }
+
+  laa_workspaces_rules_to_apply = merge(local.laa_workspaces_ingress_rules_to_apply, local.laa_workspaces_egress_rules_to_apply)
+
 
   # Custom Rules for access to selected CICA subnets from AP
 

--- a/terraform/modules/vpc-nacls/main.tf
+++ b/terraform/modules/vpc-nacls/main.tf
@@ -258,6 +258,23 @@ resource "aws_network_acl_rule" "laa_custom_tcp_rules" {
   to_port        = each.value.to_port
 }
 
+resource "aws_network_acl_rule" "laa_workspaces_tcp_rules_general_private" {
+  for_each       = local.laa_workspaces_rules_to_apply
+  cidr_block     = each.value.cidr_block
+  egress         = each.value.egress
+  from_port      = each.value.from_port
+  network_acl_id = {
+    "general-private" = aws_network_acl.general-private.id
+    "general-data"    = aws_network_acl.general-data.id
+    "general-public"  = aws_network_acl.general-public.id
+    "protected"       = aws_network_acl.protected.id
+  }[each.value.subnet_name]
+  protocol       = each.value.protocol
+  rule_action    = each.value.rule_action
+  rule_number    = each.value.rule_number
+  to_port        = each.value.to_port
+}
+
 resource "aws_network_acl_rule" "cica_custom_ap_db_rules" {
   for_each       = local.cica_db_rules_to_apply
   cidr_block     = each.value.cidr_block


### PR DESCRIPTION

## A reference to the issue / Description of it

Necessary change as part of the networking to support access from laa-new-workspaces accounts via MOJ and MP transit gateways.

## How does this PR fix the problem?

Rule 3000 effectively blocks all inter-vpc traffic within Modernisation Platform. Because laa-new-workspaces vpcs use 10.26.130.0/23 (dev) and 10.27.130.0/23 (prod) they fall within the scope of this rule & so traffic is blocked. This rule ensures that for tcp 443, access is opened.

There will be additional rules added for ports 1521, 1522 and possibly others.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
