### PR TITLE
feat(xhibit-portal): workaround on the AZ A t2.medium instance issues

### DIFF
--- a/environments/xhibit-portal.json
+++ b/environments/xhibit-portal.json
@@ -25,6 +25,7 @@
           "level": "developer"
         }
       ],
+      "instance_scheduler_skip": ["true"],
       "nuke": "exclude"
     },
     {
@@ -46,7 +47,8 @@
           "sso_group_name": "xhibit-portal-dev",
           "level": "developer"
         }
-      ]
+      ],
+      "instance_scheduler_skip": ["true"]
     },
     {
       "name": "production",


### PR DESCRIPTION
# T2.medium instance_type provisioning issues in Xhibit Portal

We faced random provisioning/scheduling issues for the t2.medium instance types - we have 6 instances in every environment - in eu-west-2a that prevent us apply changes through the 3 environments (Dev, Pre-Prod, Production).
We have at least 3 hard deadline changes we need to delivery until the end of the month so this can help us to progress.

## A reference to the issue / Description of it

(https://dsdmoj.atlassian.net/browse/XPM-580)

## How does this PR fix the problem?

If we restart all of the EC2 instances in the Development and the Pre-Production during the out of hours or when utilisation is lower those will work during the office hours when we need to do tests and changes. 

## How has this been tested?

I just restarted the Pre-Prod t2.medium instances one of the night I can use them the next working day.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

Just fix the xhibit-portal non-production issues and do not shutdown them during out of hours.

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
