### PR TITLE
Adds second codeconnection resource that will act as the replacement and use the correct github app.

### DIFF
--- a/terraform/environments/core-shared-services/transform.tf
+++ b/terraform/environments/core-shared-services/transform.tf
@@ -368,3 +368,10 @@ resource "aws_codeconnections_connection" "github" {
   provider_type = "GitHub"
   tags          = local.tags
 }
+
+## Replacement CodeConnection resource that will link to the correct github app
+resource "aws_codeconnections_connection" "github_transform" {
+  name          = "mp-aws-transform-github"
+  provider_type = "GitHub"
+  tags          = local.tags
+}


### PR DESCRIPTION

## A reference to the issue / Description of it

This will allow a github org admin to correctly point the connector at the required github app. Once confirmed as working the original connector will be deleted via a 2nd PR.

## How does this PR fix the problem?

{Please write here}

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
