### PR TITLE
User request - adds support for aws_vpc_endpoint_security_group_association resources

### DIFF
--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -415,3 +415,58 @@ module "r53_dns_firewall" {
   tags_prefix = each.key
   tags_common = local.tags
 }
+
+# ---------------------------------------------------------------------------------------------------------------------------
+# VPC Endpoint & Security Group Associations.
+# Associate security groups with the shared VPC endpoint in the given VPC.
+# Can be amended to add further associations if required.
+# ---------------------------------------------------------------------------------------------------------------------------
+
+locals {
+  vpc_endpoint_security_group_associations = [
+    {
+      business_unit     = "hmpps"
+      environment       = "preproduction"
+      api_endpoint_name = "com.amazonaws.eu-west-2.execute-api"
+      security_group_name = "allow_cp_access"
+    },
+    {
+      business_unit     = "hmpps"
+      environment       = "production"
+      api_endpoint_name = "com.amazonaws.eu-west-2.execute-api"
+      security_group_name = "allow_cp_access"
+    }
+  ]
+
+  vpc_endpoint_security_group_associations_for_workspace = {
+    for association in local.vpc_endpoint_security_group_associations :
+    "${association.business_unit}-${association.environment}" => merge(association, {
+      workspace = "core-vpc-${association.environment}"
+      vpc_name  = "${association.business_unit}-${association.environment}"
+    })
+    if "core-vpc-${association.environment}" == terraform.workspace
+  }
+}
+
+data "aws_vpc_endpoint" "shared_execute_api_endpoint" {
+  for_each = local.vpc_endpoint_security_group_associations_for_workspace
+  vpc_id       = module.vpc[each.value.vpc_name].vpc_id
+  service_name = each.value.api_endpoint_name
+}
+
+data "aws_security_group" "association_security_group" {
+  for_each = local.vpc_endpoint_security_group_associations_for_workspace
+
+  vpc_id = module.vpc[each.value.vpc_name].vpc_id
+
+  filter {
+    name   = "group-name"
+    values = [each.value.security_group_name]
+  }
+}
+
+resource "aws_vpc_endpoint_security_group_association" "shared_execute_api_endpoint_sg_association" {
+  for_each = local.vpc_endpoint_security_group_associations_for_workspace
+  vpc_endpoint_id   = data.aws_vpc_endpoint.shared_execute_api_endpoint[each.key].id
+  security_group_id = data.aws_security_group.association_security_group[each.key].id
+}


### PR DESCRIPTION
Adds terraform to support the creation of aws_vpc_endpoint_security_group_association resources for specific shared vpcs and security group names as defined in the local.

## A reference to the issue / Description of it

See slack thread https://mojdt.slack.com/archives/C01A7QK5VM1/p1786115779911719

## How does this PR fix the problem?

Creates the above resource based on values provided in a local. It is sufficiently extensible in that it will allow for further associations to be added for different VPCs if the security group exists in the shared vpc.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

See plan output below. Have checked the vpce and sg resource IDs for preprod and prod and these are valid.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
