### PR TITLE
Enable Session Manager log forwarding in secure baselines

### DIFF
--- a/terraform/environments/bootstrap/secure-baselines/main.tf
+++ b/terraform/environments/bootstrap/secure-baselines/main.tf
@@ -6,7 +6,7 @@ data "aws_kms_key" "cloudtrail_key" {
 
 #trivy:ignore:AVD-AWS-0136
 module "baselines" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=06f1c148a4aff830dec1683b971916b5c80b522a" # v10.1.2
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=b86a581b071922c2e29b56b67a8902b0ccc8c8b8" # v10.1.3
   providers = {
     # Default and replication regions
     aws                    = aws.workspace-eu-west-2
@@ -76,6 +76,9 @@ module "baselines" {
 
   # Enable Session Manager transcript logging
   enable_session_manager_logging = true
+  session_manager_log_forwarding_destination_arns = {
+    eu-west-2 = "arn:aws:logs:eu-west-2:${local.environment_management.account_ids["core-logging-production"]}:destination:session-manager-logs-destination"
+  }
 
   # Pass in pagerduty integration key for security hub alerts
   pagerduty_integration_key = local.pagerduty_integration_keys["security_hub_members"]


### PR DESCRIPTION
## Summary

Enables central forwarding of AWS Systems Manager Session Manager transcript logs from member accounts via secure baselines.

## Changes

- Bumps  from  to 
- Passes the core-logging CloudWatch Logs destination ARN for 
- Keeps Session Manager transcript logging enabled through secure baselines

## Notes

This should be applied after the core-logging PR has created the central Session Manager CloudWatch Logs destination, Firehose stream, S3 bucket, KMS key and SQS/XSIAM wiring.

## Testing

- Ran 
- Ran 