### PR TITLE
Add Integration Hub API hosting platform component

### DIFF
--- a/environments/integration-hub.json
+++ b/environments/integration-hub.json
@@ -6,6 +6,9 @@
       "name": "api-platform"
     },
     {
+      "name": "api-hosting-platform"
+    },
+    {
       "name": "downstream-mock-api"
     },
     {
@@ -63,6 +66,7 @@
     "critical-national-infrastructure": false
   },
   "github-oidc-team-repositories": [
+    "ministryofjustice/integration-hub-api-platform",
     "ministryofjustice/integration-hub-file-transfer-api"
   ],
   "go-live-date": ""


### PR DESCRIPTION
## Summary

- register the new api-hosting-platform component for Integration Hub
- allow the integration-hub-api-platform repository to use the team GitHub OIDC provider
- keep the orchestration API isolated from the legacy api-platform state now used by the file-transfer component

## Why

The benefit-checker orchestration layer needs an independently scoped Modernisation Platform component and Terraform state. Reusing api-platform would conflict with the migrated file-transfer stack.

## Follow-up

After merge, the generated component files will be used by the infrastructure change in modernisation-platform-environments.