### PR TITLE
Bug fixes found using the Athena tables to access cloudtrail logs in core-logging s3.

### DIFF
--- a/terraform/environments/core-logging/lambda/index.py
+++ b/terraform/environments/core-logging/lambda/index.py
@@ -185,13 +185,13 @@ def create_athena_table(list_accounts):
               'projection.account.type' = 'enum',
               'projection.account.values' = '%s',
               'projection.region.type' = 'enum',
-              'projection.region.values' = 'eu-west-1, eu-west-2',
+              'projection.region.values' = 'eu-west-1,eu-west-2',
               'projection.timestamp.format'='yyyy/MM/dd',
               'projection.timestamp.interval'='1',
               'projection.timestamp.interval.unit'='DAYS',
               'projection.timestamp.range'='2020/01/01,NOW',
               'projection.timestamp.type'='date',
-              'storage.location.template'='s3://modernisation-platform-logs-cloudtrail/AWSLogs/${account}/CloudTrail/${region}/${timestamp}')
+              'storage.location.template'='s3://modernisation-platform-logs-cloudtrail/AWSLogs/${account}/CloudTrail/${region}/${timestamp}'/)
       """ % list_accounts
     try:
         response = athena_client.start_query_execution(

--- a/terraform/environments/core-logging/lambda/index.py
+++ b/terraform/environments/core-logging/lambda/index.py
@@ -191,7 +191,7 @@ def create_athena_table(list_accounts):
               'projection.timestamp.interval.unit'='DAYS',
               'projection.timestamp.range'='2020/01/01,NOW',
               'projection.timestamp.type'='date',
-              'storage.location.template'='s3://modernisation-platform-logs-cloudtrail/AWSLogs/${account}/CloudTrail/${region}/${timestamp}'/)
+              'storage.location.template'='s3://modernisation-platform-logs-cloudtrail/AWSLogs/${account}/CloudTrail/${region}/${timestamp}/')
       """ % list_accounts
     try:
         response = athena_client.start_query_execution(


### PR DESCRIPTION


## A reference to the issue / Description of it

{Please write here}

## How does this PR fix the problem?

Fixes bug in the athena table whereby Athena treats the enum as  eu-west-2 with a leading space and projects a non-existent S3 prefix. Also added missing trailing / to the s3 location path.

Without these fixes, athena doesn't return any data.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
