### PR TITLE
Add `schemas:*` to permitted MemberInfrastructureAccess IAM actions

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -295,6 +295,7 @@ data "aws_iam_policy_document" "member-access-data" {
       "elasticache:*",
       "elasticfilesystem:*",
       "es:*",
+      "firehose:*",
       "fsx:*",
       "glacier:*",
       "glue:*",
@@ -304,14 +305,14 @@ data "aws_iam_policy_document" "member-access-data" {
       "lakeformation:*",
       "macie2:*",
       "quicksight:*",
-      "rds-db:*",
       "rds:*",
       "rds-data:*",
+      "rds-db:*",
       "redshift:*",
       "redshift-data:*",
       "redshift-serverless:*",
       "s3:*",
-      "firehose:*"
+      "schemas:*"
     ]
     resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
   }


### PR DESCRIPTION
## A reference to the issue / Description of it

Required by https://github.com/ministryofjustice/modernisation-platform-environments/pull/17733

## How does this PR fix the problem?

The Integration Hub File Transfer design proposes the use of stable Events as part of its architecture. This permission allows Terraform to create and populate a schema registry

## How has this been tested?

Tested through CI pipeline

## Deployment Plan / Instructions

Deploy through CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
