### PR TITLE
Fix Zizmor findings in workflows

### DIFF
--- a/.github/workflows/access-keys-monitoring.yml
+++ b/.github/workflows/access-keys-monitoring.yml
@@ -10,15 +10,15 @@ env:
     TEMPLATE_ID: "1f0f5ccc-0f67-4ee2-942f-6e48804828ea"
     EXPECTED_TEMPLATE_VERSION: "1"  # Update with your expected template version
 
-permissions:
-    id-token: write # This is required for requesting the JWT
-    contents: read # This is required for actions/checkout
-    issues: write # This is required to create issues
+permissions: {}
 
 jobs:
 
   fetch-secrets:
     uses: ministryofjustice/modernisation-platform-github-actions/.github/workflows/aws-secrets-management.yml@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read # This is required for actions/checkout
     secrets:
       MODERNISATION_PLATFORM_ACCOUNT_NUMBER: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_NUMBER }}
       PASSPHRASE: ${{ secrets.PASSPHRASE }}  
@@ -26,6 +26,10 @@ jobs:
   delete-superadmin-access-keys:
     runs-on: ubuntu-latest
     needs: fetch-secrets
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read # This is required for actions/checkout
+      issues: write # This is required to create issues
     steps:
       # Step 1: Checkout Repository
       - name: Checkout Repository
@@ -58,11 +62,12 @@ jobs:
         run: |
           python <<EOF
           from notifications_python_client.notifications import NotificationsAPIClient
+          import os
           import sys
 
-          api_key = "${{ env.GOV_UK_NOTIFY_API_KEY }}"
-          template_id = "${{ env.TEMPLATE_ID }}"
-          expected_version = int("${{ env.EXPECTED_TEMPLATE_VERSION }}")
+          api_key = os.environ["API_KEY"]
+          template_id = os.environ["TEMPLATE_ID"]
+          expected_version = int(os.environ["EXPECTED_TEMPLATE_VERSION"])
 
           client = NotificationsAPIClient(api_key)
           try:

--- a/.github/workflows/access-keys-monitoring.yml
+++ b/.github/workflows/access-keys-monitoring.yml
@@ -34,6 +34,8 @@ jobs:
       # Step 1: Checkout Repository
       - name: Checkout Repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       # Step 1.1: Decrypt Secrets
       - name: Decrypt Secrets

--- a/.github/workflows/account-network-update.yml
+++ b/.github/workflows/account-network-update.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Download network setup artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/awsnuke.yml
+++ b/.github/workflows/awsnuke.yml
@@ -95,6 +95,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       
       - name: Decrypt Secrets
         uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
@@ -132,9 +134,11 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Setup Nuke Config
+        env:
+          ACCOUNT_BLOCKLIST_STR: ${{ needs.setup-prerequisites.outputs.account_blocklist_str }}
         run: |
           export accounts_str="$ACCOUNTS_STR"
-          account_blocklist_str=$(echo "${{ needs.setup-prerequisites.outputs.account_blocklist_str }}" | base64 --decode)
+          account_blocklist_str=$(echo "$ACCOUNT_BLOCKLIST_STR" | base64 --decode)
           export account_blocklist_str
           cat scripts/nuke-config-template.txt | envsubst > nuke-config.yml
 

--- a/.github/workflows/bootstrap-sprinkler.yml
+++ b/.github/workflows/bootstrap-sprinkler.yml
@@ -40,6 +40,8 @@ jobs:
       contents: read # This is required for actions/checkout
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Decrypt Secrets
         uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
         with:
@@ -71,6 +73,8 @@ jobs:
       contents: read # This is required for actions/checkout
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Decrypt Secrets
         uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
         with:
@@ -103,6 +107,8 @@ jobs:
       contents: read # This is required for actions/checkout
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Decrypt Secrets
         uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
         with:
@@ -135,6 +141,8 @@ jobs:
       contents: read # This is required for actions/checkout
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Decrypt Secrets
         uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
         with:
@@ -168,6 +176,8 @@ jobs:
       contents: read # This is required for actions/checkout
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Decrypt Secrets
         uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
         with:
@@ -200,6 +210,8 @@ jobs:
       contents: read # This is required for actions/checkout
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Decrypt Secrets
         uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
         with:
@@ -232,6 +244,8 @@ jobs:
       contents: read # This is required for actions/checkout
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Decrypt Secrets
         uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
         with:
@@ -264,6 +278,8 @@ jobs:
       contents: read # This is required for actions/checkout
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Decrypt Secrets
         uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
         with:

--- a/.github/workflows/bootstrap-sprinkler.yml
+++ b/.github/workflows/bootstrap-sprinkler.yml
@@ -15,9 +15,7 @@ env:
   AWS_REGION: "eu-west-2"
   TF_WORKSPACE: "sprinkler-development"
 
-permissions:
-  id-token: write # This is required for requesting the JWT
-  contents: read # This is required for actions/checkout
+permissions: {}
 
 defaults:
   run:
@@ -27,6 +25,9 @@ jobs:
 
   fetch-secrets:
     uses: ministryofjustice/modernisation-platform-github-actions/.github/workflows/aws-secrets-management.yml@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read # This is required for actions/checkout
     secrets:
       MODERNISATION_PLATFORM_ACCOUNT_NUMBER: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_NUMBER }}
       PASSPHRASE: ${{ secrets.PASSPHRASE }}
@@ -34,6 +35,9 @@ jobs:
   delegate-access-plan:
     runs-on: ubuntu-latest
     needs: fetch-secrets
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read # This is required for actions/checkout
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Decrypt Secrets
@@ -62,6 +66,9 @@ jobs:
   secure-baselines-plan:
     runs-on: ubuntu-latest
     needs: [delegate-access-plan, fetch-secrets]
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read # This is required for actions/checkout
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Decrypt Secrets
@@ -91,6 +98,9 @@ jobs:
   single-sign-on-plan:
     runs-on: ubuntu-latest
     needs: [delegate-access-plan, fetch-secrets]
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read # This is required for actions/checkout
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Decrypt Secrets
@@ -120,6 +130,9 @@ jobs:
   member-bootstrap-plan:
     runs-on: ubuntu-latest
     needs: [single-sign-on-plan, fetch-secrets]
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read # This is required for actions/checkout
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Decrypt Secrets
@@ -150,6 +163,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: fetch-secrets
     environment: production
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read # This is required for actions/checkout
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Decrypt Secrets
@@ -179,6 +195,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [delegate-access-apply, fetch-secrets]
     environment: production
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read # This is required for actions/checkout
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Decrypt Secrets
@@ -208,6 +227,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [delegate-access-apply, fetch-secrets]
     environment: production
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read # This is required for actions/checkout
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Decrypt Secrets
@@ -237,6 +259,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [single-sign-on-apply, fetch-secrets]
     environment: production
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read # This is required for actions/checkout
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Decrypt Secrets

--- a/.github/workflows/check-broken-links.yml
+++ b/.github/workflows/check-broken-links.yml
@@ -24,12 +24,15 @@ jobs:
 
       - name: Get files to check
         id: files
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
+          if [ "$EVENT_NAME" = "pull_request" ]; then
             # For PRs, only check changed markdown files
-            git fetch origin ${{ github.base_ref }} --depth=1
-            FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- '*.md' '*.md.erb')
-          elif [ "${{ github.event_name }}" = "push" ]; then
+            git fetch origin "$BASE_REF" --depth=1
+            FILES=$(git diff --name-only "origin/${BASE_REF}...HEAD" -- '*.md' '*.md.erb')
+          elif [ "$EVENT_NAME" = "push" ]; then
             # Temporarily scan all markdown files on push for testing
             FILES=$(git ls-files '*.md' '*.md.erb')
           else

--- a/.github/workflows/check-broken-links.yml
+++ b/.github/workflows/check-broken-links.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Get files to check
         id: files

--- a/.github/workflows/confirm-contacts-for-environments.yml
+++ b/.github/workflows/confirm-contacts-for-environments.yml
@@ -36,6 +36,8 @@ jobs:
       # Step 1: Checkout the repository
       - name: Checkout Repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       # Step 1.1: Decrypt Secrets  
       - name: Decrypt Secrets

--- a/.github/workflows/confirm-contacts-for-environments.yml
+++ b/.github/workflows/confirm-contacts-for-environments.yml
@@ -11,14 +11,16 @@ env:
     TEMPLATE_ID: "1f0f5ccc-0f67-4ee2-942f-6e48804828ea"
     EXPECTED_TEMPLATE_VERSION: 1 # Set the expected template version here
     PERIOD: "12" # This variable determines the number of months we look back for created dates.
-permissions:
-    id-token: write
+permissions: {}
 defaults:
   run:
     shell: bash
 jobs:
   fetch-secrets:
     uses: ministryofjustice/modernisation-platform-github-actions/.github/workflows/aws-secrets-management.yml@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
+    permissions:
+      id-token: write
+      contents: read
     secrets:
       MODERNISATION_PLATFORM_ACCOUNT_NUMBER: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_NUMBER }}
       PASSPHRASE: ${{ secrets.PASSPHRASE }}  
@@ -58,10 +60,11 @@ jobs:
         run: |
           python <<EOF
           from notifications_python_client.notifications import NotificationsAPIClient
+          import os
           import sys
-          api_key = "${{ env.GOV_UK_NOTIFY_API_KEY }}"
-          template_id = "${{ env.TEMPLATE_ID }}"
-          expected_version = int("${{ env.EXPECTED_TEMPLATE_VERSION }}")
+          api_key = os.environ["API_KEY"]
+          template_id = os.environ["TEMPLATE_ID"]
+          expected_version = int(os.environ["EXPECTED_TEMPLATE_VERSION"])
           client = NotificationsAPIClient(api_key)
           try:
               template_details = client.get_template(template_id)

--- a/.github/workflows/create-newenv.yml
+++ b/.github/workflows/create-newenv.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0

--- a/.github/workflows/delete-expired-recovery-points.yml
+++ b/.github/workflows/delete-expired-recovery-points.yml
@@ -6,9 +6,7 @@ on:
 
 env:
   AWS_REGION: "eu-west-2"
-permissions:
-  id-token: write 
-  contents: read 
+permissions: {}
 
 defaults:
   run:
@@ -18,6 +16,9 @@ jobs:
 
   fetch-secrets:
     uses: ministryofjustice/modernisation-platform-github-actions/.github/workflows/aws-secrets-management.yml@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
+    permissions:
+      id-token: write
+      contents: read
     secrets:
       MODERNISATION_PLATFORM_ACCOUNT_NUMBER: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_NUMBER }}
       PASSPHRASE: ${{ secrets.PASSPHRASE }}
