### PR TITLE
Pilot Route53 Profile-native DNS for selected interface endpoints

### DIFF
--- a/terraform/environments/core-network-services/output.tf
+++ b/terraform/environments/core-network-services/output.tf
@@ -86,10 +86,16 @@ output "centralised_endpoint_vpc_id" {
 }
 
 output "centralised_interface_endpoint_arns" {
-  value = {
-    for name, endpoint in aws_vpc_endpoint.centralised_interface_endpoints :
-    name => endpoint.arn
-  }
+  value = merge(
+    {
+      for name, endpoint in aws_vpc_endpoint.centralised_interface_endpoints :
+      name => endpoint.arn
+    },
+    {
+      for name, endpoint in aws_vpc_endpoint.centralised_interface_endpoints_profile_native :
+      name => endpoint.arn
+    }
+  )
 }
 
 

--- a/terraform/environments/core-network-services/vpc-endpoints.tf
+++ b/terraform/environments/core-network-services/vpc-endpoints.tf
@@ -20,6 +20,29 @@ locals {
     replace(endpoint_name, ".", "_") => "com.amazonaws.${data.aws_region.current.region}.${endpoint_name}"
   }
 
+  # Pilot migration cohort for native Route53 Profile <-> VPC endpoint integration.
+  # Endpoints in this set use private_dns_enabled = true and are associated to the
+  # profile directly, avoiding self-managed PHZ/alias records.
+  centralised_endpoint_profile_native_service_keys = toset([
+    "detective",
+    "ecr_api",
+    "ecr_dkr",
+    "eks-auth",
+    "kinesis-firehose",
+  ])
+
+  centralised_interface_endpoint_services_profile_native = {
+    for service_name, service in local.centralised_interface_endpoint_services :
+    service_name => service
+    if contains(local.centralised_endpoint_profile_native_service_keys, service_name)
+  }
+
+  centralised_interface_endpoint_services_legacy_dns = {
+    for service_name, service in local.centralised_interface_endpoint_services :
+    service_name => service
+    if !contains(local.centralised_endpoint_profile_native_service_keys, service_name)
+  }
+
   centralised_endpoint_service_private_dns_zone_overrides = {
     detective          = "api.detective.${data.aws_region.current.region}.amazonaws.com"
     ecr_api            = "api.ecr.${data.aws_region.current.region}.amazonaws.com"
@@ -28,8 +51,8 @@ locals {
     "kinesis-firehose" = "firehose.${data.aws_region.current.region}.amazonaws.com"
   }
 
-  centralised_endpoint_service_private_dns_zones = {
-    for service_name, service in local.centralised_interface_endpoint_services :
+  centralised_endpoint_service_private_dns_zones_legacy = {
+    for service_name, service in local.centralised_interface_endpoint_services_legacy_dns :
     service_name => lookup(
       local.centralised_endpoint_service_private_dns_zone_overrides,
       service_name,
@@ -42,7 +65,7 @@ locals {
   ])
 
   centralised_endpoint_service_wildcard_alias_zones = {
-    for service_name, zone_name in local.centralised_endpoint_service_private_dns_zones :
+    for service_name, zone_name in local.centralised_endpoint_service_private_dns_zones_legacy :
     service_name => zone_name
     if contains(local.centralised_endpoint_service_wildcard_alias_zone_keys, service_name)
   }
@@ -127,7 +150,7 @@ resource "aws_security_group_rule" "centralised_endpoint_interface_ingress" {
 }
 
 resource "aws_vpc_endpoint" "centralised_interface_endpoints" {
-  for_each = local.centralised_interface_endpoint_services
+  for_each = local.centralised_interface_endpoint_services_legacy_dns
 
   vpc_id              = module.vpc_centralised_endpoints.vpc_id
   service_name        = each.value
@@ -144,8 +167,26 @@ resource "aws_vpc_endpoint" "centralised_interface_endpoints" {
   )
 }
 
+resource "aws_vpc_endpoint" "centralised_interface_endpoints_profile_native" {
+  for_each = local.centralised_interface_endpoint_services_profile_native
+
+  vpc_id              = module.vpc_centralised_endpoints.vpc_id
+  service_name        = each.value
+  vpc_endpoint_type   = "Interface"
+  private_dns_enabled = true
+  subnet_ids          = module.vpc_centralised_endpoints.non_tgw_subnet_ids_map["private"]
+  security_group_ids  = [aws_security_group.centralised_endpoint_interface.id]
+
+  tags = merge(
+    local.tags,
+    {
+      Name = "${local.application_name}-${each.key}-centralised-endpoint"
+    }
+  )
+}
+
 resource "aws_route53_zone" "centralised_endpoint_private_zones" {
-  for_each = local.centralised_endpoint_service_private_dns_zones
+  for_each = local.centralised_endpoint_service_private_dns_zones_legacy
 
   name = each.value
 
@@ -162,7 +203,7 @@ resource "aws_route53_zone" "centralised_endpoint_private_zones" {
 }
 
 resource "aws_route53_record" "centralised_endpoint_alias_records" {
-  for_each = local.centralised_endpoint_service_private_dns_zones
+  for_each = local.centralised_endpoint_service_private_dns_zones_legacy
 
   zone_id = aws_route53_zone.centralised_endpoint_private_zones[each.key].zone_id
   name    = each.value
@@ -199,6 +240,14 @@ resource "aws_route53profiles_resource_association" "centralised_endpoint_privat
   for_each = aws_route53_zone.centralised_endpoint_private_zones
 
   name         = "${local.application_name}-${each.key}-private-zone"
+  profile_id   = aws_route53profiles_profile.centralised_endpoint_dns_profile.id
+  resource_arn = each.value.arn
+}
+
+resource "aws_route53profiles_resource_association" "centralised_endpoint_profile_native_associations" {
+  for_each = aws_vpc_endpoint.centralised_interface_endpoints_profile_native
+
+  name         = "${local.application_name}-${each.key}-endpoint"
   profile_id   = aws_route53profiles_profile.centralised_endpoint_dns_profile.id
   resource_arn = each.value.arn
 }

--- a/terraform/environments/core-network-services/vpc-endpoints.tf
+++ b/terraform/environments/core-network-services/vpc-endpoints.tf
@@ -24,11 +24,8 @@ locals {
   # Endpoints in this set use private_dns_enabled = true and are associated to the
   # profile directly, avoiding self-managed PHZ/alias records.
   centralised_endpoint_profile_native_service_keys = toset([
-    "detective",
-    "ecr_api",
-    "ecr_dkr",
-    "eks-auth",
-    "kinesis-firehose",
+    "sns",
+    "sqs",
   ])
 
   centralised_interface_endpoint_services_profile_native = {


### PR DESCRIPTION
## What
Implements a phased migration path to the new Route53 Profiles + interface VPC endpoint integration in `core-network-services`.

This PR introduces a pilot cohort of endpoints that now use native profile endpoint associations (with endpoint Private DNS enabled), while the remaining endpoints continue on the existing self-managed PHZ/alias model.

## Why
Ky's testing showed a set of services with non-standard DNS naming behavior requiring bespoke PHZ exceptions and wildcard records under the legacy approach.

AWS now supports associating interface VPC endpoints directly with Route53 Profiles, which can eliminate much of that custom DNS management.

We are piloting with a small initial set agreed with Ky before expanding further.

## Pilot services moved to profile-native mode
- **SQS**
- **SNS**

## Change details
### `terraform/environments/core-network-services/vpc-endpoints.tf`
- Split endpoints into two cohorts:
  - `centralised_interface_endpoint_services_legacy_dns`
  - `centralised_interface_endpoint_services_profile_native`
- Keep legacy endpoints on:
  - `private_dns_enabled = false`
  - self-managed Route53 PHZ + alias records
- Move pilot endpoints to:
  - `private_dns_enabled = true`
  - direct `aws_route53profiles_resource_association` to endpoint ARNs
- Scope PHZ/alias resources to legacy cohort only.

### `terraform/environments/core-network-services/output.tf`
- Update `centralised_interface_endpoint_arns` output to merge ARNs from both endpoint cohorts.

## Safety / migration behavior
- This is a phased, non-big-bang migration — starting with just SQS and SNS.
- Legacy behavior remains for all non-pilot services.
- Pilot services can be expanded incrementally by adding to `centralised_endpoint_profile_native_service_keys`.
- If the pilot validates successfully, remaining services will be migrated in follow-up PRs.

## Validation
- Ran `terraform fmt` on changed files.
- Coordinated pilot scope with Ky (Cloud Platform team).