### PR TITLE
adding new Container Platform business unit TGW attachments to TGW route table and RAM share Route 53 profile

### DIFF
--- a/terraform/environments/core-network-services/container_platform_tgw_connections.tf
+++ b/terraform/environments/core-network-services/container_platform_tgw_connections.tf
@@ -18,6 +18,9 @@ locals {
     container-platform-hmpps-nonlive = {
       attachment_id = "tgw-attach-0147624fb2cebdbe4"
     }
+    container-platform-cd-nonlive = {
+      attachment_id = "tgw-attach-0070a4adb922bb95e"
+    }
   }
 
   container-platform-live-attachments = {
@@ -33,12 +36,22 @@ locals {
     container-platform-hmpps-live = {
       attachment_id = "tgw-attach-032e9a7da06ed4b63"
     }
+    container-platform-cd-live = {
+      attachment_id = "tgw-attach-075d4e80c2c920b3c"
+    }
   }
 }
 
 
 resource "aws_ec2_tag" "retag_cp_attachment" {
   for_each    = local.container-platform-nonlive-attachments
+  resource_id = each.value.attachment_id
+  key         = "Name"
+  value       = each.key
+}
+
+resource "aws_ec2_tag" "retag_cp_attachment_live" {
+  for_each    = local.container-platform-live-attachments
   resource_id = each.value.attachment_id
   key         = "Name"
   value       = each.key

--- a/terraform/environments/core-network-services/vpc-endpoints.tf
+++ b/terraform/environments/core-network-services/vpc-endpoints.tf
@@ -11,6 +11,8 @@ locals {
     container-platform-laa-nonlive   = local.environment_management.account_ids["container-platform-laa-nonlive"]
     container-platform-octo-nonlive  = local.environment_management.account_ids["container-platform-octo-nonlive"]
     container-platform-octo-live     = local.environment_management.account_ids["container-platform-octo-live"]
+    container-platform-cd-nonlive    = local.environment_management.account_ids["container-platform-cd-nonlive"]
+    container-platform-cd-live       = local.environment_management.account_ids["container-platform-cd-live"]
   }
 
   centralised_endpoint_configuration = jsondecode(file("${path.module}/centralised-vpc-endpoints.json"))


### PR DESCRIPTION
## A reference to the issue / Description of it
This PR: 

- adds the newly created TGW attachments for CP's new BU accounts to the TGW route tables.
- tags the TGW attachments.
- RAM share Route53 profile for new accounts to be able to consume MP's Centralised VPC endpoints

Relates to https://github.com/ministryofjustice/cloud-platform/issues/8412

## How does this PR fix the problem?

{Please write here}

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
