### PR TITLE
Fix broken tagging guidance links in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-environment.yml
+++ b/.github/ISSUE_TEMPLATE/new-environment.yml
@@ -173,7 +173,7 @@ body:
     value: |
       ## Tags
       These will be used to tag your AWS resources, for further details on tagging please see here 
-      https://ministryofjustice.github.io/technical-guidance/documentation/standards/documenting-infrastructure-owners.html#tags-you-should-use
+      https://cloud-optimisation-and-accountability.justice.gov.uk/documentation/finops-and-greenops-at-moj/standards/tagging.html#tagging-standard
 
       The is-production tag will be inferred from the environment and is not needed here
       

--- a/scripts/confirm-environment-owner/create-confirm-owner-issue.sh
+++ b/scripts/confirm-environment-owner/create-confirm-owner-issue.sh
@@ -42,7 +42,7 @@ jq -c '.[]' "output.json" | while IFS= read -r row; do
 
 - Create a pull request with the change and contact us on the #ask-modernisation-team slack channel to review it.
 
-For further information please read this [documentation](https://technical-guidance.service.justice.gov.uk/documentation/standards/documenting-infrastructure-owners.html#tags-you-should-use)."
+For further information please read this [documentation](https://cloud-optimisation-and-accountability.justice.gov.uk/documentation/finops-and-greenops-at-moj/standards/tagging.html#tagging-standard)."
 )
 
         # Now we send a notification email via Gov.UK Notify. (https://www.notifications.service.gov.uk/)


### PR DESCRIPTION
## A reference to the issue / Description of it

The new-environment issue template and owner-confirmation issues contain broken links to infrastructure tagging guidance.

## How does this PR fix the problem?

Updates both links to point to the tagging standard on the COAT website.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
