### PR TITLE
Support for VPC Endpoint & Sec Group Associations.

### DIFF
--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -427,7 +427,7 @@ module "r53_dns_firewall" {
 # ---------------------------------------------------------------------------------------------------------------------------
 
 locals {
-  execute_api_endpoint_access = [
+  vpc_endpoint_access = [
     {
       business_unit = "hmpps"
       environment   = "preproduction"
@@ -448,8 +448,8 @@ locals {
     }
   ]
 
-  execute_api_endpoint_access_for_workspace = {
-    for entry in local.execute_api_endpoint_access :
+  vpc_endpoint_access_for_workspace = {
+    for entry in local.vpc_endpoint_access :
     "${entry.business_unit}-${entry.environment}" => merge(entry, {
       vpc_name = "${entry.business_unit}-${entry.environment}"
     })
@@ -458,14 +458,15 @@ locals {
 }
 
 data "aws_vpc_endpoint" "vpc_endpoint" {
-  for_each = local.execute_api_endpoint_access_for_workspace
+  for_each = local.vpc_endpoint_access_for_workspace
 
   vpc_id       = module.vpc[each.value.vpc_name].vpc_id
   service_name = each.value.service_name
 }
 
 resource "aws_security_group" "vpc_endpoint_access" {
-  for_each = local.execute_api_endpoint_access_for_workspace
+  #checkov:skip=CKV2_AWS_5: "SG is associated with a VPC endpoint, not an EC2 instance"
+  for_each = local.vpc_endpoint_access_for_workspace
 
   name        = each.value.name
   description = each.value.description
@@ -480,7 +481,7 @@ resource "aws_security_group" "vpc_endpoint_access" {
 }
 
 resource "aws_vpc_security_group_ingress_rule" "vpc_endpoint_access" {
-  for_each = local.execute_api_endpoint_access_for_workspace
+  for_each = local.vpc_endpoint_access_for_workspace
 
   security_group_id = aws_security_group.vpc_endpoint_access[each.key].id
   description       = each.value.description
@@ -491,7 +492,7 @@ resource "aws_vpc_security_group_ingress_rule" "vpc_endpoint_access" {
 }
 
 resource "aws_vpc_endpoint_security_group_association" "vpc_endpoint_access" {
-  for_each = local.execute_api_endpoint_access_for_workspace
+  for_each = local.vpc_endpoint_access_for_workspace
 
   vpc_endpoint_id   = data.aws_vpc_endpoint.vpc_endpoint[each.key].id
   security_group_id = aws_security_group.vpc_endpoint_access[each.key].id

--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -415,3 +415,84 @@ module "r53_dns_firewall" {
   tags_prefix = each.key
   tags_common = local.tags
 }
+
+# ---------------------------------------------------------------------------------------------------------------------------
+# VPC Endpoint & Security Group Associations.
+# Creates a dedicated, core-vpc-owned security group per business unit/environment and associates it with the shared VPC endpoint. 
+# A dedicated SG (rather than the shared "endpoints" SG used by all consumers) keeps access grants isolated and auditable.
+#
+# NOTE: the security group MUST be owned by core-vpc (this account) - shared VPCs do not allow the VPC owner to attach a security group created by a participant account to
+# resources it owns (see https://docs.aws.amazon.com/vpc/latest/userguide/vpc-share-limitations.html).
+#
+# ---------------------------------------------------------------------------------------------------------------------------
+
+locals {
+  execute_api_endpoint_access = [
+    {
+      business_unit = "hmpps"
+      environment   = "preproduction"
+      cidr_block    = "172.20.0.0/16"
+      port          = 443
+      service_name  = "com.amazonaws.eu-west-2.execute-api"
+      name          = "hmpps-preproduction-execute-api-cp-access"
+      description   = "Allow Container Platform access to execute-api endpoint"
+    },
+    {
+      business_unit = "hmpps"
+      environment   = "production"
+      cidr_block    = "172.20.0.0/16"
+      port          = 443
+      service_name  = "com.amazonaws.eu-west-2.execute-api"
+      name          = "hmpps-production-execute-api-cp-access"
+      description   = "Allow Container Platform access to execute-api endpoint"
+    }
+  ]
+
+  execute_api_endpoint_access_for_workspace = {
+    for entry in local.execute_api_endpoint_access :
+    "${entry.business_unit}-${entry.environment}" => merge(entry, {
+      vpc_name = "${entry.business_unit}-${entry.environment}"
+    })
+    if "core-vpc-${entry.environment}" == terraform.workspace
+  }
+}
+
+data "aws_vpc_endpoint" "vpc_endpoint" {
+  for_each = local.execute_api_endpoint_access_for_workspace
+
+  vpc_id       = module.vpc[each.value.vpc_name].vpc_id
+  service_name = each.value.service_name
+}
+
+resource "aws_security_group" "vpc_endpoint_access" {
+  for_each = local.execute_api_endpoint_access_for_workspace
+
+  name        = each.value.name
+  description = each.value.description
+  vpc_id      = module.vpc[each.value.vpc_name].vpc_id
+
+  tags = merge(
+    local.tags,
+    {
+      Name = each.value.name
+    }
+  )
+}
+
+resource "aws_vpc_security_group_ingress_rule" "vpc_endpoint_access" {
+  for_each = local.execute_api_endpoint_access_for_workspace
+
+  security_group_id = aws_security_group.vpc_endpoint_access[each.key].id
+  description       = each.value.description
+  cidr_ipv4         = each.value.cidr_block
+  from_port         = each.value.port
+  to_port           = each.value.port
+  ip_protocol       = "tcp"
+}
+
+resource "aws_vpc_endpoint_security_group_association" "vpc_endpoint_access" {
+  for_each = local.execute_api_endpoint_access_for_workspace
+
+  vpc_endpoint_id   = data.aws_vpc_endpoint.vpc_endpoint[each.key].id
+  security_group_id = aws_security_group.vpc_endpoint_access[each.key].id
+}


### PR DESCRIPTION


## A reference to the issue / Description of it

Follows on from user request to add a security group to an existing api-gateway endpoint.

## How does this PR fix the problem?

This change creates security groups, ingress rules and associations with vpc endpoints. It is required in core-vpc as to create the association the owner must be the same for the sec group and the endpoint.

The earlier PR (https://github.com/ministryofjustice/modernisation-platform/pull/13751) failed as core-vpc doesn't have ownership of the security groups referenced.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
