### PR TITLE
Fix actionlint findings in workflows

### DIFF
--- a/.github/workflows/access-keys-monitoring.yml
+++ b/.github/workflows/access-keys-monitoring.yml
@@ -82,9 +82,9 @@ jobs:
       # Step 5: Set Account Number
       - name: Set Account Number
         run: |
-          ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< $ENVIRONMENT_MANAGEMENT)
+          ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< "$ENVIRONMENT_MANAGEMENT")
           echo "::add-mask::$ACCOUNT_NUMBER"
-          echo ACCOUNT_NUMBER=$ACCOUNT_NUMBER >> $GITHUB_ENV
+          echo "ACCOUNT_NUMBER=$ACCOUNT_NUMBER" >> "$GITHUB_ENV"
 
       # Step 6: Configure AWS Credentials
       - name: Configure AWS Credentials

--- a/.github/workflows/account-network-update.yml
+++ b/.github/workflows/account-network-update.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           if [ ! -f network-setup-info.json ]; then
             echo "Artifact not found. Skipping the workflow."
-            echo "SKIP=true" >> $GITHUB_ENV
+            echo "SKIP=true" >> "$GITHUB_ENV"
           fi
 
       - name: Set up Python
@@ -60,9 +60,9 @@ jobs:
         if: env.SKIP != 'true' && env.ISOLATED_ACCOUNT == 'No'
         run: |
           python scripts/network-setup.py \
-            $(jq -r '.app_name' network-setup-info.json) \
-            $(jq -r '.business_unit' network-setup-info.json) \
-            $(jq -r '.environments[]' network-setup-info.json)
+            "$(jq -r '.app_name' network-setup-info.json)" \
+            "$(jq -r '.business_unit' network-setup-info.json)" \
+            "$(jq -r '.environments[]' network-setup-info.json)"
 
       - name: Commit and push network changes
         if: env.SKIP != 'true' && env.ISOLATED_ACCOUNT == 'No'

--- a/.github/workflows/awsnuke.yml
+++ b/.github/workflows/awsnuke.yml
@@ -66,19 +66,19 @@ jobs:
       - id: set-matrix
         name: Set Up Matrix
         run: |
-          echo "matrix=$(jq -c '.nuke_accounts | sort' <<< $NUKE_ACCOUNT_IDS)" >> $GITHUB_OUTPUT
+          echo "matrix=$(jq -c '.nuke_accounts | sort' <<< "$NUKE_ACCOUNT_IDS")" >> "$GITHUB_OUTPUT"
 
       - id: set-blocklist-string
         name: Set Up Blocklist
         run: |
           account_blocklist_str=""
           while read -r account_alias _; do
-          account_number=$(jq -r -e --arg account_name "$account_alias" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)
+          account_number=$(jq -r -e --arg account_name "$account_alias" '.account_ids[$account_name]' <<< "$ENVIRONMENT_MANAGEMENT")
           account_blocklist_str+="  - \"${account_number}\" # ${account_alias}"
           account_blocklist_str+=$'\n'
-          done <<< "$(jq -c -r '.blocklist[]' <<< $NUKE_ACCOUNT_BLOCKLIST)" # Taking this approach as piping (|) to a read opens a subshell and passes the variables to it by value
+          done <<< "$(jq -c -r '.blocklist[]' <<< "$NUKE_ACCOUNT_BLOCKLIST")" # Taking this approach as piping (|) to a read opens a subshell and passes the variables to it by value
           # Encoding and passing blocklist string as an output
-          echo "account_blocklist_str=$(echo -n "${account_blocklist_str}" | base64 -w 0)" >> $GITHUB_OUTPUT
+          echo "account_blocklist_str=$(echo -n "${account_blocklist_str}" | base64 -w 0)" >> "$GITHUB_OUTPUT"
 
   nuke:
     strategy:
@@ -105,9 +105,9 @@ jobs:
 
       - name: Set Account Number
         run: |
-          ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${ACCOUNT_NAME}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)
+          ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${ACCOUNT_NAME}" '.account_ids[$account_name]' <<< "$ENVIRONMENT_MANAGEMENT")
           echo "::add-mask::$ACCOUNT_NUMBER"
-          echo "ACCOUNT_NUMBER=${ACCOUNT_NUMBER}" >> $GITHUB_ENV
+          echo "ACCOUNT_NUMBER=${ACCOUNT_NUMBER}" >> "$GITHUB_ENV"
       - name: configure aws credentials
         uses: aws-actions/configure-aws-credentials@cbe3b392738ccf3f987d68400dafcf4b0624a56c # v6.2.4
         with:
@@ -125,22 +125,25 @@ jobs:
           accounts_str+="      - \"common\""
           accounts_str+=$'\n'
           echo "$accounts_str"
-          echo "ACCOUNTS_STR<<EOF" >> $GITHUB_ENV
-          echo "$accounts_str" >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
+          {
+            echo "ACCOUNTS_STR<<EOF"
+            echo "$accounts_str"
+            echo "EOF"
+          } >> "$GITHUB_ENV"
 
       - name: Setup Nuke Config
         run: |
           export accounts_str="$ACCOUNTS_STR"
-          export account_blocklist_str=$(echo "${{ needs.setup-prerequisites.outputs.account_blocklist_str }}" | base64 --decode)
+          account_blocklist_str=$(echo "${{ needs.setup-prerequisites.outputs.account_blocklist_str }}" | base64 --decode)
+          export account_blocklist_str
           cat scripts/nuke-config-template.txt | envsubst > nuke-config.yml
 
       - name: Install AWS Nuke
         run: |
           echo "BEGIN: Install AWS Nuke"
-          mkdir -p $HOME/bin
-          wget -c "https://github.com/ekristen/aws-nuke/releases/download/${AWS_NUKE_VERSION}/aws-nuke-${AWS_NUKE_VERSION}-linux-amd64.tar.gz" -O - | tar -xz -C $HOME/bin
-          chmod +x $HOME/bin/aws-nuke
+          mkdir -p "$HOME/bin"
+          wget -c "https://github.com/ekristen/aws-nuke/releases/download/${AWS_NUKE_VERSION}/aws-nuke-${AWS_NUKE_VERSION}-linux-amd64.tar.gz" -O - | tar -xz -C "$HOME/bin"
+          chmod +x "$HOME/bin/aws-nuke"
           echo "END: Install AWS Nuke"
         env:
           AWS_NUKE_VERSION: v3.51.1
@@ -154,7 +157,7 @@ jobs:
             exit 1
           }
           echo "Running AWS Nuke (dry run)..."
-          $HOME/bin/aws-nuke run \
+          "$HOME/bin/aws-nuke" run \
             --config nuke-config.yml \
             --no-prompt
 
@@ -167,7 +170,7 @@ jobs:
             exit 1
           }
           echo "Running AWS Nuke (full apply)..."
-           $HOME/bin/aws-nuke run \
+           "$HOME/bin/aws-nuke" run \
             --config nuke-config.yml \
             --no-prompt \
             --no-dry-run

--- a/.github/workflows/bootstrap-sprinkler.yml
+++ b/.github/workflows/bootstrap-sprinkler.yml
@@ -43,9 +43,9 @@ jobs:
           PASSPHRASE: ${{ secrets.PASSPHRASE }}
       - name: Set Account Number
         run: |
-          ACCOUNT_NUMBER=$(jq -r -e '.aws_organizations_root_account_id' <<< $ENVIRONMENT_MANAGEMENT)
+          ACCOUNT_NUMBER=$(jq -r -e '.aws_organizations_root_account_id' <<< "$ENVIRONMENT_MANAGEMENT")
           echo "::add-mask::$ACCOUNT_NUMBER"
-          echo ACCOUNT_NUMBER=$ACCOUNT_NUMBER >> $GITHUB_ENV
+          echo "ACCOUNT_NUMBER=$ACCOUNT_NUMBER" >> "$GITHUB_ENV"
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@cbe3b392738ccf3f987d68400dafcf4b0624a56c # v6.2.4
         with:
@@ -71,9 +71,9 @@ jobs:
           PASSPHRASE: ${{ secrets.PASSPHRASE }}
       - name: Set Account Number
         run: |
-          ACCOUNT_NUMBER=$(jq -r -e '.account_ids["sprinkler-development"]' <<< $ENVIRONMENT_MANAGEMENT)
+          ACCOUNT_NUMBER=$(jq -r -e '.account_ids["sprinkler-development"]' <<< "$ENVIRONMENT_MANAGEMENT")
           echo "::add-mask::$ACCOUNT_NUMBER"
-          echo ACCOUNT_NUMBER=$ACCOUNT_NUMBER >> $GITHUB_ENV
+          echo "ACCOUNT_NUMBER=$ACCOUNT_NUMBER" >> "$GITHUB_ENV"
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@cbe3b392738ccf3f987d68400dafcf4b0624a56c # v6.2.4
@@ -100,9 +100,9 @@ jobs:
           PASSPHRASE: ${{ secrets.PASSPHRASE }}
       - name: Set Account Number
         run: |
-          ACCOUNT_NUMBER=$(jq -r -e '.account_ids["sprinkler-development"]' <<< $ENVIRONMENT_MANAGEMENT)
+          ACCOUNT_NUMBER=$(jq -r -e '.account_ids["sprinkler-development"]' <<< "$ENVIRONMENT_MANAGEMENT")
           echo "::add-mask::$ACCOUNT_NUMBER"
-          echo ACCOUNT_NUMBER=$ACCOUNT_NUMBER >> $GITHUB_ENV
+          echo "ACCOUNT_NUMBER=$ACCOUNT_NUMBER" >> "$GITHUB_ENV"
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@cbe3b392738ccf3f987d68400dafcf4b0624a56c # v6.2.4
@@ -129,9 +129,9 @@ jobs:
           PASSPHRASE: ${{ secrets.PASSPHRASE }}
       - name: Set Account Number
         run: |
-          ACCOUNT_NUMBER=$(jq -r -e '.account_ids["sprinkler-development"]' <<< $ENVIRONMENT_MANAGEMENT)
+          ACCOUNT_NUMBER=$(jq -r -e '.account_ids["sprinkler-development"]' <<< "$ENVIRONMENT_MANAGEMENT")
           echo "::add-mask::$ACCOUNT_NUMBER"
-          echo ACCOUNT_NUMBER=$ACCOUNT_NUMBER >> $GITHUB_ENV
+          echo "ACCOUNT_NUMBER=$ACCOUNT_NUMBER" >> "$GITHUB_ENV"
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@cbe3b392738ccf3f987d68400dafcf4b0624a56c # v6.2.4
@@ -159,9 +159,9 @@ jobs:
           PASSPHRASE: ${{ secrets.PASSPHRASE }}
       - name: Set Account Number
         run: |
