### PR TITLE
CC-4662: grant KMS key/alias lifecycle permissions to MemberInfrastructureAccessUSEast

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -719,6 +719,33 @@ data "aws_iam_policy_document" "member-access-us-east" {
     resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
   }
   statement {
+    #checkov:skip=CKV_AWS_356: KMS key lifecycle actions don't support resource-level restriction at creation time
+    # Lets members create/manage customer-managed KMS keys for us-east-1 resources (e.g. CloudWatch Logs
+    # encryption for CloudFront-scoped WAF log groups, which must live in us-east-1).
+    effect = "Allow"
+    actions = [
+      "kms:CreateKey",
+      "kms:DescribeKey",
+      "kms:GetKeyPolicy",
+      "kms:PutKeyPolicy",
+      "kms:GetKeyRotationStatus",
+      "kms:EnableKeyRotation",
+      "kms:DisableKeyRotation",
+      "kms:EnableKey",
+      "kms:DisableKey",
+      "kms:TagResource",
+      "kms:UntagResource",
+      "kms:ListResourceTags",
+      "kms:ScheduleKeyDeletion",
+      "kms:CancelKeyDeletion",
+      "kms:CreateAlias",
+      "kms:DeleteAlias",
+      "kms:UpdateAlias",
+      "kms:ListAliases"
+    ]
+    resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
+  }
+  statement {
     effect = "Deny"
     actions = [
       "iam:AddClientIDToOpenIDConnectProvider",


### PR DESCRIPTION
## Summary

`MemberInfrastructureAccessUSEast` (the role members assume for the `aws.us-east-1` provider alias) currently has zero `kms:*` permissions - its policy only grants `acm:*`, `events:*`, `lambda:*`, `logs:*`, `waf:*`, `wafv2:*`, and a few `cur:*` actions.

This blocks [ccms-ebs PR #18100](https://github.com/ministryofjustice/modernisation-platform-environments/pull/18100) (CC-4662), which needs a customer-managed KMS key in us-east-1 to encrypt a CloudFront-scoped WAF log group (`transfer_family_waf_logs`) - that log group must live in us-east-1, and KMS keys are regional, so the existing eu-west-2 CMK can't be reused. Terraform apply fails with:

```
Error: creating KMS Key: operation error KMS: CreateKey ... AccessDeniedException: ... is not authorized to perform: kms:TagResource because no identity-based policy allows the kms:TagResource action
```

## What's changed

Added a new statement to `data.aws_iam_policy_document.member-access-us-east` granting the KMS key/alias lifecycle actions Terraform needs to create and manage a customer-managed key (create, describe, key policy, rotation, enable/disable, tagging, deletion, alias management). Scoped to those specific actions rather than `kms:*`, consistent with the rest of this policy only granting what's needed rather than blanket access.

## Test plan

- [ ] Plan/apply for `ccms-ebs` PR #18100 against `development` no longer fails on `aws_kms_key.cloudwatch_logs_us_east_1`
- [ ] No other members' us-east-1 KMS usage regresses (this only adds permissions, doesn't remove any)