### PR TITLE
Allow integration-hub API repo in OIDC allowlist

### DIFF
--- a/environments/integration-hub-api.json
+++ b/environments/integration-hub-api.json
@@ -20,6 +20,8 @@
     "slack-channel": "ask-integration-hub",
     "critical-national-infrastructure": false
   },
-  "github-oidc-team-repositories": [],
+  "github-oidc-team-repositories": [
+    "ministryofjustice/integration-hub-file-transfer-api"
+  ],
   "go-live-date": ""
 }


### PR DESCRIPTION
## What
Add `ministryofjustice/integration-hub-file-transfer-api` to `github-oidc-team-repositories` in `environments/integration-hub-api.json`.

## Why
This aligns the API repo deployment workflow with the approved Modernisation Platform OIDC pattern for assuming the app deploy role into the Integration Hub API account.

## Related
- ministryofjustice/integration-hub-file-transfer-api#3
- ministryofjustice/modernisation-platform-environments#17662