-          ACCOUNT_NUMBER=$(jq -r -e '.aws_organizations_root_account_id' <<< $ENVIRONMENT_MANAGEMENT)
+          ACCOUNT_NUMBER=$(jq -r -e '.aws_organizations_root_account_id' <<< "$ENVIRONMENT_MANAGEMENT")
           echo "::add-mask::$ACCOUNT_NUMBER"
-          echo ACCOUNT_NUMBER=$ACCOUNT_NUMBER >> $GITHUB_ENV
+          echo "ACCOUNT_NUMBER=$ACCOUNT_NUMBER" >> "$GITHUB_ENV"
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@cbe3b392738ccf3f987d68400dafcf4b0624a56c # v6.2.4
         with:
@@ -188,9 +188,9 @@ jobs:
           PASSPHRASE: ${{ secrets.PASSPHRASE }}
       - name: Set Account Number
         run: |
-          ACCOUNT_NUMBER=$(jq -r -e '.account_ids["sprinkler-development"]' <<< $ENVIRONMENT_MANAGEMENT)
+          ACCOUNT_NUMBER=$(jq -r -e '.account_ids["sprinkler-development"]' <<< "$ENVIRONMENT_MANAGEMENT")
           echo "::add-mask::$ACCOUNT_NUMBER"
-          echo ACCOUNT_NUMBER=$ACCOUNT_NUMBER >> $GITHUB_ENV
+          echo "ACCOUNT_NUMBER=$ACCOUNT_NUMBER" >> "$GITHUB_ENV"
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@cbe3b392738ccf3f987d68400dafcf4b0624a56c # v6.2.4
         with:
@@ -217,9 +217,9 @@ jobs:
           PASSPHRASE: ${{ secrets.PASSPHRASE }}
       - name: Set Account Number
         run: |
-          ACCOUNT_NUMBER=$(jq -r -e '.account_ids["sprinkler-development"]' <<< $ENVIRONMENT_MANAGEMENT)
+          ACCOUNT_NUMBER=$(jq -r -e '.account_ids["sprinkler-development"]' <<< "$ENVIRONMENT_MANAGEMENT")
           echo "::add-mask::$ACCOUNT_NUMBER"
-          echo ACCOUNT_NUMBER=$ACCOUNT_NUMBER >> $GITHUB_ENV
+          echo "ACCOUNT_NUMBER=$ACCOUNT_NUMBER" >> "$GITHUB_ENV"
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@cbe3b392738ccf3f987d68400dafcf4b0624a56c # v6.2.4
         with:
@@ -246,9 +246,9 @@ jobs:
           PASSPHRASE: ${{ secrets.PASSPHRASE }}
       - name: Set Account Number
         run: |
-          ACCOUNT_NUMBER=$(jq -r -e '.account_ids["sprinkler-development"]' <<< $ENVIRONMENT_MANAGEMENT)
+          ACCOUNT_NUMBER=$(jq -r -e '.account_ids["sprinkler-development"]' <<< "$ENVIRONMENT_MANAGEMENT")
           echo "::add-mask::$ACCOUNT_NUMBER"
-          echo ACCOUNT_NUMBER=$ACCOUNT_NUMBER >> $GITHUB_ENV
+          echo "ACCOUNT_NUMBER=$ACCOUNT_NUMBER" >> "$GITHUB_ENV"
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@cbe3b392738ccf3f987d68400dafcf4b0624a56c # v6.2.4

--- a/.github/workflows/check-broken-links.yml
+++ b/.github/workflows/check-broken-links.yml
@@ -80,10 +80,12 @@ jobs:
           echo ""
 
           # Prepare report header
-          echo "## 🔗 Broken Links Report" > broken-links-report.md
-          echo "" >> broken-links-report.md
-          echo "| Status | URL | File | Line |" >> broken-links-report.md
-          echo "|--------|-----|------|------|" >> broken-links-report.md
+          {
+            echo "## 🔗 Broken Links Report"
+            echo ""
+            echo "| Status | URL | File | Line |"
+            echo "|--------|-----|------|------|"
+          } > broken-links-report.md
 
           while IFS= read -r url; do
             CHECKED=$((CHECKED + 1))
@@ -104,7 +106,7 @@ jobs:
 
               # Find all occurrences with file and line number
               while IFS= read -r file; do
-                grep -EIn 'https?://[A-Za-z0-9._~:/?#@!$&*+,;=%-]+' "$file" 2>/dev/null | grep -F "$url" | while IFS=: read -r line_num content; do
+                grep -EIn 'https?://[A-Za-z0-9._~:/?#@!$&*+,;=%-]+' "$file" 2>/dev/null | grep -F "$url" | while IFS=: read -r line_num _content; do
                   echo "     📍 $file:$line_num"
                   echo "| ${STATUS} | ${url} | ${file} | ${line_num} |" >> broken-links-report.md
                 done

--- a/.github/workflows/confirm-contacts-for-environments.yml
+++ b/.github/workflows/confirm-contacts-for-environments.yml
@@ -77,7 +77,7 @@ jobs:
       # Step 4: Get Environment Owners
       - name: Get Environment Owners         
         run: |
-          cd $GITHUB_WORKSPACE
+          cd "$GITHUB_WORKSPACE"
           pwd
           ./scripts/confirm-environment-owner/get-environment-owners.sh
       # Step 5: Create GitHub Issue and Notify Owners
@@ -86,7 +86,7 @@ jobs:
           API_KEY: ${{ env.GOV_UK_NOTIFY_API_KEY }}
           TEMPLATE_ID: ${{ env.TEMPLATE_ID }}
         run: |
-          cd $GITHUB_WORKSPACE
+          cd "$GITHUB_WORKSPACE"
           pwd
           chmod +x scripts/confirm-environment-owner/create-confirm-owner-issue.sh
           ./scripts/confirm-environment-owner/create-confirm-owner-issue.sh

--- a/.github/workflows/create-newenv.yml
+++ b/.github/workflows/create-newenv.yml
@@ -30,14 +30,15 @@ jobs:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |
           echo "$ISSUE_BODY" > issue_body.txt
-          echo "ISSUE_NUMBER=$ISSUE_NUMBER" >> $GITHUB_ENV
+          echo "ISSUE_NUMBER=$ISSUE_NUMBER" >> "$GITHUB_ENV"
 
       - name: Extract fields from issue
         run: |
           # Function to extract and sanitize field values
           extract_field() {
             local key="$1"
-            local value=$(awk -v k="$key" '$0==k {while(getline>0){if($0~/^$/)continue;if($0~/^_No response_$/){print "";exit}print $0;exit}}' issue_body.txt | xargs)
+            local value
+            value=$(awk -v k="$key" '$0==k {while(getline>0){if($0~/^$/)continue;if($0~/^_No response_$/){print "";exit}print $0;exit}}' issue_body.txt | xargs)
             # Sanitize: remove newlines/carriage returns, limit to 200 chars
             echo "$value" | tr -d '\n\r' | head -c 200
           }
@@ -71,7 +72,7 @@ jobs:
             echo "SLACK=$SLACK"
             echo "GITHUB_OWNERS=$GITHUB_OWNERS"
             echo "GITHUB_REVIEWERS=$GITHUB_REVIEWERS"
-          } >> $GITHUB_ENV
+          } >> "$GITHUB_ENV"
 
       - name: Validate Slack field (no #)
         run: |
@@ -129,8 +130,8 @@ jobs:
           fi
 
           # Remove trailing comma and wrap in brackets
-          ENV_SELECTIONS_JSON="[$(echo $ENVIRONMENTS | sed 's/,$//')]"
-          echo "ENV_SELECTIONS_JSON=$ENV_SELECTIONS_JSON" >> $GITHUB_ENV
+          ENV_SELECTIONS_JSON="[${ENVIRONMENTS%,}]"
+          echo "ENV_SELECTIONS_JSON=$ENV_SELECTIONS_JSON" >> "$GITHUB_ENV"
 
       - name: Create and checkout branch for environment request
         run: |
@@ -183,14 +184,14 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           PR_TITLE="Automated environment amendment request for $APP_NAME"
-          PR_URL=$(gh pr list --state open --search "$pr_title in:title" --json url -q '.[0].url')
+          PR_URL=$(gh pr list --state open --search "$PR_TITLE in:title" --json url -q '.[0].url')
           echo "PR URL: $PR_URL"
           REPO="${{ github.repository }}"
-          gh issue comment $ISSUE_NUMBER --repo "$REPO" --body "A pull request has been created for your environment request: $PR_URL"
+          gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body "A pull request has been created for your environment request: $PR_URL"
       
       - name: Save network setup info
         run: |
-          echo "{\"pr_number\": ${{ github.event.pull_request.number }}, ISOLATED_ACCOUNT, \"app_name\": \"$APP_NAME\", \"business_unit\": \"$BUSINESS_UNIT\", \"environments\": $(echo $ENV_SELECTIONS_JSON | jq -c 'map(.name)')}" > network-setup-info.json
+          echo "{\"pr_number\": ${{ github.event.pull_request.number }}, ISOLATED_ACCOUNT, \"app_name\": \"$APP_NAME\", \"business_unit\": \"$BUSINESS_UNIT\", \"environments\": $(echo "$ENV_SELECTIONS_JSON" | jq -c 'map(.name)')}" > network-setup-info.json
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: network-setup-info

--- a/.github/workflows/delete-expired-recovery-points.yml
+++ b/.github/workflows/delete-expired-recovery-points.yml
@@ -38,9 +38,9 @@ jobs:
 
       - name: Set Account Number
         run: |
-          ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< $ENVIRONMENT_MANAGEMENT)
+          ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< "$ENVIRONMENT_MANAGEMENT")
           echo "::add-mask::$ACCOUNT_NUMBER"
-          echo ACCOUNT_NUMBER=$ACCOUNT_NUMBER >> $GITHUB_ENV
+          echo "ACCOUNT_NUMBER=$ACCOUNT_NUMBER" >> "$GITHUB_ENV"
 
       - name: Configure AWS Credentials
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -30,7 +30,7 @@ jobs:
         git-push: "false"
 
     - name: Fix Git permissions
-      run: sudo chown -R $(whoami) .git/
+      run: sudo chown -R "$(whoami)" .git/
 
     - name: Run Signed Commit Action
       uses: ministryofjustice/modernisation-platform-github-actions/signed-commit@2988728879704953e739f82ac926d37931c6d01b # v6.1.9

--- a/.github/workflows/export-route53-records.yml
+++ b/.github/workflows/export-route53-records.yml
@@ -28,9 +28,9 @@ jobs:
           PASSPHRASE: ${{ secrets.PASSPHRASE }}
       - name: Set Account Number
         run: |
-          ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< $ENVIRONMENT_MANAGEMENT)
+          ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< "$ENVIRONMENT_MANAGEMENT")
           echo "::add-mask::$ACCOUNT_NUMBER"
