### PR TITLE
fix: adding mojowifi from nonprod laa vpc

### DIFF
--- a/terraform/environments/core-network-services/firewall-rules/development_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/development_rules.json
@@ -167,6 +167,13 @@
     "destination_port": "$LAA_MP_WORKSPACES_TCP",
     "protocol": "TCP"
   },
+  "moj_wifi_to_laa_development_mp_https": {
+    "action": "PASS",
+    "source_ip": "${moj-wifi}",
+    "destination_ip": "${laa-development}",
+    "destination_port": "443",
+    "protocol": "TCP"
+  },
   "mp_laa_development_to_cp": {
     "action": "PASS",
     "source_ip": "${laa-development}",

--- a/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/preproduction_rules.json
@@ -13,6 +13,13 @@
     "destination_port": "80",
     "protocol": "TCP"
   },
+    "moj_wifi_to_laa_preproduction_mp_https": {
+    "action": "PASS",
+    "source_ip": "${moj-wifi}",
+    "destination_ip": "${laa-preproduction}",
+    "destination_port": "443",
+    "protocol": "TCP"
+  },
   "psn_to_mp_hmpps_preproduction_https": {
     "action": "PASS",
     "source_ip": "${psn}",

--- a/terraform/environments/core-network-services/firewall-rules/test_rules.json
+++ b/terraform/environments/core-network-services/firewall-rules/test_rules.json
@@ -55,6 +55,13 @@
     "destination_port": "80",
     "protocol": "TCP"
   },
+  "moj_wifi_to_laa_test_mp_https": {
+    "action": "PASS",
+    "source_ip": "${moj-wifi}",
+    "destination_ip": "${laa-test}",
+    "destination_port": "443",
+    "protocol": "TCP"
+  },
   "noms_test_vnet_to_mp_hmpps_test": {
     "action": "PASS",
     "source_ip": "${noms-test-vnet}",


### PR DESCRIPTION
## A reference to the issue / Description of it
adding mojo wifi to non prod laa environment

## How does this PR fix the problem?

allow mojo wifi to non prod laa environment

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
