### PR TITLE
Ae sso role updates

### DIFF
--- a/terraform/environments/bootstrap/single-sign-on/locals.tf
+++ b/terraform/environments/bootstrap/single-sign-on/locals.tf
@@ -20,6 +20,22 @@ locals {
     if(data.name == local.env_name)
   }
 
+  analytics_engineering_kms_keys = {
+    dpr-prod = {
+      account_name = "digital-prison-reporting-production"
+      key_id       = "a9d617dd-1399-4116-bd2a-16ad43f710c9"
+    }
+    dpr-preprod = {
+      account_name = "digital-prison-reporting-preproduction"
+      key_id       = "7f78035f-f870-41b2-b00b-b7398cd6eb2d"
+    }
+  }
+
+  analytics_engineering_kms_key_arns = [
+    for kms_key in values(local.analytics_engineering_kms_keys) :
+    "arn:aws:kms:eu-west-2:${local.environment_management.account_ids[kms_key.account_name]}:key/${kms_key.key_id}"
+  ]
+
   tags = {
     business-unit = "Platforms"
     service-area  = "Hosting"

--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -704,6 +704,22 @@ data "aws_iam_policy_document" "analytics_engineering_athena_additional" {
       "arn:aws:s3:::dpr-structured-historical-preproduction/*"
     ]
   }
+  statement {
+    sid    = "AthenaDprKmsAllow"
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+      "kms:Encrypt",
+      "kms:GenerateDataKey",
+      "kms:DescribeKey",
+    ]
+    resources = local.analytics_engineering_kms_key_arns
+    condition {
+      test     = "StringEquals"
+      variable = "kms:ViaService"
+      values   = ["s3.eu-west-2.amazonaws.com"]
+    }
+  }
 }
 
 # quicksight administrator policy (IAM permissions needed to manage QuickSight subscription)

--- a/terraform/environments/bootstrap/single-sign-on/policies.tf
+++ b/terraform/environments/bootstrap/single-sign-on/policies.tf
@@ -657,19 +657,32 @@ data "aws_iam_policy_document" "analytics_engineering_athena_additional" {
   #checkov:skip=CKV_AWS_110
   #checkov:skip=CKV_AWS_356: Needs to access multiple resources
   statement {
-    sid    = "AthenaQueryResultsAllow"
+    sid    = "AthenaQueryResultsBucketAllow"
     effect = "Allow"
     actions = [
       "s3:GetBucketLocation",
-      "s3:GetObject",
       "s3:ListBucket",
       "s3:ListBucketMultipartUploads",
+    ]
+    resources = [
+      "arn:aws:s3:::probation-query-results-*",
+      "arn:aws:s3:::dpr-working-production",
+      "arn:aws:s3:::dpr-structured-historical-production",
+      "arn:aws:s3:::dpr-working-preproduction",
+      "arn:aws:s3:::dpr-structured-historical-preproduction"
+    ]
+  }
+  statement {
+    sid    = "AthenaQueryResultsObjectAllow"
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
       "s3:ListMultipartUploadParts",
       "s3:AbortMultipartUpload",
       "s3:PutObject",
     ]
     resources = [
-      "arn:aws:s3:::probation-query-results-*",
+      "arn:aws:s3:::probation-query-results-*/*",
       "arn:aws:s3:::dpr-working-production/analytics/*",
       "arn:aws:s3:::dpr-structured-historical-production/*",
       "arn:aws:s3:::dpr-working-preproduction/analytics/*",
@@ -677,14 +690,14 @@ data "aws_iam_policy_document" "analytics_engineering_athena_additional" {
     ]
   }
   statement {
-    sid    = "AthenaS3Allow"
+    sid    = "AthenaS3ObjectAllow"
     effect = "Allow"
     actions = [
       "s3:PutObject",
       "s3:DeleteObject",
     ]
     resources = [
-      "arn:aws:s3:::probation-datalake-*",
+      "arn:aws:s3:::probation-datalake-*/*",
       "arn:aws:s3:::dpr-working-production/analytics/*",
       "arn:aws:s3:::dpr-structured-historical-production/*",
       "arn:aws:s3:::dpr-working-preproduction/analytics/*",


### PR DESCRIPTION
## A reference to the issue / Description of it

Users still can't query data using the new SSO role we created.  

I've separated out bucket and object level permissions. Separately added some KMS key permissions - tightly scoped to DPR keys (locals)

Related to these old PRs:
- https://github.com/ministryofjustice/modernisation-platform/pull/13919
- https://github.com/ministryofjustice/modernisation-platform/pull/13412
- https://github.com/ministryofjustice/modernisation-platform/pull/13334

## How does this PR fix the problem?

Provides bucket and object level permissions.  Provides users with permissions to use KMS key and decrypt.

## How has this been tested?


## Deployment Plan / Instructions

Deployment affects an SSO role which is currently not working.  Affects a small numbers of users, but this role will increase in use once we get past all these bugs!

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