-          echo ACCOUNT_NUMBER=$ACCOUNT_NUMBER >> $GITHUB_ENV
+          echo "ACCOUNT_NUMBER=$ACCOUNT_NUMBER" >> "$GITHUB_ENV"
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@cbe3b392738ccf3f987d68400dafcf4b0624a56c # v6.2.4
         with:

--- a/.github/workflows/failed-workflows-report.yml
+++ b/.github/workflows/failed-workflows-report.yml
@@ -48,7 +48,7 @@ jobs:
         - name: Get Failed Workflows   
           id: get-failed-workflows
           run: |
-            cd $GITHUB_WORKSPACE
+            cd "$GITHUB_WORKSPACE"
             pwd
             chmod +x scripts/failed-workflows-report/get-failed-workflows.sh
             ./scripts/failed-workflows-report/get-failed-workflows.sh
@@ -69,7 +69,7 @@ jobs:
             SLACK_WEBHOOK_URL: "${{ env.SLACK_WEBHOOK_URL}}"
           run: |
             chmod +x scripts/failed-workflows-report/send-report-via-slack.sh
-            ./scripts/failed-workflows-report/send-report-via-slack.sh $SLACK_WEBHOOK_URL slack_message.json
+            ./scripts/failed-workflows-report/send-report-via-slack.sh "$SLACK_WEBHOOK_URL" slack_message.json
 
         - name: Slack failure notification
           uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0

--- a/.github/workflows/generate-dora-metrics.yml
+++ b/.github/workflows/generate-dora-metrics.yml
@@ -78,8 +78,8 @@ jobs:
               run: |
                   start_date=$(echo "${{ github.event.inputs.date_range }}" | cut -d. -f1)
                   end_date=$(echo "${{ github.event.inputs.date_range }}" | rev | cut -d. -f1 | rev)
-                  echo "start_date=$start_date" >> $GITHUB_ENV
-                  echo "end_date=$end_date" >> $GITHUB_ENV
+                  echo "start_date=$start_date" >> "$GITHUB_ENV"
+                  echo "end_date=$end_date" >> "$GITHUB_ENV"
 
             - name: Run scripts and build summary
               env:

--- a/.github/workflows/modernisation-member-information.yml
+++ b/.github/workflows/modernisation-member-information.yml
@@ -42,9 +42,9 @@ jobs:
 
       - name: Set Account Number
         run: |
-          ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< $ENVIRONMENT_MANAGEMENT)
+          ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< "$ENVIRONMENT_MANAGEMENT")
           echo "::add-mask::$ACCOUNT_NUMBER"
-          echo ACCOUNT_NUMBER=$ACCOUNT_NUMBER >> $GITHUB_ENV
+          echo "ACCOUNT_NUMBER=$ACCOUNT_NUMBER" >> "$GITHUB_ENV"
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@cbe3b392738ccf3f987d68400dafcf4b0624a56c # v6.2.4

--- a/.github/workflows/modernisation-platform-account.yml
+++ b/.github/workflows/modernisation-platform-account.yml
@@ -35,8 +35,8 @@ jobs:
     with:
       working-directory: "terraform/modernisation-platform-account"
       workflow_id: "modernisation-platform-account"
-      set_github_app_token: "true"
-      download_collaborators: "true"
+      set_github_app_token: ${{ 'true' }}
+      download_collaborators: ${{ 'true' }}
     secrets:
       MODERNISATION_PLATFORM_ACCOUNT_NUMBER: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_NUMBER }}
       PASSPHRASE: ${{ secrets.PASSPHRASE }}

--- a/.github/workflows/monitor-ecs-eks-amis.yml
+++ b/.github/workflows/monitor-ecs-eks-amis.yml
@@ -42,9 +42,9 @@ jobs:
 
       - name: Set Account Number
         run: |
-          ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< $ENVIRONMENT_MANAGEMENT)
+          ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< "$ENVIRONMENT_MANAGEMENT")
           echo "::add-mask::$ACCOUNT_NUMBER"
-          echo ACCOUNT_NUMBER=$ACCOUNT_NUMBER >> $GITHUB_ENV
+          echo "ACCOUNT_NUMBER=$ACCOUNT_NUMBER" >> "$GITHUB_ENV"
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@cbe3b392738ccf3f987d68400dafcf4b0624a56c # v6.2.4

--- a/.github/workflows/new-environment.yml
+++ b/.github/workflows/new-environment.yml
@@ -72,12 +72,12 @@ jobs:
           bash ./scripts/check-github-api-usage.sh
       - name: Set env vars
         run: |
-          echo "TF_VAR_github_token=${{ steps.app.outputs.token }}" >> $GITHUB_ENV
+          echo "TF_VAR_github_token=${{ steps.app.outputs.token }}" >> "$GITHUB_ENV"
       - name: Set Account Number
         run: |
-          ACCOUNT_NUMBER=$(jq -r -e '.aws_organizations_root_account_id' <<< $ENVIRONMENT_MANAGEMENT)
+          ACCOUNT_NUMBER=$(jq -r -e '.aws_organizations_root_account_id' <<< "$ENVIRONMENT_MANAGEMENT")
           echo "::add-mask::$ACCOUNT_NUMBER"
-          echo ACCOUNT_NUMBER=$ACCOUNT_NUMBER >> $GITHUB_ENV
+          echo "ACCOUNT_NUMBER=$ACCOUNT_NUMBER" >> "$GITHUB_ENV"
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@cbe3b392738ccf3f987d68400dafcf4b0624a56c # v6.2.4
         with:
@@ -139,12 +139,12 @@ jobs:
           bash ./scripts/check-github-api-usage.sh
       - name: Set env vars
         run: |
-          echo "TF_VAR_github_token=${{ steps.app.outputs.token }}" >> $GITHUB_ENV
+          echo "TF_VAR_github_token=${{ steps.app.outputs.token }}" >> "$GITHUB_ENV"
       - name: Set Account Number
         run: |
-          ACCOUNT_NUMBER=$(jq -r -e '.aws_organizations_root_account_id' <<< $ENVIRONMENT_MANAGEMENT)
+          ACCOUNT_NUMBER=$(jq -r -e '.aws_organizations_root_account_id' <<< "$ENVIRONMENT_MANAGEMENT")
           echo "::add-mask::$ACCOUNT_NUMBER"
-          echo ACCOUNT_NUMBER=$ACCOUNT_NUMBER >> $GITHUB_ENV
+          echo "ACCOUNT_NUMBER=$ACCOUNT_NUMBER" >> "$GITHUB_ENV"
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@cbe3b392738ccf3f987d68400dafcf4b0624a56c # v6.2.4
         with:
@@ -183,9 +183,9 @@ jobs:
           PASSPHRASE: ${{ secrets.PASSPHRASE }}
       - name: Set Account Number
         run: |
-          ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< $ENVIRONMENT_MANAGEMENT)
+          ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< "$ENVIRONMENT_MANAGEMENT")
           echo "::add-mask::$ACCOUNT_NUMBER"
-          echo ACCOUNT_NUMBER=$ACCOUNT_NUMBER >> $GITHUB_ENV
+          echo "ACCOUNT_NUMBER=$ACCOUNT_NUMBER" >> "$GITHUB_ENV"
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@cbe3b392738ccf3f987d68400dafcf4b0624a56c # v6.2.4
         with:
@@ -227,9 +227,9 @@ jobs:
           PASSPHRASE: ${{ secrets.PASSPHRASE }}
       - name: Set Account Number
         run: |
-          ACCOUNT_NUMBER=$(jq -r -e '.aws_organizations_root_account_id' <<< $ENVIRONMENT_MANAGEMENT)
+          ACCOUNT_NUMBER=$(jq -r -e '.aws_organizations_root_account_id' <<< "$ENVIRONMENT_MANAGEMENT")
           echo "::add-mask::$ACCOUNT_NUMBER"
-          echo ACCOUNT_NUMBER=$ACCOUNT_NUMBER >> $GITHUB_ENV
+          echo "ACCOUNT_NUMBER=$ACCOUNT_NUMBER" >> "$GITHUB_ENV"
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@cbe3b392738ccf3f987d68400dafcf4b0624a56c # v6.2.4
         with:
@@ -244,7 +244,7 @@ jobs:
         id: new_account
         run: |
           files=$(git diff --name-only --diff-filter=AM @^ -- 'environments/*.json' | uniq | sed 's#environments/##' | sed 's/\.json$//' | tr '\n' ',' | awk '{$1=$1};1')
-          echo "files=$files" >> $GITHUB_OUTPUT
+          echo "files=$files" >> "$GITHUB_OUTPUT"
       - name: Run delegate access
         run: |
           IFS=',' read -r -a accounts <<< "${{ steps.new_account.outputs.files }}"
@@ -282,9 +282,9 @@ jobs:
           PASSPHRASE: ${{ secrets.PASSPHRASE }}
       - name: Set Account Number
         run: |
-          ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< $ENVIRONMENT_MANAGEMENT)
+          ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< "$ENVIRONMENT_MANAGEMENT")
           echo "::add-mask::$ACCOUNT_NUMBER"
-          echo ACCOUNT_NUMBER=$ACCOUNT_NUMBER >> $GITHUB_ENV
+          echo "ACCOUNT_NUMBER=$ACCOUNT_NUMBER" >> "$GITHUB_ENV"
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@cbe3b392738ccf3f987d68400dafcf4b0624a56c # v6.2.4
         with:
@@ -295,19 +295,19 @@ jobs:
         id: new_account
         run: |
           files=$(git diff --name-only --diff-filter=AM @^ -- 'environments/*.json' | uniq | sed 's#environments/##' | sed 's/\.json$//' | tr '\n' ',' | awk '{$1=$1};1')
