### PR TITLE
Add Bedrock Guardrails permissions to OIDC roles

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -1246,6 +1246,19 @@ data "aws_iam_policy_document" "oidc_assume_role_member" {
       ]
     }
   }
+
+  statement {
+    sid    = "AllowOIDCBedrockGuardrailManagement"
+    effect = "Allow"
+    actions = [
+      "bedrock:CreateGuardrail",
+      "bedrock:CreateGuardrailVersion",
+      "bedrock:GetGuardrail",
+      "bedrock:ListTagsForResource",
+      "bedrock:UpdateGuardrail"
+    ]
+    resources = ["*"]
+  }
 }
 
 # AWS Shield Advanced SRT (Shield Response Team) support role
@@ -1647,18 +1660,6 @@ data "aws_iam_policy_document" "oidc_assume_plan_role_member" {
     }
   }
 
-  statement {
-    sid    = "AllowOIDCBedrockGuardrailManagement"
-    effect = "Allow"
-    actions = [
-      "bedrock:CreateGuardrail",
-      "bedrock:CreateGuardrailVersion",
-      "bedrock:GetGuardrail",
-      "bedrock:ListTagsForResource",
-      "bedrock:UpdateGuardrail"
-    ]
-    resources = ["*"]
-  }
 }
 
 # Role github-actions-apply to support OIDC access from Modernisation-Platform-Environments for:

--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -1607,6 +1607,8 @@ data "aws_iam_policy_document" "oidc_assume_plan_role_member" {
     actions = [
       "airflow:Get*",
       "airflow:List*",
+      "bedrock:GetGuardrail",
+      "bedrock:ListTagsForResource",
       "glue:GetConnection",
       "lakeformation:GetLFTag",
       "lakeformation:ListLFTags",
@@ -1643,6 +1645,19 @@ data "aws_iam_policy_document" "oidc_assume_plan_role_member" {
         local.environment_management.account_ids["observability-platform-production"],
       ]
     }
+  }
+
+  statement {
+    sid    = "AllowOIDCBedrockGuardrailManagement"
+    effect = "Allow"
+    actions = [
+      "bedrock:CreateGuardrail",
+      "bedrock:CreateGuardrailVersion",
+      "bedrock:GetGuardrail",
+      "bedrock:ListTagsForResource",
+      "bedrock:UpdateGuardrail"
+    ]
+    resources = ["*"]
   }
 }
 


### PR DESCRIPTION
:copilot: _This pull request body was generated by GitHub Copilot_

## Summary

Add the Bedrock Guardrails permissions required by the member-account GitHub Actions roles.

## Changes

- Allow `github-actions-plan` to call `bedrock:GetGuardrail` and `bedrock:ListTagsForResource` during Terraform refresh.
- Allow `github-actions-apply` to create, version, read, tag-list, and update Bedrock Guardrails.

This resolves the `bedrock:ListTagsForResource` access-denied error encountered by the environments Terraform plan workflow.

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>