### PR TITLE
Allow postgres ingress from cloud-platform to laa-test

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/test_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/test_rules.json
@@ -41,6 +41,13 @@
     "destination_port": "5432",
     "protocol": "TCP"
   },
+  "cp_to_laa_test_pgres": {
+    "action": "PASS",
+    "source_ip": "${cloud-platform}",
+    "destination_ip": "${laa-test}",
+    "destination_port": "5432",
+    "protocol": "TCP"
+  },
   "laa_test_to_mp_laa_test_http": {
     "action": "PASS",
     "source_ip": "${laa-lz-test}",


### PR DESCRIPTION
Adds a firewall rule to allow return traffic from Cloud Platform RDS to the laa-test VPC on port 5432.
https://mojdt.slack.com/archives/C01A7QK5VM1/p1786030003489429