### PR TITLE
Handle non-standard DNS names for centralised interface endpoints

### DIFF
--- a/terraform/environments/core-network-services/vpc-endpoints.tf
+++ b/terraform/environments/core-network-services/vpc-endpoints.tf
@@ -20,9 +20,31 @@ locals {
     replace(endpoint_name, ".", "_") => "com.amazonaws.${data.aws_region.current.region}.${endpoint_name}"
   }
 
+  centralised_endpoint_service_private_dns_zone_overrides = {
+    detective          = "api.detective.${data.aws_region.current.region}.amazonaws.com"
+    ecr_api            = "api.ecr.${data.aws_region.current.region}.amazonaws.com"
+    ecr_dkr            = "dkr.ecr.${data.aws_region.current.region}.amazonaws.com"
+    "eks-auth"         = "eks-auth.${data.aws_region.current.region}.api.aws"
+    "kinesis-firehose" = "firehose.${data.aws_region.current.region}.amazonaws.com"
+  }
+
   centralised_endpoint_service_private_dns_zones = {
     for service_name, service in local.centralised_interface_endpoint_services :
-    service_name => "${replace(service, "com.amazonaws.${data.aws_region.current.region}.", "")}.${data.aws_region.current.region}.amazonaws.com"
+    service_name => lookup(
+      local.centralised_endpoint_service_private_dns_zone_overrides,
+      service_name,
+      "${replace(service, "com.amazonaws.${data.aws_region.current.region}.", "")}.${data.aws_region.current.region}.amazonaws.com"
+    )
+  }
+
+  centralised_endpoint_service_wildcard_alias_zone_keys = toset([
+    "ecr_dkr",
+  ])
+
+  centralised_endpoint_service_wildcard_alias_zones = {
+    for service_name, zone_name in local.centralised_endpoint_service_private_dns_zones :
+    service_name => zone_name
+    if contains(local.centralised_endpoint_service_wildcard_alias_zone_keys, service_name)
   }
 }
 
@@ -144,6 +166,20 @@ resource "aws_route53_record" "centralised_endpoint_alias_records" {
 
   zone_id = aws_route53_zone.centralised_endpoint_private_zones[each.key].zone_id
   name    = each.value
+  type    = "A"
+
+  alias {
+    name                   = aws_vpc_endpoint.centralised_interface_endpoints[each.key].dns_entry[0].dns_name
+    zone_id                = aws_vpc_endpoint.centralised_interface_endpoints[each.key].dns_entry[0].hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "centralised_endpoint_wildcard_alias_records" {
+  for_each = local.centralised_endpoint_service_wildcard_alias_zones
+
+  zone_id = aws_route53_zone.centralised_endpoint_private_zones[each.key].zone_id
+  name    = "*.${each.value}"
   type    = "A"
 
   alias {


### PR DESCRIPTION
## What
Adds explicit Route53 private zone name overrides for centralised interface endpoint services that do not follow the default `<service>.<region>.amazonaws.com` pattern.

## Why
Ky's endpoint validation showed several services resolving publicly or failing DNS because the current Terraform assumes all endpoint DNS names can be derived from the endpoint service name.

Affected services:
- Detective: `api.detective.<region>.amazonaws.com`
- ECR API: `api.ecr.<region>.amazonaws.com`
- ECR Docker: `dkr.ecr.<region>.amazonaws.com`
- EKS Auth: `eks-auth.<region>.api.aws`
- Kinesis Firehose: `firehose.<region>.amazonaws.com`

Also, ECR Docker image pulls use account-specific hostnames under `*.dkr.ecr.<region>.amazonaws.com`, so a wildcard alias record is required.

## Change
In `terraform/environments/core-network-services/vpc-endpoints.tf`:
- Add `centralised_endpoint_service_private_dns_zone_overrides` map for the non-standard services above
- Apply these overrides when constructing `centralised_endpoint_service_private_dns_zones`
- Add `aws_route53_record.centralised_endpoint_wildcard_alias_records` for `*.dkr.ecr.<region>.amazonaws.com` (ECR Docker)

## Validation
- Ran `terraform fmt` on the file
- Verified override keys match configured endpoint service keys in `centralised-vpc-endpoints.json`

## Expected outcome
These services should now resolve to private `10.20.24x.x` endpoint IPs via the shared Route53 Profile and be reachable over the centralised endpoint hub.
