### PR TITLE
Allow secrets-manager-editor to read secret values

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -176,12 +176,15 @@ resource "aws_iam_policy" "secrets_manager_editor" {
 }
 
 data "aws_iam_policy_document" "secrets_manager_editor_additional" {
+  #checkov:skip=CKV_AWS_108: Required to read member-environment secrets
   #checkov:skip=CKV_AWS_111: Required to allow secrets updates across member-environment secrets
   #checkov:skip=CKV_AWS_356: Needs to access multiple resources
   statement {
     sid    = "secretsManagerEditorAllow"
     effect = "Allow"
     actions = [
+      "kms:Decrypt",
+      "secretsmanager:GetSecretValue",
       "secretsmanager:PutSecretValue",
       "secretsmanager:UpdateSecret",
       "secretsmanager:RestoreSecret"


### PR DESCRIPTION
## What
- add `secretsmanager:GetSecretValue` to the `secrets-manager-editor` role
- add `kms:Decrypt` so users can read encrypted secret values
- add the Checkov exception required for the intentionally broad secret-read permission

## Why
The role created in the previous PR provides read-only resource visibility and secret write permissions, but users cannot read secret values because AWS `ReadOnlyAccess` does not include `secretsmanager:GetSecretValue`. This completes the intended read-only plus Secrets Manager editing access for #13658.

## Validation
- `terraform fmt -check terraform/environments/bootstrap/single-sign-on/policies.tf` passed
- Editor diagnostics report no errors for the changed Terraform file
- Checkov was not available locally; the existing CI failure and its required exception are addressed

Related to #13658