### PR TITLE
New Tag Pair for Secure Baselines to Prevent AWSBackup role being wiped in analytical-platform sandbox accounts.,

### DIFF
--- a/terraform/environments/bootstrap/secure-baselines/locals.tf
+++ b/terraform/environments/bootstrap/secure-baselines/locals.tf
@@ -18,13 +18,14 @@ locals {
     "us-east-1",    # US East (N. Virginia) (for global services)
   ]
   environments = {
-    business-unit = "Platforms"
-    service-area  = "Hosting"
-    application   = "Modernisation Platform: Environments Management"
-    is-production = true
-    owner         = "Modernisation Platform: modernisation-platform@digital.justice.gov.uk"
-    component     = "secure-baselines"
-    source-code   = "https://github.com/ministryofjustice/modernisation-platform/tree/main/terraform/environments/bootstrap/secure-baselines"
+    business-unit        = "Platforms"
+    service-area         = "Hosting"
+    application          = "Modernisation Platform: Environments Management"
+    is-production        = true
+    owner                = "Modernisation Platform: modernisation-platform@digital.justice.gov.uk"
+    component            = "secure-baselines"
+    source-code          = "https://github.com/ministryofjustice/modernisation-platform/tree/main/terraform/environments/bootstrap/secure-baselines"
+    de-sandbox-nuke-keep = "true"
   }
   root_account           = data.aws_organizations_organization.root_account
   environment_management = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)


### PR DESCRIPTION


## A reference to the issue / Description of it

Added a tag to secure-baselines resources to ensure that nukes run in analytical platform sandbox accounts don't wipe MP baselines resources.

## How does this PR fix the problem?

Currently the nuke job that AP runs in analytical-platform-data-engineering-sandboxa is wiping the AWSBackup role which in turn causes the scheduled baselines job to fail as it tries to delete protected backups.

Whilst AP excluded baselines resources, this role is clearly being missed so this is an additional protection to ensure the role is not removed.

Tag pair as defined here:

https://github.com/ministryofjustice/data-engineering-cleanup/blob/main/housekeeping_sandbox.md#for-new-infrastructure-use-custom-tagging


## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
