### PR TITLE
Review and update IAM access key hygiene script documentation

### DIFF
--- a/source/user-guide/iam-hygiene-script.html.md.erb
+++ b/source/user-guide/iam-hygiene-script.html.md.erb
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#modernisation-platform"
 title: IAM Access Key Hygiene Script
-last_reviewed_on: 2026-01-07
+last_reviewed_on: 2026-07-08
 review_in: 6 months
 ---
 
@@ -114,16 +114,16 @@ To reduce execution time and avoid API throttling:
 
 Each matrix job invokes the reusable workflow and passes the script command:
 
-    bash ./scripts/iam-monitoring/inactive-keys-and-users/check_iam_users_and_keys.sh --dry-run 
+    bash ./scripts/iam-monitoring/inactive-keys-and-users/check_iam_users_and_keys.sh
 
 ### Important notes
 
-- The current configuration runs in **dry-run mode**
-- No IAM resources are modified
-- No GOV.UK Notify emails are sent
+- The current workflow configuration runs in **live mode**
+- IAM resources can be modified when inactivity thresholds are met
+- GOV.UK Notify emails can be sent when the API key and template ID are configured
 - Output files are still generated for review
 
-To enable live enforcement, remove `--dry-run`.
+To run without making changes or sending emails, add `--dry-run` to the script command, or set `DRY_RUN=true`.
 
 ---
 
@@ -217,7 +217,8 @@ Depending on configuration, it can:
 
 Dry-run is enabled when:
 
-- The first argument is `--dry-run` or `dry-run`, OR
+- The first argument is `--dry-run` or `dry-run`
+- The `DRY_RUN` environment variable is set to `true`
 
 In dry-run mode:
 
@@ -235,13 +236,13 @@ Defaults (in days):
 
 - Notify: `KEY_NOTIFY_DAYS=30`
 - Disable: `KEY_DISABLE_DAYS=60`
-- Delete: `KEY_DELETE_DAYS=90`
+- Delete: `KEY_DELETE_DAYS=150`
 
 ### Users
 
 - Notify: `USER_NOTIFY_DAYS=30`
 - Disable: `USER_DISABLE_DAYS=60`
-- Delete: `USER_DELETE_DAYS=90`
+- Delete: `USER_DELETE_DAYS=150`
 
 Thresholds can be overridden via environment variables.
 


### PR DESCRIPTION
## A reference to the issue / Description of it

https://moj.enterprise.slack.com/archives/C013RM6MFFW/p1783505379653479 - Review of the `IAM Access Key Hygiene Script` user guide page.

## How does this PR fix the problem?

This PR updates the page review date and refreshes stale content so the documentation matches the current IAM hygiene workflow and script behaviour.

The documentation now reflects that:

- The scheduled workflow currently calls `check_iam_users_and_keys.sh` without `--dry-run`, so it runs in live mode:
  https://github.com/ministryofjustice/modernisation-platform/blob/main/.github/workflows/iam-access-key-hygiene-extended-matrix.yml#L130-L131

- Dry-run mode is available by passing `--dry-run` / `dry-run`, or by setting `DRY_RUN=true`:
  https://github.com/ministryofjustice/modernisation-platform/blob/main/scripts/iam-monitoring/inactive-keys-and-users/check_iam_users_and_keys.sh#L62-L64

- The default delete thresholds are now 150 days for both access keys and users:
  https://github.com/ministryofjustice/modernisation-platform/blob/main/scripts/iam-monitoring/inactive-keys-and-users/check_iam_users_and_keys.sh#L75-L80

## How has this been tested?

Reviewed the documentation against the current workflow and script files:

- `.github/workflows/iam-access-key-hygiene-extended-matrix.yml`
- `scripts/iam-monitoring/inactive-keys-and-users/check_iam_users_and_keys.sh`

## Deployment Plan / Instructions

No platform or service impact expected. This is a documentation-only change.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)