### PR TITLE
open port 5432 from laa data factory to cloud platform in firewall

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/test_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/test_rules.json
@@ -566,6 +566,13 @@
     "destination_port": "1521",
     "protocol": "TCP"
   },
+  "laa_test_to_cloud_platform_postgres": {
+    "action": "PASS",
+    "source_ip": "${laa-test}",
+    "destination_ip": "${cloud-platform}",
+    "destination_port": "5432",
+    "protocol": "TCP"
+  },
   "laa_test_to_laa_ecp_2484": {
     "action": "PASS",
     "source_ip": "${laa-test}",


### PR DESCRIPTION
## A reference to the issue / Description of it

To allow connection to a PostgreSQL database from Data Factory LAA to Cloud Platform. 
(RDS instance used in laa-data-claims-data-factory namespace)

## How does this PR fix the problem?

Opens port 5432 From LAA subnets to the Cloud Platform

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

N/A

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No impact on existing services.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
