### PR TITLE
Fix  DuplicateSubnetsInSameZone  error when associating private subnets with the execute-api VPC endpoint

### DIFF
--- a/terraform/environments/core-vpc/vpc.tf
+++ b/terraform/environments/core-vpc/vpc.tf
@@ -465,10 +465,16 @@ locals {
           key       = "${key}-${subnet_id}"
           endpoint  = key
           subnet_id = subnet_id
+          az        = data.aws_subnet.candidate_private_subnets["${key}-${subnet_id}"].availability_zone
         }
       ]
       if entry.private_subnet_association
     ]) : pair.key => pair
+    if !contains([
+      for existing_key, existing in data.aws_subnet.existing_endpoint_subnets :
+      existing.availability_zone
+      if startswith(existing_key, "${pair.endpoint}-")
+    ], pair.az)
   }
 
 }
@@ -478,6 +484,37 @@ data "aws_vpc_endpoint" "vpc_endpoint" {
 
   vpc_id       = module.vpc[each.value.vpc_name].vpc_id
   service_name = each.value.service_name
+}
+
+data "aws_subnet" "existing_endpoint_subnets" {
+  for_each = {
+    for pair in flatten([
+      for key, ep in data.aws_vpc_endpoint.vpc_endpoint : [
+        for subnet_id in ep.subnet_ids : {
+          key       = "${key}-${subnet_id}"
+          subnet_id = subnet_id
+        }
+      ]
+    ]) : pair.key => pair.subnet_id
+  }
+
+  id = each.value
+}
+
+data "aws_subnet" "candidate_private_subnets" {
+  for_each = {
+    for pair in flatten([
+      for key, entry in local.vpc_endpoint_access_for_workspace : [
+        for subnet_id in module.vpc[entry.vpc_name].private_subnet_ids : {
+          key       = "${key}-${subnet_id}"
+          subnet_id = subnet_id
+        }
+      ]
+      if entry.private_subnet_association
+    ]) : pair.key => pair.subnet_id
+  }
+
+  id = each.value
 }
 
 # This is required to ensure the endpoint is associated with subnets that have routing outside of the VPC.


### PR DESCRIPTION

## A reference to the issue / Description of it

This change fixes an issue with the previous PR (https://github.com/ministryofjustice/modernisation-platform/pull/13768) that did not take proper account of availability zones.

## How does this PR fix the problem?

{Please write here}

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
