### PR TITLE
Exclude generated docs from code quality scans

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -21,7 +21,7 @@ jobs:
     uses: ministryofjustice/modernisation-platform-github-actions/.github/workflows/reusable-code-quality.yml@e49ac27b104b38bac12fc1e3257a13be6289a59c # v6.2.2
     with:
       validate_all_codebase: ${{ github.event_name != 'pull_request' && 'true' || 'false' }}
-      filter_regex_exclude: "^README.md$|^terraform/modules/.*\\.md$|^\\.github/workflows/documentation\\.yml$"
+      filter_regex_exclude: "(^|.*/)README\\.md$|(^|.*/)terraform/modules/.*\\.md$|(^|.*/)\\.github/workflows/documentation\\.yml$"
       codeql_languages: '["actions"]'
       checkov_arguments: >-
         --skip-check CKV_GIT_1,CKV_AWS_126,CKV2_AWS_38,CKV2_AWS_39


### PR DESCRIPTION
## What

Updates the Code Quality workflow's MegaLinter `filter_regex_exclude` so generated Terraform module documentation is ignored during code quality scans.

The exclusion now handles root-relative, `./`-prefixed, and workspace-prefixed paths for:

- `README.md`
- `terraform/modules/**/*.md`
- `.github/workflows/documentation.yml`

## Why

The documentation workflow updates Terraform module README files, and those generated documentation changes were still being picked up by Code Quality. That could cause the two workflows to keep triggering each other unnecessarily.

## Validation

- YAML parse: pass
- Regex samples: pass for `terraform/modules/r53-dns-firewall/README.md`, `./terraform/modules/r53-dns-firewall/README.md`, `/github/workspace/terraform/modules/r53-dns-firewall/README.md`, `.github/workflows/documentation.yml`, and root `README.md`
- Regex negative samples: did not match `terraform/something.md` or `docs/guide.md`
- `git diff --check`: pass

`actionlint` was not available locally in this repo environment.