### PR TITLE
remove S3 access logging from CloudTrail bucket

### DIFF
--- a/terraform/environments/core-logging/logs_cloudtrail_s3.tf
+++ b/terraform/environments/core-logging/logs_cloudtrail_s3.tf
@@ -14,13 +14,6 @@ module "s3-bucket-cloudtrail" {
   replication_object_lock_days = 7
   replication_region           = "eu-west-1"
   ownership_controls           = "BucketOwnerEnforced"
-  log_bucket                   = module.s3-bucket-cloudtrail-logging.bucket.id
-  log_buckets = tomap({
-    "log_bucket_name" : module.s3-bucket-cloudtrail-logging.bucket.id,
-    "log_bucket_arn" : module.s3-bucket-cloudtrail-logging.bucket.arn,
-    "log_bucket_policy" : module.s3-bucket-cloudtrail-logging.bucket_policy.policy,
-  })
-  log_prefix = ""
   tags = merge(local.tags, {
     backup = "false"
   })


### PR DESCRIPTION
S3 access logging is no longer required for the CloudTrail bucket. https://github.com/ministryofjustice/modernisation-platform/issues/13325