### PR TITLE
Fix new environment reusable workflow permissions

### DIFF
--- a/.github/workflows/new-environment.yml
+++ b/.github/workflows/new-environment.yml
@@ -704,10 +704,6 @@ jobs:
   modernisation-platform-account-plan-and-apply:
     uses: ./.github/workflows/reusable_terraform_plan_apply.yml
     needs: create-environment
-    permissions:
-      id-token: write
-      contents: read
-      pull-requests: write
     with:
       working-directory: "terraform/modernisation-platform-account"
       workflow_id: "modernisation-platform-account"

--- a/.github/workflows/new-environment.yml
+++ b/.github/workflows/new-environment.yml
@@ -104,7 +104,7 @@ jobs:
 
       - name: Run terraform plan in terraform/environments
         id: tf_plan
-        run: bash scripts/terraform-plan.sh terraform/environments "-refresh=false"
+        run: bash scripts/terraform-plan.sh terraform/environments
 
       - name: Update PR comment with plan summary
         env:

--- a/.github/workflows/new-environment.yml
+++ b/.github/workflows/new-environment.yml
@@ -704,6 +704,10 @@ jobs:
   modernisation-platform-account-plan-and-apply:
     uses: ./.github/workflows/reusable_terraform_plan_apply.yml
     needs: create-environment
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: write
     with:
       working-directory: "terraform/modernisation-platform-account"
       workflow_id: "modernisation-platform-account"

--- a/.github/workflows/new-environment.yml
+++ b/.github/workflows/new-environment.yml
@@ -104,7 +104,7 @@ jobs:
 
       - name: Run terraform plan in terraform/environments
         id: tf_plan
-        run: bash scripts/terraform-plan.sh terraform/environments
+        run: bash scripts/terraform-plan.sh terraform/environments "-refresh=false"
 
       - name: Update PR comment with plan summary
         env:

--- a/.github/workflows/new-environment.yml
+++ b/.github/workflows/new-environment.yml
@@ -27,7 +27,10 @@ env:
   RATE_THRESHOLD: 100
   APP_ID: 2013696
 
-permissions: {}
+permissions:
+  id-token: write # This is required for requesting the JWT
+  contents: read # This is required for actions/checkout
+  pull-requests: write # This is required for updating PR comments
 
 defaults:
   run:
@@ -37,9 +40,6 @@ jobs:
 
   fetch-secrets:
     uses: ministryofjustice/modernisation-platform-github-actions/.github/workflows/aws-secrets-management.yml@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
-    permissions:
-      id-token: write # This is required for requesting the JWT
-      contents: read # This is required for actions/checkout
     secrets:
       MODERNISATION_PLATFORM_ACCOUNT_NUMBER: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_NUMBER }}
       PASSPHRASE: ${{ secrets.PASSPHRASE }}
@@ -48,14 +48,8 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref != 'refs/heads/main' && github.event_name != 'workflow_dispatch'
     needs: fetch-secrets
-    permissions:
-      id-token: write # This is required for requesting the JWT
-      contents: read # This is required for actions/checkout
-      pull-requests: write # This is required for updating PR comments
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
       - name: Decrypt Secrets
         uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
         with:
@@ -68,9 +62,7 @@ jobs:
         with:
           client-id: ${{ env.APP_ID }}               
           private-key: ${{ env.MP_GITHUB_APP_PRIVATE_KEY }} 
-          permission-contents: read
-          permission-pull-requests: write
-          repositories: "modernisation-platform,modernisation-platform-github"
+          owner: "ministryofjustice"
       - name: Authenticate GitHub CLI as the App and Check the Rate Usage
         env:
           GH_TOKEN: ${{ steps.app.outputs.token }}
@@ -79,59 +71,33 @@ jobs:
           gh auth status
           bash ./scripts/check-github-api-usage.sh
       - name: Set env vars
-        env:
-          APP_TOKEN: ${{ steps.app.outputs.token }}
         run: |
