### PR TITLE
🇺🇸 Add KMS permissions to us-east-1 region

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -706,6 +706,7 @@ data "aws_iam_policy_document" "member-access-us-east" {
       "acm:*",
       "events:*",
       "iam:ListRoles",
+      "kms:*",
       "lambda:*",
       "logs:*",
       "waf:*",


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform-environments/pull/18995 failed because it cannot create a KMS key in us-east-1

I need a KMS key there because I am creating an event bus for a partner integration (Auth0) that does not offer a european integration

## How does this PR fix the problem?

Adds `kms:*`

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

No, but it's additive

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No, but it's additive

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

https://github.com/ministryofjustice/ministry-of-justice-engineering-platform/issues/88
