### PR TITLE
Allow CircleCI to put IAM role policies

### DIFF
--- a/terraform/environments/digital-prison-reporting/iam.tf
+++ b/terraform/environments/digital-prison-reporting/iam.tf
@@ -252,6 +252,7 @@ data "aws_iam_policy_document" "circleci_iam_policy" {
       "iam:CreatePolicy",
       "iam:DeleteRole",
       "iam:DeletePolicy",
+      "iam:PutRolePolicy",
       "iam:GetRole",
       "iam:ListRolePolicies",
       "iam:ListRoles",


### PR DESCRIPTION
## A reference to the issue / Description of it

The delta lake monitor deployment was failing in the domains repo when Terraform tried to attach the scheduler invoke policy to dpr-deltalake-monitor-scheduler-role.

CircleCI was getting an AccessDenied error because circleci_iam_role did not have permission to run iam:PutRolePolicy.

## How does this PR fix the problem?

This PR adds iam:PutRolePolicy to the permissions on circleci_iam_policy.

This allows the CircleCI deployment role to create/update the inline IAM policy required by the delta lake monitor scheduler role.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

The permission issue was reproduced during the dev deployment of the delta lake monitor Lambda.

After adding iam:PutRolePolicy to the CircleCI IAM policy, the deployment can be rerun to confirm Terraform is able to create the scheduler invoke policy successfully.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No expected impact to existing platform services.

This is an IAM permission change for the existing CircleCI deployment role. Once applied, the failed domains deployment can be rerun.

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

This change is required to support the new delta lake monitor scheduler role deployment.