### PR TITLE
Fix Terratest to run with read-only plan role

### DIFF
--- a/terraform/environments/core-logging/test/go_test.go
+++ b/terraform/environments/core-logging/test/go_test.go
@@ -12,7 +12,6 @@ func TestTransitGateway(t *testing.T) {
 		TerraformDir: "../",
 	})
 
-	terraform.RunTerraformCommand(t, terraformOptions, "refresh")
 	terraform.Plan(t, terraformOptions)
 
 	//Test private route tables

--- a/terraform/environments/core-network-services/test/go_test.go
+++ b/terraform/environments/core-network-services/test/go_test.go
@@ -14,7 +14,6 @@ func TestTransitGateway(t *testing.T) {
 		TerraformDir: "../",
 	})
 
-	terraform.RunTerraformCommand(t, terraformOptions, "refresh")
 	terraform.Plan(t, terraformOptions)
 
 	//Test transit-gateway will not be affected
@@ -32,7 +31,6 @@ func TestInspectionVPCs(t *testing.T) {
 		TerraformDir: "../",
 	})
 
-	terraform.RunTerraformCommand(t, terraformOptions, "refresh")
 	terraform.Plan(t, terraformOptions)
 
 	// Retrieve the VPC output as a map

--- a/terraform/environments/core-security/test/go_test.go
+++ b/terraform/environments/core-security/test/go_test.go
@@ -12,7 +12,6 @@ func TestTransitGateway(t *testing.T) {
 		TerraformDir: "../",
 	})
 
-	terraform.RunTerraformCommand(t, terraformOptions, "refresh")
 	terraform.Plan(t, terraformOptions)
 
 	//Test private route tables

--- a/terraform/environments/core-shared-services/test/go_test.go
+++ b/terraform/environments/core-shared-services/test/go_test.go
@@ -14,7 +14,6 @@ func TestTransitGateway(t *testing.T) {
 		TerraformDir: "../",
 	})
 
-	terraform.RunTerraformCommand(t, terraformOptions, "refresh")
 	terraform.Plan(t, terraformOptions)
 
 	//Test private route tables


### PR DESCRIPTION
## A reference to the issue / Description of it

[#187](https://github.com/ministryofjustice/modernisation-platform-security/issues/187)

## How does this PR fix the problem?
terraform refresh is not needed because terraform plan already refreshes the infrastructure state as part of the planning process. The explicit refresh was also trying to write the refreshed state back to S3, which required s3:PutObject permission that the read-only PR plan role should not have.