### PR TITLE
Fix: Remove SNS and SQS to resolve ConflictingDomainExists on profile-native endpoint migration

### DIFF
--- a/terraform/environments/core-network-services/centralised-vpc-endpoints.json
+++ b/terraform/environments/core-network-services/centralised-vpc-endpoints.json
@@ -26,8 +26,6 @@
     "rds-data",
     "secretsmanager",
     "securityhub",
-    "sns",
-    "sqs",
     "ssm",
     "sts",
     "transcribe",

--- a/terraform/environments/core-network-services/vpc-endpoints.tf
+++ b/terraform/environments/core-network-services/vpc-endpoints.tf
@@ -23,10 +23,7 @@ locals {
   # Pilot migration cohort for native Route53 Profile <-> VPC endpoint integration.
   # Endpoints in this set use private_dns_enabled = true and are associated to the
   # profile directly, avoiding self-managed PHZ/alias records.
-  centralised_endpoint_profile_native_service_keys = toset([
-    "sns",
-    "sqs",
-  ])
+  centralised_endpoint_profile_native_service_keys = toset([])
 
   centralised_interface_endpoint_services_profile_native = {
     for service_name, service in local.centralised_interface_endpoint_services :


### PR DESCRIPTION
## What
Removes SNS and SQS from the centralised endpoint service list and clears the profile-native pilot cohort.

## Why
PR #13572 introduced a pilot migration of SNS and SQS to Route53 Profile-native endpoint associations (`private_dns_enabled = true`). When applied, it failed with:

```
ConflictingDomainExists: private-dns-enabled cannot be set because there is already
a conflicting DNS domain for sqs.eu-west-2.amazonaws.com in the VPC
```

This is a Terraform sequencing problem: the new endpoint (different resource address) was created **in parallel** with the destruction of the old self-managed PHZ, which was still associated with the hub VPC when the create was attempted.

Since these services are confirmed **not currently in active use** (per Ky Truong), we can cleanly destroy the legacy endpoints and PHZs in this PR.

## Plan for this apply
- Destroy: `aws_vpc_endpoint.centralised_interface_endpoints["sns"]`
- Destroy: `aws_vpc_endpoint.centralised_interface_endpoints["sqs"]`
- Destroy: `aws_route53_zone.centralised_endpoint_private_zones["sns"]`
- Destroy: `aws_route53_zone.centralised_endpoint_private_zones["sqs"]`
- Destroy: associated Route53 records and profile PHZ associations for SNS and SQS

## Next steps
A follow-up PR will re-add SNS and SQS directly into the profile-native cohort (with `private_dns_enabled = true` and direct Route53 profile endpoint associations). With the hub VPC now clean of conflicting PHZs, the creation will succeed without conflict.

## Notes
- No impact on any other endpoints (all others remain on legacy PHZ model)
- Confirmed safe to proceed by Ky Truong (Cloud Platform team)