### PR TITLE
Fix readme documentation update

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -21,7 +21,7 @@ jobs:
     uses: ministryofjustice/modernisation-platform-github-actions/.github/workflows/reusable-code-quality.yml@e49ac27b104b38bac12fc1e3257a13be6289a59c # v6.2.2
     with:
       validate_all_codebase: ${{ github.event_name != 'pull_request' && 'true' || 'false' }}
-      filter_regex_exclude: "^README.md$"
+      filter_regex_exclude: "^README.md$|^terraform/modules/.*\\.md$|^\\.github/workflows/documentation\\.yml$"
       codeql_languages: '["actions"]'
       checkov_arguments: >-
         --skip-check CKV_GIT_1,CKV_AWS_126,CKV2_AWS_38,CKV2_AWS_39


### PR DESCRIPTION
## Description

The Terraform documentation workflow updates module Markdown files and pushes those changes back to the pull request. Code Quality then re-runs against the generated documentation, creating an unnecessary workflow loop.

## How does this PR fix the problem?

Extends the reusable Code Quality workflow's `filter_regex_exclude` input to exclude:

- the root `README.md`
- Markdown files under `terraform/modules/`
- `.github/workflows/documentation.yml`

The documentation workflow continues to run for these paths; MegaLinter skips them when Code Quality is invoked.

## How has this been tested?

- `actionlint .github/workflows/code-quality.yml`
- Ruby YAML parsing
- `git diff --check`

## Deployment Plan / Instructions

No deployment required. Merge the workflow-only change; it applies to subsequent pull request runs.

## Checklist

- [x] I have performed a self-review of my own code
- [x] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments

This intentionally leaves normal Code Quality coverage unchanged for non-generated Terraform source and documentation changes outside the excluded paths.