### PR TITLE
Adds AWS CodeConnection resource to allow Transform to access github accounts.

### DIFF
--- a/terraform/environments/core-shared-services/transform.tf
+++ b/terraform/environments/core-shared-services/transform.tf
@@ -361,3 +361,10 @@ resource "aws_iam_role_policy" "member_shared_services_transform" {
     ]
   })
 }
+
+## Code Connection Resources to be used by Transform for accessing github
+resource "aws_codeconnections_connection" "github" {
+  name          = "aws-transform-github"
+  provider_type = "GitHub"
+  tags = local.tags
+}


### PR DESCRIPTION

## A reference to the issue / Description of it

#13581 

## How does this PR fix the problem?

Required to link Transform with Github Repos.

Note that whilst the provider_type is Github, the actual provider used is aws.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
