### PR TITLE
Give hmpps dba team reporting operationrole in preprod/prod

### DIFF
--- a/environments/delius-core.json
+++ b/environments/delius-core.json
@@ -181,6 +181,10 @@
           "github_action_reviewer": "true"
         },
         {
+          "sso_group_name": "hmpps-dba",
+          "level": "reporting-operations"
+        },
+        {
           "sso_group_name": "unilink",
           "level": "developer"
         },
@@ -242,6 +246,10 @@
           "sso_group_name": "hmpps-dba",
           "level": "developer",
           "github_action_reviewer": "true"
+        },
+        {
+          "sso_group_name": "hmpps-dba",
+          "level": "reporting-operations"
         },
         {
           "sso_group_name": "unilink",


### PR DESCRIPTION
## A reference to the issue / Description of it

hmpps-dba SSO group require reporting-operations role in preprod/prod

## How does this PR fix the problem?

Gives them access

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

N/A

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

N/A

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

N/A
