### PR TITLE
Allow GitHub Actions plan and apply roles to assume business unit shared configuration roles

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -1110,7 +1110,8 @@ data "aws_iam_policy_document" "oidc_assume_role_member" {
       format("arn:aws:iam::%s:role/modernisation-account-limited-read-member-access", local.environment_management.modernisation_platform_account_id),
       format("arn:aws:iam::%s:role/ModernisationPlatformSSOReadOnly", local.environment_management.aws_organizations_root_account_id),
       # the following are required as cooker have development accounts but are in the sandbox vpc
-      local.application_name == "cooker" ? format("arn:aws:iam::%s:role/member-delegation-house-sandbox", local.environment_management.account_ids["core-vpc-sandbox"]) : format("arn:aws:iam::%s:role/modernisation-account-limited-read-member-access", local.environment_management.modernisation_platform_account_id)
+      local.application_name == "cooker" ? format("arn:aws:iam::%s:role/member-delegation-house-sandbox", local.environment_management.account_ids["core-vpc-sandbox"]) : format("arn:aws:iam::%s:role/modernisation-account-limited-read-member-access", local.environment_management.modernisation_platform_account_id),
+      local.business_unit != null ? format("arn:aws:iam::%s:role/%s-shared-configuration-access", local.environment_management.account_ids["core-shared-services-production"], lower(local.business_unit)) : ""
     ])
     condition {
       test     = "StringEquals"
@@ -1487,7 +1488,8 @@ data "aws_iam_policy_document" "oidc_assume_plan_role_member" {
       format("arn:aws:iam::%s:role/member-delegation-read-only", local.environment_management.account_ids["core-vpc-test"]),
       format("arn:aws:iam::%s:role/member-delegation-read-only", local.environment_management.account_ids["core-vpc-preproduction"]),
       format("arn:aws:iam::%s:role/member-delegation-read-only", local.environment_management.account_ids["core-vpc-production"]),
-      format("arn:aws:iam::%s:role/member-delegation-read-only", local.environment_management.account_ids["core-vpc-sandbox"])
+      format("arn:aws:iam::%s:role/member-delegation-read-only", local.environment_management.account_ids["core-vpc-sandbox"]),
+      local.business_unit != null ? format("arn:aws:iam::%s:role/%s-shared-configuration-access", local.environment_management.account_ids["core-shared-services-production"], lower(local.business_unit)) : ""
     ])
     condition {
       test     = "StringEquals"


### PR DESCRIPTION
## A reference to the issue / Description of it

#13169 

## How does this PR fix the problem?

Members who manage business unit-specific secrets in `core-shared-services `require the GitHub Actions plan and apply roles to be able to assume the corresponding shared configuration access roles. Without this permission, GitHub Actions workflows cannot access or manage those business unit secrets.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
