### PR TITLE
Adding secret for transform that holds the URL endpoint. This is required for bounding CORS actions against the S3.

### DIFF
--- a/terraform/environments/core-shared-services/transform.tf
+++ b/terraform/environments/core-shared-services/transform.tf
@@ -216,7 +216,8 @@ resource "aws_secretsmanager_secret" "aws_transform_url" {
 resource "aws_secretsmanager_secret_version" "aws_transform_url" {
   #checkov:skip=CKV_SECRET_6: Seeded placeholder value is not a real secret; actual value is set outside Terraform
   secret_id     = aws_secretsmanager_secret.aws_transform_url.id
-  secret_string = "placeholder"
+  #checkov:skip=CKV_SECRET_6: Seeded placeholder value is not a real secret; actual value is set outside Terraform
+  secret_string = "not-a-real-secret-value"
   lifecycle {
     ignore_changes = [
       # Secret value is set/updated outside Terraform.

--- a/terraform/environments/core-shared-services/transform.tf
+++ b/terraform/environments/core-shared-services/transform.tf
@@ -214,6 +214,7 @@ resource "aws_secretsmanager_secret" "aws_transform_url" {
 }
 
 resource "aws_secretsmanager_secret_version" "aws_transform_url" {
+  #checkov:skip=CKV_SECRET_6: Seeded placeholder value is not a real secret; actual value is set outside Terraform
   secret_id     = aws_secretsmanager_secret.aws_transform_url.id
   secret_string = "placeholder"
   lifecycle {

--- a/terraform/environments/core-shared-services/transform.tf
+++ b/terraform/environments/core-shared-services/transform.tf
@@ -6,6 +6,18 @@
 # application-level SSO assignment in Terraform would just be a second, driftable source of
 # truth for the same access. Both are handled manually via the console instead.
 
+locals {
+  aws_transform_url = data.aws_secretsmanager_secret_version.aws_transform_url.secret_string
+}
+
+data "aws_secretsmanager_secret" "aws_transform_url" {
+  name = aws_secretsmanager_secret.aws_transform_url.name
+}
+
+data "aws_secretsmanager_secret_version" "aws_transform_url" {
+  secret_id = data.aws_secretsmanager_secret.aws_transform_url.id
+}
+
 # Central S3 as used in Transform Configuration
 module "transform_s3_bucket" {
   source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=c8889e65f4d8a3d53d2cbd93b7be714e990020b7" # v10.2.1
@@ -162,4 +174,22 @@ data "aws_iam_policy_document" "transform_kms_key_policy" {
   }
 }
 
+resource "aws_secretsmanager_secret" "aws_transform_url" {
+  #checkov:skip=CKV2_AWS_57: Secret rotation is managed outside Terraform for this value
+  name        = "aws_transform_url"
+  description = "AWS Transform workspace URL"
 
+  tags = local.tags
+}
+
+resource "aws_secretsmanager_secret_version" "aws_transform_url" {
+  secret_id     = aws_secretsmanager_secret.aws_transform_url.id
+  secret_string = "placeholder"
+
+  lifecycle {
+    ignore_changes = [
+      # Secret value is set/updated outside Terraform.
+      secret_string,
+    ]
+  }
+}

--- a/terraform/environments/core-shared-services/transform.tf
+++ b/terraform/environments/core-shared-services/transform.tf
@@ -172,20 +172,50 @@ data "aws_iam_policy_document" "transform_kms_key_policy" {
       ]
     }
   }
+
+  statement {
+    sid    = "AllowSecretsManagerToUseKey"
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+      "kms:DescribeKey",
+      "kms:Encrypt",
+      "kms:GenerateDataKey",
+      "kms:GenerateDataKeyWithoutPlaintext"
+    ]
+
+    resources = ["*"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["secretsmanager.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "kms:ViaService"
+      values   = ["secretsmanager.eu-west-2.amazonaws.com"]
+    }
+  }
 }
 
 resource "aws_secretsmanager_secret" "aws_transform_url" {
   #checkov:skip=CKV2_AWS_57: Secret rotation is managed outside Terraform for this value
   name        = "aws_transform_url"
   description = "AWS Transform workspace URL"
-
+  kms_key_id  = aws_kms_key.transform_bucket.arn
   tags = local.tags
 }
 
 resource "aws_secretsmanager_secret_version" "aws_transform_url" {
   secret_id     = aws_secretsmanager_secret.aws_transform_url.id
   secret_string = "placeholder"
-
   lifecycle {
     ignore_changes = [
       # Secret value is set/updated outside Terraform.


### PR DESCRIPTION

## A reference to the issue / Description of it

#13581 

## How does this PR fix the problem?

This adds a secrets manager resource that will hold the Transform application endpoint URL. This is required for use by CORS-related resource to limit https access requests to the bucket only from this endpoint & so avoids it being held in clear text in the repo.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