-          echo "files=$files" >> $GITHUB_OUTPUT
+          echo "files=$files" >> "$GITHUB_OUTPUT"
       - name: Remove Default VPC
         run: |
           IFS=',' read -r -a accounts <<< "${{ steps.new_account.outputs.files }}"          
           if [[ ${#accounts[@]} -gt 0 ]]; then
             for i in "${accounts[@]}"; do
               environments=$(jq -r '.environments[].name' "environments/${i}.json")
-              for env in $environments; do
+              while IFS= read -r env; do
                 key="${i}-${env}"
                 account_number=$(echo "$AWS_ENVIRONMENTS" | jq -r ".account_ids[\"$key\"]")
                 echo "[+] Running remove-default-vpc for account ${account_number}"
                 # bash ./scripts/internal/remove-default-vpc/remove_default_vpc_new_account.sh $account_number
-              done
+              done <<< "$environments"
             done
           else
             echo "[+] There were no AWS member accounts to process"
@@ -337,9 +337,9 @@ jobs:
           PASSPHRASE: ${{ secrets.PASSPHRASE }}
       - name: Set Account Number
         run: |
-          ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< $ENVIRONMENT_MANAGEMENT)
+          ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< "$ENVIRONMENT_MANAGEMENT")
           echo "::add-mask::$ACCOUNT_NUMBER"
-          echo ACCOUNT_NUMBER=$ACCOUNT_NUMBER >> $GITHUB_ENV
+          echo "ACCOUNT_NUMBER=$ACCOUNT_NUMBER" >> "$GITHUB_ENV"
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@cbe3b392738ccf3f987d68400dafcf4b0624a56c # v6.2.4
         with:
@@ -354,7 +354,7 @@ jobs:
         id: new_account
         run: |
           files=$(git diff --name-only --diff-filter=AM @^ -- 'environments/*.json' | uniq | sed 's#environments/##' | sed 's/\.json$//' | tr '\n' ',' | awk '{$1=$1};1')
-          echo "files=$files" >> $GITHUB_OUTPUT
+          echo "files=$files" >> "$GITHUB_OUTPUT"
       - name: Run secure baselines
         run: |
           IFS=',' read -r -a accounts <<< "${{ steps.new_account.outputs.files }}"
@@ -391,9 +391,9 @@ jobs:
           PASSPHRASE: ${{ secrets.PASSPHRASE }}
       - name: Set Account Number
         run: |
-          ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< $ENVIRONMENT_MANAGEMENT)
+          ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< "$ENVIRONMENT_MANAGEMENT")
           echo "::add-mask::$ACCOUNT_NUMBER"
-          echo ACCOUNT_NUMBER=$ACCOUNT_NUMBER >> $GITHUB_ENV
+          echo "ACCOUNT_NUMBER=$ACCOUNT_NUMBER" >> "$GITHUB_ENV"
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@cbe3b392738ccf3f987d68400dafcf4b0624a56c # v6.2.4
         with:
@@ -408,7 +408,7 @@ jobs:
         id: new_account
         run: |
           files=$(git diff --name-only --diff-filter=M @^ -- 'environments/*.json' | uniq | sed 's#environments/##' | sed 's/\.json$//' | tr '\n' ',' | awk '{$1=$1};1')
-          echo "files=$files" >> $GITHUB_OUTPUT
+          echo "files=$files" >> "$GITHUB_OUTPUT"
       - name: Run single sign on
         run: |
           IFS=',' read -r -a accounts <<< "${{ steps.new_account.outputs.files }}"
@@ -437,9 +437,9 @@ jobs:
           PASSPHRASE: ${{ secrets.PASSPHRASE }}
       - name: Set Account Number
         run: |
-          ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< $ENVIRONMENT_MANAGEMENT)
+          ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< "$ENVIRONMENT_MANAGEMENT")
           echo "::add-mask::$ACCOUNT_NUMBER"
-          echo ACCOUNT_NUMBER=$ACCOUNT_NUMBER >> $GITHUB_ENV
+          echo "ACCOUNT_NUMBER=$ACCOUNT_NUMBER" >> "$GITHUB_ENV"
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@cbe3b392738ccf3f987d68400dafcf4b0624a56c # v6.2.4
         with:
@@ -454,7 +454,7 @@ jobs:
         id: new_account
         run: |
           files=$(git diff --name-only --diff-filter=AM @^ -- 'environments/*.json' | uniq | sed 's#environments/##' | sed 's/\.json$//' | tr '\n' ',' | awk '{$1=$1};1')
-          echo "files=$files" >> $GITHUB_OUTPUT
+          echo "files=$files" >> "$GITHUB_OUTPUT"
       - name: Run single sign on
         run: |
           IFS=',' read -r -a accounts <<< "${{ steps.new_account.outputs.files }}"
@@ -511,8 +511,8 @@ jobs:
         id: pr_number
         if: steps.environment_json_changes.outputs.files != ''
         run: |
-          PR_NUMBER=$(gh api repos/$GITHUB_REPOSITORY/commits/$GITHUB_SHA/pulls --jq '.[0].number')
-          echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+          PR_NUMBER=$(gh api "repos/$GITHUB_REPOSITORY/commits/$GITHUB_SHA/pulls" --jq '.[0].number')
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Send notification to Slack
@@ -527,7 +527,7 @@ jobs:
           continue
           fi
           echo "Slack channel found: $slack_channel"
-          webhook_url=$(echo $SLACK_WEBHOOKS | jq -r --arg channel "$slack_channel" '.[$channel]')
+          webhook_url=$(echo "$SLACK_WEBHOOKS" | jq -r --arg channel "$slack_channel" '.[$channel]')
           if [[ -z "$webhook_url" || "$webhook_url" == "null" ]]; then
           echo "No webhook URL found for channel $slack_channel. Skipping notification."
           continue
@@ -573,8 +573,8 @@ jobs:
       - name: Send notification to Email
         if: steps.environment_json_changes.outputs.files != ''
         run: |
-          DECODED_FILES=$(echo ${{ steps.environment_json_changes.outputs.files }} | base64 --decode)
-          python ./scripts/json-changes-notifier.py $DECODED_FILES   
+          DECODED_FILES=$(echo "${{ steps.environment_json_changes.outputs.files }}" | base64 --decode)
+          python ./scripts/json-changes-notifier.py "$DECODED_FILES"
         env:
           PR_NUMBER: ${{ steps.pr_number.outputs.pr_number }}   
   member-bootstrap:
@@ -593,9 +593,9 @@ jobs:
           PASSPHRASE: ${{ secrets.PASSPHRASE }}
       - name: Set Account Number
         run: |
-          ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< $ENVIRONMENT_MANAGEMENT)
+          ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< "$ENVIRONMENT_MANAGEMENT")
           echo "::add-mask::$ACCOUNT_NUMBER"
-          echo ACCOUNT_NUMBER=$ACCOUNT_NUMBER >> $GITHUB_ENV
+          echo "ACCOUNT_NUMBER=$ACCOUNT_NUMBER" >> "$GITHUB_ENV"
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@cbe3b392738ccf3f987d68400dafcf4b0624a56c # v6.2.4
         with:
@@ -610,7 +610,7 @@ jobs:
         id: new_account
         run: |
           files=$(git diff --name-only --diff-filter=AM @^ -- 'environments/*.json' | uniq | sed 's#environments/##' | sed 's/\.json$//' | tr '\n' ',' | awk '{$1=$1};1')
-          echo "files=$files" >> $GITHUB_OUTPUT
+          echo "files=$files" >> "$GITHUB_OUTPUT"
       - name: Run Member Bootstrap
         run: |
           IFS=',' read -r -a accounts <<< "${{ steps.new_account.outputs.files }}"
@@ -639,8 +639,8 @@ jobs:
     with:
       working-directory: "terraform/modernisation-platform-account"
       workflow_id: "modernisation-platform-account"
-      set_github_app_token: "true"
-      download_collaborators: "true"
+      set_github_app_token: ${{ 'true' }}
+      download_collaborators: ${{ 'true' }}
     secrets:
       MODERNISATION_PLATFORM_ACCOUNT_NUMBER: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_NUMBER }}
       PASSPHRASE: ${{ secrets.PASSPHRASE }}

--- a/.github/workflows/nuke-redeploy.yml
+++ b/.github/workflows/nuke-redeploy.yml
@@ -60,7 +60,7 @@ jobs:
           nuke_rebuild_account_ids: ${{ needs.fetch-secrets.outputs.nuke_rebuild_account_ids }}
           PASSPHRASE: ${{ secrets.PASSPHRASE }}
       - id: set-matrix
-        run: echo "matrix=$(jq -c '.rebuild_accounts | sort' <<< $NUKE_REBUILD_ACCOUNT_IDS)" >> $GITHUB_OUTPUT
+        run: echo "matrix=$(jq -c '.rebuild_accounts | sort' <<< "$NUKE_REBUILD_ACCOUNT_IDS")" >> "$GITHUB_OUTPUT"
 
   redeploy-after-nuke:
     permissions:
@@ -89,9 +89,9 @@ jobs:
 
       - name: Set Account Number
         run: |
-          ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${ACCOUNT_NAME}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)
+          ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${ACCOUNT_NAME}" '.account_ids[$account_name]' <<< "$ENVIRONMENT_MANAGEMENT")
           echo "::add-mask::$ACCOUNT_NUMBER"
-          echo "ACCOUNT_NUMBER=${ACCOUNT_NUMBER}" >> $GITHUB_ENV
+          echo "ACCOUNT_NUMBER=${ACCOUNT_NUMBER}" >> "$GITHUB_ENV"
 
       - name: configure aws credentials
         if: github.ref == 'refs/heads/main'
@@ -111,18 +111,18 @@ jobs:
         run: |
           terraform --version
           echo "Terraform Plan - ${ACCOUNT_NAME%-development}" # removes the -development suffix in order to get the directory name
-          bash scripts/terraform-init.sh terraform/environments/${ACCOUNT_NAME%-development}
+          bash scripts/terraform-init.sh "terraform/environments/${ACCOUNT_NAME%-development}"
           terraform -chdir="terraform/environments/${ACCOUNT_NAME%-development}" workspace select "${ACCOUNT_NAME}"
-          bash scripts/terraform-plan.sh terraform/environments/${ACCOUNT_NAME%-development}
+          bash scripts/terraform-plan.sh "terraform/environments/${ACCOUNT_NAME%-development}"
 
       - name: Apply after nuke - ${{ matrix.nuke_accts }}
         if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && inputs.mode == 'nuke-no-dry-run') }}
         run: |
           terraform --version
           echo "Terraform apply - ${ACCOUNT_NAME%-development}" # removes the -development suffix in order to get the directory name
-          bash scripts/terraform-init.sh terraform/environments/${ACCOUNT_NAME%-development}
+          bash scripts/terraform-init.sh "terraform/environments/${ACCOUNT_NAME%-development}"
           terraform -chdir="terraform/environments/${ACCOUNT_NAME%-development}" workspace select "${ACCOUNT_NAME}"
-          bash scripts/terraform-apply.sh terraform/environments/${ACCOUNT_NAME%-development}
+          bash scripts/terraform-apply.sh "terraform/environments/${ACCOUNT_NAME%-development}"
 
       - name: Slack failure notification
         uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0

--- a/.github/workflows/opa-policies.yml
+++ b/.github/workflows/opa-policies.yml
@@ -11,10 +11,6 @@ on:
       - 'scripts/tests/validate/run-opa-tests.sh'
   merge_group:
     types: [checks_requested]
-    paths:
-      - '**.json'
-      - '**.rego'
-      - 'scripts/tests/validate/run-opa-tests.sh'
 
 permissions:
   contents: read