-          echo "TF_VAR_github_token=$APP_TOKEN" >> "$GITHUB_ENV"
+          echo "TF_VAR_github_token=${{ steps.app.outputs.token }}" >> "$GITHUB_ENV"
       - name: Set Account Number
         run: |
           ACCOUNT_NUMBER=$(jq -r -e '.aws_organizations_root_account_id' <<< "$ENVIRONMENT_MANAGEMENT")
-          echo "::add-mask::$ACCOUNT_NUMBER"
-          echo "ACCOUNT_NUMBER=$ACCOUNT_NUMBER" >> "$GITHUB_ENV"
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@cbe3b392738ccf3f987d68400dafcf4b0624a56c # v6.2.4
-        with:
-          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/ModernisationPlatformGithubActionsRole"
-          role-session-name: githubactionsrolesession
-          aws-region: ${{ env.AWS_REGION }}
-      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
-        with:
-          terraform_version: "~1"
-          terraform_wrapper: false
-
-      - name: Run terraform init in terraform/environments
-        run: bash scripts/terraform-init.sh terraform/environments
-
-      - name: Run terraform plan in terraform/environments
-        id: tf_plan
         run: bash scripts/terraform-plan.sh terraform/environments
 
       - name: Update PR comment with plan summary
-        env:
-          PLAN_SUMMARY: ${{ steps.tf_plan.outputs.summary }}
-          SECRET: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           PLAN="$(printf '%s\n%s\n%s\n%s\n%s\n' \
             '### Terraform Plan Summary' \
             '_terraform/environments_' \
             '```' \
-            "$PLAN_SUMMARY" \
+            "${{ steps.tf_plan.outputs.summary }}" \
             '```')"
           bash scripts/update-pr-comments.sh "${PLAN}"
+        env:
+          SECRET: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
 
   create-environment:
     runs-on: ubuntu-latest
     if: github.event.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
     needs: fetch-secrets
-    permissions:
-      id-token: write # This is required for requesting the JWT
-      contents: read # This is required for actions/checkout
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
       - name: Decrypt Secrets
         uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
         with:
@@ -145,9 +111,7 @@ jobs:
         with:
           client-id: ${{ env.APP_ID }}               
           private-key: ${{ env.MP_GITHUB_APP_PRIVATE_KEY }} 
-          permission-contents: read
-          permission-pull-requests: write
-          repositories: "modernisation-platform,modernisation-platform-github"
+          owner: "ministryofjustice"
       - name: Authenticate GitHub CLI as the App and Check the Rate Usage
         env:
           GH_TOKEN: ${{ steps.app.outputs.token }}
@@ -156,10 +120,8 @@ jobs:
           gh auth status
           bash ./scripts/check-github-api-usage.sh
       - name: Set env vars
-        env:
-          APP_TOKEN: ${{ steps.app.outputs.token }}
         run: |
-          echo "TF_VAR_github_token=$APP_TOKEN" >> "$GITHUB_ENV"
+          echo "TF_VAR_github_token=${{ steps.app.outputs.token }}" >> "$GITHUB_ENV"
       - name: Set Account Number
         run: |
           ACCOUNT_NUMBER=$(jq -r -e '.aws_organizations_root_account_id' <<< "$ENVIRONMENT_MANAGEMENT")
@@ -193,13 +155,8 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
     needs: [fetch-secrets, create-environment]
-    permissions:
-      id-token: write # This is required for requesting the JWT
-      contents: read # This is required for actions/checkout
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
       - name: Decrypt Secrets
         uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
         with:
@@ -240,14 +197,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
     needs: [fetch-secrets, provision-workspaces]
-    permissions:
-      id-token: write # This is required for requesting the JWT
-      contents: read # This is required for actions/checkout
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-          persist-credentials: false
       - name: Decrypt Secrets
         uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
         with:
@@ -275,10 +228,8 @@ jobs:
           files=$(git diff --name-only --diff-filter=AM @^ -- 'environments/*.json' | uniq | sed 's#environments/##' | sed 's/\.json$//' | tr '\n' ',' | awk '{$1=$1};1')
           echo "files=$files" >> "$GITHUB_OUTPUT"
       - name: Run delegate access
