### PR TITLE
Fix: Add collaborator email input field to New Collaborator issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-collaborator.yml
+++ b/.github/ISSUE_TEMPLATE/new-collaborator.yml
@@ -37,14 +37,12 @@ body:
     placeholder: e.g., Frodo Baggins
   validations:
     required: true
-- type: dropdown
+- type: input
   id: collaborator-email
   attributes:
     label: Collaborator email address
-    description: Can you provide a valid email address for the new external collaborator?
-    options:
-    - "Yes"
-    - "No"
+    description: The email address of the new external collaborator.
+    placeholder: e.g., collaborator@example.gov.uk
   validations:
     required: true
 - type: input


### PR DESCRIPTION
The `Collaborator email address` field in the New Collaborator issue template was a Yes/No dropdown, which only asked whether an email could be provided rather than capturing the actual email address.

This PR replaces the dropdown with a free-text input field so requesters can enter the collaborator's email address directly when raising the issue.