--- a/.github/workflows/remove-default-vpc.yml
+++ b/.github/workflows/remove-default-vpc.yml
@@ -39,9 +39,9 @@ jobs:
 
       - name: Set Account Number
         run: |
-          ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< $ENVIRONMENT_MANAGEMENT)
+          ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< "$ENVIRONMENT_MANAGEMENT")
           echo "::add-mask::$ACCOUNT_NUMBER"
-          echo ACCOUNT_NUMBER=$ACCOUNT_NUMBER >> $GITHUB_ENV
+          echo "ACCOUNT_NUMBER=$ACCOUNT_NUMBER" >> "$GITHUB_ENV"
         
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@cbe3b392738ccf3f987d68400dafcf4b0624a56c # v6.2.4

--- a/.github/workflows/reusable-member-account-ram-association.yml
+++ b/.github/workflows/reusable-member-account-ram-association.yml
@@ -49,9 +49,9 @@ jobs:
 
       - name: Set Account Number
         run: |
-          ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< $ENVIRONMENT_MANAGEMENT)
+          ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< "$ENVIRONMENT_MANAGEMENT")
           echo "::add-mask::$ACCOUNT_NUMBER"
-          echo ACCOUNT_NUMBER=$ACCOUNT_NUMBER >> $GITHUB_ENV
+          echo "ACCOUNT_NUMBER=$ACCOUNT_NUMBER" >> "$GITHUB_ENV"
 
       - name: Configure AWS Credentials
         if: github.event.ref != 'refs/heads/main'

--- a/.github/workflows/reusable-scheduled-baselines.yml
+++ b/.github/workflows/reusable-scheduled-baselines.yml
@@ -65,7 +65,7 @@ jobs:
       steps:
         - name: Log Job Name
           run: | 
-            echo "Job Name: " ${{ inputs.JOB_NAME }}
+            echo "Job Name: ${{ inputs.JOB_NAME }}"
         - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         - name: Decrypt Secrets
           uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
@@ -77,7 +77,7 @@ jobs:
           run: |
             ACCOUNT_NUMBER=$(jq -r -e '.${{ inputs.aws_account_id_name }}' <<< "$ENVIRONMENT_MANAGEMENT")
             echo "::add-mask::$ACCOUNT_NUMBER"
-            echo ACCOUNT_NUMBER=$ACCOUNT_NUMBER >> $GITHUB_ENV
+            echo "ACCOUNT_NUMBER=$ACCOUNT_NUMBER" >> "$GITHUB_ENV"
         - name: Configure AWS Credentials
           uses: aws-actions/configure-aws-credentials@cbe3b392738ccf3f987d68400dafcf4b0624a56c # v6.2.4
           with:
@@ -93,9 +93,8 @@ jobs:
         - name: Persist terraform state to backend
           if: ${{ failure() && hashFiles(env.STATE_FILE) != '' }}
           run: |
-            bash scripts/terraform-state-push.sh "${{ inputs.working_directory }}"
-            if [ $? -eq 0 ]; then
-              echo "STATE_PUSH_SUCCESSFUL=true" >> $GITHUB_ENV
+            if bash scripts/terraform-state-push.sh "${{ inputs.working_directory }}"; then
+              echo "STATE_PUSH_SUCCESSFUL=true" >> "$GITHUB_ENV"
             fi
         - name: Slack failure notification
           uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0

--- a/.github/workflows/reusable-securityhub-findings.yml
+++ b/.github/workflows/reusable-securityhub-findings.yml
@@ -45,7 +45,7 @@ jobs:
 
         - name: Log Job Name
           run: | 
-            echo "Job Name: " ${{ inputs.account_name }}
+            echo "Job Name: ${{ inputs.account_name }}"
 
         - name: Set aws_region to env
           run: |
@@ -65,7 +65,7 @@ jobs:
           run: |
             FILENAME=$(echo "${{ inputs.account_name }}" | sed 's/-[^-]*$//').json
             echo "JSON filename: $FILENAME"
-            echo "json_filename=$FILENAME" >> $GITHUB_OUTPUT
+            echo "json_filename=$FILENAME" >> "$GITHUB_OUTPUT"
 
         - name: Check Slack Channel Configuration
           id: verify-slack-config
@@ -75,15 +75,15 @@ jobs:
                 if jq -e '.tags | has("securityhub-slack-channel")' "$FILE_PATH" > /dev/null; then
                 echo "Slack channel configured in environment tags"
                 CHANNEL=$(jq -r '.tags["securityhub-slack-channel"]' "$FILE_PATH")
-                echo "channel_exists=true" >> $GITHUB_OUTPUT
-                echo "channel_name=$CHANNEL" >> $GITHUB_OUTPUT
+                echo "channel_exists=true" >> "$GITHUB_OUTPUT"
+                echo "channel_name=$CHANNEL" >> "$GITHUB_OUTPUT"
                 else
                 echo "No Slack channel configured in environment tags"
-                echo "channel_exists=false" >> $GITHUB_OUTPUT
+                echo "channel_exists=false" >> "$GITHUB_OUTPUT"
                 fi
             else
                 echo "Environment config file $FILE_PATH not found"
-                echo "channel_exists=false" >> $GITHUB_OUTPUT
+                echo "channel_exists=false" >> "$GITHUB_OUTPUT"
             fi
 
         - name: Retrieve Slack Webhook URL
@@ -91,12 +91,12 @@ jobs:
           if: steps.verify-slack-config.outputs.channel_exists == 'true'
           run: |
             echo "Using channel name: ${{ steps.verify-slack-config.outputs.channel_name }}"
-            WEBHOOK=$(echo $SECURITYHUB_SLACK_WEBHOOKS_JSON | jq -r '.["${{ steps.verify-slack-config.outputs.channel_name }}"]')
+            WEBHOOK=$(echo "$SECURITYHUB_SLACK_WEBHOOKS_JSON" | jq -r '.["${{ steps.verify-slack-config.outputs.channel_name }}"]')
             if [ "$WEBHOOK" = "null" ] || [ -z "$WEBHOOK" ]; then
                 echo "No webhook found for this channel. Skipping."
                 exit 0
             fi
-            echo "webhook_url=$WEBHOOK" >> $GITHUB_OUTPUT
+            echo "webhook_url=$WEBHOOK" >> "$GITHUB_OUTPUT"
 
         - name: Get Account ID
           if: steps.fetch-webhook-url.outputs.webhook_url != ''
@@ -108,7 +108,7 @@ jobs:
               exit 1
             fi
             echo "::add-mask::$ACCOUNT_NUMBER"
-            echo ACCOUNT_NUMBER=$ACCOUNT_NUMBER >> $GITHUB_ENV
+            echo "ACCOUNT_NUMBER=$ACCOUNT_NUMBER" >> "$GITHUB_ENV"
 
         - name: Configure AWS Credentials
           if: steps.fetch-webhook-url.outputs.webhook_url != ''
@@ -123,9 +123,11 @@ jobs:
           if: steps.fetch-webhook-url.outputs.webhook_url != ''
           run: |
             OUTPUT=$(bash ./scripts/extract-securityhub-severity-summary.sh)
-            echo "output<<EOF" >> $GITHUB_OUTPUT
-            echo "$OUTPUT" >> $GITHUB_OUTPUT
-            echo "EOF" >> $GITHUB_OUTPUT
+            {
+              echo "output<<EOF"
+              echo "$OUTPUT"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
 
         - name: Send severity summary to Slack
           if: steps.fetch-webhook-url.outputs.webhook_url != ''

--- a/.github/workflows/reusable_terraform_plan_apply.yml
+++ b/.github/workflows/reusable_terraform_plan_apply.yml
@@ -105,23 +105,23 @@ jobs:
       - name: Set TF_VAR_github_token
         if: ${{ inputs.set_github_app_token == 'true' }}
         run: |
-          echo "TF_VAR_github_token=${{ steps.app.outputs.token }}" >> $GITHUB_ENV
+          echo "TF_VAR_github_token=${{ steps.app.outputs.token }}" >> "$GITHUB_ENV"
 
       - name: set env variables
         run: |
-          echo "TF_VAR_pagerduty_token=$PAGERDUTY_TOKEN" >> $GITHUB_ENV
-          echo "TF_VAR_pagerduty_user_token=$PAGERDUTY_USERAPI_TOKEN" >> $GITHUB_ENV
+          echo "TF_VAR_pagerduty_token=$PAGERDUTY_TOKEN" >> "$GITHUB_ENV"
+          echo "TF_VAR_pagerduty_user_token=$PAGERDUTY_USERAPI_TOKEN" >> "$GITHUB_ENV"
 
       - name: Set up variables
         id: vars
         if: ${{ inputs.environment }}
         run: |
-          account_name=$(basename ${{ inputs.working-directory }})
-          echo "ACCOUNT_NAME=${account_name}"  >> $GITHUB_ENV
-          echo "WORKSPACE_NAME=${account_name}-${{ inputs.environment }}" >> $GITHUB_ENV
+          account_name=$(basename "${{ inputs.working-directory }}")
+          echo "ACCOUNT_NAME=${account_name}"  >> "$GITHUB_ENV"
+          echo "WORKSPACE_NAME=${account_name}-${{ inputs.environment }}" >> "$GITHUB_ENV"
           # Check if test directory exists
-          if [ ${GITHUB_REF} != 'refs/heads/main' ] && [ -d "${{ inputs.working-directory }}/test" ]; then
-              echo "run_terratest=true" >> $GITHUB_OUTPUT
+          if [ "${GITHUB_REF}" != 'refs/heads/main' ] && [ -d "${{ inputs.working-directory }}/test" ]; then
+              echo "run_terratest=true" >> "$GITHUB_OUTPUT"
           fi
     
       - name: Setup Go
@@ -133,9 +133,9 @@ jobs:
 
       - name: Set Account Number
         run: |
-          ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< $ENVIRONMENT_MANAGEMENT)
+          ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< "$ENVIRONMENT_MANAGEMENT")
           echo "::add-mask::$ACCOUNT_NUMBER"
-          echo ACCOUNT_NUMBER=$ACCOUNT_NUMBER >> $GITHUB_ENV
+          echo "ACCOUNT_NUMBER=$ACCOUNT_NUMBER" >> "$GITHUB_ENV"
 
       - name: configure aws credentials
         if: github.event.ref != 'refs/heads/main'
@@ -161,12 +161,12 @@ jobs:
 
       - name: Initialize Terraform
         run: |
-          bash scripts/terraform-init.sh ${{ inputs.working-directory }}
+          bash scripts/terraform-init.sh "${{ inputs.working-directory }}"
 
       - name: Terraform Workspace Select
         if: ${{ inputs.environment }}
         run: |
-          terraform -chdir="${{ inputs.working-directory }}" workspace select ${WORKSPACE_NAME}
+          terraform -chdir="${{ inputs.working-directory }}" workspace select "${WORKSPACE_NAME}"
       
       - name: Validate Tags
         id: validate
