### PR TITLE
Add secrets-manager-editor role for read-only plus secret editing

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-environment.yml
+++ b/.github/ISSUE_TEMPLATE/new-environment.yml
@@ -87,6 +87,7 @@ body:
     multiple: true
     options:
     - view-only
+    - secrets-manager-editor
     - developer
     - sandbox
     - migration
@@ -109,6 +110,7 @@ body:
     multiple: true
     options:
     - view-only
+    - secrets-manager-editor
     - developer
     - migration
     - instance-management
@@ -130,6 +132,7 @@ body:
     multiple: true
     options:
     - view-only
+    - secrets-manager-editor
     - developer
     - migration
     - instance-management
@@ -151,6 +154,7 @@ body:
     multiple: true
     options:
     - view-only
+    - secrets-manager-editor
     - developer
     - migration
     - instance-management

--- a/policies/environments/environment-definitions.rego
+++ b/policies/environments/environment-definitions.rego
@@ -27,6 +27,7 @@ allowed_access := [
   "mwaa-user",
   "platform-engineer-admin",
   "read-only",
+  "secrets-manager-editor",
   "reporting-operations",
   "sandbox",
   "security-audit",

--- a/policies/environments/environment-definitions_test.rego
+++ b/policies/environments/environment-definitions_test.rego
@@ -43,7 +43,7 @@ test_business_units_character if {
 }
 
 test_unexpected_access if {
-  deny["`example.json` uses an unexpected access level: got `incorrect-access`, expected one of: administrator, analytics-engineer, data-engineer, data-scientist, developer, instance-access, instance-management, migration, mwaa-user, platform-engineer-admin, read-only, reporting-operations, sandbox, security-audit, ssm-session-access, view-only, powerbi-user, fleet-manager, quicksight-admin, workspace-user-admin, workspace-admin"] with input as { "filename": "example.json", "environments": [{"access": [{"level": "incorrect-access"}]}]}
+  deny["`example.json` uses an unexpected access level: got `incorrect-access`, expected one of: administrator, analytics-engineer, data-engineer, data-scientist, developer, instance-access, instance-management, migration, mwaa-user, platform-engineer-admin, read-only, secrets-manager-editor, reporting-operations, sandbox, security-audit, ssm-session-access, view-only, powerbi-user, fleet-manager, quicksight-admin, workspace-user-admin, workspace-admin"] with input as { "filename": "example.json", "environments": [{"access": [{"level": "incorrect-access"}]}]}
 }
 
 test_unexpected_access_assignment if {

--- a/source/user-guide/platform-user-roles.html.md.erb
+++ b/source/user-guide/platform-user-roles.html.md.erb
@@ -24,6 +24,14 @@ These are [defined in code](https://github.com/ministryofjustice/modernisation-p
 - Comprehensive read-only visibility of the AWS environment. As this role provides access to contents of S3 and others, it is designed for users for whom view-only is insufficient.
 - Role makes use of AWS ReadOnly managed policy and is not at present configurable beyond that.
 
+### secrets-manager-editor
+
+The secrets-manager-editor role is intended for users who need read-only visibility across an environment but also need to update application secrets.
+
+- Log into the console
+- Read-only access to resources including objects and logs that are readable via AWS ReadOnlyAccess
+- Edit Secrets Manager secrets (update secret values and metadata)
+
 ### developer
 
 The developer role is the standard role used by teams deploying infrastructure onto the Modernisation Platform.

--- a/terraform/environments/bootstrap/single-sign-on/main.tf
+++ b/terraform/environments/bootstrap/single-sign-on/main.tf
@@ -320,6 +320,29 @@ resource "aws_ssoadmin_account_assignment" "read_only" {
   target_type = "AWS_ACCOUNT"
 }
 
+resource "aws_ssoadmin_account_assignment" "secrets_manager_editor" {
+
+  for_each = {
+
+    for sso_assignment in local.sso_data[local.env_name][*] :
+
+    "${sso_assignment.sso_group_name}-${sso_assignment.level}" => sso_assignment
+
+    if(sso_assignment.level == "secrets-manager-editor")
+  }
+
+  provider = aws.sso-management
+
+  instance_arn       = local.sso_instance_arn
+  permission_set_arn = data.terraform_remote_state.mp-sso-permissions-sets.outputs.secrets_manager_editor
+
+  principal_id   = data.aws_identitystore_group.member[each.value.sso_group_name].group_id
+  principal_type = "GROUP"
+
+  target_id   = local.environment_management.account_ids[terraform.workspace]
+  target_type = "AWS_ACCOUNT"
+}
+
 resource "aws_ssoadmin_account_assignment" "data_engineer" {
 
   for_each = {

--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -176,6 +176,7 @@ resource "aws_iam_policy" "secrets_manager_editor" {
 }
 
 data "aws_iam_policy_document" "secrets_manager_editor_additional" {
+  #checkov:skip=CKV_AWS_111: Required to allow secrets updates across member-environment secrets
   #checkov:skip=CKV_AWS_356: Needs to access multiple resources
   statement {
     sid    = "secretsManagerEditorAllow"

--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -167,6 +167,28 @@ resource "aws_iam_policy" "developer" {
   policy   = data.aws_iam_policy_document.developer_additional.json
 }
 
+# secrets manager editor policy - member SSO and collaborators
+resource "aws_iam_policy" "secrets_manager_editor" {
+  provider = aws.workspace
+  name     = "secrets_manager_editor_policy"
+  path     = "/"
+  policy   = data.aws_iam_policy_document.secrets_manager_editor_additional.json
+}
+
+data "aws_iam_policy_document" "secrets_manager_editor_additional" {
+  #checkov:skip=CKV_AWS_356: Needs to access multiple resources
+  statement {
+    sid    = "secretsManagerEditorAllow"
+    effect = "Allow"
+    actions = [
+      "secretsmanager:PutSecretValue",
+      "secretsmanager:UpdateSecret",
+      "secretsmanager:RestoreSecret"
+    ]
+    resources = ["*"]
+  }
+}
+
 #tfsec:ignore:aws-iam-no-policy-wildcards
 data "aws_iam_policy_document" "developer_additional" {
   #checkov:skip=CKV_AWS_108

--- a/terraform/single-sign-on/outputs.tf
+++ b/terraform/single-sign-on/outputs.tf
@@ -10,6 +10,10 @@ output "developer" {
   value = aws_ssoadmin_permission_set.modernisation_platform_developer.arn
 }
 
+output "secrets_manager_editor" {
+  value = aws_ssoadmin_permission_set.modernisation_platform_secrets_manager_editor.arn
+}
+
 output "fleet_manager" {
   value = aws_ssoadmin_permission_set.modernisation_platform_fleet_manager.arn
 }

--- a/terraform/single-sign-on/sso-permission-sets.tf
+++ b/terraform/single-sign-on/sso-permission-sets.tf
@@ -39,6 +39,33 @@ resource "aws_ssoadmin_customer_managed_policy_attachment" "modernisation_platfo
   }
 }
 
+# Modernisation Platform secrets manager editor
+resource "aws_ssoadmin_permission_set" "modernisation_platform_secrets_manager_editor" {
+  provider         = aws.sso-management
+  name             = "modernisation-platform-secrets-manager-editor"
+  description      = "Modernisation Platform: read-only plus edit Secrets Manager values"
+  instance_arn     = local.sso_admin_instance_arn
+  session_duration = "PT8H"
+  tags             = {}
+}
+
+resource "aws_ssoadmin_managed_policy_attachment" "modernisation_platform_secrets_manager_editor" {
+  provider           = aws.sso-management
+  instance_arn       = local.sso_admin_instance_arn
+  managed_policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+  permission_set_arn = aws_ssoadmin_permission_set.modernisation_platform_secrets_manager_editor.arn
+}
+
+resource "aws_ssoadmin_customer_managed_policy_attachment" "modernisation_platform_secrets_manager_editor" {
+  provider           = aws.sso-management
+  instance_arn       = local.sso_admin_instance_arn
+  permission_set_arn = aws_ssoadmin_permission_set.modernisation_platform_secrets_manager_editor.arn
+  customer_managed_policy_reference {
+    name = "secrets_manager_editor_policy"
+    path = "/"
+  }
+}
+
 # Modernisation Platform data engineer
 resource "aws_ssoadmin_permission_set" "modernisation_platform_data_engineer" {
   provider         = aws.sso-management

--- a/terraform/single-sign-on/sso-permission-sets.tf
+++ b/terraform/single-sign-on/sso-permission-sets.tf
@@ -42,7 +42,7 @@ resource "aws_ssoadmin_customer_managed_policy_attachment" "modernisation_platfo
 # Modernisation Platform secrets manager editor
 resource "aws_ssoadmin_permission_set" "modernisation_platform_secrets_manager_editor" {
   provider         = aws.sso-management
-  name             = "modernisation-platform-secrets-manager-editor"
+  name             = "mp-secrets-manager-editor"
   description      = "Modernisation Platform: read-only plus edit Secrets Manager values"
   instance_arn     = local.sso_admin_instance_arn
   session_duration = "PT8H"


### PR DESCRIPTION
## What
- adds a new `secrets-manager-editor` access level for member environments
- creates a dedicated customer-managed IAM policy `secrets_manager_editor_policy` with scoped Secrets Manager write actions
- creates a new SSO permission set `modernisation-platform-secrets-manager-editor` composed of:
  - AWS managed `ReadOnlyAccess`
  - customer managed `secrets_manager_editor_policy`
- wires the new permission set into account assignment logic
- updates access-level validation guardrails and test expectation
- updates platform role documentation and new-environment issue template options

## Why
Fixes #13658 by providing a least-privilege option for users who need read-only visibility plus ability to edit Secrets Manager values, without granting full `developer` role permissions.

## Scope note
Vincent's separate ask (developer-like access *without* secrets access) is intentionally out of scope for this PR and should be handled in a separate issue/request.

## Validation
- `terraform fmt -check` passed for touched Terraform files
- OPA tests not run locally in this environment (`opa` not installed)
