### PR TITLE
Forward Session Manager member logs to core logging

### DIFF
--- a/terraform/environments/bootstrap/secure-baselines/main.tf
+++ b/terraform/environments/bootstrap/secure-baselines/main.tf
@@ -6,7 +6,7 @@ data "aws_kms_key" "cloudtrail_key" {
 
 #trivy:ignore:AVD-AWS-0136
 module "baselines" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=06f1c148a4aff830dec1683b971916b5c80b522a" # v10.1.2
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=b86a581b071922c2e29b56b67a8902b0ccc8c8b8" # v10.1.3
   providers = {
     # Default and replication regions
     aws                    = aws.workspace-eu-west-2
@@ -76,6 +76,9 @@ module "baselines" {
 
   # Enable Session Manager transcript logging
   enable_session_manager_logging = true
+  session_manager_log_forwarding_destination_arns = {
+    eu-west-2 = "arn:aws:logs:eu-west-2:${local.environment_management.account_ids["core-logging-production"]}:destination:session-manager-logs-destination"
+  }
 
   # Pass in pagerduty integration key for security hub alerts
   pagerduty_integration_key = local.pagerduty_integration_keys["security_hub_members"]

--- a/terraform/environments/bootstrap/secure-baselines/main.tf
+++ b/terraform/environments/bootstrap/secure-baselines/main.tf
@@ -6,7 +6,7 @@ data "aws_kms_key" "cloudtrail_key" {
 
 #trivy:ignore:AVD-AWS-0136
 module "baselines" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=b86a581b071922c2e29b56b67a8902b0ccc8c8b8" # v10.1.3
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines?ref=8d8e55e89b9d1c807c3172c1408b3ef802844b8e" # v10.1.4
   providers = {
     # Default and replication regions
     aws                    = aws.workspace-eu-west-2


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform-security/issues/114

## How does this PR fix the problem?

Enables central forwarding of AWS Systems Manager Session Manager transcript logs from member accounts via secure baselines.

## Changes

- Bumps `modernisation-platform-terraform-baselines` from `v10.1.2` to `v10.1.4`
- Passes the core-logging CloudWatch Logs destination ARN for `eu-west-2`

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