@@ -180,9 +180,9 @@ jobs:
       - name: Run Terratest
         if: ${{ steps.vars.outputs.run_terratest == 'true' }}
         run: |
-          pushd ${{ inputs.working-directory }}/test
+          pushd "${{ inputs.working-directory }}/test"
           go mod tidy
-          TEST=`go test | ${{ github.workspace }}/scripts/redact-output.sh | tee /dev/stderr | tail -n 1`
+          TEST=$(go test | "${{ github.workspace }}/scripts/redact-output.sh" | tee /dev/stderr | tail -n 1)
           popd
           TEST="> TERRATEST RESULT - ${ACCOUNT_NAME}
           ${TEST}"
@@ -194,7 +194,7 @@ jobs:
         if: github.event.ref != 'refs/heads/main'
         id: show
         run: |
-          bash scripts/terraform-plan.sh ${{ inputs.working-directory }}
+          bash scripts/terraform-plan.sh "${{ inputs.working-directory }}"
 
       - name: Get Destroy Count
         if: github.event_name == 'pull_request'
@@ -255,7 +255,7 @@ jobs:
 
       - name: terraform apply
         if: github.event.ref == 'refs/heads/main'
-        run: bash scripts/terraform-apply.sh ${{ inputs.working-directory }}
+        run: bash scripts/terraform-apply.sh "${{ inputs.working-directory }}"
 
       - name: Slack failure notification
         if: ${{ failure() && github.ref == 'refs/heads/main' }}

--- a/.github/workflows/scheduled-baseline-extended-matrix.yml
+++ b/.github/workflows/scheduled-baseline-extended-matrix.yml
@@ -63,9 +63,9 @@ jobs:
           PASSPHRASE: ${{ secrets.PASSPHRASE }}
       - name: Set Account Number
         run: |
-          ACCOUNT_NUMBER=$(jq -r -e '.aws_organizations_root_account_id' <<< $ENVIRONMENT_MANAGEMENT)
+          ACCOUNT_NUMBER=$(jq -r -e '.aws_organizations_root_account_id' <<< "$ENVIRONMENT_MANAGEMENT")
           echo "::add-mask::$ACCOUNT_NUMBER"
-          echo ACCOUNT_NUMBER=$ACCOUNT_NUMBER >> $GITHUB_ENV
+          echo "ACCOUNT_NUMBER=$ACCOUNT_NUMBER" >> "$GITHUB_ENV"
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@cbe3b392738ccf3f987d68400dafcf4b0624a56c # v6.2.4
         with:
@@ -79,7 +79,9 @@ jobs:
       - run: bash scripts/terraform-init.sh terraform/environments/bootstrap/delegate-access
       - id: set-matrix
         name: Set Up Matrix
-        run: echo "matrix=$(terraform -chdir=terraform/environments/bootstrap/delegate-access workspace list | sed -e "s/*//" -e "s/^[[:space:]]*//" -e "/default/d" -e "/^$/d" | sort -u | jq -ncR '[inputs]')" >> $GITHUB_OUTPUT
+        run: |
+          matrix=$(terraform -chdir=terraform/environments/bootstrap/delegate-access workspace list | sed -e 's/*//' -e 's/^[[:space:]]*//' -e '/default/d' -e '/^$/d' | sort -u | jq -ncR '[inputs]')
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
       - id: setup-aws-region
         name: Setup AWS Region # required to pass the aws-region as an input to the reusable workflow from the global env var
         run: |
@@ -97,7 +99,7 @@ jobs:
           )
           for key in "${!DIRS[@]}"; do
             if grep -q "${DIRS[$key]}" <<< "$CHANGES"; then
-              echo "$key=true" >> $GITHUB_OUTPUT
+              echo "$key=true" >> "$GITHUB_OUTPUT"
             fi
           done
 
@@ -558,14 +560,14 @@ jobs:
           PASSPHRASE: ${{ secrets.PASSPHRASE }}
       - name: Set Account Number
         run: |
-          ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< $ENVIRONMENT_MANAGEMENT)
+          ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< "$ENVIRONMENT_MANAGEMENT")
           echo "::add-mask::$ACCOUNT_NUMBER"
-          echo ACCOUNT_NUMBER=$ACCOUNT_NUMBER >> $GITHUB_ENV
+          echo "ACCOUNT_NUMBER=$ACCOUNT_NUMBER" >> "$GITHUB_ENV"
       - name: Set Root Account Number
         run: |
-          ROOT_ACCOUNT_NUMBER=$(jq -r -e '.aws_organizations_root_account_id' <<< $ENVIRONMENT_MANAGEMENT)
+          ROOT_ACCOUNT_NUMBER=$(jq -r -e '.aws_organizations_root_account_id' <<< "$ENVIRONMENT_MANAGEMENT")
           echo "::add-mask::$ROOT_ACCOUNT_NUMBER"
-          echo ROOT_ACCOUNT_NUMBER=$ROOT_ACCOUNT_NUMBER >> $GITHUB_ENV
+          echo "ROOT_ACCOUNT_NUMBER=$ROOT_ACCOUNT_NUMBER" >> "$GITHUB_ENV"
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@cbe3b392738ccf3f987d68400dafcf4b0624a56c # v6.2.4
         with:
@@ -574,10 +576,11 @@ jobs:
       - name: Update permission sets
         run: |
           aws sts assume-role --role-arn "arn:aws:iam::${ROOT_ACCOUNT_NUMBER}:role/ModernisationPlatformSSOAdministrator" --role-session-name ssoadminrolesession > creds
