### PR TITLE
feat: add cluster-base component to cloud-platform

### DIFF
--- a/environments/cloud-platform.json
+++ b/environments/cloud-platform.json
@@ -5,6 +5,9 @@
       "name": "cluster"
     },
     {
+      "name": "cluster-base"
+    },
+    {
       "name": "cluster-core"
     },
     {


### PR DESCRIPTION
## A reference to the issue / Description of it

We are running into dependency problems with the current terraform workspace layers we have (network, cluster, cluster-core, cluster-components), so need to add a fourth called cluster-base. As per the discussion here https://mojdt.slack.com/archives/C0AF3LD2K7D/p1784214205299269

## How does this PR fix the problem?

Adds a new layer called cluster-base

## Deployment Plan / Instructions

No impact.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)