### PR TITLE
Update resource name

### DIFF
--- a/terraform/environments/core-network-services/route53.tf
+++ b/terraform/environments/core-network-services/route53.tf
@@ -165,7 +165,7 @@ resource "aws_route53_record" "amend_a_claim_laa" {
   ]
 }
 
-resource "aws_route53_record" "amend_a_claim_laa" {
+resource "aws_route53_record" "laa_service_txt" {
   allow_overwrite = true
   name            = "laa.service.justice.gov.uk"
   ttl             = 30


### PR DESCRIPTION
Route53 TXT record resource renamed to laa_service_txt for laa.service.justice.gov.uk.