### PR TITLE
This adds an assumable role for accessing AWS Transform by authenticated users using the CLI from their local device.

### DIFF
--- a/terraform/environments/core-shared-services/transform.tf
+++ b/terraform/environments/core-shared-services/transform.tf
@@ -284,3 +284,80 @@ resource "aws_secretsmanager_secret_version" "aws_transform_url" {
     ]
   }
 }
+
+## Creates a role that can be assumed by authenticated Modernisation Platform Users allowing them to access AWS Transform Services in the central account from their local device when using the ATX CLI.
+## Scope of use based on the existing member-shared-services role & policies
+
+resource "aws_iam_role" "member_shared_services_transform" {
+  name = "member-shared-services-transform"
+  assume_role_policy = jsonencode( # checkov:skip=CKV_AWS_60: "the policy is secured with the condition"
+    {
+      "Version" : "2012-10-17",
+      "Statement" : [
+        {
+          "Effect" : "Allow",
+          "Principal" : {
+            "AWS" : "*"
+          },
+          "Action" : "sts:AssumeRole",
+          "Condition" : {
+            "ForAnyValue:StringLike" : {
+              "aws:PrincipalOrgPaths" : ["${data.aws_organizations_organization.root_account.id}/*/${local.environment_management.modernisation_platform_organisation_unit_id}/*"]
+            }
+          }
+        }
+      ]
+  })
+
+  tags = merge(
+    local.tags,
+    {
+      Name = "member-shared-services"
+    },
+  )
+}
+
+#tfsec:ignore:aws-iam-no-policy-wildcards
+resource "aws_iam_role_policy" "member_shared_services_transform" {
+  # checkov:skip=CKV_AWS_355: Resources limited to core-shared-services
+  # checkov:skip=CKV_AWS_290: Resources limited to core-shared-services
+  name = "MemberSharedServicesTransform"
+  role = aws_iam_role.member_shared_services_transform.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "transform:AccessTransformProfile"
+        ],
+        "Resource" : "arn:aws:transform:${data.aws_region.current_region.region}:${local.environment_management.account_ids["core-shared-services-production"]}:profile/*"
+      },
+      {
+        # Note for this statement the permissions cannot be bound by specific resource ARNs.
+        "Effect" : "Allow",
+        "Action" : [
+          "transform:GetWebAppUrl",
+          "transform:GetUserDetails",
+          "transform:BatchGetUserDetails",
+          "transform:GetWorkspace",
+          "transform:ListWorkspaces",
+          "transform:ListJobs",
+          "transform:GetJob",
+          "transform:ListArtifacts",
+          "transform:ListJobPlanSteps",
+          "transform:ListWorklogs",
+          "transform:ListMessages",
+          "transform:BatchGetMessage"
+        ],
+        "Resource" : "*",
+        "Condition" : {
+          "StringEquals" : {
+            "aws:ResourceAccount" : "${local.environment_management.account_ids["core-shared-services-production"]}"
+          }
+        }
+      }
+    ]
+  })
+}

--- a/terraform/environments/core-shared-services/transform.tf
+++ b/terraform/environments/core-shared-services/transform.tf
@@ -354,7 +354,7 @@ resource "aws_iam_role_policy" "member_shared_services_transform" {
         "Resource" : "*",
         "Condition" : {
           "StringEquals" : {
-            "aws:ResourceAccount" : "${local.environment_management.account_ids["core-shared-services-production"]}"
+            "aws:ResourceAccount" : local.environment_management.account_ids["core-shared-services-production"]
           }
         }
       }


### PR DESCRIPTION

## A reference to the issue / Description of it

#13581 

## How does this PR fix the problem?

This role is based on the scope of member_shared_services and restricts access to authenticated platform users.

It provides an initial set of read-only permissions and will be the basis of testing. As such further permissions may be added.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
