### PR TITLE
Adds support for associating the endpoint with a private subnet to allow access from outside of the vpc via the network firewall.

### DIFF
--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -429,22 +429,24 @@ module "r53_dns_firewall" {
 locals {
   vpc_endpoint_access = [
     {
-      business_unit = "hmpps"
-      environment   = "preproduction"
-      cidr_block    = "172.20.0.0/16"
-      port          = 443
-      service_name  = "com.amazonaws.eu-west-2.execute-api"
-      name          = "hmpps-preproduction-execute-api-cp-access"
-      description   = "Allow Container Platform access to execute-api endpoint"
+      business_unit              = "hmpps"
+      environment                = "preproduction"
+      cidr_block                 = "172.20.0.0/16"
+      port                       = 443
+      service_name               = "com.amazonaws.eu-west-2.execute-api"
+      name                       = "hmpps-preproduction-execute-api-cp-access"
+      description                = "Allow Container Platform access to execute-api endpoint"
+      private_subnet_association = true
     },
     {
-      business_unit = "hmpps"
-      environment   = "production"
-      cidr_block    = "172.20.0.0/16"
-      port          = 443
-      service_name  = "com.amazonaws.eu-west-2.execute-api"
-      name          = "hmpps-production-execute-api-cp-access"
-      description   = "Allow Container Platform access to execute-api endpoint"
+      business_unit              = "hmpps"
+      environment                = "production"
+      cidr_block                 = "172.20.0.0/16"
+      port                       = 443
+      service_name               = "com.amazonaws.eu-west-2.execute-api"
+      name                       = "hmpps-production-execute-api-cp-access"
+      description                = "Allow Container Platform access to execute-api endpoint"
+      private_subnet_association = true
     }
   ]
 
@@ -455,6 +457,20 @@ locals {
     })
     if "core-vpc-${entry.environment}" == terraform.workspace
   }
+
+  private_subnet_association = {
+    for pair in flatten([
+      for key, entry in local.vpc_endpoint_access_for_workspace : [
+        for subnet_id in module.vpc[entry.vpc_name].private_subnet_ids : {
+          key       = "${key}-${subnet_id}"
+          endpoint  = key
+          subnet_id = subnet_id
+        }
+      ]
+      if entry.private_subnet_association
+    ]) : pair.key => pair
+  }
+
 }
 
 data "aws_vpc_endpoint" "vpc_endpoint" {
@@ -462,6 +478,14 @@ data "aws_vpc_endpoint" "vpc_endpoint" {
 
   vpc_id       = module.vpc[each.value.vpc_name].vpc_id
   service_name = each.value.service_name
+}
+
+# This is required to ensure the endpoint is associated with subnets that have routing outside of the VPC.
+resource "aws_vpc_endpoint_subnet_association" "vpc_endpoint_access" {
+  for_each = local.private_subnet_association
+
+  vpc_endpoint_id = data.aws_vpc_endpoint.vpc_endpoint[each.value.endpoint].id
+  subnet_id       = each.value.subnet_id
 }
 
 resource "aws_security_group" "vpc_endpoint_access" {


### PR DESCRIPTION

## A reference to the issue / Description of it

See slack thread https://mojdt.slack.com/archives/C01A7QK5VM1/p1786464966392309

## How does this PR fix the problem?

By default, endpoints are associated with the protected subnets that have no routing from outside of the vpc. This allows the endpoint in question to be associated with the private subnets that have external routing in place.

The subnet associations added do not alter the existing associations.

This will only affect the endpoints listed in the local and so by default all other endpoints are unchanged.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
