### PR TITLE
Enable Security Group Referencing on TGW and ec2-tgw-attachment module

### DIFF
--- a/terraform/environments/core-network-services/transit-gateway.tf
+++ b/terraform/environments/core-network-services/transit-gateway.tf
@@ -5,12 +5,13 @@ resource "aws_ec2_transit_gateway" "transit-gateway" {
   #checkov:skip=CKV_AWS_331
   description = "Managed by Terraform"
 
-  amazon_side_asn                 = "64589"
-  auto_accept_shared_attachments  = "enable"
-  default_route_table_association = "disable"
-  default_route_table_propagation = "disable"
-  dns_support                     = "enable"
-  vpn_ecmp_support                = "enable"
+  amazon_side_asn                    = "64589"
+  auto_accept_shared_attachments     = "enable"
+  default_route_table_association    = "disable"
+  default_route_table_propagation    = "disable"
+  dns_support                        = "enable"
+  security_group_referencing_support = "enable"
+  vpn_ecmp_support                   = "enable"
 
   tags = merge(
     local.tags,

--- a/terraform/modules/ec2-tgw-attachment/README.md
+++ b/terraform/modules/ec2-tgw-attachment/README.md
@@ -41,6 +41,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_security_group_referencing_support"></a> [security\_group\_referencing\_support](#input\_security\_group\_referencing\_support) | Whether to enable Security Group Referencing across the Transit Gateway | `string` | `"disable"` | no |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | Subnet IDs to attach to the Transit Gateway | `list(string)` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to attach to resources, where applicable | `map(any)` | n/a | yes |
 | <a name="input_transit_gateway_id"></a> [transit\_gateway\_id](#input\_transit\_gateway\_id) | Transit Gateway ID to attach to | `string` | n/a | yes |

--- a/terraform/modules/ec2-tgw-attachment/main.tf
+++ b/terraform/modules/ec2-tgw-attachment/main.tf
@@ -32,9 +32,10 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "default" {
   transit_gateway_id = var.transit_gateway_id
   vpc_id             = var.vpc_id
 
-  appliance_mode_support = "disable"
-  dns_support            = "enable"
-  ipv6_support           = "disable"
+  appliance_mode_support             = "disable"
+  dns_support                        = "enable"
+  ipv6_support                       = "disable"
+  security_group_referencing_support = var.security_group_referencing_support
 
   # You can't change these with a RAM-shared Transit Gateway, but we'll
   # leave them here to be explicit.

--- a/terraform/modules/ec2-tgw-attachment/variables.tf
+++ b/terraform/modules/ec2-tgw-attachment/variables.tf
@@ -32,3 +32,14 @@ variable "vpc_name" {
   description = "VPC name (used for tagging)"
   type        = string
 }
+
+variable "security_group_referencing_support" {
+  description = "Whether to enable Security Group Referencing across the Transit Gateway"
+  type        = string
+  default     = "disable"
+
+  validation {
+    condition     = contains(["enable", "disable"], var.security_group_referencing_support)
+    error_message = "Accepted values are enable, disable."
+  }
+}


### PR DESCRIPTION
Refs #13562. Enables cross-account security group referencing over the Modernisation Platform Transit Gateway.

- Enable security_group_referencing_support on the core TGW resource
- Add opt-in security_group_referencing_support variable to the ec2-tgw-attachment module (default disable) and wire it into the VPC attachment resource
- Regenerate module README inputs table

## A reference to the issue / Description of it

{Please write here}

## How does this PR fix the problem?

{Please write here}

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
