### PR TITLE
switch laa data factory access level to data-engineer

### DIFF
--- a/environments/data-factory-laa.json
+++ b/environments/data-factory-laa.json
@@ -16,7 +16,7 @@
       "access": [
         {
           "sso_group_name": "laa-data-factory-engineering",
-          "level": "developer"
+          "level": "data-engineer"
         },
         {
           "sso_group_name": "laa-data-factory-engineering",


### PR DESCRIPTION
## A reference to the issue / Description of it

LAA Data Factory test account has developer level access. data-engineer access level is required

## How does this PR fix the problem?

Updates the access level. Additional group not created as developer access is not required.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.


## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?
No

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)