### PR TITLE
Adds terraform for LAA NEC Production VPN route that already exists in AWS.

### DIFF
--- a/terraform/environments/core-network-services/locals.tf
+++ b/terraform/environments/core-network-services/locals.tf
@@ -180,6 +180,9 @@ locals {
 
   laa_nec_nonprod_vpn_static_routes = ["10.120.0.0/24"]
 
+  laa_nec_prod_vpn_static_routes = ["10.110.0.0/24"]
+
+
   core-vpcs = {
     for file in fileset("../../../environments-networks", "*.json") :
     replace(file, ".json", "") => jsondecode(file("../../../environments-networks/${file}"))

--- a/terraform/environments/core-network-services/vpn.tf
+++ b/terraform/environments/core-network-services/vpn.tf
@@ -137,6 +137,17 @@ resource "aws_ec2_transit_gateway_route" "laa_nec_nonprod_routes" {
   }
 }
 
+resource "aws_ec2_transit_gateway_route" "laa_nec_prod_routes" {
+  for_each                       = toset(local.laa_nec_prod_vpn_static_routes)
+  destination_cidr_block         = each.key
+  transit_gateway_attachment_id  = aws_vpn_connection.this["NEC-Prod-VPN"].transit_gateway_attachment_id
+  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.external_inspection_out.id
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
 resource "aws_cloudwatch_log_group" "vpn_attachments" {
   # checkov:skip=CKV_AWS_158: "logs will not be shared so standard encryption fine"
   for_each          = local.vpn_attachments


### PR DESCRIPTION

## A reference to the issue / Description of it

#13620 

## How does this PR fix the problem?

Adds terraform for the route that has been imported into the state file. 

Plan show no changes to be applied.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Same scope and approach as per the prior non-prod route. 

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
