### PR TITLE
CC-4851: 🥾 Add LAA Accounts to Bootstrap Feature Enabling SecurityHub Ingestion to OP

### DIFF
--- a/terraform/environments/bootstrap/secure-baselines/locals.tf
+++ b/terraform/environments/bootstrap/secure-baselines/locals.tf
@@ -33,12 +33,24 @@ locals {
     "long-term-storage-production",
     "^core-.*"
   ]
+  environment_files = [
+    for file in fileset("../../../environments", "*.json") :
+    merge({ name = replace(file, ".json", "") }, jsondecode(file("../../../environments/${file}")))
+  ]
+  laa_workspaces = sort(distinct(flatten([
+    for app in local.environment_files : [
+      for env in app.environments :
+      lower("${app.name}-${env.name}")
+    ]
+    if lower(try(app.tags["business-unit"], "")) == "laa"
+  ])))
+  is_laa_account  = contains(local.laa_workspaces, lower(terraform.workspace))
   is_core_account = length(regexall(join("|", local.mp_owned_workspaces), terraform.workspace)) > 0
 
   # Locals that are passed to the Baselines module for slack alerts for SecurityHub issues.
   securityhub_slack_alerts_accounts        = local.is_core_account && !strcontains(terraform.workspace, "core-shared-services") # All core accounts excluding terraform workspaces containing core-shared-services.
   securityhub_slack_alerts_scope           = ["CRITICAL", "HIGH"]                                                               # The type of alert to generate alerts for. 
-  enable_securityhub_event_forwarding      = local.is_core_account
+  enable_securityhub_event_forwarding      = local.is_core_account || local.is_laa_account
   securityhub_central_event_bus_account_id = local.environment_management.account_ids["observability-platform-production"]
   securityhub_central_event_bus_arn = format(
     "arn:aws:events:%s:%s:event-bus/securityhub-central",


### PR DESCRIPTION
## A reference to the issue / Description of it

- Relates to https://dsdmoj.atlassian.net/browse/CC-4851 titled `🎨 Observability Platform - The Art of the Possible`
- LAA want to have a single view of all SecurityHub alerts across our Modernisation Platform Accounts. 

## How does this PR fix the problem?

- The Modernisation Platform currently do this by sending SecurityHub events into the Observability Platform via an EventBridge rule. This change adds the LAA accounts to the list of accounts that will have the EventBridge rule deployed via the bootstrap module.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.


## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

- No impact expected.

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
