### PR TITLE
Allow GitHub Actions roles to assume SSOApplicationAssignment

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -1108,6 +1108,7 @@ data "aws_iam_policy_document" "oidc_assume_role_member" {
       local.application_name != "cloud-platform" && !startswith(local.application_name, "container-platform-") ? format("arn:aws:iam::%s:role/member-delegation-%s-%s", local.environment_management.account_ids[format("core-vpc-%s", local.application_environment)], lower(local.business_unit), local.application_environment) : "",
       format("arn:aws:iam::%s:role/modify-dns-records", local.environment_management.account_ids["core-network-services-production"]),
       format("arn:aws:iam::%s:role/modernisation-account-limited-read-member-access", local.environment_management.modernisation_platform_account_id),
+      format("arn:aws:iam::%s:role/ModernisationPlatformSSOApplicationAssignment", local.environment_management.aws_organizations_root_account_id),
       format("arn:aws:iam::%s:role/ModernisationPlatformSSOReadOnly", local.environment_management.aws_organizations_root_account_id),
       # the following are required as cooker have development accounts but are in the sandbox vpc
       local.application_name == "cooker" ? format("arn:aws:iam::%s:role/member-delegation-house-sandbox", local.environment_management.account_ids["core-vpc-sandbox"]) : format("arn:aws:iam::%s:role/modernisation-account-limited-read-member-access", local.environment_management.modernisation_platform_account_id),
@@ -1119,6 +1120,20 @@ data "aws_iam_policy_document" "oidc_assume_role_member" {
       values   = [data.aws_organizations_organization.root_account.id]
     }
     actions = ["sts:AssumeRole"]
+  }
+
+  statement {
+    sid    = "AllowOIDCToTagSession"
+    effect = "Allow"
+    resources = compact([
+      format("arn:aws:iam::%s:role/ModernisationPlatformSSOApplicationAssignment", local.environment_management.aws_organizations_root_account_id)
+    ])
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalOrgID"
+      values   = [data.aws_organizations_organization.root_account.id]
+    }
+    actions = ["sts:TagSession"]
   }
 
   # checkov:skip=CKV_AWS_111: "Cannot restrict by KMS alias so leaving open"
@@ -1482,6 +1497,7 @@ data "aws_iam_policy_document" "oidc_assume_plan_role_member" {
     effect = "Allow"
     resources = compact([
       format("arn:aws:iam::%s:role/modernisation-account-limited-read-member-access", local.environment_management.modernisation_platform_account_id),
+      format("arn:aws:iam::%s:role/ModernisationPlatformSSOApplicationAssignment", local.environment_management.aws_organizations_root_account_id),
       format("arn:aws:iam::%s:role/ModernisationPlatformSSOReadOnly", local.environment_management.aws_organizations_root_account_id),
       format("arn:aws:iam::%s:role/read-log-records", local.environment_management.account_ids["core-network-services-production"]),
       format("arn:aws:iam::%s:role/member-delegation-read-only", local.environment_management.account_ids["core-vpc-development"]),
@@ -1497,6 +1513,20 @@ data "aws_iam_policy_document" "oidc_assume_plan_role_member" {
       values   = [data.aws_organizations_organization.root_account.id]
     }
     actions = ["sts:AssumeRole"]
+  }
+
+  statement {
+    sid    = "AllowOIDCToTagSession"
+    effect = "Allow"
+    resources = compact([
+      format("arn:aws:iam::%s:role/ModernisationPlatformSSOApplicationAssignment", local.environment_management.aws_organizations_root_account_id)
+    ])
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalOrgID"
+      values   = [data.aws_organizations_organization.root_account.id]
+    }
+    actions = ["sts:TagSession"]
   }
 
   # checkov:skip=CKV_AWS_111: "Cannot restrict by KMS alias so leaving open"
@@ -1648,6 +1678,7 @@ data "aws_iam_policy_document" "oidc_assume_nuke_role_member" {
       local.application_name != "cloud-platform" && !startswith(local.application_name, "container-platform-") ? format("arn:aws:iam::%s:role/member-delegation-%s-%s", local.environment_management.account_ids[format("core-vpc-%s", local.application_environment)], lower(local.business_unit), local.application_environment) : "",
       format("arn:aws:iam::%s:role/modify-dns-records", local.environment_management.account_ids["core-network-services-production"]),
       format("arn:aws:iam::%s:role/modernisation-account-limited-read-member-access", local.environment_management.modernisation_platform_account_id),
+      format("arn:aws:iam::%s:role/ModernisationPlatformSSOApplicationAssignment", local.environment_management.aws_organizations_root_account_id),
       format("arn:aws:iam::%s:role/ModernisationPlatformSSOReadOnly", local.environment_management.aws_organizations_root_account_id),
       #read-only-roles
       format("arn:aws:iam::%s:role/read-log-records", local.environment_management.account_ids["core-network-services-production"]),
@@ -1662,6 +1693,20 @@ data "aws_iam_policy_document" "oidc_assume_nuke_role_member" {
       values   = [data.aws_organizations_organization.root_account.id]
     }
     actions = ["sts:AssumeRole"]
+  }
+
+  statement {
+    sid    = "AllowOIDCToTagSession"
+    effect = "Allow"
+    resources = compact([
+      format("arn:aws:iam::%s:role/ModernisationPlatformSSOApplicationAssignment", local.environment_management.aws_organizations_root_account_id)
+    ])
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalOrgID"
+      values   = [data.aws_organizations_organization.root_account.id]
+    }
+    actions = ["sts:TagSession"]
   }
 
   # checkov:skip=CKV_AWS_111: "Cannot restrict by KMS alias so leaving open"


### PR DESCRIPTION
## A reference to the issue / Description of it

This PR: https://github.com/ministryofjustice/aws-root-account/pull/1583
And this PR: https://github.com/ministryofjustice/modernisation-platform-environments/pull/18029

Without this expansion, the GitHub Actions plan/apply role can't assume the new SSOApplicationAssignment role, nor can it execute the `sts:TagSession` action when assuming the new role.

## How does this PR fix the problem?

Adds required permissions. Will be tested via CI from [modernisation-platform-environments#18029](https://github.com/ministryofjustice/modernisation-platform-environments/pull/18029).

## How has this been tested?

Test via CI and through open PR in Modernisation Platform Environments repository

## Deployment Plan / Instructions

Deploy via CI

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
