### PR TITLE
Add Shared Configuration Provider

### DIFF
--- a/terraform/templates/modernisation-platform-environments-components/platform_providers.tf
+++ b/terraform/templates/modernisation-platform-environments-components/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+  default_tags { tags = local.tags }
+}

--- a/terraform/templates/modernisation-platform-environments-isolated/platform_providers.tf
+++ b/terraform/templates/modernisation-platform-environments-isolated/platform_providers.tf
@@ -53,3 +53,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+  default_tags { tags = local.tags }
+}

--- a/terraform/templates/modernisation-platform-environments/platform_providers.tf
+++ b/terraform/templates/modernisation-platform-environments/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+  default_tags { tags = local.tags }
+}


### PR DESCRIPTION
## A reference to the issue / Description of it

#13169 

## How does this PR fix the problem?

This provider is used to manage Business Unit secrets and parameters in the core-shared-services-production account. It assumes the shared configuration access IAM role, allowing Terraform to securely access and manage shared configuration resources.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [x] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
