### PR TITLE
RAM share TGW and VPC endpoints with cp-nonlive

### DIFF
--- a/terraform/environments/core-network-services/ram.tf
+++ b/terraform/environments/core-network-services/ram.tf
@@ -17,6 +17,7 @@ resource "aws_ram_principal_association" "transit-gateway" {
   for_each = {
     cloud-platform-development       = local.environment_management.account_ids["cloud-platform-development"],
     cloud-platform-preproduction     = local.environment_management.account_ids["cloud-platform-preproduction"],
+    cloud-platform-nonlive           = local.environment_management.account_ids["cloud-platform-nonlive"],
     cloud-platform-live              = local.environment_management.account_ids["cloud-platform-live"],
     container-platform-octo-nonlive  = local.environment_management.account_ids["container-platform-octo-nonlive"],
     container-platform-octo-live     = local.environment_management.account_ids["container-platform-octo-live"],

--- a/terraform/environments/core-network-services/vpc-endpoints.tf
+++ b/terraform/environments/core-network-services/vpc-endpoints.tf
@@ -4,6 +4,7 @@ locals {
   centralised_endpoint_consumer_accounts = {
     cloud-platform-development       = local.environment_management.account_ids["cloud-platform-development"]
     cloud-platform-preproduction     = local.environment_management.account_ids["cloud-platform-preproduction"]
+    cloud-platform-nonlive           = local.environment_management.account_ids["cloud-platform-nonlive"]
     cloud-platform-live              = local.environment_management.account_ids["cloud-platform-live"]
     container-platform-hmpps-live    = local.environment_management.account_ids["container-platform-hmpps-live"]
     container-platform-hmpps-nonlive = local.environment_management.account_ids["container-platform-hmpps-nonlive"]


### PR DESCRIPTION

## A reference to the issue / Description of it

Required to connect cloud-platform-non-live to the TGW.


## How does this PR fix the problem?

RAM shares the required resources


## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed


## Additional comments (if any)

{Please write here}
