### PR TITLE
prisons: add buckets to the AE SSO role s3 permissions

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -671,7 +671,9 @@ data "aws_iam_policy_document" "analytics_engineering_athena_additional" {
     resources = [
       "arn:aws:s3:::probation-query-results-*",
       "arn:aws:s3:::dpr-working-production/analytics/*",
+      "arn:aws:s3:::dpr-structured-historical-production/*",
       "arn:aws:s3:::dpr-working-preproduction/analytics/*",
+      "arn:aws:s3:::dpr-structured-historical-preproduction/*"
     ]
   }
   statement {

--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -685,8 +685,10 @@ data "aws_iam_policy_document" "analytics_engineering_athena_additional" {
     ]
     resources = [
       "arn:aws:s3:::probation-datalake-*",
-      "arn:aws:s3:::dpr-structured-historical-production/data/*",
-      "arn:aws:s3:::dpr-structured-historical-preproduction/data/*",
+      "arn:aws:s3:::dpr-working-production/analytics/*",
+      "arn:aws:s3:::dpr-structured-historical-production/*",
+      "arn:aws:s3:::dpr-working-preproduction/analytics/*",
+      "arn:aws:s3:::dpr-structured-historical-preproduction/*"
     ]
   }
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

Related to this PR: https://github.com/ministryofjustice/modernisation-platform/pull/13412/changes

I need the users of the AE role to be able to access the added paths.

## How does this PR fix the problem?

Users need to be able to read and write from the locations added.

## How has this been tested?

The role already exists and the s3 permission changes are minor.

## Deployment Plan / Instructions

Impacts one role used by a small set of users

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
