### PR TITLE
Issue/13620 - Updates NEC-PROD VPN to use modernisation_platform_vpc & laa-production

### DIFF
--- a/terraform/environments/core-network-services/vpn_attachments.json
+++ b/terraform/environments/core-network-services/vpn_attachments.json
@@ -117,7 +117,7 @@
   "NEC-Prod-VPN": {
     "bgp_asn": "64678",
     "customer_gateway_ip": "152.114.58.100",
-    "remote_ipv4_network_cidr": "0.0.0.0/0",
+    "modernisation_platform_vpc": "laa-production",
     "tunnel1_inside_cidr": "169.254.124.168/30",
     "tunnel2_inside_cidr": "169.254.31.40/30",
     "tunnel_dpd_timeout_action": "clear",


### PR DESCRIPTION

## A reference to the issue / Description of it

#13620 

## How does this PR fix the problem?

This replaces the use of the local "NEC-Prod-VPN.remote_ipv4_network_cidr" parameter with "modernisation_platform_vpc" which will correctly set the value of the terraform property "remote_ipv4_network_cidr" with the cidr range of the general subnets for laa-production.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