-          $(echo "export AWS_ACCESS_KEY_ID=$(echo $(cat creds) | sed -n 's/.*"AccessKeyId": "\([^"]*\)".*/\1/p')")
-          $(echo "export AWS_SECRET_ACCESS_KEY=$(echo $(cat creds) | sed -n 's/.*"SecretAccessKey": "\([^"]*\)".*/\1/p')")
-          $(echo "export AWS_SESSION_TOKEN=$(echo $(cat creds) | sed -n 's/.*"SessionToken": "\([^"]*\)".*/\1/p')")
-          grep "ModernisationPlatformSSOAdministrator" <<< $(aws sts get-caller-identity) || { echo 'Failed to assume role' ; exit 1; }
+          AWS_ACCESS_KEY_ID=$(jq -r '.Credentials.AccessKeyId' creds)
+          AWS_SECRET_ACCESS_KEY=$(jq -r '.Credentials.SecretAccessKey' creds)
+          AWS_SESSION_TOKEN=$(jq -r '.Credentials.SessionToken' creds)
+          export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
+          aws sts get-caller-identity | grep "ModernisationPlatformSSOAdministrator" || { echo 'Failed to assume role' ; exit 1; }
           bash scripts/update-sso-permission-sets.sh
       - name: Slack failure notification
         uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0

--- a/.github/workflows/secrets-rotation-reminder.yml
+++ b/.github/workflows/secrets-rotation-reminder.yml
@@ -66,9 +66,9 @@ jobs:
 
         - name: Set Account Number
           run: |
-            ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< $ENVIRONMENT_MANAGEMENT)
+            ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< "$ENVIRONMENT_MANAGEMENT")
             echo "::add-mask::$ACCOUNT_NUMBER"
-            echo ACCOUNT_NUMBER=$ACCOUNT_NUMBER >> $GITHUB_ENV
+            echo "ACCOUNT_NUMBER=$ACCOUNT_NUMBER" >> "$GITHUB_ENV"
   
         - name: Configure AWS Credentials
           uses: aws-actions/configure-aws-credentials@cbe3b392738ccf3f987d68400dafcf4b0624a56c # v6.2.4
@@ -82,11 +82,11 @@ jobs:
             GH_TOKEN: ${{ steps.app.outputs.token }}
           run: |
             # Get the list of secret names from AWS Secrets Manager
-            secrets=$(aws secretsmanager list-secrets --region $AWS_REGION --query "SecretList[].Name" --output text)
+            read -r -a secrets <<< "$(aws secretsmanager list-secrets --region "$AWS_REGION" --query "SecretList[].Name" --output text)"
             
             # Remove secrets from list that are exempt from rotation
             delete=("environment_management" "nuke_account_ids" "nuke_account_blocklist" "nuke_rebuild_account_ids" "mod-platform-circleci" "pagerduty_integration_keys" "nonmp-account-ids" "modernisation_platform_github_app_client_id")
-            for del in ${delete[@]}
+            for del in "${delete[@]}"
             do
               secrets=("${secrets[@]/$del}")
             done
@@ -98,8 +98,8 @@ jobs:
             current_timestamp=$(date +%s)
             
             # Loop through each secret,  check its last changed date and raise issue if required
-            for secret in $secrets; do
-              last_changed=$(aws secretsmanager list-secret-version-ids --secret-id $secret --region $AWS_REGION --query "Versions[?contains(VersionStages,'AWSCURRENT')].CreatedDate" --output text | sort -r | head -n 1)
+            for secret in "${secrets[@]}"; do
+              last_changed=$(aws secretsmanager list-secret-version-ids --secret-id "$secret" --region "$AWS_REGION" --query "Versions[?contains(VersionStages,'AWSCURRENT')].CreatedDate" --output text | sort -r | head -n 1)
               
               # If the secret has never been changed, set the last_changed date to 0
               if [ -z "$last_changed" ]; then
@@ -113,11 +113,11 @@ jobs:
               open_issue_count=$(gh issue list -R ministryofjustice/modernisation-platform --state open --limit 500 --json title --jq "[.[] | select(.title | contains(\"Rotate $secret\"))] | length")
             
               # Check if the secret is older than the threshold and if there is no existing open issue to rotate it, raise a new issue
-              if [ $age -gt $threshold ] && [ "$open_issue_count" -eq 0 ]; then
+              if [ "$age" -gt "$threshold" ] && [ "$open_issue_count" -eq 0 ]; then
                 echo "$secret secret is older than 180 days (age: $((age / (24 * 60 * 60))) days)"
                 echo "Creating GitHub Issue to rotate $secret"
                 gh issue create --title "Rotate $secret Credential" --label "security,kanban" --project "Modernisation Platform" --body "The secrets-rotation-reminder workflow has identified that the $secret credential requires rotation as it is close to or exceeding the threshold of 180 days. Consult the [documentation](https://user-guide.modernisation-platform.service.justice.gov.uk/runbooks/rotating-secrets.html#how-to-rotate-secrets) which describes the process for rotation."
-              elif [ $age -gt $threshold ] && [ "$open_issue_count" -gt 0 ]; then
+              elif [ "$age" -gt "$threshold" ] && [ "$open_issue_count" -gt 0 ]; then
                 echo "$secret secret is older than 180 days (age: $((age / (24 * 60 * 60))) days) but an issue has already been raised to address this"
               else 
                 echo "The $secret secret has not been identified for rotation (age: $((age / (24 * 60 * 60))) days)"

--- a/.github/workflows/terraform-member-environment.yml
+++ b/.github/workflows/terraform-member-environment.yml
@@ -60,10 +60,11 @@ jobs:
             CHANGED_DIRECTORIES=$(git diff HEAD^ HEAD --name-only | awk '{print $1}' | grep ".tf" | grep -a "environments//*" | cut -f1-3 -d"/" | uniq | base64 -w 0)
             CHANGED_DIRECTORY_NAMES=$(git diff HEAD^ HEAD --name-only | awk '{print $1}' | grep ".tf" | grep -a "environments//*" | cut -f3 -d"/" | uniq | jq -R -s -c 'split("\n")[:-1]')
           fi
-          echo "CHANGED_DIRECTORIES=$CHANGED_DIRECTORIES" >> $GITHUB_OUTPUT
-          echo "CHANGED_DIRECTORY_NAMES=$CHANGED_DIRECTORY_NAMES" >> $GITHUB_OUTPUT
+          echo "CHANGED_DIRECTORIES=$CHANGED_DIRECTORIES" >> "$GITHUB_OUTPUT"
+          echo "CHANGED_DIRECTORY_NAMES=$CHANGED_DIRECTORY_NAMES" >> "$GITHUB_OUTPUT"
       - name: Display changed directories
-        run: echo "Directories in scope:" ${{ steps.directories.outputs.CHANGED_DIRECTORIES }}
+        run: |
+          echo "Directories in scope: ${{ steps.directories.outputs.CHANGED_DIRECTORIES }}"
       - name: Slack failure notification
         uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
         with:
@@ -100,14 +101,14 @@ jobs:
           APPLICATION_ENVIRONMENT="${{ matrix.application }}-${{ matrix.environment }}"
           echo "Application: $APPLICATION_ENVIRONMENT"
           ACCOUNT_NUMBER=$(echo "$ENVIRONMENT_MANAGEMENT" | jq -r --arg app_env "$APPLICATION_ENVIRONMENT" '.account_ids[$app_env] // empty')
-          echo $ACCOUNT_NUMBER
+          echo "$ACCOUNT_NUMBER"
           if [ -z "$ACCOUNT_NUMBER" ]; then
             echo "::warning::Account number not found for $APPLICATION_ENVIRONMENT, skipping..."
-            echo "SKIP=true" >> $GITHUB_ENV
+            echo "SKIP=true" >> "$GITHUB_ENV"
           else
             echo "::add-mask::$ACCOUNT_NUMBER"
-            echo ACCOUNT_NUMBER=$ACCOUNT_NUMBER >> $GITHUB_ENV
-            echo "SKIP=false" >> $GITHUB_ENV
+            echo "ACCOUNT_NUMBER=$ACCOUNT_NUMBER" >> "$GITHUB_ENV"
+            echo "SKIP=false" >> "$GITHUB_ENV"
           fi
       - name: Configure AWS credentials
         if: env.SKIP == 'false'
@@ -128,7 +129,7 @@ jobs:
         id: init
         run: |
           echo "Running 'terraform init' in terraform/environments/${{ matrix.application }}" 
-          scripts/terraform-init.sh terraform/environments/${{ matrix.application }}
+          scripts/terraform-init.sh "terraform/environments/${{ matrix.application }}"
       - name: Terraform workspace
         if: env.SKIP == 'false'
         id: workspace
@@ -139,7 +140,7 @@ jobs:
         if: env.SKIP == 'false'
         id: plan
         run: |
-          scripts/terraform-plan.sh terraform/environments/${{ matrix.application }}
+          scripts/terraform-plan.sh "terraform/environments/${{ matrix.application }}"
 
   terraform-plan-preprod-prod:
     runs-on: ubuntu-latest
@@ -160,9 +161,9 @@ jobs:
           PASSPHRASE: ${{ secrets.PASSPHRASE }}        
       - name: Set account number
         run: |
-          ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< $ENVIRONMENT_MANAGEMENT)
+          ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< "$ENVIRONMENT_MANAGEMENT")
           echo "::add-mask::$ACCOUNT_NUMBER"
-          echo ACCOUNT_NUMBER=$ACCOUNT_NUMBER >> $GITHUB_ENV
+          echo "ACCOUNT_NUMBER=$ACCOUNT_NUMBER" >> "$GITHUB_ENV"
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@cbe3b392738ccf3f987d68400dafcf4b0624a56c # v6.2.4
         with:
@@ -178,39 +179,40 @@ jobs:
       - name: Terraform init
         id: init
         run: |
-          export CHANGED_DIRECTORIES=$(echo "${{ needs.find-environments.outputs.directories }}" | base64 --decode)
-          for directory in $CHANGED_DIRECTORIES; do
-            echo "Running 'terraform init' in" $directory
-            scripts/terraform-init.sh $directory
-          done
+          CHANGED_DIRECTORIES=$(echo "${{ needs.find-environments.outputs.directories }}" | base64 --decode)
+          export CHANGED_DIRECTORIES
+          while IFS= read -r directory; do
+            echo "Running 'terraform init' in $directory"
+            scripts/terraform-init.sh "$directory"
+          done <<< "$CHANGED_DIRECTORIES"
       - name: Terraform workspace
         id: workspace
         run: |
-          export CHANGED_DIRECTORIES=$(echo "${{ needs.find-environments.outputs.directories }}" | base64 --decode)
-          for directory in $CHANGED_DIRECTORIES; do
-                workspace="$(basename $directory)-${{ matrix.environment }}"
+          CHANGED_DIRECTORIES=$(echo "${{ needs.find-environments.outputs.directories }}" | base64 --decode)
+          export CHANGED_DIRECTORIES
+          while IFS= read -r directory; do
+                workspace="$(basename "$directory")-${{ matrix.environment }}"
 
                 if terraform -chdir="$directory" workspace list | grep "$workspace"; then
                   terraform -chdir="$directory" workspace select "$workspace"
 
                 else
                   echo "Workspace '$workspace' does not exist, skipping further processing"
-                  echo "skip_plan=true" >> $GITHUB_OUTPUT
+                  echo "skip_plan=true" >> "$GITHUB_OUTPUT"
                 fi
 
                 unset workspace
-          done
+          done <<< "$CHANGED_DIRECTORIES"
           echo "Selected $(terraform -chdir="$directory" workspace show)"
       - name: Terraform plan
         id: plan
         if: ${{ steps.workspace.outputs.skip_plan != 'true' }}
         run: |
-          export CHANGED_DIRECTORIES=$(echo "${{ needs.find-environments.outputs.directories }}" | base64 --decode)
-          for directory in $CHANGED_DIRECTORIES; do
-            workspace="$(basename $directory)-${{ matrix.environment }}"
-            scripts/terraform-plan.sh $directory
-            unset workspace
-          done
+          CHANGED_DIRECTORIES=$(echo "${{ needs.find-environments.outputs.directories }}" | base64 --decode)
+          export CHANGED_DIRECTORIES
+          while IFS= read -r directory; do
+            scripts/terraform-plan.sh "$directory"
+          done <<< "$CHANGED_DIRECTORIES"
       - name: Mark job skipped
         if: ${{ steps.workspace.outputs.skip_plan == 'true' }}
         run: |
@@ -241,14 +243,14 @@ jobs:
           APPLICATION_ENVIRONMENT="${{ matrix.application }}-${{ matrix.environment }}"
           echo "Application: $APPLICATION_ENVIRONMENT"
           ACCOUNT_NUMBER=$(echo "$ENVIRONMENT_MANAGEMENT" | jq -r --arg app_env "$APPLICATION_ENVIRONMENT" '.account_ids[$app_env] // empty')
-          echo $ACCOUNT_NUMBER
+          echo "$ACCOUNT_NUMBER"
           if [ -z "$ACCOUNT_NUMBER" ]; then
             echo "::warning::Account number not found for $APPLICATION_ENVIRONMENT, skipping..."
-            echo "SKIP=true" >> $GITHUB_ENV
+            echo "SKIP=true" >> "$GITHUB_ENV"
           else
             echo "::add-mask::$ACCOUNT_NUMBER"
-            echo ACCOUNT_NUMBER=$ACCOUNT_NUMBER >> $GITHUB_ENV
-            echo "SKIP=false" >> $GITHUB_ENV
+            echo "ACCOUNT_NUMBER=$ACCOUNT_NUMBER" >> "$GITHUB_ENV"
+            echo "SKIP=false" >> "$GITHUB_ENV"
           fi
       - name: Configure AWS credentials
         if: env.SKIP == 'false'
@@ -269,7 +271,7 @@ jobs:
         id: init
         run: |
           echo "Running 'terraform init' in terraform/environments/${{ matrix.application }}" 
-          scripts/terraform-init.sh terraform/environments/${{ matrix.application }}
+          scripts/terraform-init.sh "terraform/environments/${{ matrix.application }}"
       - name: Terraform workspace
         if: env.SKIP == 'false'
         id: workspace
@@ -280,7 +282,7 @@ jobs:
         if: env.SKIP == 'false'
         id: apply
         run: |
-          scripts/terraform-apply.sh terraform/environments/${{ matrix.application }}
+          scripts/terraform-apply.sh "terraform/environments/${{ matrix.application }}"
 
   terraform-apply-preprod-prod:
     if: github.ref == 'refs/heads/main'
@@ -304,9 +306,9 @@ jobs:
           PASSPHRASE: ${{ secrets.PASSPHRASE }}
       - name: Set account number
         run: |
-          ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< $ENVIRONMENT_MANAGEMENT)
+          ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< "$ENVIRONMENT_MANAGEMENT")
           echo "::add-mask::$ACCOUNT_NUMBER"
-          echo ACCOUNT_NUMBER=$ACCOUNT_NUMBER >> $GITHUB_ENV
+          echo "ACCOUNT_NUMBER=$ACCOUNT_NUMBER" >> "$GITHUB_ENV"
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@cbe3b392738ccf3f987d68400dafcf4b0624a56c # v6.2.4
         with:
@@ -322,49 +324,53 @@ jobs:
       - name: Terraform init
         id: init
         run: |
-          export CHANGED_DIRECTORIES=$(echo "${{ needs.find-environments.outputs.directories }}" | base64 --decode)
-          for directory in $CHANGED_DIRECTORIES; do
-            echo "Running 'terraform init' in" $directory
-            scripts/terraform-init.sh $directory
-          done
+          CHANGED_DIRECTORIES=$(echo "${{ needs.find-environments.outputs.directories }}" | base64 --decode)
+          export CHANGED_DIRECTORIES
+          while IFS= read -r directory; do
+            echo "Running 'terraform init' in $directory"
+            scripts/terraform-init.sh "$directory"
+          done <<< "$CHANGED_DIRECTORIES"
       - name: Terraform workspace
         id: workspace
         run: |
-          export CHANGED_DIRECTORIES=$(echo "${{ needs.find-environments.outputs.directories }}" | base64 --decode)
-          for directory in $CHANGED_DIRECTORIES; do
-                workspace="$(basename $directory)-${{ matrix.environment }}"
+          CHANGED_DIRECTORIES=$(echo "${{ needs.find-environments.outputs.directories }}" | base64 --decode)
+          export CHANGED_DIRECTORIES
+          while IFS= read -r directory; do
+                workspace="$(basename "$directory")-${{ matrix.environment }}"
 
                 if terraform -chdir="$directory" workspace list | grep "$workspace"; then
                   terraform -chdir="$directory" workspace select "$workspace"
 
                 else
                   echo "Workspace '$workspace' does not exist, skipping further processing"
-                  echo "skip_plan=true" >> $GITHUB_OUTPUT
+                  echo "skip_plan=true" >> "$GITHUB_OUTPUT"
                 fi
 
                 unset workspace
-          done
+          done <<< "$CHANGED_DIRECTORIES"
           echo "Selected $(terraform -chdir="$directory" workspace show)"
       - name: Terraform plan
         id: plan
         if: ${{ steps.workspace.outputs.skip_plan != 'true' }}
         run: |
-          export CHANGED_DIRECTORIES=$(echo "${{ needs.find-environments.outputs.directories }}" | base64 --decode)
-          for directory in $CHANGED_DIRECTORIES; do
-            workspace="$(basename $directory)-${{ matrix.environment }}"
-            scripts/terraform-plan.sh $directory -out="$workspace.tfplan"
+          CHANGED_DIRECTORIES=$(echo "${{ needs.find-environments.outputs.directories }}" | base64 --decode)
+          export CHANGED_DIRECTORIES
+          while IFS= read -r directory; do
+            workspace="$(basename "$directory")-${{ matrix.environment }}"
+            scripts/terraform-plan.sh "$directory" -out="$workspace.tfplan"
             unset workspace
-          done
+          done <<< "$CHANGED_DIRECTORIES"
       - name: Terraform apply
         id: apply
         if: ${{ steps.plan.conclusion == 'success' }}
         run: |
-          export CHANGED_DIRECTORIES=$(echo "${{ needs.find-environments.outputs.directories }}" | base64 --decode)
-          for directory in $CHANGED_DIRECTORIES; do
-            workspace="$(basename $directory)-${{ matrix.environment }}"
-            scripts/terraform-apply.sh $directory "$workspace.tfplan"
+          CHANGED_DIRECTORIES=$(echo "${{ needs.find-environments.outputs.directories }}" | base64 --decode)
+          export CHANGED_DIRECTORIES
+          while IFS= read -r directory; do
+            workspace="$(basename "$directory")-${{ matrix.environment }}"
+            scripts/terraform-apply.sh "$directory" "$workspace.tfplan"
             unset workspace
-          done
+          done <<< "$CHANGED_DIRECTORIES"
 
       - name: Slack failure notification
         uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0

--- a/.github/workflows/terraform-unlock-state.yml
+++ b/.github/workflows/terraform-unlock-state.yml
@@ -46,19 +46,25 @@ jobs:
           ENV="${{ github.event.inputs.environment }}"
 
           if [[ "$COMPONENT" == "github" || "$COMPONENT" == "pagerduty" || "$COMPONENT" == "single-sign-on" || "$COMPONENT" == "modernisation-platform-account" ]]; then
-            echo "TF_PATH=terraform/$COMPONENT" >> $GITHUB_ENV
-            echo "TF_WORKSPACE=default" >> $GITHUB_ENV
-            echo "S3_LOCK_KEY=$COMPONENT/terraform.tfstate.tflock" >> $GITHUB_ENV
+            {
+              echo "TF_PATH=terraform/$COMPONENT"
+              echo "TF_WORKSPACE=default"
+              echo "S3_LOCK_KEY=$COMPONENT/terraform.tfstate.tflock"
+            } >> "$GITHUB_ENV"
 
           elif [[ "$COMPONENT" == "environments" ]]; then
             if [[ -n "$APP_NAME" && -n "$ENV" ]]; then
-              echo "TF_PATH=terraform/environments/$APP_NAME" >> $GITHUB_ENV
-              echo "TF_WORKSPACE=${APP_NAME}-${ENV}" >> $GITHUB_ENV
-              echo "S3_LOCK_KEY=environments/accounts/$APP_NAME/${APP_NAME}-${ENV}/terraform.tfstate.tflock" >> $GITHUB_ENV
+              {
+                echo "TF_PATH=terraform/environments/$APP_NAME"
+                echo "TF_WORKSPACE=${APP_NAME}-${ENV}"
+                echo "S3_LOCK_KEY=environments/accounts/$APP_NAME/${APP_NAME}-${ENV}/terraform.tfstate.tflock"
+              } >> "$GITHUB_ENV"
             else
-              echo "TF_PATH=terraform/environments" >> $GITHUB_ENV
-              echo "TF_WORKSPACE=default" >> $GITHUB_ENV
-              echo "S3_LOCK_KEY=environments/terraform.tfstate.tflock" >> $GITHUB_ENV
+              {
+                echo "TF_PATH=terraform/environments"
+                echo "TF_WORKSPACE=default"
+                echo "S3_LOCK_KEY=environments/terraform.tfstate.tflock"
+              } >> "$GITHUB_ENV"
             fi
 
           elif [[ "$COMPONENT" == bootstrap/* ]]; then
@@ -67,9 +73,11 @@ jobs:
               exit 1
             fi
             BOOTSTRAP_COMPONENT="${COMPONENT#bootstrap/}"
-            echo "TF_PATH=terraform/environments/$COMPONENT" >> $GITHUB_ENV
-            echo "TF_WORKSPACE=${APP_NAME}-${ENV}" >> $GITHUB_ENV
-            echo "S3_LOCK_KEY=environments/bootstrap/$BOOTSTRAP_COMPONENT/${APP_NAME}-${ENV}/terraform.tfstate.tflock" >> $GITHUB_ENV
+            {
+              echo "TF_PATH=terraform/environments/$COMPONENT"
+              echo "TF_WORKSPACE=${APP_NAME}-${ENV}"
+              echo "S3_LOCK_KEY=environments/bootstrap/$BOOTSTRAP_COMPONENT/${APP_NAME}-${ENV}/terraform.tfstate.tflock"
+            } >> "$GITHUB_ENV"
 
           else
             echo "Unknown component: $COMPONENT"
@@ -98,17 +106,17 @@ jobs:
           echo "Checking for lock file at: s3://modernisation-platform-terraform-state/$S3_LOCK_KEY"
           
           if aws s3api head-object --bucket modernisation-platform-terraform-state --key "$S3_LOCK_KEY" 2>/dev/null; then
-            echo "LOCK_EXISTS=true" >> $GITHUB_OUTPUT
+            echo "LOCK_EXISTS=true" >> "$GITHUB_OUTPUT"
             echo "Lock file exists, will proceed with unlock"
           else
-            echo "LOCK_EXISTS=false" >> $GITHUB_OUTPUT
+            echo "LOCK_EXISTS=false" >> "$GITHUB_OUTPUT"
             echo "Lock file does not exist, already unlocked"
           fi
 
       - name: Force Unlock State
         if: steps.check_lock.outputs.LOCK_EXISTS == 'true'
         working-directory: ${{ env.TF_PATH }}
-        run: terraform force-unlock -force ${{ github.event.inputs.lock_id }}
+        run: terraform force-unlock -force "${{ github.event.inputs.lock_id }}"
 
       - name: Lock already removed
         if: steps.check_lock.outputs.LOCK_EXISTS == 'false'

--- a/.github/workflows/update-securityhub-slack-secret.yml
+++ b/.github/workflows/update-securityhub-slack-secret.yml
@@ -26,8 +26,8 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
       - name: MASK Slack webhook
         run: |
-          slack_webhook_url=$(cat $GITHUB_EVENT_PATH | jq -r '.inputs.slack_webhook_url' )
+          slack_webhook_url=$(cat "$GITHUB_EVENT_PATH" | jq -r '.inputs.slack_webhook_url' )
           echo "::add-mask::$slack_webhook_url" 
-           echo "SLACK_WEBHOOK_URL=$slack_webhook_url" >> $GITHUB_ENV
+           echo "SLACK_WEBHOOK_URL=$slack_webhook_url" >> "$GITHUB_ENV"
       - name: Run Secret Update Script
-        run: ./scripts/update_securityhub_secret.sh ${{ github.event.inputs.application }} ${{ env.SLACK_WEBHOOK_URL }}
+        run: ./scripts/update_securityhub_secret.sh "${{ github.event.inputs.application }}" "${{ env.SLACK_WEBHOOK_URL }}"

--- a/.github/workflows/upload-cost-explorer-to-s3.yml
+++ b/.github/workflows/upload-cost-explorer-to-s3.yml
@@ -32,9 +32,9 @@ jobs:
 
       - name: Set Account Number
         run: |
-          ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< $ENVIRONMENT_MANAGEMENT)
+          ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< "$ENVIRONMENT_MANAGEMENT")
           echo "::add-mask::$ACCOUNT_NUMBER"
-          echo ACCOUNT_NUMBER=$ACCOUNT_NUMBER >> $GITHUB_ENV
+          echo "ACCOUNT_NUMBER=$ACCOUNT_NUMBER" >> "$GITHUB_ENV"
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@cbe3b392738ccf3f987d68400dafcf4b0624a56c # v6.2.4


### PR DESCRIPTION
## What

Resolves the scheduled Code Quality `ACTION/actionlint` findings across the top-level GitHub Actions workflows.

The changes are focused on actionlint/ShellCheck remediation, including:

- quoting shell variable expansions and `GITHUB_ENV` / `GITHUB_OUTPUT` writes
- grouping repeated output redirects where ShellCheck requested it
- replacing fragile generated shell execution when assuming STS credentials
- preserving string-typed reusable workflow inputs using explicit string expressions
- removing unsupported `paths` filtering from the `merge_group` event in the OPA policy workflow
- fixing a `PR_TITLE` / `pr_title` variable mismatch in the environment request workflow

## Why

The scheduled Code Quality workflow reported a large number of `ACTION/actionlint` findings. This PR addresses that linter class separately so the wider Code Quality rollout can be reviewed and validated in smaller, clearer chunks.

## Validation

- `actionlint` against all top-level `.github/workflows/*.yml` and `.github/workflows/*.yaml`: pass
- `git diff --check`: pass