### PR TITLE
Fix invalid workflow: add permissions to reusable-scheduled-baselines callers

### DIFF
--- a/.github/workflows/scheduled-baseline-extended-matrix.yml
+++ b/.github/workflows/scheduled-baseline-extended-matrix.yml
@@ -1,16 +1,17 @@
+---
 name: "Terraform: scheduled baseline - Extended Matrix"
 
-on:
+"on":
   schedule:
-     - cron: "30 22 * * 0"
+    - cron: "30 22 * * 0"
   push:
     branches:
       - main
     paths:
-       - '.github/workflows/scheduled-baseline.yml'
-       - 'terraform/environments/bootstrap/**'
-       - '!**.md'
-       - 'scripts/update-sso-permission-sets.sh'
+      - '.github/workflows/scheduled-baseline.yml'
+      - 'terraform/environments/bootstrap/**'
+      - '!**.md'
+      - 'scripts/update-sso-permission-sets.sh'
   workflow_dispatch:
 
 env:
@@ -23,13 +24,13 @@ defaults:
   run:
     shell: bash
 
-concurrency: 
+concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false
 
 jobs:
 
-# fetch-secrets
+  # fetch-secrets
 
   fetch-secrets:
     uses: ministryofjustice/modernisation-platform-github-actions/.github/workflows/aws-secrets-management.yml@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
@@ -40,7 +41,7 @@ jobs:
       MODERNISATION_PLATFORM_ACCOUNT_NUMBER: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_NUMBER }}
       PASSPHRASE: ${{ secrets.PASSPHRASE }}
 
-# setup-prerequisites
+  # setup-prerequisites
 
   setup-prerequisites:
     runs-on: ubuntu-latest
