### PR TITLE
Fix TFLint null provider constraint in pagerduty

### DIFF
--- a/terraform/pagerduty/versions.tf
+++ b/terraform/pagerduty/versions.tf
@@ -4,6 +4,10 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 6.0"
     }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.2"
+    }
     pagerduty = {
       source  = "pagerduty/pagerduty"
       version = "~> 3.15"


### PR DESCRIPTION
## What
Add a missing `null` provider constraint in `terraform/pagerduty/versions.tf`.

## Why
`terraform/pagerduty/status-page-subscriptions.tf` uses `null_resource`, and TFLint (`terraform_required_providers`) fails without an explicit `hashicorp/null` entry in `required_providers`.

## Change
- Added:
  - `null` provider source: `hashicorp/null`
  - `null` provider version: `~> 3.2`

## Validation
- Addresses CI warning:
  - `Missing version constraint for provider "null" in required_providers`