### PR TITLE
Sets NEC Non-Prod VPN remote CIDR to 10.120.0.0/24 as agreed with LAA.

### DIFF
--- a/terraform/environments/core-network-services/vpn_attachments.json
+++ b/terraform/environments/core-network-services/vpn_attachments.json
@@ -97,7 +97,7 @@
   "NEC-NonProd-VPN": {
     "bgp_asn": "64678",
     "customer_gateway_ip": "152.114.58.102",
-    "remote_ipv4_network_cidr": "0.0.0.0/0",
+    "remote_ipv4_network_cidr": "10.120.0.0/24",
     "tunnel1_inside_cidr": "169.254.155.0/30",
     "tunnel2_inside_cidr": "169.254.214.8/30",
     "tunnel_dpd_timeout_action": "clear",


### PR DESCRIPTION
## A reference to the issue / Description of it

#13620 

## How does this PR fix the problem?

Sets value of remote network CIDR for the NEC non-prod VPN to "10.120.0.0/24" as agreed with LAA and NEC. 

Note that this will require testing by the LAA and they will arrange the window. Contacts are Jon Elcock & Sanjay Baranwal.

PR to remain as Draft until agreement with LAA.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