@@ -25,6 +26,9 @@ jobs:
   delete-expired-recovery-points:
     runs-on: ubuntu-latest
     needs: fetch-secrets
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/delete-expired-recovery-points.yml
+++ b/.github/workflows/delete-expired-recovery-points.yml
@@ -32,6 +32,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Decrypt Secrets
         uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@2988728879704953e739f82ac926d37931c6d01b # v6.1.9

--- a/.github/workflows/export-route53-records.yml
+++ b/.github/workflows/export-route53-records.yml
@@ -6,19 +6,23 @@ on:
   workflow_dispatch:
 env:
   AWS_REGION: "eu-west-2"
-permissions:
-  id-token: write # This is required for requesting the JWT
-  contents: read # This is required for actions/checkout
+permissions: {}
 
 jobs:
   fetch-secrets:
     uses: ministryofjustice/modernisation-platform-github-actions/.github/workflows/aws-secrets-management.yml@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read # This is required for actions/checkout
     secrets:
       MODERNISATION_PLATFORM_ACCOUNT_NUMBER: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_NUMBER }}
       PASSPHRASE: ${{ secrets.PASSPHRASE }}
   export-route53-records:
     runs-on: ubuntu-latest
     needs: fetch-secrets
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read # This is required for actions/checkout
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Decrypt Secrets

--- a/.github/workflows/export-route53-records.yml
+++ b/.github/workflows/export-route53-records.yml
@@ -25,6 +25,8 @@ jobs:
       contents: read # This is required for actions/checkout
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Decrypt Secrets
         uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
         with:

--- a/.github/workflows/failed-workflows-report.yml
+++ b/.github/workflows/failed-workflows-report.yml
@@ -38,6 +38,8 @@ jobs:
 
         - name: Checkout Repository
           uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+          with:
+            persist-credentials: false
 
         - name: Decrypt Secrets
           uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@2988728879704953e739f82ac926d37931c6d01b # v6.1.9

--- a/.github/workflows/failed-workflows-report.yml
+++ b/.github/workflows/failed-workflows-report.yml
@@ -5,11 +5,7 @@ on:
     schedule:
       - cron: '45 8 * * 1-5'
 
-permissions:
-    actions: read
-    statuses: read  
-    contents: read
-    id-token: write
+permissions: {}
 
 env:
     GITHUB_REPO: ${{ github.repository }}
@@ -24,6 +20,9 @@ jobs:
 
   fetch-secrets:
     uses: ministryofjustice/modernisation-platform-github-actions/.github/workflows/aws-secrets-management.yml@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
+    permissions:
+      id-token: write
+      contents: read
     secrets:
       MODERNISATION_PLATFORM_ACCOUNT_NUMBER: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_NUMBER }}
       PASSPHRASE: ${{ secrets.PASSPHRASE }}  
@@ -31,6 +30,10 @@ jobs:
   generate-report:
     runs-on: ubuntu-latest
     needs: fetch-secrets
+    permissions:
+      actions: read
+      statuses: read
+      contents: read
     steps:
 
         - name: Checkout Repository

--- a/.github/workflows/generate-dora-metrics.yml
+++ b/.github/workflows/generate-dora-metrics.yml
@@ -54,6 +54,24 @@ jobs:
                   client-id: ${{ env.APP_ID }}
                   private-key: ${{ env.MP_GITHUB_APP_PRIVATE_KEY }}
                   owner: "ministryofjustice"
+                  permission-actions: read
+                  permission-contents: read
+                  permission-pull-requests: read
+                  repositories: >-
+                      modernisation-platform,modernisation-platform-ami-builds,modernisation-platform-cp-network-test,
+                      modernisation-platform-github-oidc-provider,modernisation-platform-github-oidc-role,
+                      modernisation-platform-instance-scheduler,modernisation-platform-terraform-aws-vm-import,
+                      modernisation-platform-terraform-baselines,modernisation-platform-terraform-bastion-linux,
+                      modernisation-platform-terraform-cross-account-access,modernisation-platform-terraform-dns-certificates,
+                      modernisation-platform-terraform-ec2-autoscaling-group,modernisation-platform-terraform-ec2-instance,
+                      modernisation-platform-terraform-ecs-cluster,modernisation-platform-terraform-environments,
+                      modernisation-platform-terraform-iam-superadmins,modernisation-platform-terraform-lambda-function,
+                      modernisation-platform-terraform-loadbalancer,modernisation-platform-terraform-member-vpc,
+                      modernisation-platform-terraform-pagerduty-integration,modernisation-platform-terraform-s3-bucket,
+                      modernisation-platform-terraform-s3-bucket-replication-role,modernisation-platform-terraform-ssm-patching,
+                      modernisation-platform-terraform-aws-chatbot,modernisation-platform-terraform-aws-waf,
+                      modernisation-platform-terraform-certificate-dns-validations,
+                      modernisation-platform-terraform-aws-data-firehose,modernisation-platform-github-actions
 
             - name: Set up Python
               uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 #v7.0.0
@@ -75,9 +93,11 @@ jobs:
 
             - name: Parse date_range input
               if: github.event.inputs.date_range != ''
+              env:
+                  DATE_RANGE: ${{ github.event.inputs.date_range }}
               run: |
-                  start_date=$(echo "${{ github.event.inputs.date_range }}" | cut -d. -f1)
-                  end_date=$(echo "${{ github.event.inputs.date_range }}" | rev | cut -d. -f1 | rev)
+                  start_date=$(echo "$DATE_RANGE" | cut -d. -f1)
+                  end_date=$(echo "$DATE_RANGE" | rev | cut -d. -f1 | rev)
                   echo "start_date=$start_date" >> "$GITHUB_ENV"
                   echo "end_date=$end_date" >> "$GITHUB_ENV"
 

--- a/.github/workflows/generate-dora-metrics.yml
+++ b/.github/workflows/generate-dora-metrics.yml
@@ -55,7 +55,6 @@ jobs:
               with:
                   client-id: ${{ env.APP_ID }}
                   private-key: ${{ env.MP_GITHUB_APP_PRIVATE_KEY }}
-                  owner: "ministryofjustice"
                   permission-actions: read
                   permission-contents: read
                   permission-pull-requests: read

--- a/.github/workflows/generate-dora-metrics.yml
+++ b/.github/workflows/generate-dora-metrics.yml
@@ -40,6 +40,8 @@ jobs:
         steps:
             - name: Checkout code
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+              with:
+                  persist-credentials: false
 
             - name: Decrypt Secrets
               uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@2988728879704953e739f82ac926d37931c6d01b # v6.1.9

--- a/.github/workflows/generate-dora-metrics.yml
+++ b/.github/workflows/generate-dora-metrics.yml
@@ -49,6 +49,28 @@ jobs:
                   mp_github_app_private_key: ${{ needs.fetch-secrets.outputs.mp_github_app_private_key }}
                   PASSPHRASE: ${{ secrets.PASSPHRASE }}
 
