### PR TITLE
Step 2: Re-add SNS and SQS as profile-native centralised interface endpoints

### DIFF
--- a/terraform/environments/core-network-services/centralised-vpc-endpoints.json
+++ b/terraform/environments/core-network-services/centralised-vpc-endpoints.json
@@ -26,6 +26,8 @@
     "rds-data",
     "secretsmanager",
     "securityhub",
+    "sns",
+    "sqs",
     "ssm",
     "sts",
     "transcribe",

--- a/terraform/environments/core-network-services/vpc-endpoints.tf
+++ b/terraform/environments/core-network-services/vpc-endpoints.tf
@@ -23,7 +23,10 @@ locals {
   # Pilot migration cohort for native Route53 Profile <-> VPC endpoint integration.
   # Endpoints in this set use private_dns_enabled = true and are associated to the
   # profile directly, avoiding self-managed PHZ/alias records.
-  centralised_endpoint_profile_native_service_keys = toset([])
+  centralised_endpoint_profile_native_service_keys = toset([
+    "sns",
+    "sqs",
+  ])
 
   centralised_interface_endpoint_services_profile_native = {
     for service_name, service in local.centralised_interface_endpoint_services :


### PR DESCRIPTION
## What
Re-adds SNS and SQS to the centralised endpoint service list and places them into the Route53 Profile-native pilot cohort (`private_dns_enabled = true` with direct profile endpoint associations).

## Why / Context
This is the follow-up to PR #13573, which cleanly removed the legacy SNS and SQS endpoints and their self-managed PHZs.

PR #13572 (the original pilot attempt) failed at apply with:
```
ConflictingDomainExists: private-dns-enabled cannot be set because there is already
a conflicting DNS domain for sqs.eu-west-2.amazonaws.com in the VPC
```
This was because Terraform attempted to create the new native endpoints in parallel with destroying the old PHZs, and AWS rejects `private_dns_enabled=true` while a matching PHZ is still associated with the VPC.

PR #13573 resolved this by first removing SNS and SQS entirely. With those PHZs now destroyed, this PR re-adds them directly into the native cohort with no conflict.

## Expected plan for this apply
- **Create**: `aws_vpc_endpoint.centralised_interface_endpoints_profile_native["sns"]` (`private_dns_enabled=true`)
- **Create**: `aws_vpc_endpoint.centralised_interface_endpoints_profile_native["sqs"]` (`private_dns_enabled=true`)
- **Create**: `aws_route53profiles_resource_association` for both endpoints → profile

No PHZ resources will be created for these services (they are profile-native only).

## Validation
- JSON is valid (verified)
- `terraform fmt` run on changed files
- Confirmed safe to proceed by Ky Truong (Cloud Platform team)