### PR TITLE
use plan/apply oidc roles in member account RAM association workflow

### DIFF
--- a/.github/workflows/reusable-member-account-ram-association.yml
+++ b/.github/workflows/reusable-member-account-ram-association.yml
@@ -54,10 +54,19 @@ jobs:
           echo ACCOUNT_NUMBER=$ACCOUNT_NUMBER >> $GITHUB_ENV
 
       - name: Configure AWS Credentials
+        if: github.event.ref != 'refs/heads/main'
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
-          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
-          role-session-name: githubactionsrolesession
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions-plan"
+          role-session-name: githubactionsplanrolesession
+          aws-region: ${{ inputs.aws_region }}
+      
+      - name: Configure AWS Credentials
+        if: github.event.ref == 'refs/heads/main'
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions-apply"
+          role-session-name: githubactionsapplyrolesession
           aws-region: ${{ inputs.aws_region }}
 
       - name: Setup Terraform


### PR DESCRIPTION
Updates the `reusable member-account-ram-association` workflow to use separate OIDC roles depending on branch. The previous github-actions role is being decommissioned for this repository. [#187](https://github.com/ministryofjustice/modernisation-platform-security/issues/187)