### PR TITLE
Allow HMPPS development HTTPS access to Cloud Platform

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/development_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/development_rules.json
@@ -265,6 +265,13 @@
     "destination_port": "1521",
     "protocol": "TCP"
   },
+  "hmpps_development_to_cp_https": {
+    "action": "PASS",
+    "source_ip": "${hmpps-development}",
+    "destination_ip": "${cloud-platform}",
+    "destination_port": "443",
+    "protocol": "TCP"
+  },
   "hmpps_development_to_pgres_tcp": {
     "action": "PASS",
     "source_ip": "${hmpps-development}",


### PR DESCRIPTION
## A reference to the issue / Description of it

https://mojdt.slack.com/archives/C01A7QK5VM1/p1787227881885269

An EC2 instance in `electronic-monitoring-data-development` cannot reach an internal Cloud Platform non-production API over HTTPS. The request times out because there is no central firewall rule allowing TCP 443 from the HMPPS development VPC to the Cloud Platform network.

## How does this PR fix the problem?

Adds a central firewall `PASS` rule allowing `hmpps-development` (`10.26.24.0/21`) to reach the Cloud Platform range (`172.20.0.0/16`) on TCP 443.

The existing routing and NACL configuration already permits this traffic, so no changes to those components are required.

## How has this been tested?

See tests below

## Deployment Plan / Instructions

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)
