### PR TITLE
🔧 Rename Integration Hub zones to file-transfer

### DIFF
--- a/terraform/environments/core-network-services/route53.tf
+++ b/terraform/environments/core-network-services/route53.tf
@@ -11,10 +11,10 @@ locals {
     dacp                              = "divorce-section-search.service.justice.gov.uk",
     delius-jitbit                     = "jitbit.cr.probation.service.justice.gov.uk",
     equip                             = "equip.service.justice.gov.uk",
-    integration-hub-mft-development   = "development.managed-file-transfer.service.justice.gov.uk",
-    integration-hub-mft-preproduction = "preproduction.managed-file-transfer.service.justice.gov.uk",
-    integration-hub-mft-prod          = "managed-file-transfer.service.justice.gov.uk",
-    integration-hub-mft-test          = "test.managed-file-transfer.service.justice.gov.uk",
+    integration-hub-file-transfer-development   = "development.file-transfer.service.justice.gov.uk",
+    integration-hub-file-transfer-preproduction = "preproduction.file-transfer.service.justice.gov.uk",
+    integration-hub-file-transfer-production    = "file-transfer.service.justice.gov.uk",
+    integration-hub-file-transfer-test          = "test.file-transfer.service.justice.gov.uk",
     laa-apex                          = "laa-apex.service.justice.gov.uk",
     maat                              = "means-assessment-administration.service.justice.gov.uk",
     mlra                              = "maat-libra-administration-tool.service.justice.gov.uk",
@@ -315,14 +315,14 @@ resource "aws_route53_record" "cwa-prod-db2" {
   }
 }
 
-module "r53_delegations_integration_hub_mft" {
+module "r53_delegations_integration_hub_file_transfer" {
   source = "git::https://github.com/terraform-aws-modules/terraform-aws-route53.git?ref=301fdd6f0876acfd737005dace317e6ac8cae186" # v6.5.0
 
   # Do not create the parent zone here; use the existing one.
   create_zone = false
-  name        = local.application-zones["integration-hub-mft-prod"]
+  name        = local.application-zones["integration-hub-file-transfer-production"]
 
-  depends_on = [aws_route53_zone.application_zones["integration-hub-mft-prod"]]
+  depends_on = [aws_route53_zone.application_zones["integration-hub-file-transfer-production"]]
 
   records = {
     for zone_key in toset([
@@ -335,7 +335,7 @@ module "r53_delegations_integration_hub_mft" {
       ttl             = 30
       allow_overwrite = true
 
-      records = aws_route53_zone.application_zones["integration-hub-mft-${zone_key}"].name_servers
+      records = aws_route53_zone.application_zones["integration-hub-file-transfer-${zone_key}"].name_servers
     }
   }
 


### PR DESCRIPTION
:copilot: _This pull request body was generated by GitHub Copilot_

## What is changing

The production-shaped Integration Hub service is being named `file-transfer` rather than `managed-file-transfer`. This updates the hosted-zone names and Terraform keys for the parent zone and its development, test, and preproduction zones.

The delegation module is renamed to match and continues to delegate the child zones from `file-transfer.service.justice.gov.uk`.

## Why the ordering matters

The parent hosted zone must exist before Route 53 can look it up for delegation. The explicit dependency keeps that ordering in the same apply. The delegation records then use the name servers from the child zones, so those delegations are in place before records are added to the zones by the account Terraform.

## Testing

The branch contains the Terraform-only rename and has been pushed for CI validation.

Signed-off-by: dms1981 <10881569+dms1981@users.noreply.github.com>