### PR TITLE
fix for checks

### DIFF
--- a/terraform/environments/core-logging/athena.tf
+++ b/terraform/environments/core-logging/athena.tf
@@ -97,6 +97,8 @@ resource "aws_iam_role" "athena_lambda" {
 }
 
 resource "aws_iam_policy" "athena_lambda_policy" {
+  #checkov:skip=CKV_AWS_290:This write permission is strictly required for this automated process
+  #checkov:skip=CKV_AWS_355:This write permission is strictly required for this automated process
   name = "athena_lambda_policy"
   policy = jsonencode({
     Version = "2012-10-17"


### PR DESCRIPTION
## A reference to the issue / Description of it

fix for the the failing terraform tests
       _               _
   ___| |__   ___  ___| | _______   __
  / __| '_ \ / _ \/ __| |/ / _ \ \ / /
 | (__| | | |  __/ (__|   < (_) \ V /
  \___|_| |_|\___|\___|_|\_\___/ \_/

By Prisma Cloud | version: 3.3.8 
terraform scan results:

Passed checks: 4874, Failed checks: 2, Skipped checks: 1337

Check: CKV_AWS_290: "Ensure IAM policies does not allow write access without constraints"
	FAILED for resource: aws_iam_policy.athena_lambda_policy
Error: 	File: /terraform/environments/core-logging/athena.tf:99-181
	Guide: https://docs.prismacloud.io/en/enterprise-edition/policy-reference/aws-policies/aws-iam-policies/bc-aws-290

		Code lines for this resource are too many. Please use IDE of your choice to review the file.
Check: CKV_AWS_355: "Ensure no IAM policies documents allow "*" as a statement's resource for restrictable actions"
	FAILED for resource: aws_iam_policy.athena_lambda_policy
Error: 	File: /terraform/environments/core-logging/athena.tf:99-181
	Guide: https://docs.prismacloud.io/en/enterprise-edition/policy-reference/aws-policies/aws-iam-policies/bc-aws-355

		Code lines for this resource are too many. Please use IDE of your choice to review the file.

## How does this PR fix the problem?

{Please write here}

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