@@ -58,7 +59,7 @@ jobs:
       aws-region: ${{ steps.setup-aws-region.outputs.aws-region }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with: 
+        with:
           fetch-depth: 0
           persist-credentials: false
       - name: Decrypt Secrets
@@ -145,7 +146,7 @@ jobs:
           done
 
 
-# delegate-access
+  # delegate-access
 
   delegate-access-1:
     needs: [fetch-secrets, setup-prerequisites, define-jobs]
@@ -173,7 +174,7 @@ jobs:
       aws_account_id_name: "aws_organizations_root_account_id"
     secrets:
       PASSPHRASE: ${{ secrets.PASSPHRASE }}
-  
+
   delegate-access-2:
     needs: [fetch-secrets, setup-prerequisites, define-jobs]
     if: |
@@ -255,10 +256,10 @@ jobs:
     secrets:
       PASSPHRASE: ${{ secrets.PASSPHRASE }}
 
-# secure-baselines
+  # secure-baselines
 
   secure-baselines-1:
-    needs: [fetch-secrets,setup-prerequisites, define-jobs, delegate-access-1]
+    needs: [fetch-secrets, setup-prerequisites, define-jobs, delegate-access-1]
     if: |
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
@@ -284,7 +285,7 @@ jobs:
       PASSPHRASE: ${{ secrets.PASSPHRASE }}
 
   secure-baselines-2:
-    needs: [fetch-secrets,setup-prerequisites, define-jobs, delegate-access-2]
+    needs: [fetch-secrets, setup-prerequisites, define-jobs, delegate-access-2]
     if: |
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
@@ -310,7 +311,7 @@ jobs:
       PASSPHRASE: ${{ secrets.PASSPHRASE }}
 
   secure-baselines-3:
-    needs: [fetch-secrets,setup-prerequisites, define-jobs, delegate-access-3]
+    needs: [fetch-secrets, setup-prerequisites, define-jobs, delegate-access-3]
     if: |
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
@@ -336,7 +337,7 @@ jobs:
       PASSPHRASE: ${{ secrets.PASSPHRASE }}
 
   secure-baselines-4:
-    needs: [fetch-secrets,setup-prerequisites, define-jobs, delegate-access-4]
+    needs: [fetch-secrets, setup-prerequisites, define-jobs, delegate-access-4]
     if: |
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
@@ -362,10 +363,10 @@ jobs:
       PASSPHRASE: ${{ secrets.PASSPHRASE }}
 
 
-# single-sign-on
+  # single-sign-on
 
   single-sign-on-1:
-    needs: [fetch-secrets,setup-prerequisites, define-jobs, delegate-access-1]
+    needs: [fetch-secrets, setup-prerequisites, define-jobs, delegate-access-1]
     if: |
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
@@ -391,7 +392,7 @@ jobs:
       PASSPHRASE: ${{ secrets.PASSPHRASE }}
 
   single-sign-on-2:
-    needs: [fetch-secrets,setup-prerequisites, define-jobs, delegate-access-2]
+    needs: [fetch-secrets, setup-prerequisites, define-jobs, delegate-access-2]
     if: |
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
@@ -417,7 +418,7 @@ jobs:
       PASSPHRASE: ${{ secrets.PASSPHRASE }}
 
   single-sign-on-3:
-    needs: [fetch-secrets,setup-prerequisites, define-jobs, delegate-access-3]
+    needs: [fetch-secrets, setup-prerequisites, define-jobs, delegate-access-3]
     if: |
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
@@ -443,7 +444,7 @@ jobs:
       PASSPHRASE: ${{ secrets.PASSPHRASE }}
 
   single-sign-on-4:
-    needs: [fetch-secrets,setup-prerequisites, define-jobs, delegate-access-4]
+    needs: [fetch-secrets, setup-prerequisites, define-jobs, delegate-access-4]
     if: |
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
@@ -469,10 +470,10 @@ jobs:
       PASSPHRASE: ${{ secrets.PASSPHRASE }}
 
 
-# member-bootstrap
+  # member-bootstrap
 
   member-bootstrap-1:
-    needs: [fetch-secrets,setup-prerequisites, define-jobs, single-sign-on-1]
+    needs: [fetch-secrets, setup-prerequisites, define-jobs, single-sign-on-1]
     if: |
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
@@ -498,7 +499,7 @@ jobs:
       PASSPHRASE: ${{ secrets.PASSPHRASE }}
 
   member-bootstrap-2:
-    needs: [fetch-secrets,setup-prerequisites, define-jobs, single-sign-on-2]
+    needs: [fetch-secrets, setup-prerequisites, define-jobs, single-sign-on-2]
     if: |
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
@@ -524,7 +525,7 @@ jobs:
       PASSPHRASE: ${{ secrets.PASSPHRASE }}
 
   member-bootstrap-3:
-    needs: [fetch-secrets,setup-prerequisites, define-jobs, single-sign-on-3]
+    needs: [fetch-secrets, setup-prerequisites, define-jobs, single-sign-on-3]
     if: |
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
@@ -550,7 +551,7 @@ jobs:
       PASSPHRASE: ${{ secrets.PASSPHRASE }}
 
   member-bootstrap-4:
-    needs: [fetch-secrets,setup-prerequisites, define-jobs, single-sign-on-4]
+    needs: [fetch-secrets, setup-prerequisites, define-jobs, single-sign-on-4]
     if: |
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
@@ -574,9 +575,8 @@ jobs:
       aws_account_id_name: "modernisation_platform_account_id"
     secrets:
       PASSPHRASE: ${{ secrets.PASSPHRASE }}
-  
 
-# update-permission-sets
+  # update-permission-sets
 
   update-permission-sets:
     runs-on: ubuntu-latest

--- a/.github/workflows/scheduled-baseline-extended-matrix.yml
+++ b/.github/workflows/scheduled-baseline-extended-matrix.yml
@@ -158,6 +158,9 @@ jobs:
       fail-fast: false
       matrix:
         workspaces: ${{ fromJSON(needs.define-jobs.outputs.block_1) }}
+    permissions:
+      id-token: write
+      contents: read
     uses: ./.github/workflows/reusable-scheduled-baselines.yml
     with:
       JOB_NAME: "delegate-access-1"
@@ -182,6 +185,9 @@ jobs:
       fail-fast: false
       matrix:
         workspaces: ${{ fromJSON(needs.define-jobs.outputs.block_2) }}
+    permissions:
+      id-token: write
+      contents: read
     uses: ./.github/workflows/reusable-scheduled-baselines.yml
     with:
       JOB_NAME: "delegate-access-2"
@@ -206,6 +212,9 @@ jobs:
       fail-fast: false
       matrix:
         workspaces: ${{ fromJSON(needs.define-jobs.outputs.block_3) }}
+    permissions:
+      id-token: write
+      contents: read
     uses: ./.github/workflows/reusable-scheduled-baselines.yml
     with:
       JOB_NAME: "delegate-access-3"
@@ -230,6 +239,9 @@ jobs:
       fail-fast: false
       matrix:
         workspaces: ${{ fromJSON(needs.define-jobs.outputs.block_4) }}
+    permissions:
+      id-token: write
+      contents: read
     uses: ./.github/workflows/reusable-scheduled-baselines.yml
     with:
       JOB_NAME: "delegate-access-4"
@@ -255,6 +267,9 @@ jobs:
       fail-fast: false
       matrix:
         workspaces: ${{ fromJSON(needs.define-jobs.outputs.block_1) }}
+    permissions:
+      id-token: write
+      contents: read
     uses: ./.github/workflows/reusable-scheduled-baselines.yml
     with:
       JOB_NAME: "secure-baselines-1"
@@ -278,6 +293,9 @@ jobs:
       fail-fast: false
       matrix:
         workspaces: ${{ fromJSON(needs.define-jobs.outputs.block_2) }}
+    permissions:
+      id-token: write
+      contents: read
     uses: ./.github/workflows/reusable-scheduled-baselines.yml
     with:
       JOB_NAME: "secure-baselines-2"
@@ -301,6 +319,9 @@ jobs:
       fail-fast: false
       matrix:
         workspaces: ${{ fromJSON(needs.define-jobs.outputs.block_3) }}
+    permissions:
+      id-token: write
+      contents: read
     uses: ./.github/workflows/reusable-scheduled-baselines.yml
     with:
       JOB_NAME: "secure-baselines-3"
@@ -324,6 +345,9 @@ jobs:
       fail-fast: false
       matrix:
         workspaces: ${{ fromJSON(needs.define-jobs.outputs.block_4) }}
+    permissions:
+      id-token: write
+      contents: read
     uses: ./.github/workflows/reusable-scheduled-baselines.yml
     with:
       JOB_NAME: "secure-baselines-4"
@@ -350,6 +374,9 @@ jobs:
       fail-fast: false
       matrix:
         workspaces: ${{ fromJSON(needs.define-jobs.outputs.block_1) }}
+    permissions:
+      id-token: write
+      contents: read
     uses: ./.github/workflows/reusable-scheduled-baselines.yml
     with:
       JOB_NAME: "single-sign-on-1"
@@ -373,6 +400,9 @@ jobs:
       fail-fast: false
       matrix:
         workspaces: ${{ fromJSON(needs.define-jobs.outputs.block_2) }}
+    permissions:
+      id-token: write
+      contents: read
     uses: ./.github/workflows/reusable-scheduled-baselines.yml
     with:
       JOB_NAME: "single-sign-on-2"
@@ -396,6 +426,9 @@ jobs:
       fail-fast: false
       matrix:
         workspaces: ${{ fromJSON(needs.define-jobs.outputs.block_3) }}
+    permissions:
+      id-token: write
+      contents: read
     uses: ./.github/workflows/reusable-scheduled-baselines.yml
     with:
       JOB_NAME: "single-sign-on-3"
@@ -419,6 +452,9 @@ jobs:
       fail-fast: false
       matrix:
         workspaces: ${{ fromJSON(needs.define-jobs.outputs.block_4) }}
+    permissions:
+      id-token: write
+      contents: read
     uses: ./.github/workflows/reusable-scheduled-baselines.yml
     with:
       JOB_NAME: "single-sign-on-4"
@@ -445,6 +481,9 @@ jobs:
       fail-fast: false
       matrix:
         workspaces: ${{ fromJSON(needs.define-jobs.outputs.block_1) }}
+    permissions:
+      id-token: write
+      contents: read
     uses: ./.github/workflows/reusable-scheduled-baselines.yml
     with:
       JOB_NAME: "member-bootstrap-1"
@@ -468,6 +507,9 @@ jobs:
       fail-fast: false
       matrix:
         workspaces: ${{ fromJSON(needs.define-jobs.outputs.block_2) }}
+    permissions:
+      id-token: write
+      contents: read
     uses: ./.github/workflows/reusable-scheduled-baselines.yml
     with:
       JOB_NAME: "member-bootstrap-2"
@@ -491,6 +533,9 @@ jobs:
       fail-fast: false
       matrix:
         workspaces: ${{ fromJSON(needs.define-jobs.outputs.block_3) }}
+    permissions:
+      id-token: write
+      contents: read
     uses: ./.github/workflows/reusable-scheduled-baselines.yml
     with:
       JOB_NAME: "member-bootstrap-3"
@@ -514,6 +559,9 @@ jobs:
       fail-fast: false
       matrix:
         workspaces: ${{ fromJSON(needs.define-jobs.outputs.block_4) }}
+    permissions:
+      id-token: write
+      contents: read
     uses: ./.github/workflows/reusable-scheduled-baselines.yml
     with:
       JOB_NAME: "member-bootstrap-4"


### PR DESCRIPTION
## Summary

Fixes an invalid workflow file in `scheduled-baseline-extended-matrix.yml` that has prevented "Terraform: scheduled baseline - Extended Matrix" from starting since yesterday's Zizmor/actionlint changes.

## Why

```
The workflow is not valid. .github/workflows/scheduled-baseline-extended-matrix.yml (Line: 150, Col: 3):
Error calling workflow 'ministryofjustice/modernisation-platform/.github/workflows/reusable-scheduled-baselines.yml@...'.
The nested job 'main' is requesting 'contents: read, id-token: write', but is only allowed 'contents: none, id-token: none'.
```

`reusable-scheduled-baselines.yml` sets `permissions: {}` at the workflow level and its `main` job requests `id-token: write` and `contents: read`. All 16 caller jobs in this file (`delegate-access-1..4`, `secure-baselines-1..4`, `single-sign-on-1..4`, `member-bootstrap-1..4`) invoke that reusable workflow via `uses:` but none of them granted these permissions, so GitHub rejects the workflow before it can run.

## Changes

- Add
  ```yaml
  permissions:
    id-token: write
    contents: read
  ```
  to each of the 16 caller jobs, matching the permissions already granted on `fetch-secrets` and `setup-prerequisites` in this same file.
- No changes to job logic, `with:`/`secrets:` inputs, or the reusable workflow itself.

## Validation

- `actionlint .github/workflows/scheduled-baseline-extended-matrix.yml`
- `git diff --check`