### PR TITLE
TM-2120: core-network-services: allow nfs to legacy probaction accounts

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/development_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/development_rules.json
@@ -384,6 +384,13 @@
     "destination_port": "1522",
     "protocol": "TCP"
   },
+  "hmpps_development_to_delius_mis_dev_nfs": {
+    "action": "PASS",
+    "source_ip": "${hmpps-development}",
+    "destination_ip": "${delius-mis-dev}",
+    "destination_port": "2049",
+    "protocol": "TCP"
+  },
   "delius_mis_dev_to_hmpps_development_ldap": {
     "action": "PASS",
     "source_ip": "${delius-mis-dev}",

--- a/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
@@ -365,6 +365,20 @@
     "destination_port": "389",
     "protocol": "TCP"
   },
+  "hmpps_preproduction_to_delius_stage_nfs": {
+    "action": "PASS",
+    "source_ip": "${hmpps-preproduction}",
+    "destination_ip": "${delius-stage}",
+    "destination_port": "2049",
+    "protocol": "TCP"
+  },
+  "hmpps_preproduction_to_delius_preproduction_nfs": {
+    "action": "PASS",
+    "source_ip": "${hmpps-preproduction}",
+    "destination_ip": "${delius-pre-prod}",
+    "destination_port": "2049",
+    "protocol": "TCP"
+  },
   "cp_to_mp_hmpps_preproduction_ldap": {
     "action": "PASS",
     "source_ip": "${cloud-platform}",

--- a/terraform/environments/core-network-services/firewall-rules/production_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/production_rules.json
@@ -336,6 +336,13 @@
     "destination_port": "636",
     "protocol": "TCP"
   },
+  "hmpps_production_to_delius_production_nfs": {
+    "action": "PASS",
+    "source_ip": "${hmpps-production}",
+    "destination_ip": "${delius-prod}",
+    "destination_port": "2049",
+    "protocol": "TCP"
+  },
   "delius_prod_to_hmpps_production_ldap": {
     "action": "PASS",
     "source_ip": "${delius-prod}",


### PR DESCRIPTION
## A reference to the issue / Description of it

The Mod Platforms NDMIS cannot mount NextCloud EFS storage in corresponding legacy delius accounts

## How does this PR fix the problem?

Adds required firewall rules for NFS

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

n/a

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
