### PR TITLE
Adds custom endpoints for use by electronic-monitoring-data 

### DIFF
--- a/terraform/environments/core-vpc/custom_endpoints.tf
+++ b/terraform/environments/core-vpc/custom_endpoints.tf
@@ -1,11 +1,11 @@
 
 # ---------------------------------------------------------------------------------------------------------------------------
-# Terraform to create custom VPC Endpoints, Subnet & Security Group Associations.
+# Terraform to create custom VPC Endpoints and Security Group Associations.
 #
 # For each entry in the vpc_endpoint_access local, this creates an Interface VPC endpoint (for the given service_name) owned
-# directly by core-vpc, and associates it with the general-private subnets (across all three AZs) of the relevant member VPC.
+# directly by core-vpc, with subnet_ids set to the general-private subnets (across all three AZs) of the relevant member VPC.
 #
-# This is used for endpoints that need subnet associations other than Protected - e.g. endpoints that need to be accessible
+# This is used for endpoints that need subnet placement other than Protected - e.g. endpoints that need to be accessible
 # from member account services or other MoJ Platforms - and is independent of the member-vpc module's additional_endpoints.
 #
 # It also creates a dedicated, core-vpc-owned security group per business unit/environment and associates it with the endpoint.
@@ -55,7 +55,7 @@ locals {
   # member-vpc only ever creates subnets in the first 3 AZs (a, b, c) of the region, so exclude any others (e.g. eu-west-2d)
   availability_zones = [for az in sort(data.aws_availability_zones.available.names) : az if contains(["a", "b", "c"], substr(az, -1, 1))]
 
-  # one entry per vpc_endpoint_access entry x availability zone, to look up the general-private subnet in each az
+  # one entry per vpc_endpoint_access entry x availability zone, used to look up the general-private subnet id in each az
   vpc_endpoint_access_subnets = {
     for entry in flatten([
       for key, value in local.vpc_endpoint_access_for_workspace : [
@@ -67,6 +67,15 @@ locals {
         }
       ]
     ]) : entry.key => entry
+  }
+
+  # subnet ids per endpoint (set on aws_vpc_endpoint.subnet_ids below), grouped back up from the per-az lookups above
+  vpc_endpoint_access_subnet_ids = {
+    for key in keys(local.vpc_endpoint_access_for_workspace) : key => [
+      for subnet_key, subnet in local.vpc_endpoint_access_subnets :
+      data.aws_subnet.vpc_endpoint_access[subnet_key].id
+      if subnet.endpoint_key == key
+    ]
   }
 }
 
