### PR TITLE
Fixes apply failures caused by missing role in the source account.

### DIFF
--- a/terraform/environments/core-shared-services/ecr_repos.tf
+++ b/terraform/environments/core-shared-services/ecr_repos.tf
@@ -1266,7 +1266,8 @@ module "create_a_derived_table_ecr_repo" {
     local.environment_management.account_ids["electronic-monitoring-data-test"],
     local.environment_management.account_ids["electronic-monitoring-data-preproduction"],
     local.environment_management.account_ids["electronic-monitoring-data-production"],
-    "arn:aws:iam::${local.environment_management.account_ids["electronic-monitoring-data-development"]}:role/ecs_execution_cadt"
+    # Note adding the wildcard back to the role below as this currently does not exist in the account and is fauling an apply failure 
+    "arn:aws:iam::${local.environment_management.account_ids["electronic-monitoring-data-development"]}:role/ecs_execution_cadt*"
   ]
 
   # Tags


### PR DESCRIPTION
Reverts the removal of the wildcard suffix for the ecs_execution_cadt role reference as it missing from the account in question causes apply failures.

## A reference to the issue / Description of it

{Please write here}

## How does this PR fix the problem?

{Please write here}

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
