### PR TITLE
Fix secrets-rotation-reminder workflow: filter empty secret IDs

### DIFF
--- a/.github/workflows/secrets-rotation-reminder.yml
+++ b/.github/workflows/secrets-rotation-reminder.yml
@@ -97,6 +97,13 @@ jobs:
             do
               secrets=("${secrets[@]/$del}")
             done
+
+            # Substitution above leaves empty elements in place of removed entries; drop them
+            filtered_secrets=()
+            for secret in "${secrets[@]}"; do
+              [ -n "$secret" ] && filtered_secrets+=("$secret")
+            done
+            secrets=("${filtered_secrets[@]}")
             
             # Define the threshold in seconds (180 days)
             threshold=$((180 * 24 * 60 * 60))

--- a/.github/workflows/secrets-rotation-reminder.yml
+++ b/.github/workflows/secrets-rotation-reminder.yml
@@ -1,26 +1,26 @@
 ---
 name: Secrets Rotation Reminder
-on:
+"on":
   pull_request:
     branches:
-      - "main" 
+      - "main"
     paths:
       - ".github/workflows/secrets-rotation-reminder.yml"
-  schedule: 
-      - cron: '30 11 * * *' # run at 11:30 daily 
+  schedule:
+    - cron: '30 11 * * *' # run at 11:30 daily
   workflow_dispatch:
 
 env:
-    AWS_REGION: "eu-west-2"
-    SECRET: ${{ secrets.GITHUB_TOKEN }}
-    RATE_THRESHOLD: 100
-    APP_ID: 2013696
-    
+  AWS_REGION: "eu-west-2"
+  SECRET: ${{ secrets.GITHUB_TOKEN }}
+  RATE_THRESHOLD: 100
+  APP_ID: 2013696
+
 permissions: {}
-    
+
 defaults:
-    run:
-        shell: bash
+  run:
+    shell: bash
 
 jobs:
 
@@ -31,66 +31,66 @@ jobs:
       contents: read # This is required for actions/checkout
     secrets:
       MODERNISATION_PLATFORM_ACCOUNT_NUMBER: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_NUMBER }}
-      PASSPHRASE: ${{ secrets.PASSPHRASE }}  
+      PASSPHRASE: ${{ secrets.PASSPHRASE }}
 
   secrets-rotation-reminder:
-      runs-on: ubuntu-latest
-      needs: fetch-secrets
-      permissions:
-        id-token: write # This is required for requesting the JWT
-        contents: read # This is required for actions/checkout
-        issues: write # This is required to create issues
-      steps:
-        - name: Checkout Repository
-          uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-          with:
-            persist-credentials: false
+    runs-on: ubuntu-latest
+    needs: fetch-secrets
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read # This is required for actions/checkout
+      issues: write # This is required to create issues
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
-        - name: Decrypt Secrets
-          uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
-          with:
-            environment_management: ${{ needs.fetch-secrets.outputs.environment_management }}
-            mp_github_app_private_key: ${{ needs.fetch-secrets.outputs.mp_github_app_private_key }}
-            PASSPHRASE: ${{ secrets.PASSPHRASE }}
+      - name: Decrypt Secrets
+        uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
+        with:
+          environment_management: ${{ needs.fetch-secrets.outputs.environment_management }}
+          mp_github_app_private_key: ${{ needs.fetch-secrets.outputs.mp_github_app_private_key }}
+          PASSPHRASE: ${{ secrets.PASSPHRASE }}
 
-        - name: Create GitHub App token
-          id: app
-          uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-          with:
-            client-id: ${{ env.APP_ID }}               
-            private-key: ${{ env.MP_GITHUB_APP_PRIVATE_KEY }} 
-            permission-contents: read
-            permission-issues: write
-            repositories: "modernisation-platform"
+      - name: Create GitHub App token
+        id: app
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ env.APP_ID }}
+          private-key: ${{ env.MP_GITHUB_APP_PRIVATE_KEY }}
+          permission-contents: read
+          permission-issues: write
+          repositories: "modernisation-platform"
 
-        - name: Authenticate GitHub CLI as the App and Check the Rate Usage
-          env:
-            GH_TOKEN: ${{ steps.app.outputs.token }}
-          run: |
-            # gh automatically uses GH_TOKEN if set — no `gh auth login` needed
-            gh auth status
-            bash ./scripts/check-github-api-usage.sh
+      - name: Authenticate GitHub CLI as the App and Check the Rate Usage
+        env:
+          GH_TOKEN: ${{ steps.app.outputs.token }}
+        run: |
+          # gh automatically uses GH_TOKEN if set — no `gh auth login` needed
+          gh auth status
+          bash ./scripts/check-github-api-usage.sh
 
