### PR TITLE
Add coat-tag-validator step to reusable terraform plan/apply workflow

### DIFF
--- a/.github/workflows/reusable_terraform_plan_apply.yml
+++ b/.github/workflows/reusable_terraform_plan_apply.yml
@@ -167,7 +167,7 @@ jobs:
         with:
           terraform_directory: ${{ inputs.working-directory }}
           terraform_workspace: ${{ env.WORKSPACE_NAME || 'default' }}
-
+          terraform_plan_backend: 'remote'
       - name: Run Terratest
         if: ${{ steps.vars.outputs.run_terratest == 'true' }}
         run: |

--- a/.github/workflows/reusable_terraform_plan_apply.yml
+++ b/.github/workflows/reusable_terraform_plan_apply.yml
@@ -158,6 +158,15 @@ jobs:
         if: ${{ inputs.environment }}
         run: |
           terraform -chdir="${{ inputs.working-directory }}" workspace select ${WORKSPACE_NAME}
+      
+      - name: Validate Tags
+        id: validate
+        if: github.event.ref != 'refs/heads/main'
+        uses: ministryofjustice/coat-tag-validator@354cc92dc6a1ebcca99ad3a0db4bd36a9c8418c4 # v2.2.2
+        continue-on-error: true
+        with:
+          terraform_directory: ${{ inputs.working-directory }}
+          terraform_workspace: ${{ env.WORKSPACE_NAME || 'default' }}
 
       - name: Run Terratest
         if: ${{ steps.vars.outputs.run_terratest == 'true' }}


### PR DESCRIPTION
This introduces tag validation during plan runs so tagging issues are surfaced earlier in CI, while keeping current deployment/apply behavior unchanged. #13175 