### PR TITLE
Add modernisation-platform-audit security-audit access to CCMS non-prod accounts

### DIFF
--- a/environments/ccms-ebs-upgrade.json
+++ b/environments/ccms-ebs-upgrade.json
@@ -21,6 +21,10 @@
         {
           "sso_group_name": "laa-sre-admins",
           "level": "sandbox"
+        },
+        {
+          "sso_group_name": "modernisation-platform-audit",
+          "level": "security-audit"
         }
       ],
       "nuke": "exclude"
@@ -47,6 +51,10 @@
           "sso_group_name": "laa-ccms-migration-team",
           "level": "instance-management",
           "nuke": "exclude"
+        },
+        {
+          "sso_group_name": "modernisation-platform-audit",
+          "level": "security-audit"
         }
       ]
     }

--- a/environments/ccms-ebs.json
+++ b/environments/ccms-ebs.json
@@ -41,6 +41,10 @@
         {
           "sso_group_name": "modernisation-platform-security",
           "level": "view-only"
+        },
+        {
+          "sso_group_name": "modernisation-platform-audit",
+          "level": "security-audit"
         }
       ],
       "nuke": "exclude"
@@ -83,6 +87,10 @@
         {
           "sso_group_name": "modernisation-platform-security",
           "level": "view-only"
+        },
+        {
+          "sso_group_name": "modernisation-platform-audit",
+          "level": "security-audit"
         }
       ]
     },
@@ -120,6 +128,10 @@
         {
           "sso_group_name": "modernisation-platform-security",
           "level": "view-only"
+        },
+        {
+          "sso_group_name": "modernisation-platform-audit",
+          "level": "security-audit"
         }
       ]
     },

--- a/environments/ccms-edrms.json
+++ b/environments/ccms-edrms.json
@@ -20,6 +20,10 @@
         {
           "sso_group_name": "laa-dba",
           "level": "developer"
+        },
+        {
+          "sso_group_name": "modernisation-platform-audit",
+          "level": "security-audit"
         }
       ],
       "nuke": "exclude"
@@ -42,6 +46,10 @@
         {
           "sso_group_name": "laa-dba",
           "level": "developer"
+        },
+        {
+          "sso_group_name": "modernisation-platform-audit",
+          "level": "security-audit"
         }
       ]
     },
@@ -63,6 +71,10 @@
         {
           "sso_group_name": "laa-dba",
           "level": "developer"
+        },
+        {
+          "sso_group_name": "modernisation-platform-audit",
+          "level": "security-audit"
         }
       ]
     },

--- a/environments/ccms-oia.json
+++ b/environments/ccms-oia.json
@@ -19,6 +19,10 @@
         {
           "sso_group_name": "laa-dba",
           "level": "developer"
+        },
+        {
+          "sso_group_name": "modernisation-platform-audit",
+          "level": "security-audit"
         }
       ],
       "nuke": "exclude"
@@ -41,6 +45,10 @@
         {
           "sso_group_name": "laa-dba",
           "level": "developer"
+        },
+        {
+          "sso_group_name": "modernisation-platform-audit",
+          "level": "security-audit"
         }
       ]
     },
@@ -62,6 +70,10 @@
         {
           "sso_group_name": "laa-dba",
           "level": "developer"
+        },
+        {
+          "sso_group_name": "modernisation-platform-audit",
+          "level": "security-audit"
         }
       ]
     },

--- a/environments/ccms-pui-internal.json
+++ b/environments/ccms-pui-internal.json
@@ -13,6 +13,10 @@
         {
           "sso_group_name": "laa-sre-admins",
           "level": "sandbox"
+        },
+        {
+          "sso_group_name": "modernisation-platform-audit",
+          "level": "security-audit"
         }
       ],
       "nuke": "exclude"
@@ -23,6 +27,10 @@
         {
           "sso_group_name": "laa-sre-admins",
           "level": "developer"
+        },
+        {
+          "sso_group_name": "modernisation-platform-audit",
+          "level": "security-audit"
         }
       ]
     },
@@ -32,6 +40,10 @@
         {
           "sso_group_name": "laa-sre-admins",
           "level": "developer"
+        },
+        {
+          "sso_group_name": "modernisation-platform-audit",
+          "level": "security-audit"
         }
       ]
     },

--- a/environments/ccms-pui.json
+++ b/environments/ccms-pui.json
@@ -11,6 +11,10 @@
         {
           "sso_group_name": "laa-ccms-developers",
           "level": "developer"
+        },
+        {
+          "sso_group_name": "modernisation-platform-audit",
+          "level": "security-audit"
         }
       ],
       "nuke": "exclude"
@@ -29,6 +33,10 @@
         {
           "sso_group_name": "laa-ccms-developers",
           "level": "developer"
+        },
+        {
+          "sso_group_name": "modernisation-platform-audit",
+          "level": "security-audit"
         }
       ]
     },
@@ -46,6 +54,10 @@
         {
           "sso_group_name": "laa-ccms-developers",
           "level": "developer"
+        },
+        {
+          "sso_group_name": "modernisation-platform-audit",
+          "level": "security-audit"
         }
       ]
     },


### PR DESCRIPTION
## What
Adds the `modernisation-platform-audit` team with `security-audit` access to the requested CCMS non-production account environments.

## Accounts covered
- ccms-ebs-development
- ccms-ebs-preproduction
- ccms-ebs-test
- ccms-ebs-upgrade-development
- ccms-ebs-upgrade-test
- ccms-edrms-development
- ccms-edrms-preproduction
- ccms-edrms-test
- ccms-oia-development
- ccms-oia-preproduction
- ccms-oia-test
- ccms-pui-development
- ccms-pui-preproduction
- ccms-pui-test
- ccms-pui-internal-development
- ccms-pui-internal-preproduction
- ccms-pui-internal-test

## Change details
Updated access lists in:
- `environments/ccms-ebs.json`
- `environments/ccms-ebs-upgrade.json`
- `environments/ccms-edrms.json`
- `environments/ccms-oia.json`
- `environments/ccms-pui.json`
- `environments/ccms-pui-internal.json`

Each target environment now includes:
- `sso_group_name`: `modernisation-platform-audit`
- `level`: `security-audit`

## Validation
- All modified JSON files parse successfully.
- Verified all 17 requested account/environment combinations now include the new access entry.