-        - name: Set Account Number
-          run: |
-            ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< "$ENVIRONMENT_MANAGEMENT")
-            echo "::add-mask::$ACCOUNT_NUMBER"
-            echo "ACCOUNT_NUMBER=$ACCOUNT_NUMBER" >> "$GITHUB_ENV"
-  
-        - name: Configure AWS Credentials
-          uses: aws-actions/configure-aws-credentials@cbe3b392738ccf3f987d68400dafcf4b0624a56c # v6.2.4
-          with:
-            role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions-apply"
-            role-session-name: githubactionsrolesession
-            aws-region: ${{ env.AWS_REGION }}
-  
-        - name: Run Secrets Rotation Reminder Script
-          env:
-            GH_TOKEN: ${{ steps.app.outputs.token }}
-          run: |
+      - name: Set Account Number
+        run: |
+          ACCOUNT_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< "$ENVIRONMENT_MANAGEMENT")
+          echo "::add-mask::$ACCOUNT_NUMBER"
+          echo "ACCOUNT_NUMBER=$ACCOUNT_NUMBER" >> "$GITHUB_ENV"
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@cbe3b392738ccf3f987d68400dafcf4b0624a56c # v6.2.4
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions-apply"
+          role-session-name: githubactionsrolesession
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Run Secrets Rotation Reminder Script
+        env:
+          GH_TOKEN: ${{ steps.app.outputs.token }}
+        run: |
             # Get the list of secret names from AWS Secrets Manager
             read -r -a secrets <<< "$(aws secretsmanager list-secrets --region "$AWS_REGION" --query "SecretList[].Name" --output text)"
-            
+
             # Remove secrets from list that are exempt from rotation
             delete=("environment_management" "nuke_account_ids" "nuke_account_blocklist" "nuke_rebuild_account_ids" "mod-platform-circleci" "pagerduty_integration_keys" "nonmp-account-ids" "modernisation_platform_github_app_client_id")
             for del in "${delete[@]}"
@@ -104,28 +104,28 @@ jobs:
               [ -n "$secret" ] && filtered_secrets+=("$secret")
             done
             secrets=("${filtered_secrets[@]}")
-            
+
             # Define the threshold in seconds (180 days)
             threshold=$((180 * 24 * 60 * 60))
-            
+
             # Get the current timestamp in seconds
             current_timestamp=$(date +%s)
-            
+
             # Loop through each secret,  check its last changed date and raise issue if required
             for secret in "${secrets[@]}"; do
               last_changed=$(aws secretsmanager list-secret-version-ids --secret-id "$secret" --region "$AWS_REGION" --query "Versions[?contains(VersionStages,'AWSCURRENT')].CreatedDate" --output text | sort -r | head -n 1)
-              
+
               # If the secret has never been changed, set the last_changed date to 0
               if [ -z "$last_changed" ]; then
                 last_changed=0
               fi
-            
+
               # Calculate the age of the secret in seconds
               age=$((current_timestamp - $(date -d "$last_changed" +%s)))
 
               # Check if there is an existing open issue to rotate the secret
               open_issue_count=$(gh issue list -R ministryofjustice/modernisation-platform --state open --limit 500 --json title --jq "[.[] | select(.title | contains(\"Rotate $secret\"))] | length")
-            
+
               # Check if the secret is older than the threshold and if there is no existing open issue to rotate it, raise a new issue
               if [ "$age" -gt "$threshold" ] && [ "$open_issue_count" -eq 0 ]; then
                 echo "$secret secret is older than 180 days (age: $((age / (24 * 60 * 60))) days)"
@@ -133,7 +133,7 @@ jobs:
                 gh issue create --title "Rotate $secret Credential" --label "security,kanban" --project "Modernisation Platform" --body "The secrets-rotation-reminder workflow has identified that the $secret credential requires rotation as it is close to or exceeding the threshold of 180 days. Consult the [documentation](https://user-guide.modernisation-platform.service.justice.gov.uk/runbooks/rotating-secrets.html#how-to-rotate-secrets) which describes the process for rotation."
               elif [ "$age" -gt "$threshold" ] && [ "$open_issue_count" -gt 0 ]; then
                 echo "$secret secret is older than 180 days (age: $((age / (24 * 60 * 60))) days) but an issue has already been raised to address this"
-              else 
+              else
                 echo "The $secret secret has not been identified for rotation (age: $((age / (24 * 60 * 60))) days)"
               fi
             done


### PR DESCRIPTION
## What
Filters out empty entries left in the `secrets` array after excluding exempt secrets in `secrets-rotation-reminder.yml`.

## Why
`secrets=("${secrets[@]/$del}")` replaces matching elements with an empty string but doesn't remove them from the array. The subsequent loop then called `aws secretsmanager list-secret-version-ids --secret-id ""` for these empty entries, failing with:
```
aws: [ERROR]: An error occurred (ParamValidation): Parameter validation failed:
Invalid length for parameter SecretId, value: 0, valid min length: 1
```

## Fix
After building the exclusion-filtered array, drop any blank elements before iterating over secrets.