-        env:
-          NEW_ACCOUNT_FILES: ${{ steps.new_account.outputs.files }}
         run: |
-          IFS=',' read -r -a accounts <<< "$NEW_ACCOUNT_FILES"
+          IFS=',' read -r -a accounts <<< "${{ steps.new_account.outputs.files }}"
           if [[ ${#accounts[@]} -gt 0 ]]; then
             for i in "${accounts[@]}"; do
               echo "[+] Running delegate-access baseline for account ${i}"
@@ -301,14 +252,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
     needs: [fetch-secrets, delegate-access]
-    permissions:
-      id-token: write # This is required for requesting the JWT
-      contents: read # This is required for actions/checkout
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-          persist-credentials: false
       - name: Decrypt Secrets
         uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
         with:
@@ -332,10 +279,8 @@ jobs:
           files=$(git diff --name-only --diff-filter=AM @^ -- 'environments/*.json' | uniq | sed 's#environments/##' | sed 's/\.json$//' | tr '\n' ',' | awk '{$1=$1};1')
           echo "files=$files" >> "$GITHUB_OUTPUT"
       - name: Remove Default VPC
-        env:
-          NEW_ACCOUNT_FILES: ${{ steps.new_account.outputs.files }}
         run: |
-          IFS=',' read -r -a accounts <<< "$NEW_ACCOUNT_FILES"
+          IFS=',' read -r -a accounts <<< "${{ steps.new_account.outputs.files }}"          
           if [[ ${#accounts[@]} -gt 0 ]]; then
             for i in "${accounts[@]}"; do
               environments=$(jq -r '.environments[].name' "environments/${i}.json")
@@ -362,14 +307,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
     needs: [fetch-secrets,delegate-access]
-    permissions:
-      id-token: write # This is required for requesting the JWT
-      contents: read # This is required for actions/checkout
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-          persist-credentials: false
       - name: Decrypt Secrets
         uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
         with:
@@ -397,10 +338,8 @@ jobs:
           files=$(git diff --name-only --diff-filter=AM @^ -- 'environments/*.json' | uniq | sed 's#environments/##' | sed 's/\.json$//' | tr '\n' ',' | awk '{$1=$1};1')
           echo "files=$files" >> "$GITHUB_OUTPUT"
       - name: Run secure baselines
-        env:
-          NEW_ACCOUNT_FILES: ${{ steps.new_account.outputs.files }}
         run: |
-          IFS=',' read -r -a accounts <<< "$NEW_ACCOUNT_FILES"
+          IFS=',' read -r -a accounts <<< "${{ steps.new_account.outputs.files }}"
           if [[ ${#accounts[@]} -gt 0 ]]; then
             for i in "${accounts[@]}"; do
               echo "[+] Running secure baseline for account ${i}"
@@ -423,14 +362,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.ref != 'refs/heads/main' || github.event_name != 'workflow_dispatch'
     needs: fetch-secrets
-    permissions:
-      id-token: write # This is required for requesting the JWT
-      contents: read # This is required for actions/checkout
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-          persist-credentials: false
       - name: Decrypt Secrets
         uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
         with:
@@ -457,10 +392,8 @@ jobs:
           files=$(git diff --name-only --diff-filter=M @^ -- 'environments/*.json' | uniq | sed 's#environments/##' | sed 's/\.json$//' | tr '\n' ',' | awk '{$1=$1};1')
           echo "files=$files" >> "$GITHUB_OUTPUT"
       - name: Run single sign on
-        env:
-          NEW_ACCOUNT_FILES: ${{ steps.new_account.outputs.files }}
         run: |
-          IFS=',' read -r -a accounts <<< "$NEW_ACCOUNT_FILES"
+          IFS=',' read -r -a accounts <<< "${{ steps.new_account.outputs.files }}"
           if [[ ${#accounts[@]} -gt 0 ]]; then
             for i in "${accounts[@]}"; do
               echo "[+] Running single sign on baseline for account ${i}"
@@ -474,14 +407,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
     needs: [fetch-secrets, provision-workspaces, delegate-access]
-    permissions:
-      id-token: write # This is required for requesting the JWT
-      contents: read # This is required for actions/checkout
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-          persist-credentials: false
       - name: Decrypt Secrets
         uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
         with:
@@ -509,10 +438,8 @@ jobs:
           files=$(git diff --name-only --diff-filter=AM @^ -- 'environments/*.json' | uniq | sed 's#environments/##' | sed 's/\.json$//' | tr '\n' ',' | awk '{$1=$1};1')
           echo "files=$files" >> "$GITHUB_OUTPUT"
       - name: Run single sign on
-        env:
-          NEW_ACCOUNT_FILES: ${{ steps.new_account.outputs.files }}
         run: |
-          IFS=',' read -r -a accounts <<< "$NEW_ACCOUNT_FILES"
+          IFS=',' read -r -a accounts <<< "${{ steps.new_account.outputs.files }}"
           if [[ ${#accounts[@]} -gt 0 ]]; then
             for i in "${accounts[@]}"; do
               echo "[+] Running single sign on baseline for account ${i}"
@@ -535,15 +462,11 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.ref == 'refs/heads/main'
     needs: [fetch-secrets, single-sign-on]
-    permissions:
-      contents: read # This is required for actions/checkout
-      pull-requests: read # This is required for looking up the merged PR
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-          persist-credentials: false
-          
+
       - name: Decrypt Secrets
         uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
         with:
@@ -576,15 +499,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Send notification to Slack
         if: steps.environment_json_changes.outputs.files != ''
-        env:
-          CHANGED_FILES: ${{ steps.environment_json_changes.outputs.files }}
-          PR_NUMBER: ${{ steps.pr_number.outputs.pr_number }}
-          SLACK_WEBHOOKS: ${{ env.SLACK_WEBHOOKS }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
         run: |
-          DECODED_FILES=$(echo "$CHANGED_FILES" | base64 --decode)
+          DECODED_FILES=$(echo "${{ steps.environment_json_changes.outputs.files }}" | base64 --decode)
           echo "$DECODED_FILES" | while IFS= read -r file; do
-          PR_PATH="https://github.com/${GITHUB_REPOSITORY}/pull/${PR_NUMBER}/files"
+          PR_PATH="https://github.com/${GITHUB_REPOSITORY}/pull/${{ steps.pr_number.outputs.pr_number }}/files"
           slack_channel=$(jq -r '.tags["slack-channel"] // empty' "environments/$file")
           if [[ -z "$slack_channel" ]]; then
           echo "No Slack channel specified in the $file or the field does not exist. Skipping."
@@ -605,6 +523,9 @@ jobs:
           )
           curl -X POST -H 'Content-type: application/json' --data "$PAYLOAD" "$webhook_url"
           done
+        env:
+          SLACK_WEBHOOKS: ${{ env.SLACK_WEBHOOKS }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
       - name: Validate Notify Template Version
         if: steps.environment_json_changes.outputs.files != ''
         run: |
@@ -616,16 +537,16 @@ jobs:
           api_key = os.getenv('GOV_UK_NOTIFY_API_KEY')
           template_id = os.getenv('TEMPLATE_ID')
           expected_version = int(os.environ.get('EXPECTED_TEMPLATE_VERSION'))
-    
+
           client = NotificationsAPIClient(api_key)
           try:
               template_details = client.get_template(template_id)
               actual_version = template_details.get("version")
-      
+
               if actual_version != expected_version:
                   print(f"Error: Template version mismatch! Expected: {expected_version}, Actual: {actual_version}")
                   sys.exit(1)
-      
+
               print(f"Template version {actual_version} validated successfully.")
           except Exception as e:
               print(f"Failed to fetch template details: {e}")
@@ -633,24 +554,19 @@ jobs:
           EOF
       - name: Send notification to Email
         if: steps.environment_json_changes.outputs.files != ''
-        env:
-          CHANGED_FILES: ${{ steps.environment_json_changes.outputs.files }}
-          PR_NUMBER: ${{ steps.pr_number.outputs.pr_number }}
         run: |
-          DECODED_FILES=$(echo "$CHANGED_FILES" | base64 --decode)
+          DECODED_FILES=$(echo "${{ steps.environment_json_changes.outputs.files }}" | base64 --decode)
           python ./scripts/json-changes-notifier.py "$DECODED_FILES"
+        env:
+          PR_NUMBER: ${{ steps.pr_number.outputs.pr_number }}   
   member-bootstrap:
     runs-on: ubuntu-latest
     if: github.event.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
     needs: [fetch-secrets, secure-baselines, single-sign-on]
-    permissions:
-      id-token: write # This is required for requesting the JWT
-      contents: read # This is required for actions/checkout
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-          persist-credentials: false
       - name: Decrypt Secrets
         uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
         with:
@@ -678,10 +594,8 @@ jobs:
           files=$(git diff --name-only --diff-filter=AM @^ -- 'environments/*.json' | uniq | sed 's#environments/##' | sed 's/\.json$//' | tr '\n' ',' | awk '{$1=$1};1')
           echo "files=$files" >> "$GITHUB_OUTPUT"
       - name: Run Member Bootstrap
-        env:
-          NEW_ACCOUNT_FILES: ${{ steps.new_account.outputs.files }}
         run: |
-          IFS=',' read -r -a accounts <<< "$NEW_ACCOUNT_FILES"
+          IFS=',' read -r -a accounts <<< "${{ steps.new_account.outputs.files }}"
           if [[ ${#accounts[@]} -gt 0 ]]; then
             for i in "${accounts[@]}"; do
               echo "[+] Running secure baseline for account ${i}"
@@ -700,19 +614,15 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ env.SLACK_WEBHOOK_URL }}
         if: ${{ failure() }}
-  
+
   modernisation-platform-account-plan-and-apply:
     uses: ./.github/workflows/reusable_terraform_plan_apply.yml
     needs: create-environment
-    permissions:
-      id-token: write
-      contents: read
-      pull-requests: write
     with:
       working-directory: "terraform/modernisation-platform-account"
       workflow_id: "modernisation-platform-account"
-      set_github_app_token: true
-      download_collaborators: true
+      set_github_app_token: ${{ 'true' }}
+      download_collaborators: ${{ 'true' }}
     secrets:
       MODERNISATION_PLATFORM_ACCOUNT_NUMBER: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_NUMBER }}
       PASSPHRASE: ${{ secrets.PASSPHRASE }}

--- a/.github/workflows/reusable_terraform_plan_apply.yml
+++ b/.github/workflows/reusable_terraform_plan_apply.yml
@@ -27,13 +27,13 @@ on:
       set_github_app_token:
         description: "Whether to set the GitHub App token"
         required: false
-        type: boolean
-        default: false
+        type: string
+        default: "false"
       download_collaborators:
         description: "Whether to download collaborators.json from modernisation-platform-github"
         required: false
-        type: boolean
-        default: false
+        type: string
+        default: "false"
     secrets:
       MODERNISATION_PLATFORM_ACCOUNT_NUMBER:
         required: true
@@ -66,8 +66,6 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
 
       - name: Decrypt Secrets
         uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
@@ -80,27 +78,23 @@ jobs:
           PASSPHRASE: ${{ secrets.PASSPHRASE }}
 
       - name: Create GitHub App token
-        if: ${{ inputs.set_github_app_token }}
+        if: ${{ inputs.set_github_app_token == 'true' }}
         id: app
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ env.APP_ID }}               
           private-key: ${{ env.MP_GITHUB_APP_PRIVATE_KEY }} 
-          permission-contents: read
-          permission-pull-requests: write
-          repositories: "modernisation-platform,modernisation-platform-github"
-      
+          owner: "ministryofjustice"
+
       - name: Download collaborators.json from modernisation-platform-github
-        if: ${{ inputs.download_collaborators && inputs.set_github_app_token }}
-        env:
-          APP_TOKEN: ${{ steps.app.outputs.token }}
+        if: ${{ inputs.download_collaborators == 'true' && inputs.set_github_app_token == 'true' }}
         run: |
-          curl -H "Authorization: token $APP_TOKEN" \
+          curl -H "Authorization: token ${{ steps.app.outputs.token }}" \
             -o collaborators.json \
             https://raw.githubusercontent.com/ministryofjustice/modernisation-platform-github/main/collaborators.json
 
       - name: Authenticate GitHub CLI as the App and Check the Rate Usage
-        if: ${{ inputs.set_github_app_token }}
+        if: ${{ inputs.set_github_app_token == 'true' }}
         env:
           GH_TOKEN: ${{ steps.app.outputs.token }}
         run: |
@@ -109,11 +103,9 @@ jobs:
           bash ./scripts/check-github-api-usage.sh
 
       - name: Set TF_VAR_github_token
-        if: ${{ inputs.set_github_app_token }}
-        env:
-          APP_TOKEN: ${{ steps.app.outputs.token }}
+        if: ${{ inputs.set_github_app_token == 'true' }}
         run: |
-          echo "TF_VAR_github_token=$APP_TOKEN" >> "$GITHUB_ENV"
+          echo "TF_VAR_github_token=${{ steps.app.outputs.token }}" >> "$GITHUB_ENV"
 
       - name: set env variables
         run: |
@@ -123,15 +115,12 @@ jobs:
       - name: Set up variables
         id: vars
         if: ${{ inputs.environment }}
-        env:
-          ENVIRONMENT_NAME: ${{ inputs.environment }}
-          WORKING_DIRECTORY: ${{ inputs.working-directory }}
         run: |
-          account_name=$(basename "$WORKING_DIRECTORY")
+          account_name=$(basename "${{ inputs.working-directory }}")
           echo "ACCOUNT_NAME=${account_name}"  >> "$GITHUB_ENV"
-          echo "WORKSPACE_NAME=${account_name}-${ENVIRONMENT_NAME}" >> "$GITHUB_ENV"
+          echo "WORKSPACE_NAME=${account_name}-${{ inputs.environment }}" >> "$GITHUB_ENV"
           # Check if test directory exists
-          if [ "${GITHUB_REF}" != 'refs/heads/main' ] && [ -d "$WORKING_DIRECTORY/test" ]; then
+          if [ "${GITHUB_REF}" != 'refs/heads/main' ] && [ -d "${{ inputs.working-directory }}/test" ]; then
               echo "run_terratest=true" >> "$GITHUB_OUTPUT"
           fi
     
@@ -171,17 +160,13 @@ jobs:
           terraform_wrapper: false
 
       - name: Initialize Terraform
-        env:
-          WORKING_DIRECTORY: ${{ inputs.working-directory }}
         run: |
-          bash scripts/terraform-init.sh "$WORKING_DIRECTORY"
+          bash scripts/terraform-init.sh "${{ inputs.working-directory }}"
 
       - name: Terraform Workspace Select
         if: ${{ inputs.environment }}
-        env:
-          WORKING_DIRECTORY: ${{ inputs.working-directory }}
         run: |
-          terraform -chdir="$WORKING_DIRECTORY" workspace select "${WORKSPACE_NAME}"
+          terraform -chdir="${{ inputs.working-directory }}" workspace select "${WORKSPACE_NAME}"
       
       - name: Validate Tags
         id: validate
@@ -194,10 +179,8 @@ jobs:
           terraform_plan_backend: 'remote'
       - name: Run Terratest
         if: ${{ steps.vars.outputs.run_terratest == 'true' }}
-        env:
-          WORKING_DIRECTORY: ${{ inputs.working-directory }}
         run: |
-          pushd "$WORKING_DIRECTORY/test"
+          pushd "${{ inputs.working-directory }}/test"
           go mod tidy
           TEST=$(go test | "${{ github.workspace }}/scripts/redact-output.sh" | tee /dev/stderr | tail -n 1)
           popd
@@ -210,10 +193,8 @@ jobs:
       - name: Run Terraform Plan
         if: github.event.ref != 'refs/heads/main'
         id: show
-        env:
-          WORKING_DIRECTORY: ${{ inputs.working-directory }}
         run: |
-          bash scripts/terraform-plan.sh "$WORKING_DIRECTORY"
+          bash scripts/terraform-plan.sh "${{ inputs.working-directory }}"
 
       - name: Get Destroy Count
         if: github.event_name == 'pull_request'
@@ -231,9 +212,6 @@ jobs:
         env:
           destroy_count: ${{ steps.get_destroy_count.outputs.destroy_count }}
           destroy_threshold: ${{ env.TF_DESTROY_THRESHOLD }}
-          PLAN_SUMMARY: ${{ steps.show.outputs.summary }}
-          WORKFLOW_ID: ${{ inputs.workflow_id }}
-          WORKSPACE_NAME: ${{ env.WORKSPACE_NAME }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -241,9 +219,9 @@ jobs:
             const teamSlug = 'modernisation-platform';
             const destroyCount = parseInt(process.env.destroy_count, 10);
             const destroyThreshold = parseInt(process.env.destroy_threshold, 10);
-            const summary = `\`${process.env.PLAN_SUMMARY}\``;
-            const workflowId = process.env.WORKSPACE_NAME;
-            const identifier = workflowId ? `_${workflowId}_\n` : `_${process.env.WORKFLOW_ID}_\n`;
+            const summary = `\`${{ steps.show.outputs.summary }}\``;
+            const workflowId = "${{ env.WORKSPACE_NAME }}";
+            const identifier = workflowId ? `_${workflowId}_\n` : `_${{ inputs.workflow_id }}_\n`;
 
             if (destroyCount >= destroyThreshold) {
               await github.rest.pulls.createReview({
@@ -258,16 +236,12 @@ jobs:
       - name: Post Comment
         if: github.event.ref != 'refs/heads/main'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          PLAN_SUMMARY: ${{ steps.show.outputs.summary }}
-          WORKFLOW_ID: ${{ inputs.workflow_id }}
-          WORKSPACE_NAME: ${{ env.WORKSPACE_NAME }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const workflowId = process.env.WORKSPACE_NAME;
-            const identifier = workflowId ? `_${workflowId}_\n` : `_${process.env.WORKFLOW_ID}_\n`;
-            const summary = `\`${process.env.PLAN_SUMMARY}\``;
+            const workflowId = "${{ env.WORKSPACE_NAME }}";
+            const identifier = workflowId ? `_${workflowId}_\n` : `_${{ inputs.workflow_id }}_\n`;
+            const summary = `\`${{ steps.show.outputs.summary }}\``;
             const issue_number = context.payload.pull_request ? context.payload.pull_request.number : null;
             if (!issue_number) {
               console.log('No issue number found, skipping comment.');
@@ -281,9 +255,7 @@ jobs:
 
       - name: terraform apply
         if: github.event.ref == 'refs/heads/main'
-        env:
-          WORKING_DIRECTORY: ${{ inputs.working-directory }}
-        run: bash scripts/terraform-apply.sh "$WORKING_DIRECTORY"
+        run: bash scripts/terraform-apply.sh "${{ inputs.working-directory }}"
 
       - name: Slack failure notification
         if: ${{ failure() && github.ref == 'refs/heads/main' }}

--- a/.github/workflows/reusable_terraform_plan_apply.yml
+++ b/.github/workflows/reusable_terraform_plan_apply.yml
@@ -86,12 +86,9 @@ jobs:
         with:
           client-id: ${{ env.APP_ID }}               
           private-key: ${{ env.MP_GITHUB_APP_PRIVATE_KEY }} 
-          owner: "ministryofjustice"
-          permission-actions: write
           permission-contents: read
           permission-pull-requests: write
-          permission-secrets: write
-          repositories: "modernisation-platform,modernisation-platform-github,modernisation-platform-ami-builds,modernisation-platform-configuration-management,modernisation-platform-security"
+          repositories: "modernisation-platform,modernisation-platform-github"
       
       - name: Download collaborators.json from modernisation-platform-github
         if: ${{ inputs.download_collaborators && inputs.set_github_app_token }}

--- a/.github/workflows/reusable_terraform_plan_apply.yml
+++ b/.github/workflows/reusable_terraform_plan_apply.yml
@@ -86,10 +86,10 @@ jobs:
         with:
           client-id: ${{ env.APP_ID }}               
           private-key: ${{ env.MP_GITHUB_APP_PRIVATE_KEY }} 
+          owner: "ministryofjustice"
           permission-actions: write
           permission-contents: read
           permission-pull-requests: write
-          repositories: "modernisation-platform,modernisation-platform-github,modernisation-platform-ami-builds,modernisation-platform-configuration-management,modernisation-platform-security"
       
       - name: Download collaborators.json from modernisation-platform-github
         if: ${{ inputs.download_collaborators && inputs.set_github_app_token }}

--- a/.github/workflows/reusable_terraform_plan_apply.yml
+++ b/.github/workflows/reusable_terraform_plan_apply.yml
@@ -91,6 +91,7 @@ jobs:
           permission-contents: read
           permission-pull-requests: write
           permission-secrets: write
+          repositories: "modernisation-platform,modernisation-platform-github,modernisation-platform-ami-builds,modernisation-platform-configuration-management,modernisation-platform-security"
       
       - name: Download collaborators.json from modernisation-platform-github
         if: ${{ inputs.download_collaborators && inputs.set_github_app_token }}

--- a/.github/workflows/reusable_terraform_plan_apply.yml
+++ b/.github/workflows/reusable_terraform_plan_apply.yml
@@ -86,9 +86,10 @@ jobs:
         with:
           client-id: ${{ env.APP_ID }}               
           private-key: ${{ env.MP_GITHUB_APP_PRIVATE_KEY }} 
+          permission-actions: write
           permission-contents: read
           permission-pull-requests: write
-          repositories: "modernisation-platform,modernisation-platform-github"
+          repositories: "modernisation-platform,modernisation-platform-github,modernisation-platform-ami-builds,modernisation-platform-configuration-management,modernisation-platform-security"
       
       - name: Download collaborators.json from modernisation-platform-github
         if: ${{ inputs.download_collaborators && inputs.set_github_app_token }}

--- a/.github/workflows/reusable_terraform_plan_apply.yml
+++ b/.github/workflows/reusable_terraform_plan_apply.yml
@@ -90,6 +90,7 @@ jobs:
           permission-actions: write
           permission-contents: read
           permission-pull-requests: write
+          permission-secrets: write
       
       - name: Download collaborators.json from modernisation-platform-github
         if: ${{ inputs.download_collaborators && inputs.set_github_app_token }}

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,4 +1,7 @@
 rules:
+  github-app:
+    ignore:
+      - reusable_terraform_plan_apply.yml
   self-repository:
     ignore:
       - modernisation-platform-account.yml

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,7 +1,4 @@
 rules:
-  github-app:
-    ignore:
-      - reusable_terraform_plan_apply.yml
   self-repository:
     ignore:
       - modernisation-platform-account.yml


### PR DESCRIPTION
## Summary

Revert the recent workflow changes while the required GitHub App permissions are being resolved.

## Why

The updated workflows require GitHub App access to manage Actions secrets across multiple repositories. The current App installation does not have the required repository access or Actions Secrets permissions, causing Terraform plans to fail with:

`403 Resource not accessible by integration`

Keeping these changes in place would leave the workflow failing until the App permissions are updated.

## Changes

- Revert the changes to:
  - `.github/workflows/reusable_terraform_plan_apply.yml`
  - `.github/workflows/new-environment.yml`

Once the GitHub App has the required permissions, the workflow hardening and Zizmor fixes can be reapplied in a separate change.