### PR TITLE
feat: add Entra SSO access for data-platform and data-platform-governance

### DIFF
--- a/environments/data-platform-governance.json
+++ b/environments/data-platform-governance.json
@@ -14,6 +14,10 @@
           "sso_group_name": "data-platform-engineering",
           "level": "platform-engineer-admin",
           "github_action_reviewer": "true"
+        },
+        {
+          "sso_group_name": "azure-aws-sso-data-platform-engineering",
+          "level": "platform-engineer-admin"
         }
       ],
       "instance_scheduler_skip": ["true"],
@@ -26,6 +30,10 @@
           "sso_group_name": "data-platform-engineering",
           "level": "platform-engineer-admin",
           "github_action_reviewer": "true"
+        },
+        {
+          "sso_group_name": "azure-aws-sso-data-platform-engineering",
+          "level": "platform-engineer-admin"
         }
       ],
       "instance_scheduler_skip": ["true"]
@@ -37,6 +45,10 @@
           "sso_group_name": "data-platform-engineering",
           "level": "platform-engineer-admin",
           "github_action_reviewer": "true"
+        },
+        {
+          "sso_group_name": "azure-aws-sso-data-platform-engineering",
+          "level": "platform-engineer-admin"
         }
       ],
       "instance_scheduler_skip": ["true"]
@@ -48,6 +60,10 @@
           "sso_group_name": "data-platform-engineering",
           "level": "platform-engineer-admin",
           "github_action_reviewer": "true"
+        },
+        {
+          "sso_group_name": "azure-aws-sso-data-platform-engineering",
+          "level": "platform-engineer-admin"
         },
         {
           "sso_group_name": "modernisation-platform-audit",

--- a/environments/data-platform.json
+++ b/environments/data-platform.json
@@ -35,6 +35,10 @@
           "sso_group_name": "data-platform-engineering",
           "level": "platform-engineer-admin",
           "github_action_reviewer": "true"
+        },
+        {
+          "sso_group_name": "azure-aws-sso-data-platform-engineering",
+          "level": "platform-engineer-admin"
         }
       ],
       "instance_scheduler_skip": ["true"],
@@ -47,6 +51,10 @@
           "sso_group_name": "data-platform-engineering",
           "level": "platform-engineer-admin",
           "github_action_reviewer": "true"
+        },
+        {
+          "sso_group_name": "azure-aws-sso-data-platform-engineering",
+          "level": "platform-engineer-admin"
         }
       ],
       "instance_scheduler_skip": ["true"]
@@ -58,6 +66,10 @@
           "sso_group_name": "data-platform-engineering",
           "level": "platform-engineer-admin",
           "github_action_reviewer": "true"
+        },
+        {
+          "sso_group_name": "azure-aws-sso-data-platform-engineering",
+          "level": "platform-engineer-admin"
         }
       ],
       "instance_scheduler_skip": ["true"]
@@ -69,6 +81,10 @@
           "sso_group_name": "data-platform-engineering",
           "level": "platform-engineer-admin",
           "github_action_reviewer": "true"
+        },
+        {
+          "sso_group_name": "azure-aws-sso-data-platform-engineering",
+          "level": "platform-engineer-admin"
         },
         {
           "sso_group_name": "modernisation-platform-audit",


### PR DESCRIPTION
## A reference to the issue / Description of it

Issue is [here](https://github.com/ministryofjustice/data-platform/issues/133)

## How does this PR fix the problem?

Adds the Entra-backed SSO group azure-aws-sso-data-platform-engineering at platform-engineer-admin to all four environments (development, test, preproduction, production) in both environments/data-platform.json and environments/data-platform-governance.json, alongside the existing GitHub-backed data-platform-engineering group.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No. This is an access-control change only - it adds an AWS IAM Identity Center account assignment (the Entra group → platform-engineer-admin permission set) for the data-platform and data-platform-governance accounts. It doesn't touch any infrastructure, workloads, networking, or data on the platform, so there's no downtime or service impact.

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
