### PR TITLE
Add permissions for CP identity role to access state bucket

### DIFF
--- a/terraform/modernisation-platform-account/s3.tf
+++ b/terraform/modernisation-platform-account/s3.tf
@@ -981,7 +981,7 @@ data "aws_iam_policy_document" "allow-state-access-from-root-account" {
     }
   }
   statement {
-    sid    = "AllowCloudPlatformDevelopmentClusterAccess"
+    sid    = "AllowCloudPlatformAccess"
     effect = "Allow"
     actions = [
       "s3:GetObject",
@@ -993,7 +993,8 @@ data "aws_iam_policy_document" "allow-state-access-from-root-account" {
     principals {
       type = "AWS"
       identifiers = [
-        "arn:aws:iam::${local.environment_management.account_ids["cloud-platform-development"]}:role/github-actions-development-cluster"
+        "arn:aws:iam::${local.environment_management.account_ids["cloud-platform-development"]}:role/github-actions-development-cluster",
+        "arn:aws:iam::${local.environment_management.account_ids["cloud-platform-live"]}:role/github-actions-container-platform-identity-apply"
       ]
     }
   }


### PR DESCRIPTION

## A reference to the issue / Description of it

This Identity terraform creates permissions sets in the AWS root account, writing the state to cloud-platform/container-platform-identity/ to keep all the CP state in one place (the cloud-platform folder in the MP state bucket)

## How has this been tested?

Following existing access pattern.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
