### PR TITLE
TGW Ram share with container-platform-cd accounts

### DIFF
--- a/terraform/environments/core-network-services/ram.tf
+++ b/terraform/environments/core-network-services/ram.tf
@@ -23,7 +23,9 @@ resource "aws_ram_principal_association" "transit-gateway" {
     container-platform-laa-nonlive   = local.environment_management.account_ids["container-platform-laa-nonlive"],
     container-platform-laa-live      = local.environment_management.account_ids["container-platform-laa-live"],
     container-platform-hmpps-nonlive = local.environment_management.account_ids["container-platform-hmpps-nonlive"],
-    container-platform-hmpps-live    = local.environment_management.account_ids["container-platform-hmpps-live"]
+    container-platform-hmpps-live    = local.environment_management.account_ids["container-platform-hmpps-live"],
+    container-platform-cd-nonlive    = local.environment_management.account_ids["container-platform-cd-nonlive"],
+    container-platform-cd-live       = local.environment_management.account_ids["container-platform-cd-live"]
   }
 
   principal          = each.value


### PR DESCRIPTION
This pull request adds two new AWS account associations to the `aws_ram_principal_association` resource in `ram.tf`. The new accounts, `container-platform-cd-nonlive` and `container-platform-cd-live`, are now included in the list of principals for RAM (Resource Access Manager) sharing.

**Infrastructure updates:**

* Added `container-platform-cd-nonlive` and `container-platform-cd-live` accounts to the `local.environment_management.account_ids` mapping for RAM principal associations in `ram.tf`.



## How does this PR fix the problem?

{Please write here}

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