+            - name: Set GitHub App repository scope
+              id: app-scope
+              env:
+                  JSON_FILE_PATH: ${{ github.event.inputs.json_file_path }}
+              run: |
+                  set -euo pipefail
+                  shopt -s nullglob
+
+                  if [ -n "$JSON_FILE_PATH" ]; then
+                    json_files=("$JSON_FILE_PATH")
+                  else
+                    json_files=(scripts/dora-the-explora/*.json)
+                  fi
+
+                  if [ ${#json_files[@]} -eq 0 ]; then
+                    echo "::error::No DORA repository definition files found."
+                    exit 1
+                  fi
+
+                  repositories=$(jq -r -s '[.[].repos[]] | unique | join(",")' "${json_files[@]}")
+                  echo "repositories=$repositories" >> "$GITHUB_OUTPUT"
+
             - name: Create GitHub App token
               id: app
               uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
@@ -58,21 +80,7 @@ jobs:
                   permission-actions: read
                   permission-contents: read
                   permission-pull-requests: read
-                  repositories: >-
-                      modernisation-platform,modernisation-platform-ami-builds,modernisation-platform-cp-network-test,
-                      modernisation-platform-github-oidc-provider,modernisation-platform-github-oidc-role,
-                      modernisation-platform-instance-scheduler,modernisation-platform-terraform-aws-vm-import,
-                      modernisation-platform-terraform-baselines,modernisation-platform-terraform-bastion-linux,
-                      modernisation-platform-terraform-cross-account-access,modernisation-platform-terraform-dns-certificates,
-                      modernisation-platform-terraform-ec2-autoscaling-group,modernisation-platform-terraform-ec2-instance,
-                      modernisation-platform-terraform-ecs-cluster,modernisation-platform-terraform-environments,
-                      modernisation-platform-terraform-iam-superadmins,modernisation-platform-terraform-lambda-function,
-                      modernisation-platform-terraform-loadbalancer,modernisation-platform-terraform-member-vpc,
-                      modernisation-platform-terraform-pagerduty-integration,modernisation-platform-terraform-s3-bucket,
-                      modernisation-platform-terraform-s3-bucket-replication-role,modernisation-platform-terraform-ssm-patching,
-                      modernisation-platform-terraform-aws-chatbot,modernisation-platform-terraform-aws-waf,
-                      modernisation-platform-terraform-certificate-dns-validations,
-                      modernisation-platform-terraform-aws-data-firehose,modernisation-platform-github-actions
+                  repositories: ${{ steps.app-scope.outputs.repositories }}
 
             - name: Set up Python
               uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 #v7.0.0

--- a/.github/workflows/modernisation-member-information.yml
+++ b/.github/workflows/modernisation-member-information.yml
@@ -30,6 +30,8 @@ jobs:
     steps:
       - name: Checkout modernisation-platform Repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Checkout modernisation-platform-environments repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -37,6 +39,7 @@ jobs:
           repository: 'ministryofjustice/modernisation-platform-environments'
           token: ${{ secrets.GITHUB_TOKEN }}
           path: 'modernisation-platform-environments'
+          persist-credentials: false
 
       - name: Decrypt Secrets
         uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@2988728879704953e739f82ac926d37931c6d01b # v6.1.9

--- a/.github/workflows/modernisation-member-information.yml
+++ b/.github/workflows/modernisation-member-information.yml
@@ -8,14 +8,15 @@ on:
 env:
     AWS_REGION: "eu-west-2"
 
-permissions:
-    id-token: write # This is required for requesting the JWT
-    contents: read # This is required for actions/checkout
+permissions: {}
 
 jobs:
 
   fetch-secrets:
     uses: ministryofjustice/modernisation-platform-github-actions/.github/workflows/aws-secrets-management.yml@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read # This is required for actions/checkout
     secrets:
       MODERNISATION_PLATFORM_ACCOUNT_NUMBER: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_NUMBER }}
       PASSPHRASE: ${{ secrets.PASSPHRASE }}  
@@ -23,6 +24,9 @@ jobs:
   member-information:
     runs-on: ubuntu-latest
     needs: fetch-secrets
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read # This is required for actions/checkout
     steps:
       - name: Checkout modernisation-platform Repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/modernisation-platform-account.yml
+++ b/.github/workflows/modernisation-platform-account.yml
@@ -35,8 +35,8 @@ jobs:
     with:
       working-directory: "terraform/modernisation-platform-account"
       workflow_id: "modernisation-platform-account"
-      set_github_app_token: ${{ 'true' }}
-      download_collaborators: ${{ 'true' }}
+      set_github_app_token: true
+      download_collaborators: true
     secrets:
       MODERNISATION_PLATFORM_ACCOUNT_NUMBER: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_NUMBER }}
       PASSPHRASE: ${{ secrets.PASSPHRASE }}

--- a/.github/workflows/monitor-ecs-eks-amis.yml
+++ b/.github/workflows/monitor-ecs-eks-amis.yml
@@ -37,6 +37,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Decrypt Secrets
         uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@2988728879704953e739f82ac926d37931c6d01b # v6.1.9

--- a/.github/workflows/monitor-ecs-eks-amis.yml
+++ b/.github/workflows/monitor-ecs-eks-amis.yml
@@ -10,9 +10,7 @@ on:
 
 env:
   AWS_REGION: "eu-west-2"
-permissions:
-  id-token: write # This is required for requesting the JWT
-  contents: read # This is required for actions/checkout
+permissions: {}
 
 defaults:
   run:
@@ -22,6 +20,9 @@ jobs:
 
   fetch-secrets:
     uses: ministryofjustice/modernisation-platform-github-actions/.github/workflows/aws-secrets-management.yml@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read # This is required for actions/checkout
     secrets:
       MODERNISATION_PLATFORM_ACCOUNT_NUMBER: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_NUMBER }}
       PASSPHRASE: ${{ secrets.PASSPHRASE }}
@@ -29,6 +30,9 @@ jobs:
   monitor-ecs-eks-amis:
     runs-on: ubuntu-latest
     needs: fetch-secrets
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read # This is required for actions/checkout
 
     steps:
       - name: Checkout code

--- a/.github/workflows/new-environment.yml
+++ b/.github/workflows/new-environment.yml
@@ -54,6 +54,8 @@ jobs:
       pull-requests: write # This is required for updating PR comments
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Decrypt Secrets
         uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
         with:
@@ -78,8 +80,10 @@ jobs:
           gh auth status
           bash ./scripts/check-github-api-usage.sh
       - name: Set env vars
+        env:
+          APP_TOKEN: ${{ steps.app.outputs.token }}
         run: |
-          echo "TF_VAR_github_token=${{ steps.app.outputs.token }}" >> "$GITHUB_ENV"
+          echo "TF_VAR_github_token=$APP_TOKEN" >> "$GITHUB_ENV"
       - name: Set Account Number
         run: |
           ACCOUNT_NUMBER=$(jq -r -e '.aws_organizations_root_account_id' <<< "$ENVIRONMENT_MANAGEMENT")
@@ -104,18 +108,19 @@ jobs:
         run: bash scripts/terraform-plan.sh terraform/environments
 
       - name: Update PR comment with plan summary
+        env:
+          PLAN_SUMMARY: ${{ steps.tf_plan.outputs.summary }}
+          SECRET: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           PLAN="$(printf '%s\n%s\n%s\n%s\n%s\n' \
             '### Terraform Plan Summary' \
             '_terraform/environments_' \
             '```' \
-            "${{ steps.tf_plan.outputs.summary }}" \
+            "$PLAN_SUMMARY" \
             '```')"
           bash scripts/update-pr-comments.sh "${PLAN}"
-        env:
-          SECRET: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
 
   create-environment:
     runs-on: ubuntu-latest
@@ -126,6 +131,8 @@ jobs:
       contents: read # This is required for actions/checkout
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Decrypt Secrets
         uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
         with:
@@ -151,8 +158,10 @@ jobs:
           gh auth status
           bash ./scripts/check-github-api-usage.sh
       - name: Set env vars
+        env:
+          APP_TOKEN: ${{ steps.app.outputs.token }}
         run: |
-          echo "TF_VAR_github_token=${{ steps.app.outputs.token }}" >> "$GITHUB_ENV"
+          echo "TF_VAR_github_token=$APP_TOKEN" >> "$GITHUB_ENV"
       - name: Set Account Number
         run: |
           ACCOUNT_NUMBER=$(jq -r -e '.aws_organizations_root_account_id' <<< "$ENVIRONMENT_MANAGEMENT")
@@ -191,6 +200,8 @@ jobs:
       contents: read # This is required for actions/checkout
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Decrypt Secrets
         uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
         with:
@@ -238,6 +249,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Decrypt Secrets
         uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
         with:
@@ -265,8 +277,10 @@ jobs:
           files=$(git diff --name-only --diff-filter=AM @^ -- 'environments/*.json' | uniq | sed 's#environments/##' | sed 's/\.json$//' | tr '\n' ',' | awk '{$1=$1};1')
           echo "files=$files" >> "$GITHUB_OUTPUT"
       - name: Run delegate access
+        env:
+          NEW_ACCOUNT_FILES: ${{ steps.new_account.outputs.files }}
         run: |
-          IFS=',' read -r -a accounts <<< "${{ steps.new_account.outputs.files }}"
+          IFS=',' read -r -a accounts <<< "$NEW_ACCOUNT_FILES"
           if [[ ${#accounts[@]} -gt 0 ]]; then
             for i in "${accounts[@]}"; do
               echo "[+] Running delegate-access baseline for account ${i}"
@@ -296,6 +310,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Decrypt Secrets
         uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
         with:
@@ -319,8 +334,10 @@ jobs:
           files=$(git diff --name-only --diff-filter=AM @^ -- 'environments/*.json' | uniq | sed 's#environments/##' | sed 's/\.json$//' | tr '\n' ',' | awk '{$1=$1};1')
           echo "files=$files" >> "$GITHUB_OUTPUT"
       - name: Remove Default VPC
+        env:
+          NEW_ACCOUNT_FILES: ${{ steps.new_account.outputs.files }}
         run: |
-          IFS=',' read -r -a accounts <<< "${{ steps.new_account.outputs.files }}"          
+          IFS=',' read -r -a accounts <<< "$NEW_ACCOUNT_FILES"
           if [[ ${#accounts[@]} -gt 0 ]]; then
             for i in "${accounts[@]}"; do
               environments=$(jq -r '.environments[].name' "environments/${i}.json")
@@ -354,6 +371,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Decrypt Secrets
         uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
         with:
@@ -381,8 +399,10 @@ jobs:
           files=$(git diff --name-only --diff-filter=AM @^ -- 'environments/*.json' | uniq | sed 's#environments/##' | sed 's/\.json$//' | tr '\n' ',' | awk '{$1=$1};1')
           echo "files=$files" >> "$GITHUB_OUTPUT"
       - name: Run secure baselines
+        env:
+          NEW_ACCOUNT_FILES: ${{ steps.new_account.outputs.files }}
         run: |
-          IFS=',' read -r -a accounts <<< "${{ steps.new_account.outputs.files }}"
+          IFS=',' read -r -a accounts <<< "$NEW_ACCOUNT_FILES"
           if [[ ${#accounts[@]} -gt 0 ]]; then
             for i in "${accounts[@]}"; do
               echo "[+] Running secure baseline for account ${i}"
@@ -412,6 +432,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Decrypt Secrets
         uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
         with:
@@ -438,8 +459,10 @@ jobs:
           files=$(git diff --name-only --diff-filter=M @^ -- 'environments/*.json' | uniq | sed 's#environments/##' | sed 's/\.json$//' | tr '\n' ',' | awk '{$1=$1};1')
           echo "files=$files" >> "$GITHUB_OUTPUT"
       - name: Run single sign on
+        env:
+          NEW_ACCOUNT_FILES: ${{ steps.new_account.outputs.files }}
         run: |
-          IFS=',' read -r -a accounts <<< "${{ steps.new_account.outputs.files }}"
+          IFS=',' read -r -a accounts <<< "$NEW_ACCOUNT_FILES"
           if [[ ${#accounts[@]} -gt 0 ]]; then
             for i in "${accounts[@]}"; do
               echo "[+] Running single sign on baseline for account ${i}"
@@ -460,6 +483,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Decrypt Secrets
         uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
         with:
@@ -487,8 +511,10 @@ jobs:
           files=$(git diff --name-only --diff-filter=AM @^ -- 'environments/*.json' | uniq | sed 's#environments/##' | sed 's/\.json$//' | tr '\n' ',' | awk '{$1=$1};1')
           echo "files=$files" >> "$GITHUB_OUTPUT"
       - name: Run single sign on
+        env:
+          NEW_ACCOUNT_FILES: ${{ steps.new_account.outputs.files }}
         run: |
-          IFS=',' read -r -a accounts <<< "${{ steps.new_account.outputs.files }}"
+          IFS=',' read -r -a accounts <<< "$NEW_ACCOUNT_FILES"
           if [[ ${#accounts[@]} -gt 0 ]]; then
             for i in "${accounts[@]}"; do
               echo "[+] Running single sign on baseline for account ${i}"
@@ -518,6 +544,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
           
       - name: Decrypt Secrets
         uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
@@ -551,10 +578,15 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Send notification to Slack
         if: steps.environment_json_changes.outputs.files != ''
+        env:
+          CHANGED_FILES: ${{ steps.environment_json_changes.outputs.files }}
+          PR_NUMBER: ${{ steps.pr_number.outputs.pr_number }}
+          SLACK_WEBHOOKS: ${{ env.SLACK_WEBHOOKS }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
         run: |
-          DECODED_FILES=$(echo "${{ steps.environment_json_changes.outputs.files }}" | base64 --decode)
+          DECODED_FILES=$(echo "$CHANGED_FILES" | base64 --decode)
           echo "$DECODED_FILES" | while IFS= read -r file; do
-          PR_PATH="https://github.com/${GITHUB_REPOSITORY}/pull/${{ steps.pr_number.outputs.pr_number }}/files"
+          PR_PATH="https://github.com/${GITHUB_REPOSITORY}/pull/${PR_NUMBER}/files"
           slack_channel=$(jq -r '.tags["slack-channel"] // empty' "environments/$file")
           if [[ -z "$slack_channel" ]]; then
           echo "No Slack channel specified in the $file or the field does not exist. Skipping."
@@ -575,9 +607,6 @@ jobs:
           )
           curl -X POST -H 'Content-type: application/json' --data "$PAYLOAD" "$webhook_url"
           done
-        env:
-          SLACK_WEBHOOKS: ${{ env.SLACK_WEBHOOKS }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
       - name: Validate Notify Template Version
         if: steps.environment_json_changes.outputs.files != ''
         run: |
@@ -606,11 +635,12 @@ jobs:
           EOF
       - name: Send notification to Email
         if: steps.environment_json_changes.outputs.files != ''
-        run: |
-          DECODED_FILES=$(echo "${{ steps.environment_json_changes.outputs.files }}" | base64 --decode)
-          python ./scripts/json-changes-notifier.py "$DECODED_FILES"
         env:
-          PR_NUMBER: ${{ steps.pr_number.outputs.pr_number }}   
+          CHANGED_FILES: ${{ steps.environment_json_changes.outputs.files }}
+          PR_NUMBER: ${{ steps.pr_number.outputs.pr_number }}
+        run: |
+          DECODED_FILES=$(echo "$CHANGED_FILES" | base64 --decode)
+          python ./scripts/json-changes-notifier.py "$DECODED_FILES"
   member-bootstrap:
     runs-on: ubuntu-latest
     if: github.event.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
@@ -622,6 +652,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Decrypt Secrets
         uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
         with:
@@ -649,8 +680,10 @@ jobs:
           files=$(git diff --name-only --diff-filter=AM @^ -- 'environments/*.json' | uniq | sed 's#environments/##' | sed 's/\.json$//' | tr '\n' ',' | awk '{$1=$1};1')
           echo "files=$files" >> "$GITHUB_OUTPUT"
       - name: Run Member Bootstrap
+        env:
+          NEW_ACCOUNT_FILES: ${{ steps.new_account.outputs.files }}
         run: |
-          IFS=',' read -r -a accounts <<< "${{ steps.new_account.outputs.files }}"
+          IFS=',' read -r -a accounts <<< "$NEW_ACCOUNT_FILES"
           if [[ ${#accounts[@]} -gt 0 ]]; then
             for i in "${accounts[@]}"; do
               echo "[+] Running secure baseline for account ${i}"

--- a/.github/workflows/new-environment.yml
+++ b/.github/workflows/new-environment.yml
@@ -68,7 +68,6 @@ jobs:
         with:
           client-id: ${{ env.APP_ID }}               
           private-key: ${{ env.MP_GITHUB_APP_PRIVATE_KEY }} 
-          owner: "ministryofjustice"
           permission-contents: read
           permission-pull-requests: write
           repositories: "modernisation-platform,modernisation-platform-github"
@@ -146,7 +145,6 @@ jobs:
         with:
           client-id: ${{ env.APP_ID }}               
           private-key: ${{ env.MP_GITHUB_APP_PRIVATE_KEY }} 
-          owner: "ministryofjustice"
           permission-contents: read
           permission-pull-requests: write
           repositories: "modernisation-platform,modernisation-platform-github"

--- a/.github/workflows/new-environment.yml
+++ b/.github/workflows/new-environment.yml
@@ -27,10 +27,7 @@ env:
   RATE_THRESHOLD: 100
   APP_ID: 2013696
 
-permissions:
-  id-token: write # This is required for requesting the JWT
-  contents: read # This is required for actions/checkout
-  pull-requests: write # This is required for updating PR comments
+permissions: {}
 
 defaults:
   run:
@@ -40,6 +37,9 @@ jobs:
 
   fetch-secrets:
     uses: ministryofjustice/modernisation-platform-github-actions/.github/workflows/aws-secrets-management.yml@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read # This is required for actions/checkout
     secrets:
       MODERNISATION_PLATFORM_ACCOUNT_NUMBER: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_NUMBER }}
       PASSPHRASE: ${{ secrets.PASSPHRASE }}
@@ -48,6 +48,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref != 'refs/heads/main' && github.event_name != 'workflow_dispatch'
     needs: fetch-secrets
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read # This is required for actions/checkout
+      pull-requests: write # This is required for updating PR comments
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Decrypt Secrets
@@ -63,6 +67,9 @@ jobs:
           client-id: ${{ env.APP_ID }}               
           private-key: ${{ env.MP_GITHUB_APP_PRIVATE_KEY }} 
           owner: "ministryofjustice"
+          permission-contents: read
+          permission-pull-requests: write
+          repositories: "modernisation-platform,modernisation-platform-github"
       - name: Authenticate GitHub CLI as the App and Check the Rate Usage
         env:
           GH_TOKEN: ${{ steps.app.outputs.token }}
@@ -114,6 +121,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
     needs: fetch-secrets
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read # This is required for actions/checkout
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Decrypt Secrets
@@ -130,6 +140,9 @@ jobs:
           client-id: ${{ env.APP_ID }}               
           private-key: ${{ env.MP_GITHUB_APP_PRIVATE_KEY }} 
           owner: "ministryofjustice"
+          permission-contents: read
+          permission-pull-requests: write
+          repositories: "modernisation-platform,modernisation-platform-github"
       - name: Authenticate GitHub CLI as the App and Check the Rate Usage
         env:
           GH_TOKEN: ${{ steps.app.outputs.token }}
@@ -173,6 +186,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
     needs: [fetch-secrets, create-environment]
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read # This is required for actions/checkout
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Decrypt Secrets
@@ -215,6 +231,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
     needs: [fetch-secrets, provision-workspaces]
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read # This is required for actions/checkout
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -270,6 +289,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
     needs: [fetch-secrets, delegate-access]
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read # This is required for actions/checkout
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -325,6 +347,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
     needs: [fetch-secrets,delegate-access]
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read # This is required for actions/checkout
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -380,6 +405,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.ref != 'refs/heads/main' || github.event_name != 'workflow_dispatch'
     needs: fetch-secrets
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read # This is required for actions/checkout
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -425,6 +453,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
     needs: [fetch-secrets, provision-workspaces, delegate-access]
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read # This is required for actions/checkout
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -480,6 +511,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.ref == 'refs/heads/main'
     needs: [fetch-secrets, single-sign-on]
+    permissions:
+      contents: read # This is required for actions/checkout
+      pull-requests: read # This is required for looking up the merged PR
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -581,6 +615,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
     needs: [fetch-secrets, secure-baselines, single-sign-on]
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read # This is required for actions/checkout
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -639,8 +676,8 @@ jobs:
     with:
       working-directory: "terraform/modernisation-platform-account"
       workflow_id: "modernisation-platform-account"
-      set_github_app_token: ${{ 'true' }}
-      download_collaborators: ${{ 'true' }}
+      set_github_app_token: true
+      download_collaborators: true
     secrets:
       MODERNISATION_PLATFORM_ACCOUNT_NUMBER: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_NUMBER }}
       PASSPHRASE: ${{ secrets.PASSPHRASE }}

--- a/.github/workflows/nuke-redeploy.yml
+++ b/.github/workflows/nuke-redeploy.yml
@@ -80,6 +80,7 @@ jobs:
         with:
           repository: 'ministryofjustice/modernisation-platform-environments'
           token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
       - name: Decrypt Secrets
         uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
         with:

--- a/.github/workflows/opa-policies.yml
+++ b/.github/workflows/opa-policies.yml
@@ -30,6 +30,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Get changed files/directories and add PR comment for high risk changes
         run: bash scripts/pr-warning-comments.sh          
       - name: Setup Regal

--- a/.github/workflows/remove-default-vpc.yml
+++ b/.github/workflows/remove-default-vpc.yml
@@ -34,6 +34,8 @@ jobs:
       contents: read # This is required for actions/checkout
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Decrypt Secrets
         uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@2988728879704953e739f82ac926d37931c6d01b # v6.1.9

--- a/.github/workflows/remove-default-vpc.yml
+++ b/.github/workflows/remove-default-vpc.yml
@@ -9,9 +9,7 @@ on:
 env:
   AWS_REGION: "eu-west-2"
 
-permissions:
-  id-token: write # This is required for requesting the JWT
-  contents: read # This is required for actions/checkout
+permissions: {}
 
 defaults:
   run:
@@ -21,6 +19,9 @@ jobs:
 
   fetch-secrets:
     uses: ministryofjustice/modernisation-platform-github-actions/.github/workflows/aws-secrets-management.yml@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read # This is required for actions/checkout
     secrets:
       MODERNISATION_PLATFORM_ACCOUNT_NUMBER: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_NUMBER }}
       PASSPHRASE: ${{ secrets.PASSPHRASE }}
@@ -28,6 +29,9 @@ jobs:
   remove-default-vpc:
     runs-on: ubuntu-latest
     needs: fetch-secrets
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read # This is required for actions/checkout
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/.github/workflows/reusable-member-account-ram-association.yml
+++ b/.github/workflows/reusable-member-account-ram-association.yml
@@ -77,12 +77,15 @@ jobs:
       - name: Plan RAM principal associations (targeted)
         if: github.ref != 'refs/heads/main'
         env:
+          ENVIRONMENT: ${{ inputs.environment }}
           TERRAFORM_ACTION: plan
-        run: bash scripts/get-applications-and-run-ram.sh ${{ inputs.environment }}
+        run: bash scripts/get-applications-and-run-ram.sh "$ENVIRONMENT"
 
       - name: Apply RAM associations and subnet tagging
         if: github.ref == 'refs/heads/main'
-        run: bash scripts/get-applications-and-run-ram.sh ${{ inputs.environment }}
+        env:
+          ENVIRONMENT: ${{ inputs.environment }}
+        run: bash scripts/get-applications-and-run-ram.sh "$ENVIRONMENT"
 
       - name: Slack failure notification
         uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0

--- a/.github/workflows/reusable-member-account-ram-association.yml
+++ b/.github/workflows/reusable-member-account-ram-association.yml
@@ -39,6 +39,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
       
       - name: Decrypt Secrets
         uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@2988728879704953e739f82ac926d37931c6d01b # v6.1.9

--- a/.github/workflows/reusable-scheduled-baselines.yml
+++ b/.github/workflows/reusable-scheduled-baselines.yml
@@ -69,6 +69,8 @@ jobs:
           run: | 
             echo "Job Name: $JOB_NAME"
         - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+          with:
+            persist-credentials: false
         - name: Decrypt Secrets
           uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
           with:

--- a/.github/workflows/reusable-scheduled-baselines.yml
+++ b/.github/workflows/reusable-scheduled-baselines.yml
@@ -64,8 +64,10 @@ jobs:
       name: "Job - ${{ inputs.JOB_NAME }}"
       steps:
         - name: Log Job Name
+          env:
+            JOB_NAME: ${{ inputs.JOB_NAME }}
           run: | 
-            echo "Job Name: ${{ inputs.JOB_NAME }}"
+            echo "Job Name: $JOB_NAME"
         - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         - name: Decrypt Secrets
           uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
@@ -74,8 +76,10 @@ jobs:
             slack_webhook_url: ${{ inputs.slack_webhook_url }}
             PASSPHRASE: ${{ secrets.PASSPHRASE }}
         - name: Set Account Number
+          env:
+            AWS_ACCOUNT_ID_NAME: ${{ inputs.aws_account_id_name }}
           run: |
-            ACCOUNT_NUMBER=$(jq -r -e '.${{ inputs.aws_account_id_name }}' <<< "$ENVIRONMENT_MANAGEMENT")
+            ACCOUNT_NUMBER=$(jq -r -e --arg key "$AWS_ACCOUNT_ID_NAME" '.[$key]' <<< "$ENVIRONMENT_MANAGEMENT")
             echo "::add-mask::$ACCOUNT_NUMBER"
             echo "ACCOUNT_NUMBER=$ACCOUNT_NUMBER" >> "$GITHUB_ENV"
         - name: Configure AWS Credentials
@@ -88,12 +92,18 @@ jobs:
           with:
             terraform_version: "~1"
             terraform_wrapper: false
-        - run: bash scripts/terraform-init.sh "${{ inputs.working_directory }}"
-        - run: bash scripts/terraform-apply.sh "${{ inputs.working_directory }}"
+        - env:
+            WORKING_DIRECTORY: ${{ inputs.working_directory }}
+          run: bash scripts/terraform-init.sh "$WORKING_DIRECTORY"
+        - env:
+            WORKING_DIRECTORY: ${{ inputs.working_directory }}
+          run: bash scripts/terraform-apply.sh "$WORKING_DIRECTORY"
         - name: Persist terraform state to backend
           if: ${{ failure() && hashFiles(env.STATE_FILE) != '' }}
+          env:
+            WORKING_DIRECTORY: ${{ inputs.working_directory }}
           run: |
-            if bash scripts/terraform-state-push.sh "${{ inputs.working_directory }}"; then
+            if bash scripts/terraform-state-push.sh "$WORKING_DIRECTORY"; then
               echo "STATE_PUSH_SUCCESSFUL=true" >> "$GITHUB_ENV"
             fi
         - name: Slack failure notification

--- a/.github/workflows/reusable-securityhub-findings.yml
+++ b/.github/workflows/reusable-securityhub-findings.yml
@@ -44,12 +44,16 @@ jobs:
       steps:
 
         - name: Log Job Name
+          env:
+            ACCOUNT_NAME: ${{ inputs.account_name }}
           run: | 
-            echo "Job Name: ${{ inputs.account_name }}"
+            echo "Job Name: $ACCOUNT_NAME"
 
         - name: Set aws_region to env
+          env:
+            AWS_REGION_INPUT: ${{ inputs.aws_region }}
           run: |
-             echo "AWS_REGION=${{ inputs.aws_region }}" >> "$GITHUB_ENV"
+             echo "AWS_REGION=$AWS_REGION_INPUT" >> "$GITHUB_ENV"
 
         - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -62,15 +66,19 @@ jobs:
 
         - name: Determine Environment Config File
           id: derive-json-filename
+          env:
+            ACCOUNT_NAME: ${{ inputs.account_name }}
           run: |
-            FILENAME=$(echo "${{ inputs.account_name }}" | sed 's/-[^-]*$//').json
+            FILENAME="${ACCOUNT_NAME%-*}.json"
             echo "JSON filename: $FILENAME"
             echo "json_filename=$FILENAME" >> "$GITHUB_OUTPUT"
 
         - name: Check Slack Channel Configuration
           id: verify-slack-config
+          env:
+            JSON_FILENAME: ${{ steps.derive-json-filename.outputs.json_filename }}
           run: |
-            FILE_PATH="environments/${{ steps.derive-json-filename.outputs.json_filename }}"
+            FILE_PATH="environments/$JSON_FILENAME"
             if [ -f "$FILE_PATH" ]; then
                 if jq -e '.tags | has("securityhub-slack-channel")' "$FILE_PATH" > /dev/null; then
                 echo "Slack channel configured in environment tags"
@@ -89,9 +97,11 @@ jobs:
         - name: Retrieve Slack Webhook URL
           id: fetch-webhook-url
           if: steps.verify-slack-config.outputs.channel_exists == 'true'
+          env:
+            CHANNEL_NAME: ${{ steps.verify-slack-config.outputs.channel_name }}
           run: |
-            echo "Using channel name: ${{ steps.verify-slack-config.outputs.channel_name }}"
-            WEBHOOK=$(echo "$SECURITYHUB_SLACK_WEBHOOKS_JSON" | jq -r '.["${{ steps.verify-slack-config.outputs.channel_name }}"]')
+            echo "Using channel name: $CHANNEL_NAME"
+            WEBHOOK=$(echo "$SECURITYHUB_SLACK_WEBHOOKS_JSON" | jq -r --arg channel "$CHANNEL_NAME" '.[$channel]')
             if [ "$WEBHOOK" = "null" ] || [ -z "$WEBHOOK" ]; then
                 echo "No webhook found for this channel. Skipping."
                 exit 0
@@ -100,11 +110,13 @@ jobs:
 
         - name: Get Account ID
           if: steps.fetch-webhook-url.outputs.webhook_url != ''
+          env:
+            ACCOUNT_NAME: ${{ inputs.account_name }}
           run: |
             # Note that this uses a slightly different method to getting the account ID than usual
-            ACCOUNT_NUMBER=$(jq -r -e --arg n "${{ inputs.account_name }}" '.account_ids[$n] // empty' <<< "$ENVIRONMENT_MANAGEMENT")
+            ACCOUNT_NUMBER=$(jq -r -e --arg n "$ACCOUNT_NAME" '.account_ids[$n] // empty' <<< "$ENVIRONMENT_MANAGEMENT")
             if [ -z "$ACCOUNT_NUMBER" ]; then
-              echo "Account '${{ inputs.account_name }}' not found in ENVIRONMENT_MANAGEMENT.account_ids" >&2
+              echo "Account '$ACCOUNT_NAME' not found in ENVIRONMENT_MANAGEMENT.account_ids" >&2
               exit 1
             fi
             echo "::add-mask::$ACCOUNT_NUMBER"
@@ -135,6 +147,7 @@ jobs:
             SLACK_WEBHOOK_URL: ${{ steps.fetch-webhook-url.outputs.webhook_url }}
             ACCOUNT_NAME: ${{ inputs.account_name }}
             ACCOUNT_NUMBER: ${{ env.ACCOUNT_NUMBER }}
+            FINDINGS_OUTPUT: ${{ steps.analyze-findings.outputs.output }}
           run: |
-            MESSAGE="*Security Hub Severity Summary - $ACCOUNT_NAME ($ACCOUNT_NUMBER)*\n\`\`\`\n${{ steps.analyze-findings.outputs.output }}\n\`\`\`"
+            MESSAGE="*Security Hub Severity Summary - $ACCOUNT_NAME ($ACCOUNT_NUMBER)*\n\`\`\`\n$FINDINGS_OUTPUT\n\`\`\`"
             curl -X POST -H 'Content-type: application/json' --data "{\"text\": \"$MESSAGE\"}" "$SLACK_WEBHOOK_URL"

--- a/.github/workflows/reusable-securityhub-findings.yml
+++ b/.github/workflows/reusable-securityhub-findings.yml
@@ -56,6 +56,8 @@ jobs:
              echo "AWS_REGION=$AWS_REGION_INPUT" >> "$GITHUB_ENV"
 
         - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+          with:
+            persist-credentials: false
 
         - name: Decrypt Secrets
           uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@2988728879704953e739f82ac926d37931c6d01b # v6.1.9

--- a/.github/workflows/reusable_terraform_plan_apply.yml
+++ b/.github/workflows/reusable_terraform_plan_apply.yml
@@ -86,7 +86,6 @@ jobs:
         with:
           client-id: ${{ env.APP_ID }}               
           private-key: ${{ env.MP_GITHUB_APP_PRIVATE_KEY }} 
-          owner: "ministryofjustice"
           permission-contents: read
           permission-pull-requests: write
           repositories: "modernisation-platform,modernisation-platform-github"

--- a/.github/workflows/reusable_terraform_plan_apply.yml
+++ b/.github/workflows/reusable_terraform_plan_apply.yml
@@ -85,6 +85,9 @@ jobs:
           client-id: ${{ env.APP_ID }}               
           private-key: ${{ env.MP_GITHUB_APP_PRIVATE_KEY }} 
           owner: "ministryofjustice"
+          permission-contents: read
+          permission-pull-requests: write
+          repositories: "modernisation-platform,modernisation-platform-github"
       
       - name: Download collaborators.json from modernisation-platform-github
         if: ${{ inputs.download_collaborators && inputs.set_github_app_token }}

--- a/.github/workflows/reusable_terraform_plan_apply.yml
+++ b/.github/workflows/reusable_terraform_plan_apply.yml
@@ -66,6 +66,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Decrypt Secrets
         uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@2988728879704953e739f82ac926d37931c6d01b # v6.1.9

--- a/.github/workflows/reusable_terraform_plan_apply.yml
+++ b/.github/workflows/reusable_terraform_plan_apply.yml
@@ -27,13 +27,13 @@ on:
       set_github_app_token:
         description: "Whether to set the GitHub App token"
         required: false
-        type: string
-        default: "false"
+        type: boolean
+        default: false
       download_collaborators:
         description: "Whether to download collaborators.json from modernisation-platform-github"
         required: false
-        type: string
-        default: "false"
+        type: boolean
+        default: false
     secrets:
       MODERNISATION_PLATFORM_ACCOUNT_NUMBER:
         required: true
@@ -78,7 +78,7 @@ jobs:
           PASSPHRASE: ${{ secrets.PASSPHRASE }}
 
       - name: Create GitHub App token
-        if: ${{ inputs.set_github_app_token == 'true' }}
+        if: ${{ inputs.set_github_app_token }}
         id: app
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
@@ -87,14 +87,16 @@ jobs:
           owner: "ministryofjustice"
       
       - name: Download collaborators.json from modernisation-platform-github
-        if: ${{ inputs.download_collaborators == 'true' && inputs.set_github_app_token == 'true' }}
+        if: ${{ inputs.download_collaborators && inputs.set_github_app_token }}
+        env:
+          APP_TOKEN: ${{ steps.app.outputs.token }}
         run: |
-          curl -H "Authorization: token ${{ steps.app.outputs.token }}" \
+          curl -H "Authorization: token $APP_TOKEN" \
             -o collaborators.json \
             https://raw.githubusercontent.com/ministryofjustice/modernisation-platform-github/main/collaborators.json
 
       - name: Authenticate GitHub CLI as the App and Check the Rate Usage
-        if: ${{ inputs.set_github_app_token == 'true' }}
+        if: ${{ inputs.set_github_app_token }}
         env:
           GH_TOKEN: ${{ steps.app.outputs.token }}
         run: |
@@ -103,9 +105,11 @@ jobs:
           bash ./scripts/check-github-api-usage.sh
 
       - name: Set TF_VAR_github_token
-        if: ${{ inputs.set_github_app_token == 'true' }}
+        if: ${{ inputs.set_github_app_token }}
+        env:
+          APP_TOKEN: ${{ steps.app.outputs.token }}
         run: |
-          echo "TF_VAR_github_token=${{ steps.app.outputs.token }}" >> "$GITHUB_ENV"
+          echo "TF_VAR_github_token=$APP_TOKEN" >> "$GITHUB_ENV"
 
       - name: set env variables
         run: |
@@ -115,12 +119,15 @@ jobs:
       - name: Set up variables
         id: vars
         if: ${{ inputs.environment }}
+        env:
+          ENVIRONMENT_NAME: ${{ inputs.environment }}
+          WORKING_DIRECTORY: ${{ inputs.working-directory }}
         run: |
-          account_name=$(basename "${{ inputs.working-directory }}")
+          account_name=$(basename "$WORKING_DIRECTORY")
           echo "ACCOUNT_NAME=${account_name}"  >> "$GITHUB_ENV"
-          echo "WORKSPACE_NAME=${account_name}-${{ inputs.environment }}" >> "$GITHUB_ENV"
+          echo "WORKSPACE_NAME=${account_name}-${ENVIRONMENT_NAME}" >> "$GITHUB_ENV"
           # Check if test directory exists
-          if [ "${GITHUB_REF}" != 'refs/heads/main' ] && [ -d "${{ inputs.working-directory }}/test" ]; then
+          if [ "${GITHUB_REF}" != 'refs/heads/main' ] && [ -d "$WORKING_DIRECTORY/test" ]; then
               echo "run_terratest=true" >> "$GITHUB_OUTPUT"
           fi
     
@@ -160,13 +167,17 @@ jobs:
           terraform_wrapper: false
 
       - name: Initialize Terraform
+        env:
+          WORKING_DIRECTORY: ${{ inputs.working-directory }}
         run: |
-          bash scripts/terraform-init.sh "${{ inputs.working-directory }}"
+          bash scripts/terraform-init.sh "$WORKING_DIRECTORY"
 
       - name: Terraform Workspace Select
         if: ${{ inputs.environment }}
+        env:
+          WORKING_DIRECTORY: ${{ inputs.working-directory }}
         run: |
-          terraform -chdir="${{ inputs.working-directory }}" workspace select "${WORKSPACE_NAME}"
+          terraform -chdir="$WORKING_DIRECTORY" workspace select "${WORKSPACE_NAME}"
       
       - name: Validate Tags
         id: validate
@@ -179,8 +190,10 @@ jobs:
           terraform_plan_backend: 'remote'
       - name: Run Terratest
         if: ${{ steps.vars.outputs.run_terratest == 'true' }}
+        env:
+          WORKING_DIRECTORY: ${{ inputs.working-directory }}
         run: |
-          pushd "${{ inputs.working-directory }}/test"
+          pushd "$WORKING_DIRECTORY/test"
           go mod tidy
           TEST=$(go test | "${{ github.workspace }}/scripts/redact-output.sh" | tee /dev/stderr | tail -n 1)
           popd
@@ -193,8 +206,10 @@ jobs:
       - name: Run Terraform Plan
         if: github.event.ref != 'refs/heads/main'
         id: show
+        env:
+          WORKING_DIRECTORY: ${{ inputs.working-directory }}
         run: |
-          bash scripts/terraform-plan.sh "${{ inputs.working-directory }}"
+          bash scripts/terraform-plan.sh "$WORKING_DIRECTORY"
 
       - name: Get Destroy Count
         if: github.event_name == 'pull_request'
@@ -212,6 +227,9 @@ jobs:
         env:
           destroy_count: ${{ steps.get_destroy_count.outputs.destroy_count }}
           destroy_threshold: ${{ env.TF_DESTROY_THRESHOLD }}
+          PLAN_SUMMARY: ${{ steps.show.outputs.summary }}
+          WORKFLOW_ID: ${{ inputs.workflow_id }}
+          WORKSPACE_NAME: ${{ env.WORKSPACE_NAME }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -219,9 +237,9 @@ jobs:
             const teamSlug = 'modernisation-platform';
             const destroyCount = parseInt(process.env.destroy_count, 10);
             const destroyThreshold = parseInt(process.env.destroy_threshold, 10);
-            const summary = `\`${{ steps.show.outputs.summary }}\``;
-            const workflowId = "${{ env.WORKSPACE_NAME }}";
-            const identifier = workflowId ? `_${workflowId}_\n` : `_${{ inputs.workflow_id }}_\n`;
+            const summary = `\`${process.env.PLAN_SUMMARY}\``;
+            const workflowId = process.env.WORKSPACE_NAME;
+            const identifier = workflowId ? `_${workflowId}_\n` : `_${process.env.WORKFLOW_ID}_\n`;
 
             if (destroyCount >= destroyThreshold) {
               await github.rest.pulls.createReview({
@@ -236,12 +254,16 @@ jobs:
       - name: Post Comment
         if: github.event.ref != 'refs/heads/main'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PLAN_SUMMARY: ${{ steps.show.outputs.summary }}
+          WORKFLOW_ID: ${{ inputs.workflow_id }}
+          WORKSPACE_NAME: ${{ env.WORKSPACE_NAME }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const workflowId = "${{ env.WORKSPACE_NAME }}";
-            const identifier = workflowId ? `_${workflowId}_\n` : `_${{ inputs.workflow_id }}_\n`;
-            const summary = `\`${{ steps.show.outputs.summary }}\``;
+            const workflowId = process.env.WORKSPACE_NAME;
+            const identifier = workflowId ? `_${workflowId}_\n` : `_${process.env.WORKFLOW_ID}_\n`;
+            const summary = `\`${process.env.PLAN_SUMMARY}\``;
             const issue_number = context.payload.pull_request ? context.payload.pull_request.number : null;
             if (!issue_number) {
               console.log('No issue number found, skipping comment.');
@@ -255,7 +277,9 @@ jobs:
 
       - name: terraform apply
         if: github.event.ref == 'refs/heads/main'
-        run: bash scripts/terraform-apply.sh "${{ inputs.working-directory }}"
+        env:
+          WORKING_DIRECTORY: ${{ inputs.working-directory }}
+        run: bash scripts/terraform-apply.sh "$WORKING_DIRECTORY"
 
       - name: Slack failure notification
         if: ${{ failure() && github.ref == 'refs/heads/main' }}

--- a/.github/workflows/scheduled-baseline-extended-matrix.yml
+++ b/.github/workflows/scheduled-baseline-extended-matrix.yml
@@ -60,6 +60,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with: 
           fetch-depth: 0
+          persist-credentials: false
       - name: Decrypt Secrets
         uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
         with:
@@ -559,6 +560,8 @@ jobs:
       contents: read # This is required for actions/checkout
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Decrypt Secrets
         uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
         with:

--- a/.github/workflows/scheduled-baseline-extended-matrix.yml
+++ b/.github/workflows/scheduled-baseline-extended-matrix.yml
@@ -17,9 +17,7 @@ env:
   TF_IN_AUTOMATION: true
   AWS_REGION: "eu-west-2"
 
-permissions:
-  id-token: write # This is required for requesting the JWT
-  contents: read # This is required for actions/checkout
+permissions: {}
 
 defaults:
   run:
@@ -35,6 +33,9 @@ jobs:
 
   fetch-secrets:
     uses: ministryofjustice/modernisation-platform-github-actions/.github/workflows/aws-secrets-management.yml@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read # This is required for actions/checkout
     secrets:
       MODERNISATION_PLATFORM_ACCOUNT_NUMBER: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_NUMBER }}
       PASSPHRASE: ${{ secrets.PASSPHRASE }}
@@ -44,6 +45,9 @@ jobs:
   setup-prerequisites:
     runs-on: ubuntu-latest
     needs: fetch-secrets
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read # This is required for actions/checkout
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
       run-delegate-access: ${{ steps.changes.outputs.run-delegate-access }}
@@ -550,6 +554,9 @@ jobs:
           needs.delegate-access-4.result == 'success'
         )
       ))
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read # This is required for actions/checkout
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Decrypt Secrets

--- a/.github/workflows/secrets-rotation-reminder.yml
+++ b/.github/workflows/secrets-rotation-reminder.yml
@@ -43,6 +43,8 @@ jobs:
       steps:
         - name: Checkout Repository
           uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+          with:
+            persist-credentials: false
 
         - name: Decrypt Secrets
           uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@2988728879704953e739f82ac926d37931c6d01b # v6.1.9

--- a/.github/workflows/secrets-rotation-reminder.yml
+++ b/.github/workflows/secrets-rotation-reminder.yml
@@ -59,7 +59,6 @@ jobs:
           with:
             client-id: ${{ env.APP_ID }}               
             private-key: ${{ env.MP_GITHUB_APP_PRIVATE_KEY }} 
-            owner: "ministryofjustice"
             permission-contents: read
             permission-issues: write
             repositories: "modernisation-platform"

--- a/.github/workflows/secrets-rotation-reminder.yml
+++ b/.github/workflows/secrets-rotation-reminder.yml
@@ -16,10 +16,7 @@ env:
     RATE_THRESHOLD: 100
     APP_ID: 2013696
     
-permissions:
-    id-token: write # This is required for requesting the JWT
-    contents: read # This is required for actions/checkout
-    issues: write # This is required to create issues
+permissions: {}
     
 defaults:
     run:
@@ -29,6 +26,9 @@ jobs:
 
   fetch-secrets:
     uses: ministryofjustice/modernisation-platform-github-actions/.github/workflows/aws-secrets-management.yml@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read # This is required for actions/checkout
     secrets:
       MODERNISATION_PLATFORM_ACCOUNT_NUMBER: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_NUMBER }}
       PASSPHRASE: ${{ secrets.PASSPHRASE }}  
@@ -36,6 +36,10 @@ jobs:
   secrets-rotation-reminder:
       runs-on: ubuntu-latest
       needs: fetch-secrets
+      permissions:
+        id-token: write # This is required for requesting the JWT
+        contents: read # This is required for actions/checkout
+        issues: write # This is required to create issues
       steps:
         - name: Checkout Repository
           uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -54,6 +58,8 @@ jobs:
             client-id: ${{ env.APP_ID }}               
             private-key: ${{ env.MP_GITHUB_APP_PRIVATE_KEY }} 
             owner: "ministryofjustice"
+            permission-contents: read
+            permission-issues: write
             repositories: "modernisation-platform"
 
         - name: Authenticate GitHub CLI as the App and Check the Rate Usage

--- a/.github/workflows/terraform-member-environment.yml
+++ b/.github/workflows/terraform-member-environment.yml
@@ -47,6 +47,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Decrypt Secrets
         uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
         with:
@@ -66,8 +68,10 @@ jobs:
           echo "CHANGED_DIRECTORIES=$CHANGED_DIRECTORIES" >> "$GITHUB_OUTPUT"
           echo "CHANGED_DIRECTORY_NAMES=$CHANGED_DIRECTORY_NAMES" >> "$GITHUB_OUTPUT"
       - name: Display changed directories
+        env:
+          CHANGED_DIRECTORIES: ${{ steps.directories.outputs.CHANGED_DIRECTORIES }}
         run: |
-          echo "Directories in scope: ${{ steps.directories.outputs.CHANGED_DIRECTORIES }}"
+          echo "Directories in scope: $CHANGED_DIRECTORIES"
       - name: Slack failure notification
         uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
         with:
@@ -97,14 +101,19 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Decrypt Secrets
         uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
         with:
           environment_management: ${{ needs.fetch-secrets.outputs.environment_management }}
           PASSPHRASE: ${{ secrets.PASSPHRASE }}
       - name: Set account number
+        env:
+          APPLICATION: ${{ matrix.application }}
+          ENVIRONMENT_NAME: ${{ matrix.environment }}
         run: |
-          APPLICATION_ENVIRONMENT="${{ matrix.application }}-${{ matrix.environment }}"
+          APPLICATION_ENVIRONMENT="${APPLICATION}-${ENVIRONMENT_NAME}"
           echo "Application: $APPLICATION_ENVIRONMENT"
           ACCOUNT_NUMBER=$(echo "$ENVIRONMENT_MANAGEMENT" | jq -r --arg app_env "$APPLICATION_ENVIRONMENT" '.account_ids[$app_env] // empty')
           echo "$ACCOUNT_NUMBER"
@@ -133,20 +142,27 @@ jobs:
       - name: Terraform init
         if: env.SKIP == 'false'
         id: init
+        env:
+          APPLICATION: ${{ matrix.application }}
         run: |
-          echo "Running 'terraform init' in terraform/environments/${{ matrix.application }}" 
-          scripts/terraform-init.sh "terraform/environments/${{ matrix.application }}"
+          echo "Running 'terraform init' in terraform/environments/$APPLICATION"
+          scripts/terraform-init.sh "terraform/environments/$APPLICATION"
       - name: Terraform workspace
         if: env.SKIP == 'false'
         id: workspace
+        env:
+          APPLICATION: ${{ matrix.application }}
+          ENVIRONMENT_NAME: ${{ matrix.environment }}
         run: |
-          workspace="${{ matrix.application }}-${{ matrix.environment }}"
-          terraform -chdir="terraform/environments/${{ matrix.application }}" workspace select "$workspace"
+          workspace="${APPLICATION}-${ENVIRONMENT_NAME}"
+          terraform -chdir="terraform/environments/$APPLICATION" workspace select "$workspace"
       - name: Terraform plan
         if: env.SKIP == 'false'
         id: plan
+        env:
+          APPLICATION: ${{ matrix.application }}
         run: |
-          scripts/terraform-plan.sh "terraform/environments/${{ matrix.application }}"
+          scripts/terraform-plan.sh "terraform/environments/$APPLICATION"
 
   terraform-plan-preprod-prod:
     runs-on: ubuntu-latest
@@ -163,6 +179,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Decrypt Secrets
         uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
         with:
@@ -187,8 +205,10 @@ jobs:
           terraform_wrapper: false
       - name: Terraform init
         id: init
+        env:
+          CHANGED_DIRECTORIES_ENCODED: ${{ needs.find-environments.outputs.directories }}
         run: |
-          CHANGED_DIRECTORIES=$(echo "${{ needs.find-environments.outputs.directories }}" | base64 --decode)
+          CHANGED_DIRECTORIES=$(echo "$CHANGED_DIRECTORIES_ENCODED" | base64 --decode)
           export CHANGED_DIRECTORIES
           while IFS= read -r directory; do
             echo "Running 'terraform init' in $directory"
@@ -196,11 +216,14 @@ jobs:
           done <<< "$CHANGED_DIRECTORIES"
       - name: Terraform workspace
         id: workspace
+        env:
+          CHANGED_DIRECTORIES_ENCODED: ${{ needs.find-environments.outputs.directories }}
+          ENVIRONMENT_NAME: ${{ matrix.environment }}
         run: |
-          CHANGED_DIRECTORIES=$(echo "${{ needs.find-environments.outputs.directories }}" | base64 --decode)
+          CHANGED_DIRECTORIES=$(echo "$CHANGED_DIRECTORIES_ENCODED" | base64 --decode)
           export CHANGED_DIRECTORIES
           while IFS= read -r directory; do
-                workspace="$(basename "$directory")-${{ matrix.environment }}"
+                workspace="$(basename "$directory")-${ENVIRONMENT_NAME}"
 
                 if terraform -chdir="$directory" workspace list | grep "$workspace"; then
                   terraform -chdir="$directory" workspace select "$workspace"
@@ -216,8 +239,10 @@ jobs:
       - name: Terraform plan
         id: plan
         if: ${{ steps.workspace.outputs.skip_plan != 'true' }}
+        env:
+          CHANGED_DIRECTORIES_ENCODED: ${{ needs.find-environments.outputs.directories }}
         run: |
-          CHANGED_DIRECTORIES=$(echo "${{ needs.find-environments.outputs.directories }}" | base64 --decode)
+          CHANGED_DIRECTORIES=$(echo "$CHANGED_DIRECTORIES_ENCODED" | base64 --decode)
           export CHANGED_DIRECTORIES
           while IFS= read -r directory; do
             scripts/terraform-plan.sh "$directory"
@@ -245,14 +270,19 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Decrypt Secrets
         uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
         with:
           environment_management: ${{ needs.fetch-secrets.outputs.environment_management }}
           PASSPHRASE: ${{ secrets.PASSPHRASE }}
       - name: Set account number
+        env:
+          APPLICATION: ${{ matrix.application }}
+          ENVIRONMENT_NAME: ${{ matrix.environment }}
         run: |
-          APPLICATION_ENVIRONMENT="${{ matrix.application }}-${{ matrix.environment }}"
+          APPLICATION_ENVIRONMENT="${APPLICATION}-${ENVIRONMENT_NAME}"
           echo "Application: $APPLICATION_ENVIRONMENT"
           ACCOUNT_NUMBER=$(echo "$ENVIRONMENT_MANAGEMENT" | jq -r --arg app_env "$APPLICATION_ENVIRONMENT" '.account_ids[$app_env] // empty')
           echo "$ACCOUNT_NUMBER"
@@ -281,20 +311,27 @@ jobs:
       - name: Terraform init
         if: env.SKIP == 'false'
         id: init
+        env:
+          APPLICATION: ${{ matrix.application }}
         run: |
-          echo "Running 'terraform init' in terraform/environments/${{ matrix.application }}" 
-          scripts/terraform-init.sh "terraform/environments/${{ matrix.application }}"
+          echo "Running 'terraform init' in terraform/environments/$APPLICATION"
+          scripts/terraform-init.sh "terraform/environments/$APPLICATION"
       - name: Terraform workspace
         if: env.SKIP == 'false'
         id: workspace
+        env:
+          APPLICATION: ${{ matrix.application }}
+          ENVIRONMENT_NAME: ${{ matrix.environment }}
         run: |
-          workspace="${{ matrix.application }}-${{ matrix.environment }}"
-          terraform -chdir="terraform/environments/${{ matrix.application }}" workspace select "$workspace"
+          workspace="${APPLICATION}-${ENVIRONMENT_NAME}"
+          terraform -chdir="terraform/environments/$APPLICATION" workspace select "$workspace"
       - name: Terraform apply
         if: env.SKIP == 'false'
         id: apply
+        env:
+          APPLICATION: ${{ matrix.application }}
         run: |
-          scripts/terraform-apply.sh "terraform/environments/${{ matrix.application }}"
+          scripts/terraform-apply.sh "terraform/environments/$APPLICATION"
 
   terraform-apply-preprod-prod:
     if: github.ref == 'refs/heads/main'
@@ -313,6 +350,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Decrypt Secrets
         uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
         with:
@@ -338,8 +377,10 @@ jobs:
           terraform_wrapper: false
       - name: Terraform init
         id: init
+        env:
+          CHANGED_DIRECTORIES_ENCODED: ${{ needs.find-environments.outputs.directories }}
         run: |
-          CHANGED_DIRECTORIES=$(echo "${{ needs.find-environments.outputs.directories }}" | base64 --decode)
+          CHANGED_DIRECTORIES=$(echo "$CHANGED_DIRECTORIES_ENCODED" | base64 --decode)
           export CHANGED_DIRECTORIES
           while IFS= read -r directory; do
             echo "Running 'terraform init' in $directory"
@@ -347,11 +388,14 @@ jobs:
           done <<< "$CHANGED_DIRECTORIES"
       - name: Terraform workspace
         id: workspace
+        env:
+          CHANGED_DIRECTORIES_ENCODED: ${{ needs.find-environments.outputs.directories }}
+          ENVIRONMENT_NAME: ${{ matrix.environment }}
         run: |
-          CHANGED_DIRECTORIES=$(echo "${{ needs.find-environments.outputs.directories }}" | base64 --decode)
+          CHANGED_DIRECTORIES=$(echo "$CHANGED_DIRECTORIES_ENCODED" | base64 --decode)
           export CHANGED_DIRECTORIES
           while IFS= read -r directory; do
-                workspace="$(basename "$directory")-${{ matrix.environment }}"
+                workspace="$(basename "$directory")-${ENVIRONMENT_NAME}"
 
                 if terraform -chdir="$directory" workspace list | grep "$workspace"; then
                   terraform -chdir="$directory" workspace select "$workspace"
@@ -367,22 +411,28 @@ jobs:
       - name: Terraform plan
         id: plan
         if: ${{ steps.workspace.outputs.skip_plan != 'true' }}
+        env:
+          CHANGED_DIRECTORIES_ENCODED: ${{ needs.find-environments.outputs.directories }}
+          ENVIRONMENT_NAME: ${{ matrix.environment }}
         run: |
-          CHANGED_DIRECTORIES=$(echo "${{ needs.find-environments.outputs.directories }}" | base64 --decode)
+          CHANGED_DIRECTORIES=$(echo "$CHANGED_DIRECTORIES_ENCODED" | base64 --decode)
           export CHANGED_DIRECTORIES
           while IFS= read -r directory; do
-            workspace="$(basename "$directory")-${{ matrix.environment }}"
+            workspace="$(basename "$directory")-${ENVIRONMENT_NAME}"
             scripts/terraform-plan.sh "$directory" -out="$workspace.tfplan"
             unset workspace
           done <<< "$CHANGED_DIRECTORIES"
       - name: Terraform apply
         id: apply
         if: ${{ steps.plan.conclusion == 'success' }}
+        env:
+          CHANGED_DIRECTORIES_ENCODED: ${{ needs.find-environments.outputs.directories }}
+          ENVIRONMENT_NAME: ${{ matrix.environment }}
         run: |
-          CHANGED_DIRECTORIES=$(echo "${{ needs.find-environments.outputs.directories }}" | base64 --decode)
+          CHANGED_DIRECTORIES=$(echo "$CHANGED_DIRECTORIES_ENCODED" | base64 --decode)
           export CHANGED_DIRECTORIES
           while IFS= read -r directory; do
-            workspace="$(basename "$directory")-${{ matrix.environment }}"
+            workspace="$(basename "$directory")-${ENVIRONMENT_NAME}"
             scripts/terraform-apply.sh "$directory" "$workspace.tfplan"
             unset workspace
           done <<< "$CHANGED_DIRECTORIES"

--- a/.github/workflows/terraform-member-environment.yml
+++ b/.github/workflows/terraform-member-environment.yml
@@ -26,14 +26,15 @@ defaults:
 env:
   TF_IN_AUTOMATION: true
   AWS_REGION: "eu-west-2"
-permissions:
-  id-token: write # This is required for requesting the JWT
-  contents: read # This is required for actions/checkout
+permissions: {}
 
 jobs:
 
   fetch-secrets:
     uses: ministryofjustice/modernisation-platform-github-actions/.github/workflows/aws-secrets-management.yml@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read # This is required for actions/checkout
     secrets:
       MODERNISATION_PLATFORM_ACCOUNT_NUMBER: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_NUMBER }}
       PASSPHRASE: ${{ secrets.PASSPHRASE }}
@@ -41,6 +42,8 @@ jobs:
   find-environments:
     runs-on: ubuntu-latest
     needs: fetch-secrets
+    permissions:
+      contents: read # This is required for actions/checkout
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -81,6 +84,9 @@ jobs:
   terraform-plan-dev-test:
     runs-on: ubuntu-latest
     needs: [fetch-secrets, find-environments]
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read # This is required for actions/checkout
     strategy:
       fail-fast: false
       matrix:
@@ -145,6 +151,9 @@ jobs:
   terraform-plan-preprod-prod:
     runs-on: ubuntu-latest
     needs: [fetch-secrets, find-environments]
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read # This is required for actions/checkout
     strategy:
       fail-fast: false
       matrix:
@@ -222,6 +231,9 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     needs: [fetch-secrets, find-environments, terraform-plan-dev-test]
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read # This is required for actions/checkout
     strategy:
       fail-fast: false
       matrix:
@@ -288,6 +300,9 @@ jobs:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: [fetch-secrets, find-environments, terraform-plan-preprod-prod]
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read # This is required for actions/checkout
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/terraform-unlock-state.yml
+++ b/.github/workflows/terraform-unlock-state.yml
@@ -37,6 +37,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Determine Terraform path and workspace
         id: setup

--- a/.github/workflows/terraform-unlock-state.yml
+++ b/.github/workflows/terraform-unlock-state.yml
@@ -40,11 +40,11 @@ jobs:
 
       - name: Determine Terraform path and workspace
         id: setup
+        env:
+          APP_NAME: ${{ github.event.inputs.application_name }}
+          COMPONENT: ${{ github.event.inputs.component }}
+          ENVIRONMENT_NAME: ${{ github.event.inputs.environment }}
         run: |
-          COMPONENT="${{ github.event.inputs.component }}"
-          APP_NAME="${{ github.event.inputs.application_name }}"
-          ENV="${{ github.event.inputs.environment }}"
-
           if [[ "$COMPONENT" == "github" || "$COMPONENT" == "pagerduty" || "$COMPONENT" == "single-sign-on" || "$COMPONENT" == "modernisation-platform-account" ]]; then
             {
               echo "TF_PATH=terraform/$COMPONENT"
@@ -53,11 +53,11 @@ jobs:
             } >> "$GITHUB_ENV"
 
           elif [[ "$COMPONENT" == "environments" ]]; then
-            if [[ -n "$APP_NAME" && -n "$ENV" ]]; then
+            if [[ -n "$APP_NAME" && -n "$ENVIRONMENT_NAME" ]]; then
               {
                 echo "TF_PATH=terraform/environments/$APP_NAME"
-                echo "TF_WORKSPACE=${APP_NAME}-${ENV}"
-                echo "S3_LOCK_KEY=environments/accounts/$APP_NAME/${APP_NAME}-${ENV}/terraform.tfstate.tflock"
+                echo "TF_WORKSPACE=${APP_NAME}-${ENVIRONMENT_NAME}"
+                echo "S3_LOCK_KEY=environments/accounts/$APP_NAME/${APP_NAME}-${ENVIRONMENT_NAME}/terraform.tfstate.tflock"
               } >> "$GITHUB_ENV"
             else
               {
@@ -68,15 +68,15 @@ jobs:
             fi
 
           elif [[ "$COMPONENT" == bootstrap/* ]]; then
-            if [[ -z "$APP_NAME" || -z "$ENV" ]]; then
+            if [[ -z "$APP_NAME" || -z "$ENVIRONMENT_NAME" ]]; then
               echo "You must provide 'application_name' and 'environment' for bootstrap"
               exit 1
             fi
             BOOTSTRAP_COMPONENT="${COMPONENT#bootstrap/}"
             {
               echo "TF_PATH=terraform/environments/$COMPONENT"
-              echo "TF_WORKSPACE=${APP_NAME}-${ENV}"
-              echo "S3_LOCK_KEY=environments/bootstrap/$BOOTSTRAP_COMPONENT/${APP_NAME}-${ENV}/terraform.tfstate.tflock"
+              echo "TF_WORKSPACE=${APP_NAME}-${ENVIRONMENT_NAME}"
+              echo "S3_LOCK_KEY=environments/bootstrap/$BOOTSTRAP_COMPONENT/${APP_NAME}-${ENVIRONMENT_NAME}/terraform.tfstate.tflock"
             } >> "$GITHUB_ENV"
 
           else
@@ -116,10 +116,14 @@ jobs:
       - name: Force Unlock State
         if: steps.check_lock.outputs.LOCK_EXISTS == 'true'
         working-directory: ${{ env.TF_PATH }}
-        run: terraform force-unlock -force "${{ github.event.inputs.lock_id }}"
+        env:
+          LOCK_ID: ${{ github.event.inputs.lock_id }}
+        run: terraform force-unlock -force "$LOCK_ID"
 
       - name: Lock already removed
         if: steps.check_lock.outputs.LOCK_EXISTS == 'false'
+        env:
+          LOCK_ID: ${{ github.event.inputs.lock_id }}
         run: |
           echo "✅ The Terraform state lock has already been removed."
-          echo "Lock ID ${{ github.event.inputs.lock_id }} is not present in the state."
+          echo "Lock ID $LOCK_ID is not present in the state."

--- a/.github/workflows/update-securityhub-slack-secret.yml
+++ b/.github/workflows/update-securityhub-slack-secret.yml
@@ -30,4 +30,6 @@ jobs:
           echo "::add-mask::$slack_webhook_url" 
            echo "SLACK_WEBHOOK_URL=$slack_webhook_url" >> "$GITHUB_ENV"
       - name: Run Secret Update Script
-        run: ./scripts/update_securityhub_secret.sh "${{ github.event.inputs.application }}" "${{ env.SLACK_WEBHOOK_URL }}"
+        env:
+          APPLICATION: ${{ github.event.inputs.application }}
+        run: ./scripts/update_securityhub_secret.sh "$APPLICATION" "$SLACK_WEBHOOK_URL"

--- a/.github/workflows/update-securityhub-slack-secret.yml
+++ b/.github/workflows/update-securityhub-slack-secret.yml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@cbe3b392738ccf3f987d68400dafcf4b0624a56c # v6.2.4
         with:

--- a/.github/workflows/upload-cost-explorer-to-s3.yml
+++ b/.github/workflows/upload-cost-explorer-to-s3.yml
@@ -27,6 +27,8 @@ jobs:
       contents: read # This is required for actions/checkout
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Decrypt Secrets
         uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@2988728879704953e739f82ac926d37931c6d01b # v6.1.9

--- a/.github/workflows/upload-cost-explorer-to-s3.yml
+++ b/.github/workflows/upload-cost-explorer-to-s3.yml
@@ -6,14 +6,15 @@ on:
   workflow_dispatch:
 env:
   AWS_REGION: "eu-west-2"
-permissions:
-  id-token: write # This is required for requesting the JWT
-  contents: read # This is required for actions/checkout
+permissions: {}
 
 jobs:
 
   fetch-secrets:
     uses: ministryofjustice/modernisation-platform-github-actions/.github/workflows/aws-secrets-management.yml@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read # This is required for actions/checkout
     secrets:
       MODERNISATION_PLATFORM_ACCOUNT_NUMBER: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_NUMBER }}
       PASSPHRASE: ${{ secrets.PASSPHRASE }}
@@ -21,6 +22,9 @@ jobs:
   upload-cost-explorer-csv:
     runs-on: ubuntu-latest
     needs: fetch-secrets
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read # This is required for actions/checkout
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,6 @@
+rules:
+  self-repository:
+    ignore:
+      - modernisation-platform-account.yml
+      - new-environment.yml
+      - scheduled-baseline-extended-matrix.yml


### PR DESCRIPTION
## What

Resolves the scheduled Code Quality Zizmor findings across the selected GitHub Actions workflows.

Changes include:

- moving GitHub context, matrix values, workflow inputs, and step outputs into step environment variables before shell or Python use
- moving broad workflow-level permissions down to the jobs that need them
- scoping GitHub App tokens with explicit repositories and permissions in a form compatible with MegaLinter's Zizmor v1.25.0
- deriving the DORA GitHub App repository scope from the same JSON definition files used by the DORA scripts, so new repositories are not missed when the JSON is updated
- adding `persist-credentials: false` to checkout steps
- adding a narrow `.github/zizmor.yml` exception for `self-repository`, because Zizmor recommends `$/...` syntax but the current actionlint/GitHub workflow schema rejects it
- preserving the existing local reusable workflow calls and GitHub-compatible syntax

## Validation

- `actionlint` across all top-level workflow YAML files: pass
- `git diff --check`: pass
- `uvx zizmor==1.25.0` against the 28 CI-listed workflows: `No findings to report`
- DORA repository scope generation validated with `jq`

The remaining Zizmor output is suppressed findings from the repository configuration; no active findings remain in the CI-listed workflow set.