### PR TITLE
Register Integration Hub benefit checker API component

### DIFF
--- a/environments/integration-hub-api.json
+++ b/environments/integration-hub-api.json
@@ -1,5 +1,10 @@
 {
   "account-type": "member",
+  "components": [
+    {
+      "name": "benefit-checker-api"
+    }
+  ],
   "environments": [
     {
       "name": "development",
@@ -21,6 +26,7 @@
     "critical-national-infrastructure": false
   },
   "github-oidc-team-repositories": [
+    "ministryofjustice/integration-hub-api-platform",
     "ministryofjustice/integration-hub-file-transfer-api"
   ],
   "go-live-date": ""

--- a/environments/integration-hub.json
+++ b/environments/integration-hub.json
@@ -6,9 +6,6 @@
       "name": "api-platform"
     },
     {
-      "name": "api-hosting-platform"
-    },
-    {
       "name": "downstream-mock-api"
     },
     {
@@ -66,7 +63,6 @@
     "critical-national-infrastructure": false
   },
   "github-oidc-team-repositories": [
-    "ministryofjustice/integration-hub-api-platform",
     "ministryofjustice/integration-hub-file-transfer-api"
   ],
   "go-live-date": ""


### PR DESCRIPTION
## Summary

- register benefit-checker-api as a component of integration-hub-api
- allow integration-hub-api-platform to use the integration-hub-api GitHub OIDC provider
- remove the mistakenly registered api-hosting-platform component and OIDC entry from the legacy integration-hub application

## Why

This follows the component boundary agreed with the Integration Hub team:

- networking is for VPC-level resources
- platform is for shared API-hosting platform capabilities
- benefit-checker-api is the interim per-API component that owns this API Gateway, Lambda, authentication and monitoring stack

The previous api-hosting-platform registration was never used to deploy application resources; its generated folder contains only platform scaffold files.

## Follow-up

After this PR is merged and Modernisation Platform generates the component files, ministryofjustice/modernisation-platform-environments#18570 will be rebased onto those generated files and will use the component-specific backend.