### PR TITLE
Add codeconnections:* to MemberInfrastructureAccess

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -194,6 +194,7 @@ data "aws_iam_policy_document" "member-access-compute" {
       "cloudtrail:Get*",
       "cloudtrail:List*",
       "codebuild:*",
+      "codeconnections:*",
       "codedeploy:*",
       "codepipeline:*",
       "cognito-idp:*",


### PR DESCRIPTION
The Cloud Platform team is building a new container platform (CP3) on EKS with ArgoCD for GitOps-based multi-cluster deployments. We're using the EKS-managed ArgoCD Capability, which is a fully AWS-managed service that runs outside customer VPCs. This managed ArgoCD cannot make outbound HTTPS requests to github.com directly — it accesses Git repositories exclusively through the AWS CodeConnections git-http proxy. We need to create an aws_codeconnections_connection resource in each hub account via Terraform so the ArgoCD Capability can clone our GitOps repository.

This permisson enables that.


## A reference to the issue / Description of it

Closes https://github.com/ministryofjustice/modernisation-platform/issues/13635

## How does this PR fix the problem?

Give the required permissions

## How has this been tested?

Standard policy update, applied to sprinkler and verified present

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