@@ -87,9 +96,11 @@ data "aws_subnet" "vpc_endpoint_access" {
 resource "aws_vpc_endpoint" "vpc_endpoint_access" {
   for_each = local.vpc_endpoint_access_for_workspace
 
-  vpc_id            = module.vpc[each.value.vpc_name].vpc_id
-  service_name      = each.value.service_name
-  vpc_endpoint_type = "Interface"
+  vpc_id              = module.vpc[each.value.vpc_name].vpc_id
+  service_name        = each.value.service_name
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = local.vpc_endpoint_access_subnet_ids[each.key]
+  private_dns_enabled = true
 
   tags = merge(
     local.tags,
@@ -97,13 +108,6 @@ resource "aws_vpc_endpoint" "vpc_endpoint_access" {
       Name = each.value.name
     }
   )
-}
-
-resource "aws_vpc_endpoint_subnet_association" "vpc_endpoint_access" {
-  for_each = local.vpc_endpoint_access_subnets
-
-  vpc_endpoint_id = aws_vpc_endpoint.vpc_endpoint_access[each.value.endpoint_key].id
-  subnet_id       = data.aws_subnet.vpc_endpoint_access[each.key].id
 }
 
 resource "aws_security_group" "vpc_endpoint_access" {

--- a/terraform/environments/core-vpc/custom_endpoints.tf
+++ b/terraform/environments/core-vpc/custom_endpoints.tf
@@ -29,7 +29,7 @@ locals {
       port               = 443
       service_name       = "com.amazonaws.eu-west-2.execute-api"
       name               = "hmpps-preproduction-execute-api-cp-access"
-      description        = "Created for electronic-monitoring-data"
+      description        = "Allow Container Platform access to execute-api endpoint"
       subnet_name_prefix = "general-private"
     },
     {
@@ -39,7 +39,7 @@ locals {
       port               = 443
       service_name       = "com.amazonaws.eu-west-2.execute-api"
       name               = "hmpps-production-execute-api-cp-access"
-      description        = "Created for electronic-monitoring-data"
+      description        = "Allow Container Platform access to execute-api endpoint"
       subnet_name_prefix = "general-private"
     }
   ]

--- a/terraform/environments/core-vpc/custom_endpoints.tf
+++ b/terraform/environments/core-vpc/custom_endpoints.tf
@@ -1,12 +1,21 @@
 
 # ---------------------------------------------------------------------------------------------------------------------------
 # Terraform to create custom VPC Endpoints, Subnet & Security Group Associations.
-# 
-# This is used to create VPC endpoints that have subnet associations other than Protected. For example endpoints that are accessible from member account services or other MoJ Platforms.
-# It also creates a dedicated, core-vpc-owned security group per business unit/environment and associates it with the shared VPC endpoint. 
+#
+# For each entry in the vpc_endpoint_access local, this creates an Interface VPC endpoint (for the given service_name) owned
+# directly by core-vpc, and associates it with the general-private subnets (across all three AZs) of the relevant member VPC.
+#
+# This is used for endpoints that need subnet associations other than Protected - e.g. endpoints that need to be accessible
+# from member account services or other MoJ Platforms - and is independent of the member-vpc module's additional_endpoints.
+#
+# It also creates a dedicated, core-vpc-owned security group per business unit/environment and associates it with the endpoint.
 # A dedicated SG (rather than the shared "endpoints" SG used by all consumers) keeps access grants isolated and auditable.
 #
-# NOTE: the security group MUST be owned by core-vpc (this account) - shared VPCs do not allow the VPC owner to attach a security group created by a participant account to
+# NOTE: 
+#
+# - Currently supports just one ingress rule per security group.
+#
+# - the security group MUST be owned by core-vpc (this account) - shared VPCs do not allow the VPC owner to attach a security group created by a participant account to
 # resources it owns (see https://docs.aws.amazon.com/vpc/latest/userguide/vpc-share-limitations.html).
 #
 # ---------------------------------------------------------------------------------------------------------------------------
@@ -14,48 +23,87 @@
 locals {
   vpc_endpoint_access = [
     {
-      business_unit = "hmpps"
-      environment   = "preproduction"
-      cidr_block    = "172.20.0.0/16"
-      port          = 443
-      service_name  = "com.amazonaws.eu-west-2.execute-api"
-      name          = "hmpps-preproduction-execute-api-cp-access"
-      description   = "Allow Container Platform access to execute-api endpoint"
+      business_unit      = "hmpps"
+      environment        = "preproduction"
+      cidr_block         = "172.20.0.0/16"
+      port               = 443
+      service_name       = "com.amazonaws.eu-west-2.execute-api"
+      name               = "hmpps-preproduction-execute-api-cp-access"
+      description        = "Created for electronic-monitoring-data"
+      subnet_name_prefix = "general-private"
     },
     {
-      business_unit = "hmpps"
-      environment   = "production"
-      cidr_block    = "172.20.0.0/16"
-      port          = 443
-      service_name  = "com.amazonaws.eu-west-2.execute-api"
-      name          = "hmpps-production-execute-api-cp-access"
-      description   = "Allow Container Platform access to execute-api endpoint"
+      business_unit      = "hmpps"
+      environment        = "production"
+      cidr_block         = "172.20.0.0/16"
+      port               = 443
+      service_name       = "com.amazonaws.eu-west-2.execute-api"
+      name               = "hmpps-production-execute-api-cp-access"
+      description        = "Created for electronic-monitoring-data"
+      subnet_name_prefix = "general-private"
     }
   ]
 
   vpc_endpoint_access_for_workspace = {
     for entry in local.vpc_endpoint_access :
-    "${entry.business_unit}-${entry.environment}" => merge(entry, {
+    entry.name => merge(entry, {
       vpc_name = "${entry.business_unit}-${entry.environment}"
     })
     if "core-vpc-${entry.environment}" == terraform.workspace
   }
-}
 
-# Plural "aws_vpc_endpoints" data source doesn't exist in this provider, so gate the singular
-# lookup on the endpoint actually being configured for the VPC - otherwise it errors when missing.
-locals {
-  vpc_endpoint_access_existing = {
-    for key, value in local.vpc_endpoint_access_for_workspace : key => value
-    if contains(local.vpcs[terraform.workspace][value.vpc_name].options.additional_endpoints, value.service_name)
+  # member-vpc only ever creates subnets in the first 3 AZs (a, b, c) of the region, so exclude any others (e.g. eu-west-2d)
+  availability_zones = [for az in sort(data.aws_availability_zones.available.names) : az if contains(["a", "b", "c"], substr(az, -1, 1))]
+
+  # one entry per vpc_endpoint_access entry x availability zone, to look up the general-private subnet in each az
+  vpc_endpoint_access_subnets = {
+    for entry in flatten([
+      for key, value in local.vpc_endpoint_access_for_workspace : [
+        for az in local.availability_zones : {
+          key          = "${key}-${az}"
+          endpoint_key = key
+          vpc_name     = value.vpc_name
+          name         = "${value.vpc_name}-${value.subnet_name_prefix}-${az}"
+        }
+      ]
+    ]) : entry.key => entry
   }
 }
 
-data "aws_vpc_endpoint" "vpc_endpoint" {
-  for_each = local.vpc_endpoint_access_existing
+data "aws_availability_zones" "available" {
+  state = "available"
+}
 
-  vpc_id       = module.vpc[each.value.vpc_name].vpc_id
-  service_name = each.value.service_name
+data "aws_subnet" "vpc_endpoint_access" {
+  for_each = local.vpc_endpoint_access_subnets
+
+  vpc_id = module.vpc[each.value.vpc_name].vpc_id
+
+  tags = {
+    Name = each.value.name
+  }
+}
+
+resource "aws_vpc_endpoint" "vpc_endpoint_access" {
+  for_each = local.vpc_endpoint_access_for_workspace
+
+  vpc_id            = module.vpc[each.value.vpc_name].vpc_id
+  service_name      = each.value.service_name
+  vpc_endpoint_type = "Interface"
+
+  tags = merge(
+    local.tags,
+    {
+      Name = each.value.name
+    }
+  )
+}
+
+resource "aws_vpc_endpoint_subnet_association" "vpc_endpoint_access" {
+  for_each = local.vpc_endpoint_access_subnets
+
+  vpc_endpoint_id = aws_vpc_endpoint.vpc_endpoint_access[each.value.endpoint_key].id
+  subnet_id       = data.aws_subnet.vpc_endpoint_access[each.key].id
 }
 
 resource "aws_security_group" "vpc_endpoint_access" {
@@ -86,10 +134,8 @@ resource "aws_vpc_security_group_ingress_rule" "vpc_endpoint_access" {
 }
 
 resource "aws_vpc_endpoint_security_group_association" "vpc_endpoint_access" {
-  # for_each is scoped to endpoints that are actually configured so the association (and the SG it
-  # depends on) is never removed just because the endpoint temporarily can't be found.
-  for_each = local.vpc_endpoint_access_existing
+  for_each = local.vpc_endpoint_access_for_workspace
 
-  vpc_endpoint_id   = data.aws_vpc_endpoint.vpc_endpoint[each.key].id
+  vpc_endpoint_id   = aws_vpc_endpoint.vpc_endpoint_access[each.key].id
   security_group_id = aws_security_group.vpc_endpoint_access[each.key].id
 }

--- a/terraform/environments/core-vpc/custom_endpoints.tf
+++ b/terraform/environments/core-vpc/custom_endpoints.tf
@@ -46,7 +46,7 @@ locals {
 
   vpc_endpoint_access_for_workspace = {
     for entry in local.vpc_endpoint_access :
-    entry.name => merge(entry, {
+    "${entry.business_unit}-${entry.environment}" => merge(entry, {
       vpc_name = "${entry.business_unit}-${entry.environment}"
     })
     if "core-vpc-${entry.environment}" == terraform.workspace


### PR DESCRIPTION

## A reference to the issue / Description of it

Slack thread - https://mojdt.slack.com/archives/C01A7QK5VM1/p1786464966392309

The summary of the issue:

- All endpoints created via entries in *.json in environments-networks have their subnet associations added to Protected subnets.
- Protected subnets are neither shared to member accounts, nor do they have routing from outside of the VPC.
- Electronic Monitoring requires execute-api endpoints that are accessible from cloud-platform whilst remaining private & secure.
- The change will create the required endpoints & subnet associations in general-private, which are reachable from cloud-platform.

## How does this PR fix the problem?

Creates VPC endpoints and security group associations based on local.vpc_endpoint_access. 

Endpoint and subnet association resources are based on those created in the vpc module - subnet_ids are provided inline to the endpoint resource rather than creating a separate aws_vpc_endpoint_subnet_association resource.

Security groups & ingress rules already exist and this PR ensures they are not recreated.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

See PR plan below. 

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
