### PR TITLE
🇺🇸 Add events.amazonaws.com to allowed services of `iam:PassRole`

### DIFF
--- a/terraform/environments/bootstrap/member-bootstrap/iam.tf
+++ b/terraform/environments/bootstrap/member-bootstrap/iam.tf
@@ -773,7 +773,10 @@ data "aws_iam_policy_document" "member-access-us-east" {
     condition {
       test     = "StringEquals"
       variable = "iam:PassedToService"
-      values   = ["lambda.amazonaws.com"]
+      values   = [
+        "events.amazonaws.com",
+        "lambda.amazonaws.com"
+      ]
     }
   }
 


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform-environments/actions/runs/33899135209/job/101109896469#step:11:24

```
operation error EventBridge: PutTargets, https response error StatusCode: 400, RequestID: 7ff6f251-c607-4065-a43c-4a231180990b, AccessDeniedException:
```

## How does this PR fix the problem?

Adds the events service to the allowed services

:copilot: says

> The Auth0 EventBridge target is created in us-east-1, so Terraform assumes MemberInfrastructureAccessUSEast. That role permits events:*, but its iam:PassRole allowlist only permitted Lambda.
> 
> Creating the cross-region EventBridge target passes a delivery role to events.amazonaws.com; IAM simulation confirms this is currently denied. The standard MemberInfrastructureAccess role already permits this pattern.
> 
> PR [#13931](https://github.com/ministryofjustice/modernisation-platform/pull/13931) extends the existing US-East iam:PassRole condition to also allow events.amazonaws.com. This is the minimal platform-wide fix and does not name or privilege any application-specific role.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

It's additive

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

It's additive

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

https://github.com/ministryofjustice/ministry-of-justice-engineering-platform/issues/88
