### PR TITLE
Feat/business unit shared configuration access

### DIFF
--- a/terraform/environments/core-shared-services/business-unit-shared-configuration-access.tf
+++ b/terraform/environments/core-shared-services/business-unit-shared-configuration-access.tf
@@ -31,15 +31,14 @@ locals {
   }
 }
 
+#checkov:skip=CKV_AWS_60:Cross-account trust is intentional. Access is restricted to approved business unit AWS accounts.
 resource "aws_iam_role" "shared_services_secrets_access" {
   for_each = local.grouped_accounts
   name = "${lower(each.key)}-shared-configuration-access"
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
-
     Statement = [{
       Effect = "Allow"
-
       Principal = {
         AWS = [
           for account_name in each.value :
@@ -62,6 +61,7 @@ resource "aws_iam_role_policy_attachment" "shared_secrets_access" {
   policy_arn = aws_iam_policy.shared_secrets_access[each.key].arn
 }
 
+#checkov:skip=CKV_AWS_355:AWS Secrets Manager ListSecrets and SSM DescribeParameters require wildcard resource permissions
 resource "aws_iam_policy" "shared_secrets_access" {
 
   for_each = local.grouped_accounts

--- a/terraform/environments/core-shared-services/business-unit-shared-configuration-access.tf
+++ b/terraform/environments/core-shared-services/business-unit-shared-configuration-access.tf
@@ -1,15 +1,15 @@
 locals {
-  environment_files = fileset("../../../environments", "*.json")
+  platform_environment_files = fileset("../../../environments", "*.json")
 
-  environments = {
-    for file in local.environment_files :
+  platform_environments = {
+    for file in local.platform_environment_files :
     trimsuffix(file, ".json") => jsondecode(
       file("../../../environments/${file}")
     )
   }
 
   accounts = flatten([
-    for app_name, config in local.environments : [
+    for app_name, config in local.platform_environments : [
       for env in config.environments : {
         business_unit = config.tags["business-unit"]
         account_name = "${app_name}-${env.name}"
@@ -17,12 +17,12 @@ locals {
     ]
   ])
 
-  business_units = distinct([
+  platform_business_units = distinct([
     for a in local.accounts : a.business_unit
   ])
 
   grouped_accounts = {
-    for bu in local.business_units :
+    for bu in local.platform_business_units :
     bu => [
       for a in local.accounts :
       a.account_name

--- a/terraform/environments/core-shared-services/business-unit-shared-configuration-access.tf
+++ b/terraform/environments/core-shared-services/business-unit-shared-configuration-access.tf
@@ -1,0 +1,129 @@
+locals {
+  environment_files = fileset("../../../environments", "*.json")
+
+  environments = {
+    for file in local.environment_files :
+    trimsuffix(file, ".json") => jsondecode(
+      file("../../../environments/${file}")
+    )
+  }
+
+  accounts = flatten([
+    for app_name, config in local.environments : [
+      for env in config.environments : {
+        business_unit = config.tags["business-unit"]
+        account_name = "${app_name}-${env.name}"
+      }
+    ]
+  ])
+
+  business_units = distinct([
+    for a in local.accounts : a.business_unit
+  ])
+
+  grouped_accounts = {
+    for bu in local.business_units :
+    bu => [
+      for a in local.accounts :
+      a.account_name
+      if a.business_unit == bu
+    ]
+  }
+}
+
+resource "aws_iam_role" "shared_services_secrets_access" {
+  for_each = local.grouped_accounts
+  name = "${lower(each.key)}-shared-configuration-access"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+
+    Statement = [{
+      Effect = "Allow"
+
+      Principal = {
+        AWS = [
+          for account_name in each.value :
+          "arn:aws:iam::${local.environment_management.account_ids[account_name]}:root"
+        ]
+      }
+      Action = "sts:AssumeRole"
+      Condition = {
+        StringEquals = {
+        "aws:PrincipalOrgID" = data.aws_organizations_organization.current.id
+        }
+      }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "shared_secrets_access" {
+  for_each = local.grouped_accounts
+  role = aws_iam_role.shared_services_secrets_access[each.key].name
+  policy_arn = aws_iam_policy.shared_secrets_access[each.key].arn
+}
+
+resource "aws_iam_policy" "shared_secrets_access" {
+
+  for_each = local.grouped_accounts
+  name = "${lower(each.key)}-shared-configuration-access"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid = "SecretsManagerAccess"
+        Effect = "Allow"
+        Action = [
+          "secretsmanager:CreateSecret",
+          "secretsmanager:GetSecretValue",
+          "secretsmanager:GetResourcePolicy",
+          "secretsmanager:PutSecretValue",
+          "secretsmanager:UpdateSecret",
+          "secretsmanager:DeleteSecret",
+          "secretsmanager:DescribeSecret",
+          "secretsmanager:ListSecretVersionIds",
+          "secretsmanager:RestoreSecret",
+          "secretsmanager:TagResource",
+          "secretsmanager:UntagResource"
+        ]
+        Resource = [
+          "arn:aws:secretsmanager:eu-west-2:${local.environment_management.account_ids[terraform.workspace]}:secret:${lower(each.key)}/*"
+        ]
+      },
+      {
+        Sid = "ListSecrets"
+        Effect = "Allow"
+        Action = [
+          "secretsmanager:ListSecrets"
+        ]
+        Resource = "*"
+      },
+      {
+        Sid = "SSMParameterAccess"
+        Effect = "Allow"
+        Action = [
+          "ssm:PutParameter",
+          "ssm:GetParameter",
+          "ssm:GetParameters",
+          "ssm:GetParametersByPath",
+          "ssm:DeleteParameter",
+          "ssm:DeleteParameters",
+          "ssm:DescribeParameters",
+          "ssm:AddTagsToResource",
+          "ssm:RemoveTagsFromResource",
+          "ssm:ListTagsForResource"
+        ]
+        Resource = [
+          "arn:aws:ssm:eu-west-2:${local.environment_management.account_ids[terraform.workspace]}:parameter/${lower(each.key)}/*"
+        ]
+      },
+      {
+        Sid = "SSMParameterList"
+        Effect = "Allow"
+        Action = [
+          "ssm:DescribeParameters"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}

--- a/terraform/environments/core-shared-services/data.tf
+++ b/terraform/environments/core-shared-services/data.tf
@@ -1,6 +1,8 @@
 # Discover current region name - used when setting up vpc endpoints
 data "aws_region" "current_region" {}
 
+data "aws_organizations_organization" "current" {}
+
 data "aws_kms_key" "general_shared" {
   key_id = "arn:aws:kms:eu-west-2:${local.environment_management.account_ids["core-shared-services-production"]}:alias/general-${lower(local.tags.business-unit)}"
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

#13169 

## How does this PR fix the problem?

This PR introduces business-unit scoped IAM roles and policies to provide controlled access to shared configuration resources hosted in the `core shared services` account.

The access includes:
- AWS Secrets Manager secrets
- SSM Parameter Store parameters

Each business unit receives a dedicated IAM role that can be assumed by the accounts belonging to that business unit.

## How has this been tested?

tested in the sprinkler

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
